### PR TITLE
set version to 3.0 and fix base build

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -36,7 +36,7 @@ ENV BUNDLE_GEMFILE=$APP_HOME/Gemfile \
   BUNDLE_JOBS=4
 
 COPY  --chown=app Gemfile* $APP_HOME/
-RUN /sbin/setuser app bundle install
+RUN /sbin/setuser app /bin/bash -l -c 'cd /home/app/webapp && gem install bundler -v "$(grep -A 1 "BUNDLED WITH" Gemfile.lock | tail -n 1)" && bundle install'
 
 COPY  --chown=app . $APP_HOME
 

--- a/config/initializers/version.rb
+++ b/config/initializers/version.rb
@@ -1,3 +1,3 @@
 module Hyku
-  VERSION = '2.1'.freeze
+  VERSION = '3.0'.freeze
 end


### PR DESCRIPTION
This sets the version number to 3.0 and makes sure the bundler version matches the Gemfile.lock both now and in the future as needed to refresh the Docker hub images.