### PR TITLE
Remove labs from several badge links to reflect new repo home

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Hyku, the Hydra-in-a-Box Repository Application
 
 Code: 
-[![Build Status](https://travis-ci.org/samvera-labs/hyku.svg)](https://travis-ci.org/samvera-labs/hyku)
-[![Coverage Status](https://coveralls.io/repos/samvera-labs/hyku/badge.svg?branch=master&service=github)](https://coveralls.io/github/samvera-labs/hyku?branch=master)
+[![Build Status](https://travis-ci.org/samvera/hyku.svg)](https://travis-ci.org/samvera/hyku)
+[![Coverage Status](https://coveralls.io/repos/samvera/hyku/badge.svg?branch=master&service=github)](https://coveralls.io/github/samvera/hyku?branch=master)
 [![Stories in Ready](https://img.shields.io/waffle/label/samvera-labs/hyku/ready.svg)](https://waffle.io/samvera-labs/hyku)
 
 Docs: 
-[![Documentation](http://img.shields.io/badge/DOCUMENTATION-wiki-blue.svg)](https://github.com/samvera-labs/hyku/wiki)
+[![Documentation](http://img.shields.io/badge/DOCUMENTATION-wiki-blue.svg)](https://github.com/samvera/hyku/wiki)
 [![Contribution Guidelines](http://img.shields.io/badge/CONTRIBUTING-Guidelines-blue.svg)](./CONTRIBUTING.md)
 [![Apache 2.0 License](http://img.shields.io/badge/APACHE2-license-blue.svg)](./LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Code: 
 [![Build Status](https://travis-ci.org/samvera/hyku.svg)](https://travis-ci.org/samvera/hyku)
 [![Coverage Status](https://coveralls.io/repos/samvera/hyku/badge.svg?branch=master&service=github)](https://coveralls.io/github/samvera/hyku?branch=master)
-[![Stories in Ready](https://img.shields.io/waffle/label/samvera-labs/hyku/ready.svg)](https://waffle.io/samvera-labs/hyku)
+[![Stories in Ready](https://img.shields.io/waffle/label/samvera/hyku/ready.svg)](https://waffle.io/samvera/hyku)
 
 Docs: 
 [![Documentation](http://img.shields.io/badge/DOCUMENTATION-wiki-blue.svg)](https://github.com/samvera/hyku/wiki)

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ DISABLE_REDIS_CLUSTER=true bundle exec rails server -b 0.0.0.0
 ```
 ### For testing
 
-See the [Hyku Development Guide](https://github.com/samvera-labs/hyku/wiki/Hyku-Development-Guide) for how to run tests.
+See the [Hyku Development Guide](https://github.com/samvera/hyku/wiki/Hyku-Development-Guide) for how to run tests.
 
 ### Working with Translations
 


### PR DESCRIPTION
Part of trying to get Coveralls back in a working spot.