### PR TITLE
Fix CollectionThumbnailPathService

### DIFF
--- a/app/services/hyrax/collection_thumbnail_path_service.rb
+++ b/app/services/hyrax/collection_thumbnail_path_service.rb
@@ -4,7 +4,9 @@ module Hyrax
   class CollectionThumbnailPathService < Hyrax::ThumbnailPathService
     class << self
       def default_image
-        Site.instance.default_collection_image&.url&.presence || ActionController::Base.helpers.image_path('collection.png')
+        hyrax_default_collection_image = ActionController::Base.helpers.image_path('collection.png')
+
+        Site.instance.default_collection_image&.url&.presence || hyrax_default_collection_image
       end
     end
   end

--- a/app/services/hyrax/collection_thumbnail_path_service.rb
+++ b/app/services/hyrax/collection_thumbnail_path_service.rb
@@ -6,7 +6,7 @@ module Hyrax
       def default_image
         hyrax_default_collection_image = ActionController::Base.helpers.image_path('collection.png')
 
-        Site.instance.default_collection_image&.url&.presence || hyrax_default_collection_image
+        Site.instance.default_collection_image&.url.presence || hyrax_default_collection_image
       end
     end
   end

--- a/app/services/hyrax/collection_thumbnail_path_service.rb
+++ b/app/services/hyrax/collection_thumbnail_path_service.rb
@@ -4,7 +4,7 @@ module Hyrax
   class CollectionThumbnailPathService < Hyrax::ThumbnailPathService
     class << self
       def default_image
-        Site.instance.default_collection_image.presence || ActionController::Base.helpers.image_path('collection.png')
+        Site.instance.default_collection_image&.url&.presence || ActionController::Base.helpers.image_path('collection.png')
       end
     end
   end


### PR DESCRIPTION
## As a point of clarification: 

All references to "default collection images" or the like within this PR refer to theming default images that are uploaded under the Appearance Dashboard tab, _not_ the Hyrax default collection image. 

# Summary

The `Hyrax::CollectionThumbnailPathService` was attempting to shove the entire `Hyrax::AvatarUploader` object into the `thumbnail_path_ss` Solr field: 

```ruby
RSolr::Error::Http: RSolr::Error::Http - 400 Bad Request
Error parsing JSON field value. Unexpected OBJECT_START at [513], field=thumbnail_path_ss
```

# Expected Behavior

`Collection` creation should no longer fail in production environments. Default collection images should be applied to newly created `Collections` (and `AdminSets`) successfully and resize appropriately. 

# Additional Info 

1.  The determining factor of whether this bug occurred or not was whether a Tenant had a default collection image or not. 

1.  This error was **not** reproducible locally; attempting to create `Collections` before applying the fix did not result in the creation failing catastrophically. Instead, the only noticeable difference was whether the `thumbnail_path_ss` Solr field was set or not. This did, however, cause visual bugs:

![Screen Shot 2020-04-15 at 2 39 51 PM](https://user-images.githubusercontent.com/32469930/79808922-10138f00-8324-11ea-9b6c-e0f0b708d2fc.png)

@samvera/hyrax-code-reviewers

Please note contribution for this PR comes from the PALNI/PALCI project. 