### PR TITLE
Reduce Feature Flapping

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -61,6 +61,7 @@ Hyrax::Admin
 ActiveRecord::Migration.maintain_test_schema!
 
 # Uses faster rack_test driver when JavaScript support not needed
+Capybara.default_max_wait_time = 8
 Capybara.default_driver = :rack_test
 
 if ENV['CHROME_HOSTNAME'].present?


### PR DESCRIPTION
Facinatinly the feature spec flapping did not turn out to be related to order of
spec run! I was able to get semi-reliable failure running only one feature spec
over and over again. Running just create_image I could get failure locally about
50% of the time over 300 runs.

The issue with feature specs failing appears to stem from not waiting long
enough for the page to load after clicking a button. This ups from 2 seconds
to 8 seconds of wait time. It will only make specs that fail take longs than
nessisary practice and only by the 6 seconds. I ran 100 runs of the feature
specs locally with 3, 5 and 8 seconds. I got about 50% failure with 3 seconds
1% failure with 5 seconds and 0% failure with 8 seconds. So here is hoping
we can put the feature failure behind us.

cc @bess as I know you found this particular bug particularly frustrating.

@samvera/hyku-code-reviewers
