### PR TITLE
Set tmp/cache permisisons and do not force RAILS_ENV

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,7 +106,6 @@ services:
       - SETTINGS__ZOOKEEPER__CONNECTION_STR=zookeeper_cluster:2181/configs
       - SOLR_URL=http://solr:8983/solr/
       - PASSENGER_APP_ENV=development
-      - RAILS_ENV=development
     volumes:
       - app:/home/app/webapp/tmp/uploads
       - assets:/home/app/webapp/public/assets

--- a/ops/nginx.sh
+++ b/ops/nginx.sh
@@ -7,6 +7,7 @@ if [[ ! -e /var/log/nginx/error.log ]]; then
         (sleep 1 && sv restart /etc/service/nginx-log-forwarder)
 fi
 
+/bin/bash -l -c 'chown -R app:app /home/app/webapp/tmp/cache' # mounted volume may have wrong permissions
 
 if [ -z $PASSENGER_APP_ENV ]
 then
@@ -20,7 +21,6 @@ fi
 
 if [[ $PASSENGER_APP_ENV == "production" ]] || [[ $PASSENGER_APP_ENV == "staging" ]]
 then
-    /bin/bash -l -c 'chown -R app:app /home/app/webapp/tmp' # mounted volume may have wrong permissions
     /bin/bash -l -c 'chown -R app:app /home/app/webapp/public/assets' # mounted volume may have wrong permissions
     /sbin/setuser app /bin/bash -l -c 'cd /home/app/webapp && rsync -a public/assets-new/ public/assets/'
 fi


### PR DESCRIPTION
Forcing RAILS_ENV to development makes the specs run in the development environment instead of test

We mount tmp/cache to speed up page loads, but that volume often gets defaulted to root permissions.

