### PR TITLE
Add missing Mailboxer gem migrations

### DIFF
--- a/app/models/concerns/account_switch.rb
+++ b/app/models/concerns/account_switch.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AccountSwitch
   extend ActiveSupport::Concern
 
@@ -6,10 +8,10 @@ module AccountSwitch
       account = if cname_or_name_or_account.is_a?(Account)
                   cname_or_name_or_account
                   # is it a domain name?
-                elsif cname_or_name_or_account =~/^((?!-)[A-Za-z0-9-]{1, 63}(?<!-)\\.)+[A-Za-z]{2, 6}$”/
+                elsif cname_or_name_or_account =~ /^((?!-)[A-Za-z0-9-]{1, 63}(?<!-)\\.)+[A-Za-z]{2, 6}$”/
                   Account.joins(:domain_names).find_by(domain_names: {
-                    is_active: true, cname: Account.canonical_cname(cname)
-                  })
+                                                         is_active: true, cname: Account.canonical_cname(cname)
+                                                       })
                 else
                   Account.find_by(name: cname_or_name_account)
                 end

--- a/db/migrate/20210729105649_add_delivery_tracking_info_to_mailboxer_receipts.mailboxer_engine.rb
+++ b/db/migrate/20210729105649_add_delivery_tracking_info_to_mailboxer_receipts.mailboxer_engine.rb
@@ -1,0 +1,8 @@
+# This migration comes from mailboxer_engine (originally 20151103080417)
+class AddDeliveryTrackingInfoToMailboxerReceipts < ActiveRecord::Migration[4.2]
+  def change
+    add_column :mailboxer_receipts, :is_delivered, :boolean, default: false
+    add_column :mailboxer_receipts, :delivery_method, :string
+    add_column :mailboxer_receipts, :message_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_30_194003) do
+ActiveRecord::Schema.define(version: 2021_07_29_105649) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -273,6 +273,9 @@ ActiveRecord::Schema.define(version: 2020_07_30_194003) do
     t.string "mailbox_type", limit: 25
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "is_delivered", default: false
+    t.string "delivery_method"
+    t.string "message_id"
     t.index ["notification_id"], name: "index_mailboxer_receipts_on_notification_id"
     t.index ["receiver_id", "receiver_type"], name: "index_mailboxer_receipts_on_receiver_id_and_receiver_type"
   end


### PR DESCRIPTION
Fixes #1732 

Adds a missing migration of the Mailboxer gem that was making the email notification delivery throw a 500 error.

The migration file has been generated using the instructions at: https://github.com/mailboxer/mailboxer/issues/391

``` ruby
rails g mailboxer:install
```

Changes proposed in this pull request:
* Run rails g mailboxer:install to add the missing migration file

@samvera/hyku-code-reviewers
