### PR TITLE
set default scope for users to exclude guests, remove old guests

### DIFF
--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -12,7 +12,7 @@ class RolesController < ApplicationController
   end
 
   def index
-    @users = @users.where(guest: false)
+    @users = User.all
     add_breadcrumb t(:'hyrax.controls.home'), root_path
     add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
     add_breadcrumb t(:'hyrax.admin.sidebar.roles_and_permissions'), site_roles_path

--- a/app/jobs/delete_old_guests_job.rb
+++ b/app/jobs/delete_old_guests_job.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class DeleteOldGuestsJob < ApplicationJob
+  non_tenant_job
+  after_perform do |job|
+    reenqueue
+  end
+
+  def perform
+    User.where("guest = ? and updated_at < ?", true, Time.now - 7.days).each { |x| x.destroy}
+  end
+
+  private
+
+  def reenqueue
+    DeleteOldGuestsJob.set(wait_until: Date.tomorrow.midnight).perform_later
+  end
+end

--- a/app/jobs/delete_old_guests_job.rb
+++ b/app/jobs/delete_old_guests_job.rb
@@ -7,7 +7,7 @@ class DeleteOldGuestsJob < ApplicationJob
   end
 
   def perform
-    User.where("guest = ? and updated_at < ?", true, Time.current - 7.days).each(&:destroy)
+    User.unscope(:where).where("guest = ? and updated_at < ?", true, Time.current - 7.days).destroy_all
   end
 
   private

--- a/app/jobs/delete_old_guests_job.rb
+++ b/app/jobs/delete_old_guests_job.rb
@@ -2,17 +2,17 @@
 
 class DeleteOldGuestsJob < ApplicationJob
   non_tenant_job
-  after_perform do |job|
+  after_perform do |_job|
     reenqueue
   end
 
   def perform
-    User.where("guest = ? and updated_at < ?", true, Time.now - 7.days).each { |x| x.destroy}
+    User.where("guest = ? and updated_at < ?", true, Time.current - 7.days).each(&:destroy)
   end
 
   private
 
-  def reenqueue
-    DeleteOldGuestsJob.set(wait_until: Date.tomorrow.midnight).perform_later
-  end
+    def reenqueue
+      DeleteOldGuestsJob.set(wait_until: Date.tomorrow.midnight).perform_later
+    end
 end

--- a/app/models/hyku/group.rb
+++ b/app/models/hyku/group.rb
@@ -28,7 +28,7 @@ module Hyku
     end
 
     def add_members_by_id(ids, member_class: DEFAULT_MEMBER_CLASS)
-      new_members = member_class.find(ids)
+      new_members = member_class.unscoped.find(ids)
       Array.wrap(new_members).collect { |m| m.add_role(MEMBERSHIP_ROLE, self) }
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,6 +23,11 @@ class User < ApplicationRecord
     joins(:roles)
   }
 
+  # set default scope to exclude guest users
+  def self.default_scope
+    where(guest: false)
+  end
+
   # Method added by Blacklight; Blacklight uses #to_s on your
   # user class to get a user-displayable login/identifier.
   def to_s

--- a/app/presenters/hyrax/admin/dashboard_presenter.rb
+++ b/app/presenters/hyrax/admin/dashboard_presenter.rb
@@ -6,7 +6,7 @@ module Hyrax
     class DashboardPresenter
       # @return [Fixnum] the number of currently registered users
       def user_count
-        ::User.registered.for_repository.without_system_accounts.uniq.count
+        ::User.for_repository.count
       end
 
       def repository_objects

