### PR TITLE
Add more citations tags

### DIFF
--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -1,4 +1,5 @@
 <% provide :page_title, @presenter.page_title %>
+<%= render './shared/additional_citations' %>
 <div itemscope itemtype="http://schema.org/CreativeWork" class="row">
   <div class="col-xs-12">
     <header>

--- a/app/views/shared/_additional_citations.html.erb
+++ b/app/views/shared/_additional_citations.html.erb
@@ -1,0 +1,11 @@
+<% content_for(:gscholar_meta) do %>
+  <% unless @presenter.description.blank? %>
+    <meta name="description" content="<%= @presenter.description.join %>" />
+  <%end %>
+  <% unless @presenter.keyword.blank? %>
+    <meta name="citation_keywords" content="<%= @presenter.keyword.join('; ') %>" />
+  <% end %>
+  <% unless @presenter.publisher.blank? %>
+    <meta name="citation_publisher" content="<%= @presenter.publisher.join %>" />
+  <% end %>
+<% end %>


### PR DESCRIPTION
More fields added to the gscholar metadata tags: description, keywords, publisher.

Blank fields don't display, as per Google Scholar recommendation to "skip/drop all missing fields".

@samvera/hyrax-code-reviewers