### PR TITLE
Remove Honeybadger Gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -121,8 +121,6 @@ gem 'sidekiq'
 
 gem 'secure_headers'
 
-gem 'honeybadger', '~> 3.0'
-
 gem 'codemirror-rails'
 gem 'riiif', '~> 1.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -384,7 +384,6 @@ GEM
     hashdiff (1.0.1)
     highline (2.0.3)
     hiredis (0.6.3)
-    honeybadger (3.3.1)
     htmlentities (4.3.4)
     http_logger (0.6.0)
     httpclient (2.8.3)
@@ -1024,7 +1023,6 @@ DEPENDENCIES
   fcrepo_wrapper (~> 0.4)
   flipflop (~> 2.3)
   flutie
-  honeybadger (~> 3.0)
   hyrax (~> 2.9, >= 2.9.1)
   i18n-debug
   i18n-tasks

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,8 +26,6 @@ class ApplicationController < ActionController::Base
   before_action :elevate_single_tenant!, if: :singletenant?
   skip_after_action :discard_flash_if_xhr
 
-  before_action :add_honeybadger_context
-
   rescue_from Apartment::TenantNotFound do
     raise ActionController::RoutingError, 'Not Found'
   end
@@ -92,10 +90,6 @@ class ApplicationController < ActionController::Base
       payload[:request_id] = request.uuid
       payload[:user_id] = current_user.id if current_user
       payload[:account_id] = current_account.cname if current_account
-    end
-
-    def add_honeybadger_context
-      Honeybadger.context(user_email: current_user.email) if current_user
     end
 
     def ssl_configured?

--- a/lib/active_job_tenant.rb
+++ b/lib/active_job_tenant.rb
@@ -11,7 +11,6 @@ module ActiveJobTenant
 
   module ClassMethods
     def deserialize(job_data)
-      Honeybadger.context(job_data: job_data)
       super.tap do |job|
         job.tenant = job_data['tenant']
         job.current_account = nil

--- a/public/500.html
+++ b/public/500.html
@@ -61,9 +61,6 @@
       <h1>We're sorry, but something went wrong.</h1>
     </div>
     <p>If you are the application owner check the logs for more information.</p>
-    <!-- HONEYBADGER FEEDBACK -->
-
-    <!-- HONEYBADGER ERROR -->
   </div>
 </body>
 </html>


### PR DESCRIPTION
This might be a little forward of me however the Gem causes an almost intolerable amount of log noise when used with Ruby 2.7.x. 

```
> docker-compose exec web bundle exec rails console
# ...
Hyrax::Engine.after_initialize - persisting registered roles!
** [Honeybadger] Initializing Honeybadger Error Tracker for Ruby. Ship it! version=3.3.1 framework=rails level=1 pid=45
** [Honeybadger] Development mode is enabled. Data will not be reported until you deploy your app. level=2 pid=45
/usr/local/bundle/gems/honeybadger-3.3.1/lib/honeybadger/plugin.rb:19: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/usr/local/bundle/gems/honeybadger-3.3.1/lib/honeybadger/plugin.rb:65: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/usr/local/bundle/gems/honeybadger-3.3.1/lib/honeybadger/plugin.rb:65: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/usr/local/bundle/gems/honeybadger-3.3.1/lib/honeybadger/plugin.rb:65: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/usr/local/bundle/gems/honeybadger-3.3.1/lib/honeybadger/plugin.rb:65: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/usr/local/bundle/gems/honeybadger-3.3.1/lib/honeybadger/plugin.rb:69: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/usr/local/bundle/gems/honeybadger-3.3.1/lib/honeybadger/plugin.rb:19: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/usr/local/bundle/gems/honeybadger-3.3.1/lib/honeybadger/plugin.rb:65: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/usr/local/bundle/gems/honeybadger-3.3.1/lib/honeybadger/plugin.rb:69: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/usr/local/bundle/gems/honeybadger-3.3.1/lib/honeybadger/plugin.rb:19: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/usr/local/bundle/gems/honeybadger-3.3.1/lib/honeybadger/plugin.rb:65: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/usr/local/bundle/gems/honeybadger-3.3.1/lib/honeybadger/plugin.rb:69: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/usr/local/bundle/gems/honeybadger-3.3.1/lib/honeybadger/plugin.rb:19: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/usr/local/bundle/gems/honeybadger-3.3.1/lib/honeybadger/plugin.rb:65: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/usr/local/bundle/gems/honeybadger-3.3.1/lib/honeybadger/plugin.rb:69: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/usr/local/bundle/gems/honeybadger-3.3.1/lib/honeybadger/plugin.rb:19: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/usr/local/bundle/gems/honeybadger-3.3.1/lib/honeybadger/plugin.rb:65: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/usr/local/bundle/gems/honeybadger-3.3.1/lib/honeybadger/plugin.rb:69: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/usr/local/bundle/gems/honeybadger-3.3.1/lib/honeybadger/plugin.rb:19: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/usr/local/bundle/gems/honeybadger-3.3.1/lib/honeybadger/plugin.rb:65: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/usr/local/bundle/gems/honeybadger-3.3.1/lib/honeybadger/plugin.rb:69: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/usr/local/bundle/gems/honeybadger-3.3.1/lib/honeybadger/plugin.rb:19: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/usr/local/bundle/gems/honeybadger-3.3.1/lib/honeybadger/plugin.rb:65: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/usr/local/bundle/gems/honeybadger-3.3.1/lib/honeybadger/plugin.rb:65: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/usr/local/bundle/gems/honeybadger-3.3.1/lib/honeybadger/plugin.rb:65: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/usr/local/bundle/gems/honeybadger-3.3.1/lib/honeybadger/plugin.rb:69: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/usr/local/bundle/gems/honeybadger-3.3.1/lib/honeybadger/plugin.rb:19: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/usr/local/bundle/gems/honeybadger-3.3.1/lib/honeybadger/plugin.rb:65: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/usr/local/bundle/gems/honeybadger-3.3.1/lib/honeybadger/plugin.rb:69: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/usr/local/bundle/gems/honeybadger-3.3.1/lib/honeybadger/plugin.rb:19: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/usr/local/bundle/gems/honeybadger-3.3.1/lib/honeybadger/plugin.rb:65: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/usr/local/bundle/gems/honeybadger-3.3.1/lib/honeybadger/plugin.rb:69: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/usr/local/bundle/gems/honeybadger-3.3.1/lib/honeybadger/plugin.rb:19: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/usr/local/bundle/gems/honeybadger-3.3.1/lib/honeybadger/plugin.rb:65: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/usr/local/bundle/gems/honeybadger-3.3.1/lib/honeybadger/plugin.rb:65: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/usr/local/bundle/gems/honeybadger-3.3.1/lib/honeybadger/plugin.rb:69: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
Loading development environment (Rails 5.2.4.5)
irb: warn: can't alias context from irb_context.
irb(main):001:0>
```

It doesn't seem that the Gem is extensively used around the application and rom my foray round the codebase it seems that the Gem version was last updated about 4 years ago in the following commit: 

https://github.com/samvera/hyku/commit/918ccaed0828ba5d963046ba1511667f4fd7d7b0

I realise this might be controvertial, however if an organisation needs Honeybadger, wouldn't they also likely require a version less than 4 years old and if so, would likely be able to install it themselves. 

