### PR TITLE
Remove guard clause to ensure switch callbacks work

### DIFF
--- a/config/initializers/apartment.rb
+++ b/config/initializers/apartment.rb
@@ -52,7 +52,7 @@ unless ENV['DB_ADAPTER'] == 'nulldb'
     Apartment::Tenant.adapter.class.set_callback :switch, :after, ->() do
       account = Account.find_by(tenant: current)
       account.switch! if account
-    end if ActiveRecord::Base.connected?
+    end
   end
 
   Rails.application.config.middleware.use AccountElevator


### PR DESCRIPTION
Fixes issue where switch callbacks weren't firing in rails console and possibly other cases like activejobs and single tenants.

@samvera/hyku-code-reviewers
