### PR TITLE
Add proxy-body-size to ingress

### DIFF
--- a/chart/sample.yaml
+++ b/chart/sample.yaml
@@ -73,9 +73,12 @@ rails:
 
 ingress:
   tlsSecretName: demoapp-puma-tls
-  
-  # helm upgrade release-name . --set ingress.localhost
   host: hyku.docker
+  # use "0" for unlimited
+  annotations: {
+    kubernetes.io/ingress.class: "nginx",
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+  }
 
 # Used for naming k8s resources (eg. staging-hyku-web) 
 nameOverride:

--- a/chart/templates/web-ing-wildcard.yaml
+++ b/chart/templates/web-ing-wildcard.yaml
@@ -4,9 +4,9 @@ kind: Ingress
 metadata:
   name: {{ template "hyku.web.name" . }}-in-wildcard
   annotations:
-    # kubernetes.io/ingress.allow-http: "false"
-    # for GKE
-    # kubernetes.io/ingress.global-static-ip-name: rails-k8s-hyku
+  {{- range $key, $value := .Values.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
 spec:
   # tls:
   # - hosts:

--- a/chart/templates/web-ing.yaml
+++ b/chart/templates/web-ing.yaml
@@ -4,9 +4,9 @@ kind: Ingress
 metadata:
   name: {{ template "hyku.web.name" . }}-in
   annotations:
-    # kubernetes.io/ingress.allow-http: "false"
-    # for GKE
-    # kubernetes.io/ingress.global-static-ip-name: rails-k8s-hyku
+  {{- range $key, $value := .Values.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
 spec:
   # tls:
   # - hosts:


### PR DESCRIPTION
The ingress resource will apply a default 1m setting to `client_max_body_size`. Setting `proxy-body-size` via an annotation allows us to override this.
