### PR TITLE
Remove size from collection pages

### DIFF
--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -1,0 +1,24 @@
+  # OVERRIDE FILE from Hyrax v2.9.0
+#
+# Override this class using #class_eval to avoid needing to copy the entire file over from
+# the dependency. For more info, see the "Overrides using #class_eval" section in the README.
+require_dependency Hyrax::Engine.root.join('app', 'presenters', 'hyrax', 'collection_presenter').to_s
+
+Hyrax::CollectionPresenter.class_eval do
+
+  # Terms is the list of fields displayed by
+  # app/views/collections/_show_descriptions.html.erb
+  # OVERRIDE Hyrax - removed size
+  def self.terms
+    %i[total_items resource_type creator contributor keyword license publisher date_created subject language identifier based_near related_url]
+  end
+
+  def [](key)
+    case key
+    when :total_items
+      total_items
+    else
+      solr_document.send key
+    end
+  end
+end

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -1,16 +1,23 @@
-  # OVERRIDE FILE from Hyrax v2.9.0
-#
+# frozen_string_literal: true
+# OVERRIDE FILE from Hyrax v2.9.0
 # Override this class using #class_eval to avoid needing to copy the entire file over from
 # the dependency. For more info, see the "Overrides using #class_eval" section in the README.
 require_dependency Hyrax::Engine.root.join('app', 'presenters', 'hyrax', 'collection_presenter').to_s
-
 Hyrax::CollectionPresenter.class_eval do
-
   # Terms is the list of fields displayed by
   # app/views/collections/_show_descriptions.html.erb
   # OVERRIDE Hyrax - removed size
   def self.terms
-    %i[total_items resource_type creator contributor keyword license publisher date_created subject language identifier based_near related_url]
+    %i[ total_items 
+        resource_type 
+        creator contributor 
+        keyword license 
+        publisher 
+        date_created 
+        subject language 
+        identifier 
+        based_near 
+        related_url ]
   end
 
   def [](key)

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # OVERRIDE FILE from Hyrax v2.9.0
 # Override this class using #class_eval to avoid needing to copy the entire file over from
 # the dependency. For more info, see the "Overrides using #class_eval" section in the README.
@@ -8,16 +9,16 @@ Hyrax::CollectionPresenter.class_eval do
   # app/views/collections/_show_descriptions.html.erb
   # OVERRIDE Hyrax - removed size
   def self.terms
-    %i[ total_items 
-        resource_type 
-        creator contributor 
-        keyword license 
-        publisher 
-        date_created 
-        subject language 
-        identifier 
-        based_near 
-        related_url ]
+    %i[ total_items
+        resource_type
+        creator contributor
+        keyword license
+        publisher
+        date_created
+        subject language
+        identifier
+        based_near
+        related_url]
   end
 
   def [](key)


### PR DESCRIPTION
# Summary

Collection pages currently show size in KB, but it is broken and isn’t helpful. Notch8 will remove this from the application. 

# Acceptance Criteria
- [ ] on a collection home page, no size shows.  

# Screenshots

BEFORE
<img width="500" alt="before" src="https://user-images.githubusercontent.com/73361970/136870050-33d0fd7b-a4af-4b88-b9ff-384bed7f003c.png">


AFTER
<img width="500" alt="after" src="https://user-images.githubusercontent.com/73361970/136870061-56bc47df-c8dd-4859-91b8-d090d97f8982.png">


**_Code Contribution courtesy of Palni-Palci_**

@samvera/hyku-code-reviewers
