### PR TITLE
Use specific work type presenter since it is a subclass of Hyku::WorkShowPresenter

### DIFF
--- a/app/controllers/hyrax/images_controller.rb
+++ b/app/controllers/hyrax/images_controller.rb
@@ -11,6 +11,6 @@ module Hyrax
     self.curation_concern_type = ::Image
 
     # Use this line if you want to use a custom presenter
-    self.show_presenter = Hyku::WorkShowPresenter
+    self.show_presenter = Hyrax::ImagePresenter
   end
 end


### PR DESCRIPTION
Fixing this allows for Hyrax plugins to work as expected when injecting module mixins into the normal Hyrax presenters.

See #1646 and https://github.com/samvera/hyku/blob/master/app/presenters/hyrax/image_presenter.rb#L6
@samvera/hyku-code-reviewers
