### PR TITLE
Seed files were erroring

### DIFF
--- a/app/services/create_account.rb
+++ b/app/services/create_account.rb
@@ -20,7 +20,7 @@ class CreateAccount
   # Account (i.e. creation steps complete, endpoints populated).  THEREFORE, `create_tenant`
   # must be called *after* all external resources are provisioned.
   def create_external_resources
-    create_account_inline && create_tenant
+    create_account_inline && account.save && create_tenant
   end
 
   ##


### PR DESCRIPTION

When running the seed file, the fedora and solr endpoints are not being saved. Added account.save to the CreateAccount.create_external_services method to fix this.

Changes proposed in this pull request:
* added account.save in the CreateAccount.create_external_services method


@samvera/hyku-code-reviewers
