### PR TITLE
fix links (wiki migration)

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -22,15 +22,15 @@ mutual respect and reasoned argument.
 Community members work together to promote a respectful and safe
 community. In the event that someone’s conduct is causing offence or
 distress, Samvera has a detailed
-[Anti-Harassment Policy and Protocol](https://wiki.duraspace.org/display/hydra/Anti-Harassment+Policy)
+[Anti-Harassment Policy and Protocol](https://samvera.atlassian.net/wiki/spaces/samvera/pages/405211680)
 which can be applied to address the problem. The first step in dealing
 with any serious misconduct is to contact a local meeting organizer,
 the
-[Samvera community helpers](https://wiki.duraspace.org/display/hydra/Hydra+Community+Helpers)
-([email](mailto:helpers@projecthydra.org)), a community member you
+[Samvera community helpers](https://samvera.atlassian.net/wiki/spaces/samvera/pages/405211681)
+([email](mailto:helpers@samvera.org)), a community member you
 trust, or the
-[Samvera Steering Group](https://wiki.duraspace.org/display/hydra/Samvera+Steering+Group+membership)
+[Samvera Steering Group](https://samvera.atlassian.net/wiki/spaces/samvera/pages/405210594)
 immediately; at Samvera events, these people can be identified by
 distinctive name badges. The
-[Policy and Protocol](https://wiki.duraspace.org/display/hydra/Anti-Harassment+Policy)
+[Policy and Protocol](https://samvera.atlassian.net/wiki/spaces/samvera/pages/405211680)
 should be consulted for fuller details.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -18,7 +18,7 @@ All code contributors must have an Individual Contributor License Agreement
 an institution, the institution must have a Corporate Contributor License 
 Agreement (cCLA) on file.
 
-https://wiki.duraspace.org/display/hydra/Hydra+Project+Intellectual+Property+Licensing+and+Ownership
+[Samvera Community Intellectual Property Licensing and Ownership](https://samvera.atlassian.net/wiki/spaces/samvera/pages/405211651)
 
 You should also add yourself to the `CONTRIBUTORS.md` file in the root of the project.
 

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,3 +1,3 @@
 If you would like to report an issue with Hyku, first do search [the list of issues](https://github.com/samvera-labs/hyku/issues/) to see if someone else has already reported it, and then feel free to [create a new issue](https://github.com/samvera-labs/hyku/issues/new).
 
-If you have questions or need help, please email [the Samvera community tech list](mailto:samvera-tech@googlegroups.com) or stop by the #dev channel in [the Samvera community Slack team](https://wiki.duraspace.org/pages/viewpage.action?pageId=87460391#Getintouch!-Slack).
+If you have questions or need help, please email [the Samvera community tech list](https://groups.google.com/forum/#!forum/samvera-tech) or stop by the #dev channel in [the Samvera community Slack team](http://slack.samvera.org/).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -22,15 +22,15 @@ mutual respect and reasoned argument.
 Community members work together to promote a respectful and safe
 community. In the event that someone’s conduct is causing offence or
 distress, Samvera has a detailed
-[Anti-Harassment Policy and Protocol](https://wiki.duraspace.org/display/samvera/Anti-Harassment+Policy)
+[Anti-Harassment Policy and Protocol](https://samvera.atlassian.net/wiki/spaces/samvera/pages/405211680)
 which can be applied to address the problem. The first step in dealing
 with any serious misconduct is to contact a local meeting organizer,
 the
-[Samvera community helpers](https://wiki.duraspace.org/display/samvera/Samvera+Community+Helpers)
+[Samvera community helpers](https://samvera.atlassian.net/wiki/spaces/samvera/pages/405211681)
 ([email](mailto:helpers@samvera.org)), a community member you
 trust, or the
-[Samvera Steering Group](https://wiki.duraspace.org/display/samvera/Samvera+Steering+Group+membership)
+[Samvera Steering Group](https://samvera.atlassian.net/wiki/spaces/samvera/pages/405210594)
 immediately; at Samvera events, these people can be identified by
 distinctive name badges. The
-[Policy and Protocol](https://wiki.duraspace.org/display/samvera/Anti-Harassment+Policy)
+[Policy and Protocol](https://samvera.atlassian.net/wiki/spaces/samvera/pages/405211680)
 should be consulted for fuller details.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ All code contributors must have an Individual Contributor License Agreement
 an institution, the institution must have a Corporate Contributor License
 Agreement (cCLA) on file.
 
-https://wiki.duraspace.org/display/samvera/Samvera+Community+Intellectual+Property+Licensing+and+Ownership
+[Samvera Community Intellectual Property Licensing and Ownership](https://samvera.atlassian.net/wiki/spaces/samvera/pages/405211651)
 
 You should also add yourself to the `CONTRIBUTORS.md` file in the root of the project.
 

--- a/README.md
+++ b/README.md
@@ -177,4 +177,4 @@ This software was developed by the Hydra-in-a-Box Project (DPLA, DuraSpace, and 
 This software is brought to you by the Samvera community.  Learn more at the
 [Samvera website](http://samvera.org/).
 
-![Samvera Logo](https://wiki.duraspace.org/download/thumbnails/87459292/samvera-fall-font2-200w.png?version=1&modificationDate=1498550535816&api=v2)
+![Samvera Logo](https://samvera.atlassian.net/wiki/download/attachments/405216084/samvera-fall-TM-220w-transparent.png?version=1&modificationDate=1540440075555&cacheVersion=1&api=v2)

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,5 +1,5 @@
-If you would like to report an issue, first search [the list of issues](https://github.com/samvera/questioning_authority/issues/) to see if someone else has already reported it, and then feel free to [create a new issue](https://github.com/samvera/questioning_authority/issues/new).
+If you would like to report an issue, first search [the list of issues](https://github.com/samvera/hyku/issues/) to see if someone else has already reported it, and then feel free to [create a new issue](https://github.com/samvera/hyku/issues/new).
 
-If you have questions or need help, please email [the Samvera community tech list](https://groups.google.com/forum/#!forum/samvera-tech) or stop by the #dev channel in [the Samvera community Slack team](https://wiki.duraspace.org/pages/viewpage.action?pageId=87460391#Getintouch!-Slack).
+If you have questions or need help, please email [the Samvera community tech list](https://groups.google.com/forum/#!forum/samvera-tech) or stop by the #dev channel in [the Samvera community Slack team](http://slack.samvera.org/).
 
-You can learn more about the various Samvera communication channels on the [Get in touch!](https://wiki.duraspace.org/pages/viewpage.action?pageId=87460391) wiki page.
+You can learn more about the various Samvera communication channels on the [Getting Started in the Samvera Community](https://samvera.atlassian.net/wiki/spaces/samvera/pages/405211682/) wiki page.


### PR DESCRIPTION
Replaces links to wiki.duraspace with their Samvera confluence equivalents.

The website in Github's repository should be:
https://samvera.atlassian.net/wiki/spaces/samvera/pages/419533203/