### PR TITLE
allow redis password in config

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -6,4 +6,4 @@ test:
 
 production:
   adapter: redis
-  url: redis://<%= ENV['REDIS_HOST'] || 'localhost' %>:<%= ENV['REDIS_PORT'] || '6379' %>
+  url: <%= ENV.fetch("REDIS_URL") { sprintf "redis://%s%s:%s/1", (ENV['REDIS_PASSWORD'].present? ? ":#{ENV['REDIS_PASSWORD']}@" : ''), ENV.fetch('REDIS_HOST', 'localhost'), ENV.fetch('REDIS_PORT', '6379') } %>

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -7,3 +7,4 @@ test:
 production:
   host: <%= ENV['REDIS_HOST'] || 'localhost' %>
   port: <%= ENV['REDIS_PORT'] || 6379 %>
+  password: <%= ENV['REDIS_PASSWORD'] %>


### PR DESCRIPTION
the hyrax chart provides a `REDIS_PASSWORD`. the default configuration should
use it in production.

@samvera/hyku-code-reviewers
