### PR TITLE
Use label tag to allow accessibly access

### DIFF
--- a/app/views/admin/work_types/edit.html.erb
+++ b/app/views/admin/work_types/edit.html.erb
@@ -1,19 +1,19 @@
 <% provide :page_header do %>
-	<h1><span class="fa fa-address-book"></span> <%= t('hyku.admin.work_types') %></h1>
+  <h1><span class="fa fa-address-book"></span> <%= t('hyku.admin.work_types') %></h1>
 <% end %>
 
 <div class="panel panel-default">
-	<div class="panel-body">
-		<%= simple_form_for @site, url: '/admin/work_types' do |f| %>
-			<% Hyrax.config.registered_curation_concern_types.each do |type| %>
-				<div class="checkbox">
-					<label for="input-<%= type %>">
-						<%= check_box_tag 'available_works[]', type, @site.available_works&.include?(type), id: "input-#{type}" %>
-						<span><%= type %></span><br />
-					</label>
-				</div>
-			<% end %>
-			<%= f.submit class: 'btn btn-primary' %>
-		<% end %>
-	</div>
+  <div class="panel-body">
+    <%= simple_form_for @site, url: '/admin/work_types' do |f| %>
+      <% Hyrax.config.registered_curation_concern_types.each do |type| %>
+        <div class="checkbox">
+          <label for="input-<%= type %>">
+            <%= check_box_tag 'available_works[]', type, @site.available_works&.include?(type), id: "input-#{type}" %>
+            <span><%= type %></span><br />
+          </label>
+        </div>
+      <% end %>
+      <%= f.submit class: 'btn btn-primary' %>
+    <% end %>
+  </div>
 </div>

--- a/app/views/admin/work_types/edit.html.erb
+++ b/app/views/admin/work_types/edit.html.erb
@@ -1,15 +1,19 @@
 <% provide :page_header do %>
-  <h1><span class="fa fa-address-book"></span> <%= t('hyku.admin.work_types') %></h1>
+	<h1><span class="fa fa-address-book"></span> <%= t('hyku.admin.work_types') %></h1>
 <% end %>
 
 <div class="panel panel-default">
-  <div class="panel-body">
-    <%= simple_form_for @site, url: '/admin/work_types' do |f| %>
-      <% Hyrax.config.registered_curation_concern_types.each do |type| %>
-        <%= check_box_tag 'available_works[]', type, @site.available_works&.include?(type) %>
-        <span><%= type %></span><br />
-      <% end %>
-      <%= f.submit class: 'btn btn-primary' %>
-    <% end %>
-  </div>
+	<div class="panel-body">
+		<%= simple_form_for @site, url: '/admin/work_types' do |f| %>
+			<% Hyrax.config.registered_curation_concern_types.each do |type| %>
+				<div class="checkbox">
+					<label for="input-<%= type %>">
+						<%= check_box_tag 'available_works[]', type, @site.available_works&.include?(type), id: "input-#{type}" %>
+						<span><%= type %></span><br />
+					</label>
+				</div>
+			<% end %>
+			<%= f.submit class: 'btn btn-primary' %>
+		<% end %>
+	</div>
 </div>


### PR DESCRIPTION
By default it seems that the checkboxes on the work type select page are not wrapped in labels and thus far harder to select than it they were. This mini-PR adds a label around each checkbox. 

@samvera/hyku-code-reviewers
