### PR TITLE
Registered Users cannot create Works unless given explicit permission

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -5,7 +5,6 @@ class Ability
   include Hyrax::Ability
 
   self.ability_logic += %i[
-    everyone_can_create_curation_concerns
     group_permissions
     superadmin_permissions
   ]

--- a/spec/features/create_work_spec.rb
+++ b/spec/features/create_work_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe 'Creating a new Work', :clean do
-  let(:user) { create(:user) }
+  let(:user) { create(:admin) }
 
   before do
     AdminSet.find_or_create_default_admin_set_id

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -13,10 +13,12 @@ RSpec.describe Ability do
     it { is_expected.not_to be_able_to(:manage, :all) }
   end
 
-  describe 'an ordinary user' do
+  describe 'a registered user' do
     let(:user) { FactoryBot.create(:user) }
+    let(:curation_concerns_models) { [::FileSet, ::Collection] + Hyrax.config.curation_concerns }
 
     it { is_expected.not_to be_able_to(:manage, :all) }
+    it { is_expected.not_to be_able_to(:create, curation_concerns_models) }
   end
 
   describe 'an administrative user' do


### PR DESCRIPTION
Restrict access to who can create Works.

This change means that registered Users will not be able to create Works unless given explicit permission to do so. For example, a User who is an admin of Tenant A, but not of Tenant B, will no longer be able to deposit Works into Tenant B. 

Changes proposed in this pull request:
* Remove [ability logic that allows all registered users to create curation concerns](https://github.com/samvera/hyrax/blob/b9cc7744f37875c7b7762a01deaa53c7ae5a889f/app/models/concerns/hyrax/ability.rb#L96-L101) 

@samvera/hyku-code-reviewers
