### PR TITLE
Tweak Gemfile and Gemfile.lock for docker building

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -113,7 +113,8 @@ group :aws, :test do
 end
 
 group :aws do
-  gem 'active_elastic_job', github: 'tawan/active-elastic-job'
+  gem 'active_elastic_job', git: 'https://github.com/tawan/active-elastic-job.git'
+  gem 'aws-sdk-sqs'
 end
 
 gem 'sidekiq'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -994,6 +994,7 @@ DEPENDENCIES
   active_elastic_job!
   activerecord-nulldb-adapter
   apartment
+  aws-sdk-sqs
   blacklight (~> 6.7)
   blacklight_oai_provider (~> 6.0)
   bootstrap-datepicker-rails
@@ -1055,6 +1056,3 @@ DEPENDENCIES
   webmock
   willow_sword!
   zk
-
-BUNDLED WITH
-   2.1.4


### PR DESCRIPTION
Running docker-compose up web on a fresh checkout wasn't working without these changes:
- Switch active_elastic_job to `git: https://github.com/` from `github:`
- Add aws-sdk-sqs under the aws group
- Remove the BUNDLED WITH from the bottom of Gemfile.lock

@samvera/hyku-code-reviewers
