### PR TITLE
(fix) solr collection name should match upstream hyrax chart default

### DIFF
--- a/ops/review-deploy.tmpl.yaml
+++ b/ops/review-deploy.tmpl.yaml
@@ -87,7 +87,7 @@ extraEnvVars:
   - name: SOLR_ADMIN_USER
     value: admin
   - name: SOLR_COLLECTION_NAME
-    value: $CI_COMMIT_SHORT_SHA
+    value: hyrax
   - name: SOLR_CONFIGSET_NAME
     value: $CI_COMMIT_SHORT_SHA
   - name: SMTP_ENABLED
@@ -176,7 +176,7 @@ worker:
   - name: SOLR_ADMIN_USER
     value: admin
   - name: SOLR_COLLECTION_NAME
-    value: $CI_COMMIT_SHORT_SHA
+    value: hyrax
   - name: SOLR_CONFIGSET_NAME
     value: $CI_COMMIT_SHORT_SHA
   - name: SMTP_ENABLED


### PR DESCRIPTION
Fixes startup issue in the `load-solr-config` InitContainer for the hyrax pod due to a solr collection name mismatch. The default value is `hyrax` upstream. If it's intended to use `$CI_COMMIT_SHORT_SHA`, then we'd just need to do the opposite and set the collection name under the `solr` property.

@samvera/hyku-code-reviewers
