### PR TITLE
update bulkrax

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,11 +9,13 @@ GIT
 
 GIT
   remote: https://github.com/samvera-labs/bulkrax.git
-  revision: 08765558e700f8cbf6b15bb43c72a5a152e4f0f5
+  revision: 82dffb267c382c3f096c1337ee09a084c9f0335e
   specs:
     bulkrax (0.1.0)
       bagit (~> 0.4)
+      coderay
       iso8601 (~> 0.9.0)
+      kaminari
       language_list (~> 1.2, >= 1.2.1)
       libxml-ruby (~> 3.1.0)
       loofah (>= 2.2.3)
@@ -210,6 +212,7 @@ GEM
     clipboard-rails (1.7.1)
     codemirror-rails (5.16.0)
       railties (>= 3.0, < 6.0)
+    coderay (1.1.3)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -651,7 +654,7 @@ GEM
     noid-rails (3.0.3)
       actionpack (>= 5.0.0, < 7)
       noid (~> 0.9)
-    nokogiri (1.11.4)
+    nokogiri (1.11.5)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     nokogumbo (2.0.5)


### PR DESCRIPTION
ran `bundle update bulkrax`.

the prior target version for `bulkrax` fails repeated migrations, which motivated this change.

@samvera/hyku-code-reviewers
