### PR TITLE
all users where showing on admin user list instead of just the users of a given tenant

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,7 +23,7 @@ class User < ApplicationRecord
     joins(:roles)
   }
 
-  scope :registered, ->() { for_repository.group(:id).where(guest: false) }
+  scope :registered, -> { for_repository.group(:id).where(guest: false) }
 
   # set default scope to exclude guest users
   def self.default_scope

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,6 +23,8 @@ class User < ApplicationRecord
     joins(:roles)
   }
 
+  scope :registered, ->() { for_repository.group(:id).where(guest: false) }
+
   # set default scope to exclude guest users
   def self.default_scope
     where(guest: false)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -109,6 +109,16 @@ ActiveRecord::Schema.define(version: 2020_07_30_194003) do
     t.index ["user_id"], name: "index_curation_concerns_operations_on_user_id"
   end
 
+  create_table "domain_names", force: :cascade do |t|
+    t.bigint "account_id"
+    t.string "cname"
+    t.boolean "is_active", default: true
+    t.boolean "is_ssl_enabled", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id"], name: "index_domain_names_on_account_id"
+  end
+
   create_table "domain_terms", id: :serial, force: :cascade do |t|
     t.string "model"
     t.string "term"


### PR DESCRIPTION
We missed a page found here: https://share.getcloudapp.com/kpuDxy4K when doing the user scope limiting. This limits the scope of all "registered" calls to make sure there are not other missing

This work is sponsored by the British Library

@samvera/hyku-code-reviewers
