### PR TITLE
Add network_files to Helm chart

### DIFF
--- a/chart/sample.yaml
+++ b/chart/sample.yaml
@@ -69,7 +69,9 @@ rails:
   shared:
     storage:
       size: 1Gi
-      className: nfs
+      # uncomment / change as per your local setup
+      # className: nfs
+      # className: efs
 
 ingress:
   tlsSecretName: demoapp-puma-tls

--- a/chart/templates/sidekiq-deploy.yaml
+++ b/chart/templates/sidekiq-deploy.yaml
@@ -58,9 +58,12 @@ spec:
             - mountPath: /home/app/webapp/tmp/exports
               name: shared
               subPath: export_path
-            - mountPath: /home/app/webapp/tmp/derivatives_path
+            - mountPath: /home/app/webapp/tmp/derivatives
               name: shared
               subPath: derivatives_path
+            - mountPath: /home/app/webapp/tmp/network_files
+              name: shared
+              subPath: network_files
             - mountPath: /home/app/webapp/tmp/uploads
               name: shared
               subPath: upload_path

--- a/chart/templates/web-deploy.yaml
+++ b/chart/templates/web-deploy.yaml
@@ -50,6 +50,9 @@ spec:
             - mountPath: /home/app/webapp/tmp/derivatives
               name: shared
               subPath: derivatives_path
+            - mountPath: /home/app/webapp/tmp/network_files
+              name: shared
+              subPath: network_files
             - mountPath: /home/app/webapp/tmp/uploads
               name: shared
               subPath: upload_path


### PR DESCRIPTION
This PR:

1. adds network_files to the shared mounts
2. fixes a typo which was mounting different paths for derivatives on sidekiq and web