### PR TITLE
Small Docker Build Fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,10 @@ RUN mkdir -p /app/fits && \
     chmod a+x /app/fits/fits.sh
 ENV PATH="${PATH}:/app/fits"
 
-COPY --chown=1001:101 $APP_PATH/Gemfile* /app/samvera/hyrax-webapp
+COPY --chown=1001:101 $APP_PATH/Gemfile* /app/samvera/hyrax-webapp/
 RUN bundle install --jobs "$(nproc)"
+
+COPY --chown=1001:101 $APP_PATH /app/samvera/hyrax-webapp
 
 RUN RAILS_ENV=production SECRET_KEY_BASE=`bin/rake secret` DB_ADAPTER=nulldb DATABASE_URL='postgresql://fake' bundle exec rake assets:precompile
 

--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ dory up
 #### Basic steps
 
 ```bash
-docker-compose up web workers
+docker-compose up web
 ```
+
 This command starts the whole stack in individual containers allowing Rails to be started or stopped independent of the other services.  Once that starts (you'll see the line `Passenger core running in multi-application mode.` to indicate a successful boot), you can view your app in a web browser with at either hyku.test or localhost:3000 (see above).  When done `docker-compose stop` shuts down everything.
 
 #### Tests in Docker
@@ -103,7 +104,7 @@ https://github.com/hybox/aws
 We distribute two `docker-compose.yml` configuration files.  The first is set up for development / running the specs. The other, `docker-compose.production.yml` is for running the Hyku stack in a production setting. . Once you have [docker](https://docker.com) installed and running, launch the stack using e.g.:
 
 ```bash
-docker-compose up -d web workers
+docker-compose up -d web
 ```
 
 Note: You may need to add your user to the "docker" group.


### PR DESCRIPTION
No slash version works on some versions of Docker, but not others, the code copy got lost in a merge. Fix both.
