### PR TITLE
Allow Dory to resolve subdomains

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,7 +111,7 @@ services:
     <<: *app
     environment:
       - VIRTUAL_PORT=3000
-      - VIRTUAL_HOST=hyku.test
+      - VIRTUAL_HOST=.hyku.test
     depends_on:
       initialize_app:
         condition: service_healthy


### PR DESCRIPTION
Dory needs a dot to use as a wildcard for subdomain resolution. It was sometimes working by accident because it falls back to the "first" one if no match is found.

@samvera/hyku-code-reviewers
