### PR TITLE
Add Blacklight OAI to Hyku

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,6 +76,7 @@ group :development do
 end
 
 gem 'blacklight', '~> 6.7'
+gem 'blacklight_oai_provider', '~> 6.0'
 
 gem 'hyrax', '~>2.3.0'
 gem 'rsolr', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,10 @@ GEM
       bootstrap-sass (~> 3.0)
       openseadragon (>= 0.2.0)
       rails
+    blacklight_oai_provider (6.0.0)
+      blacklight (~> 6.0)
+      oai (~> 0.4)
+      rails (>= 4.2, < 6)
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
@@ -252,6 +256,8 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday-encoding (0.0.4)
       faraday
+    faraday_middleware (0.13.1)
+      faraday (>= 0.7.4, < 1.0)
     fcrepo_wrapper (0.9.0)
       ruby-progressbar
     ffi (1.9.25)
@@ -540,6 +546,10 @@ GEM
       activesupport (>= 3.2.18)
       i18n
       nokogiri
+    oai (0.4.0)
+      builder (>= 3.1.0)
+      faraday
+      faraday_middleware
     oauth (0.5.4)
     oauth2 (1.4.0)
       faraday (>= 0.8, < 0.13)
@@ -876,6 +886,7 @@ DEPENDENCIES
   active_elastic_job (~> 2.0)
   apartment
   blacklight (~> 6.7)
+  blacklight_oai_provider (~> 6.0)
   byebug
   capybara
   carrierwave-aws

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1,6 +1,7 @@
 class CatalogController < ApplicationController
   include Hydra::Catalog
   include Hydra::Controller::ControllerBehavior
+  include BlacklightOaiProvider::Controller
 
   # These before_action filters apply the hydra access controls
   before_action :enforce_show_permissions, only: :show
@@ -336,6 +337,21 @@ class CatalogController < ApplicationController
     config.add_sort_field "#{modified_field} desc", label: "date modified \u25BC"
     config.add_sort_field "#{modified_field} asc", label: "date modified \u25B2"
 
+    config.oai = {
+      provider: {
+        repository_name: Settings.oai.name,
+        repository_url: Settings.oai.url,
+        record_prefix: Settings.oai.prefix,
+        admin_email: Settings.oai.email,
+        sample_id: Settings.oai.sample_id
+      },
+      document: {
+        limit: 25, # number of records returned with each request, default: 15
+        set_fields: [ # ability to define ListSets, optional, default: nil
+          { label: 'collection', solr_field: 'isPartOf_ssim' }
+        ]
+      }
+    }
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.
     config.spell_max = 5

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -2,6 +2,8 @@
 
 class SolrDocument
   include Blacklight::Solr::Document
+  include BlacklightOaiProvider::SolrDocument
+
   include Blacklight::Gallery::OpenseadragonSolrDocument
 
   # Adds Hyrax behaviors to the SolrDocument.
@@ -26,4 +28,20 @@ class SolrDocument
   use_extension(Hydra::ContentNegotiation)
 
   attribute :extent, Solr::Array, solr_name('extent')
+  attribute :rendering_ids, Solr::Array, solr_name('hasFormat', :symbol)
+
+  field_semantics.merge!(
+    contributor: 'contributor_tesim',
+    creator: 'creator_tesim',
+    date: 'date_created_tesim',
+    description: 'description_tesim',
+    identifier: 'identifier_tesim',
+    language: 'language_tesim',
+    publisher: 'publisher_tesim',
+    relation: 'nesting_collection__pathnames_ssim',
+    rights: 'rights_statement_tesim',
+    subject: 'subject_tesim',
+    title: 'title_tesim',
+    type: 'human_readable_type_tesim'
+  )
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 Rails.application.routes.draw do
+  concern :oai_provider, BlacklightOaiProvider::Routes.new
 
   mount Riiif::Engine => 'images', as: :riiif if Hyrax.config.iiif_image_server?
-  
+
   if Settings.multitenancy.enabled
     constraints host: Account.admin_host do
       get '/account/sign_up' => 'account_sign_up#new', as: 'new_sign_up'
@@ -39,6 +40,8 @@ Rails.application.routes.draw do
   curation_concerns_basic_routes
 
   resource :catalog, only: [:index], as: 'catalog', path: '/catalog', controller: 'catalog' do
+    concerns :oai_provider
+
     concerns :searchable
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -63,3 +63,10 @@ devise:
   account_signup: true
   # The address from which user invitations are sent
   invitation_from_email: "change-me-in-hyku-settings@example.org"
+
+oai:
+  name: Hyku
+  url: http://example.org/catalog/oai
+  prefix: oai:hyku
+  email: change-me-in-hyku-settings@example.org
+  sample_id: 806bbc5e-8ebe-468c-a188-b7c14fbe34df

--- a/spec/features/oai_pmh_spec.rb
+++ b/spec/features/oai_pmh_spec.rb
@@ -1,0 +1,35 @@
+RSpec.describe "OAI PMH Support", type: :feature do
+  let(:user) { create(:user) }
+  let(:work) { create(:work, user: user) }
+  let(:identifier) { work.id }
+
+  before do
+    login_as(user, scope: :user)
+    work
+  end
+
+  context 'oai interface with works present' do
+    it 'lists metadata prefixess' do
+      visit oai_catalog_path(verb: 'ListMetadataFormats')
+      expect(page).to have_content('oai_dc')
+    end
+
+    it 'retrieves a list of records' do
+      visit oai_catalog_path(verb: 'ListRecords', metadataPrefix: 'oai_dc')
+      expect(page).to have_content("oai:hyku:#{identifier}")
+      expect(page).to have_content(work.title.first)
+    end
+
+    it 'retrieves a single record' do
+      visit oai_catalog_path(verb: 'GetRecord', metadataPrefix: 'oai_dc', identifier: identifier)
+      expect(page).to have_content("oai:hyku:#{identifier}")
+      expect(page).to have_content(work.title.first)
+    end
+
+    it 'retrieves a list of identifiers' do
+      visit oai_catalog_path(verb: 'ListIdentifiers', metadataPrefix: 'oai_dc')
+      expect(page).to have_content("oai:hyku:#{identifier}")
+      expect(page).not_to have_content(work.title.first)
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1499 This work was sponsored by [PALNI](http://www.palni.org)

Brings in and configures the existing blackight-oai gem. 

This allows each tenant to have a /catalog/oai endpoint which provides OAI-PMH access to the collections within.  This is an initial feature offering, so I'm expecting it to become more sophisticated over time.

<img width="1680" alt="Screen Shot 2019-03-17 at 8 14 45 PM" src="https://user-images.githubusercontent.com/1054448/54504573-72b08500-48f1-11e9-946a-fb93559edf5d.png">


@samvera/hyrax-code-reviewers