### PR TITLE
Allow uploads to non-acl mounts like Samba or EFS

### DIFF
--- a/app/middleware/account_elevator.rb
+++ b/app/middleware/account_elevator.rb
@@ -17,7 +17,7 @@ class AccountElevator < Apartment::Elevators::Generic
     elsif Account.any?
       raise "No tenant found for #{cname}"
     else
-      logger.info "It looks like we're in single tenant mode. No tenant found for #{cname}"
+      Rails.logger.info "It looks like we're in single tenant mode. No tenant found for #{cname}"
     end
   end
 end

--- a/config/initializers/carrierwave_config.rb
+++ b/config/initializers/carrierwave_config.rb
@@ -11,4 +11,9 @@ if Settings.s3.upload_bucket
     config.aws_bucket = Settings.s3.upload_bucket
     config.aws_acl = 'bucket-owner-full-control'
   end
+elsif !Settings.file_acl || Settings.file_acl == 'false'
+  CarrierWave.configure do |config|
+    config.permissions = nil
+    config.directory_permissions = nil
+  end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -11,6 +11,7 @@ multitenancy:
   root_host:
 
 ssl_configured: false
+file_acl: true
 
 action_controller:
   asset_host:


### PR DESCRIPTION
some file systems (nfs/samba) do not support chmod. This allows it to be disabled so carrierwave will still work on these shared drives.

@samvera/hyku-code-reviewers
