### PR TITLE
Prevent an error occuring in admin when no work types are selected

### DIFF
--- a/app/views/admin/work_types/edit.html.erb
+++ b/app/views/admin/work_types/edit.html.erb
@@ -6,7 +6,7 @@
   <div class="panel-body">
     <%= simple_form_for @site, url: '/admin/work_types' do |f| %>
       <% Hyrax.config.registered_curation_concern_types.each do |type| %>
-        <%= check_box_tag 'available_works[]', type, @site.available_works.include?(type) %>
+        <%= check_box_tag 'available_works[]', type, @site.available_works&.include?(type) %>
         <span><%= type %></span><br />
       <% end %>
       <%= f.submit class: 'btn btn-primary' %>


### PR DESCRIPTION
When no work types are selected from the available options, then an `undefined method `include?' for nil:NilClass` will be thrown, preventing the user from selecting an option and resolving the issue. 

![image](https://user-images.githubusercontent.com/1199977/107027235-c1948b80-67a3-11eb-8bd4-2436b0c765ba.png)

This tiny PR just catches the error and allows the checkboxes to be unchecked.

@samvera/hyku-code-reviewers
