### PR TITLE
Prevent users who do not have roles on a given tenant from being in the registered group automatically

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -42,4 +42,14 @@ class Ability
   def superadmin?
     current_user.has_role? :superadmin
   end
+
+  # Override from blacklight-access_controls-0.6.2 to define registered to include having a role on this tenant
+  def user_groups
+    return @user_groups if @user_groups
+
+    @user_groups = default_user_groups
+    @user_groups |= current_user.groups if current_user.respond_to? :groups
+    @user_groups |= ['registered'] if (!current_user.new_record? && current_user.roles.count > 0)
+    @user_groups
+  end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -49,7 +49,7 @@ class Ability
 
     @user_groups = default_user_groups
     @user_groups |= current_user.groups if current_user.respond_to? :groups
-    @user_groups |= ['registered'] if (!current_user.new_record? && current_user.roles.count > 0)
+    @user_groups |= ['registered'] if !current_user.new_record? && current_user.roles.count.positive?
     @user_groups
   end
 end

--- a/spec/features/create_work_spec.rb
+++ b/spec/features/create_work_spec.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.describe 'Creating a new Work', :clean do
-  let(:user) { create(:user) }
+  let(:user) do
+    u = create(:user)
+    u.add_role(:depositor)
+    u
+  end
 
   before do
     AdminSet.find_or_create_default_admin_set_id

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -17,6 +17,40 @@ RSpec.describe Ability do
     let(:user) { FactoryBot.create(:user) }
 
     it { is_expected.not_to be_able_to(:manage, :all) }
+
+    describe "#user_groups" do
+      subject { ability.user_groups }
+
+      it "does not have the registered group" do
+        expect(subject).to_not include 'registered'
+      end
+
+      it "does not have the admin group" do
+        expect(subject).to_not include 'admin'
+      end
+    end
+  end
+
+  describe 'an ordinary user with a role on this tenant' do
+    let(:user) do
+      u = FactoryBot.create(:user)
+      u.add_role(:depositor)
+      u
+    end
+
+    it { is_expected.not_to be_able_to(:manage, :all) }
+
+    describe "#user_groups" do
+      subject { ability.user_groups }
+
+      it "does have the registered group" do
+        expect(subject).to include 'registered'
+      end
+
+      it "does not have the admin group" do
+        expect(subject).to_not include 'admin'
+      end
+    end
   end
 
   describe 'an administrative user' do

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -22,11 +22,11 @@ RSpec.describe Ability do
       subject { ability.user_groups }
 
       it "does not have the registered group" do
-        expect(subject).to_not include 'registered'
+        expect(subject).not_to include 'registered'
       end
 
       it "does not have the admin group" do
-        expect(subject).to_not include 'admin'
+        expect(subject).not_to include 'admin'
       end
     end
   end
@@ -48,7 +48,7 @@ RSpec.describe Ability do
       end
 
       it "does not have the admin group" do
-        expect(subject).to_not include 'admin'
+        expect(subject).not_to include 'admin'
       end
     end
   end


### PR DESCRIPTION
- Do not show institution only works to users who do not have at least one role on the tenant in question.
- Do not allow creation of works unless the user has at least one role on the tenant in question.

My understanding is these are the 2 blockers for the 3.0 release.

@samvera/hyku-code-reviewers