--- a/spec/jobs/delete_old_guests_job_spec.rb
+++ b/spec/jobs/delete_old_guests_job_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.describe EmbargoAutoExpiryJob do
+  before do
+    ActiveJob::Base.queue_adapter = :test
+  end
+
+  after do
+    clear_enqueued_jobs
+  end
+
+  let(:past_date) { 8.days.ago }
+
+  let(:old_user) { create(:user, guest: false, created_at: past_date, updated_at: past_date )}
+  let(:old_guest) { create(:user, guest: true, created_at: past_date, updated_at: past_date )}
+  let(:new_user) { create(:user, guest: false )}
+  let(:new_guest) { create(:user, guest: true )}
+
+  describe '#reenqueue' do
+    it 'Enques an DeleteOldGuestsJob after perform' do
+      expect { DeleteOldGuestsJob.perform_now }.to have_enqueued_job(DeleteOldGuestsJob)
+    end
+  end
+
+  describe '#perform' do
+    it "Removes only guests older than 7 days" do
+      expect(old_user).to be
+      expect(old_guest).to be
+      expect(new_user).to be
+      expect(new_guest).to be
+      ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
+      expect{ DeleteOldGuestsJob.perform_now }.to change{User.count}.from(4).to(3)
+      expect(User.find_by(id: old_user.id)).to be
+      expect(User.find_by(id: old_guest)).to_not be
+      expect(User.find_by(id: new_user)).to be
+      expect(User.find_by(id: new_guest)).to be
+    end
+  end
+end

--- a/spec/jobs/delete_old_guests_job_spec.rb
+++ b/spec/jobs/delete_old_guests_job_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe EmbargoAutoExpiryJob do
+RSpec.describe DeleteOldGuestsJob do
   before do
     ActiveJob::Base.queue_adapter = :test
   end
@@ -11,10 +11,10 @@ RSpec.describe EmbargoAutoExpiryJob do
 
   let(:past_date) { 8.days.ago }
 
-  let(:old_user) { create(:user, guest: false, created_at: past_date, updated_at: past_date )}
-  let(:old_guest) { create(:user, guest: true, created_at: past_date, updated_at: past_date )}
-  let(:new_user) { create(:user, guest: false )}
-  let(:new_guest) { create(:user, guest: true )}
+  let(:old_user) { create(:user, guest: false, created_at: past_date, updated_at: past_date) }
+  let(:old_guest) { create(:user, guest: true, created_at: past_date, updated_at: past_date) }
+  let(:new_user) { create(:user, guest: false) }
+  let(:new_guest) { create(:user, guest: true) }
 
   describe '#reenqueue' do
     it 'Enques an DeleteOldGuestsJob after perform' do
@@ -29,9 +29,9 @@ RSpec.describe EmbargoAutoExpiryJob do
       expect(new_user).to be
       expect(new_guest).to be
       ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
-      expect{ DeleteOldGuestsJob.perform_now }.to change{User.count}.from(4).to(3)
+      expect { DeleteOldGuestsJob.perform_now }.to change(User, :count).from(4).to(3)
       expect(User.find_by(id: old_user.id)).to be
-      expect(User.find_by(id: old_guest)).to_not be
+      expect(User.find_by(id: old_guest)).not_to be
       expect(User.find_by(id: new_user)).to be
       expect(User.find_by(id: new_guest)).to be
     end

--- a/spec/jobs/delete_old_guests_job_spec.rb
+++ b/spec/jobs/delete_old_guests_job_spec.rb
@@ -29,11 +29,11 @@ RSpec.describe DeleteOldGuestsJob do
       expect(new_user).to be
       expect(new_guest).to be
       ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
-      expect { DeleteOldGuestsJob.perform_now }.to change(User, :count).from(4).to(3)
-      expect(User.find_by(id: old_user.id)).to be
-      expect(User.find_by(id: old_guest)).not_to be
-      expect(User.find_by(id: new_user)).to be
-      expect(User.find_by(id: new_guest)).to be
+      expect { DeleteOldGuestsJob.perform_now }.to change { User.unscope(:where).count }.from(4).to(3)
+      expect(User.unscope(:where).find_by(id: old_user.id)).to be
+      expect(User.unscope(:where).find_by(id: old_guest)).not_to be
+      expect(User.unscope(:where).find_by(id: new_user)).to be
+      expect(User.unscope(:where).find_by(id: new_guest)).to be
     end
   end
 end


### PR DESCRIPTION
Fixes #606 

Make sure we do not display guest users in the UI. These are created and used for Blacklight sessions, but have no value to admins or other logged in users of the system. Also prune guest users periodically.

@samvera/hyku-code-reviewers
