### PR TITLE
Fix zookeeper bundle install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,8 @@ jobs:
       RACK_ENV: test
       FCREPO_TEST_PORT: 8080/fcrepo
       SPEC_OPTS: --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
+      # CFLAGS need to be set for zookeeper to compile native extensions
+      CFLAGS: -Wno-error=format-overflow
     steps:
       - samvera/cached_checkout
 


### PR DESCRIPTION
Fixes the CircleCI build which is failing currently.  See https://app.circleci.com/pipelines/github/samvera/hyku/323/workflows/74d691c6-f883-4db9-af65-28ac6f8302aa/jobs/352

@samvera/hyku-code-reviewers
