### PR TITLE
Upgrade to Redis v5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -776,8 +776,8 @@ GEM
       rdf (~> 3.1)
     redic (1.5.3)
       hiredis
-    redis (4.2.1)
-    redis-namespace (1.7.0)
+    redis (4.2.2)
+    redis-namespace (1.8.0)
       redis (>= 3.0.4)
     redlock (1.2.0)
       redis (>= 3.0.0, < 5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -679,8 +679,6 @@ GEM
       rails (~> 5.0)
       rdf
     rack (2.2.3)
-    rack-protection (2.0.8.1)
-      rack
     rack-test (0.7.0)
       rack (>= 1.0, < 3)
     rails (5.2.4.3)
@@ -874,11 +872,10 @@ GEM
       rdf-xsd (~> 3.1)
       sparql (~> 3.1)
       sxp (~> 1.1)
-    sidekiq (6.0.7)
+    sidekiq (6.1.2)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
-      rack-protection (>= 2.0.0)
-      redis (>= 4.1.0)
+      redis (>= 4.2.0)
     signet (0.14.0)
       addressable (~> 2.3)
       faraday (>= 0.17.3, < 2.0)
@@ -1056,3 +1053,6 @@ DEPENDENCIES
   webmock
   willow_sword!
   zk
+
+BUNDLED WITH
+   2.0.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -167,7 +167,7 @@ services:
       - db
 
   redis:
-    image: redis:3
+    image: redis:5
     command: redis-server
     volumes:
       - redis:/data


### PR DESCRIPTION
Sidekiq requires a newer version of Redis (>= 4), otherwise the workers container falls over locally and background jobs don't get processed. 

Changes proposed in this pull request:
* Upgrade Redis to major version 5 
* Update sidekiq/redis gem/redis-namespace to fix `#exists` vs `#exists?` issue 

@samvera/hyku-code-reviewers 

 This code was provided to Hyku by PALNI/PALCI.