### PR TITLE
Make sure help text was mapping to the correct place in the yaml files

### DIFF
--- a/app/views/hyrax/admin/appearances/_banner_image_form.html.erb
+++ b/app/views/hyrax/admin/appearances/_banner_image_form.html.erb
@@ -1,7 +1,7 @@
 <%= simple_form_for @form, url: admin_appearance_path do |f| %>
   <div class="panel-body">
     <%# Upload Banner Image %>
-    <%= f.input :banner_image, as: :file, wrapper: :vertical_file_input, hint: t('.forms.banner_image.hint') %>
+    <%= f.input :banner_image, as: :file, wrapper: :vertical_file_input, hint: t('hyrax.admin.appearances.show.forms.banner_image.hint') %>
     <%= image_tag @form.banner_image.url, class: "img-responsive" if @form.banner_image? %>
   </div>
   <div class="panel-footer">

--- a/app/views/hyrax/admin/appearances/_default_images_form.html.erb
+++ b/app/views/hyrax/admin/appearances/_default_images_form.html.erb
@@ -1,9 +1,9 @@
 <%= simple_form_for @form, url: admin_appearance_path do |f| %>
   <div class="panel-body">
-    <%= f.input :default_collection_image, as: :file, wrapper: :vertical_file_input, hint: t('.forms.default_images.hint'), required: false %>
+    <%= f.input :default_collection_image, as: :file, wrapper: :vertical_file_input, hint: t('hyrax.admin.appearances.show.forms.default_images.hint'), required: false %>
     <%= image_tag @form.default_collection_image.url, class: "img-responsive" if @form.default_collection_image? %>
 
-    <%= f.input :default_work_image, as: :file, wrapper: :vertical_file_input, hint: t('.forms.default_images.hint'), required: false %>
+    <%= f.input :default_work_image, as: :file, wrapper: :vertical_file_input, hint: t('hyrax.admin.appearances.show.forms.default_images.hint'), required: false %>
     <%= image_tag @form.default_work_image.url, class: "img-responsive" if @form.default_work_image? %>
   </div>
   <div class="panel-footer">

--- a/app/views/hyrax/admin/appearances/_directory_image_form.html.erb
+++ b/app/views/hyrax/admin/appearances/_directory_image_form.html.erb
@@ -1,7 +1,7 @@
 <%= simple_form_for @form, url: admin_appearance_path do |f| %>
   <div class="panel-body">
     <%# Upload Directory Image %>
-    <%= f.input :directory_image, as: :file, wrapper: :vertical_file_input, hint: t('.forms.directory_image.hint') %>
+    <%= f.input :directory_image, as: :file, wrapper: :vertical_file_input, hint: t('hyrax.admin.appearances.show.forms.directory_image.hint') %>
     <%= image_tag @form.directory_image.url, class: "img-responsive" if @form.directory_image? %>
   </div>
   <div class="panel-footer">

--- a/app/views/hyrax/admin/appearances/_logo_image_form.html.erb
+++ b/app/views/hyrax/admin/appearances/_logo_image_form.html.erb
@@ -1,7 +1,7 @@
 <%= simple_form_for @form, url: admin_appearance_path do |f| %>
   <div class="panel-body">
     <%# Upload Logo Image %>
-    <%= f.input :logo_image, as: :file, wrapper: :vertical_file_input, hint: t('.forms.logo_image.hint') %>
+    <%= f.input :logo_image, as: :file, wrapper: :vertical_file_input, hint: t('hyrax.admin.appearances.show.forms.logo_image.hint') %>
     <%= image_tag @form.logo_image.url, class: "img-responsive" if @form.logo_image? %>
   </div>
   <div class="panel-footer">


### PR DESCRIPTION
# Summary

When an admin navigates to the Dashboard Settings page and clicks the Appearance tab, the help-blocks for the Logo, Banner Image, Directory Image, and Default Image say `Hint` rather than the appropriate text.

# Observed Behavior

The help-block texts say `Hint` rather than the appropriate text.

# Expected Behavior

The help-block texts should say the appropriate text to help the user with the setting. 


# Steps to Reproduce / Testing Instructions

* [x]  As a logged in admin, navigate to Dashboard > Settings > Appearance
* [x]  Click through the Logo, Banner Image, Directory Image, and Default Image tabs to read the help-block text and verify if it is correct or not

## Screenshots
BEFORE
<img width="963" alt="Screen Shot 2021-10-11 at 4 31 32 PM" src="https://user-images.githubusercontent.com/73361970/136867305-e519f951-22bc-4af2-bb65-18aed3c685c0.png">


AFTER
<img width="974" alt="Screen Shot 2021-10-11 at 4 32 03 PM" src="https://user-images.githubusercontent.com/73361970/136867312-301edce6-ad27-4722-860e-7cdc657bcaac.png">

@samvera/hyku-code-reviewers

**_Code Contribution courtesy of Palni-Palci_**
