### PR TITLE
fixes the spacing for the Institutional Repository theme slider

### DIFF
--- a/app/assets/stylesheets/themes/institutional_repository.scss
+++ b/app/assets/stylesheets/themes/institutional_repository.scss
@@ -166,15 +166,10 @@
     }
   }
 
-  .institutional-repository-carousel .cloneditem-1,
-  .institutional-repository-carousel .cloneditem-2,
-  .institutional-repository-carousel .cloneditem-3 {
-    display: none;
-  }
-
   .carousel .item .col-xs-12 {
     padding: 0;
   }
+  
 
   ////// All Collections //////
 
@@ -185,6 +180,15 @@
   }
 
   ////// Stats Carousel Media Queries //////
+
+  @media (max-width: 767px) {
+    .institutional-repository-carousel .cloneditem-1,
+    .institutional-repository-carousel .cloneditem-2,
+    .institutional-repository-carousel .cloneditem-3 {
+      display: none;
+    }
+  }
+  
   @media only screen and (max-width: 992px) {
     .carousel .item .col-xs-12:nth-last-child(-n+2) {
       display: none;

--- a/app/views/themes/institutional_repository/hyrax/homepage/_resource_type_slider.html.erb
+++ b/app/views/themes/institutional_repository/hyrax/homepage/_resource_type_slider.html.erb
@@ -3,7 +3,7 @@
     <% resource_types.each.with_index do |(k,v), i| %>
       <% next if v[0].zero? %>
       <div class="item <%= i.zero? ? 'active' : '' %>">
-        <div class="col-xs-12 col-sm-4 col-md-2">
+        <div class="col-xs-12 col-sm-3 col-md-2">
           <div class="text-center">
             <i class='<%= "#{v[1]}" %>' aria-hidden="true"></i>
             <h5><%= k %></h5>

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 RSpec.describe Account, type: :model do

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -1,3 +1,4 @@
+
 # frozen_string_literal: true
 
 RSpec.describe Account, type: :model do


### PR DESCRIPTION
# Summary
The IR theme's slider on the homepage had irregular spacing when at the medium breakpoint: this MR makes the spacing correct at all breakpoints.

### Video

https://share.getcloudapp.com/OAuneX6n

### Testing Instructions
1. Go to the dashboard and change the theme for the homepage to "Institutional Repository"
2. Create a generic work and select at least 7 work types
3. Save the work and make sure it is public and approved if necessary
4. Navigate to the home page
5. Check that the resource type carousel has even spacing at all breakpoints

## Acceptance Criteria
- [ ] The resource type carousel has even spacing at all breakpoints

**_Code Contribution Courtesy of Palni-Palci_**

@samvera/hyku-code-reviewers
