### PR TITLE
Don't try to assign registered role on global tenant

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -73,8 +73,9 @@ class User < ApplicationRecord
   # If this user is the first user on the tenant, they become its admin
   # unless we are in the global tenant
   def add_default_roles
-    add_role :admin, Site.instance unless
-      self.class.joins(:roles).where("roles.name = ?", "admin").any? || Account.global_tenant?
+    return if Account.global_tenant?
+
+    add_role :admin, Site.instance unless self.class.joins(:roles).where("roles.name = ?", "admin").any?
     # Role for any given site
     add_role :registered, Site.instance
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe User, type: :model do
     end
 
     it 'does not get the admin role' do
+      expect(subject.persisted?).to eq true
       expect(subject).not_to have_role :admin
     end
   end
@@ -17,6 +18,7 @@ RSpec.describe User, type: :model do
     subject { FactoryBot.create(:base_user) }
 
     it 'is given the admin role' do
+      expect(subject.persisted?).to eq true
       expect(subject).to have_role :admin, Site.instance
     end
   end
@@ -26,6 +28,7 @@ RSpec.describe User, type: :model do
     let!(:next_user) { FactoryBot.create(:base_user) }
 
     it 'does not get the admin role' do
+      expect(next_user.persisted?).to eq true
       expect(next_user).not_to have_role :admin
     end
   end


### PR DESCRIPTION
On a fresh checkout of hyku, I was not able to register a user on the global tenant because the
before_create callback errored when trying to add the registered role
due to a validation error on the role: `Resource type is not included in the list`
This was not caught in the tests because there wasn't a check that the
user actually got created.

@samvera/hyku-code-reviewers
