### PR TITLE
Use specific work type presenter since it is a subclass of Hyku::WorkShowPresenter

### DIFF
--- a/app/controllers/hyrax/generic_works_controller.rb
+++ b/app/controllers/hyrax/generic_works_controller.rb
@@ -11,6 +11,6 @@ module Hyrax
     self.curation_concern_type = ::GenericWork
 
     # Use this line if you want to use a custom presenter
-    self.show_presenter = Hyku::WorkShowPresenter
+    self.show_presenter = Hyrax::GenericWorkPresenter
   end
 end


### PR DESCRIPTION
Fixing this allows for Hyrax plugins to work as expected when injecting module mixins into the normal Hyrax presenters.

See https://github.com/samvera/hyku/blob/master/app/presenters/hyrax/generic_work_presenter.rb#L6

@samvera/hyrax-repo-managers