### PR TITLE
Fix justification on homepage

### DIFF
--- a/app/assets/stylesheets/hyku.scss
+++ b/app/assets/stylesheets/hyku.scss
@@ -27,11 +27,14 @@
   // allows full width if tabs are turned off with feature flipper
   .home-content {
     display: flex;
-    justify-content: space-between;
+    // justify-content: space-between;
   }
 
   .home-tabs-left {
     min-width: 50%;
+  }
+  .home-tabs-right, .home-tabs-left {
+    margin: 0 10px;
   }
 }
 

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 RSpec.describe Account, type: :model do

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -1,3 +1,4 @@
+
 # frozen_string_literal: true
 
 RSpec.describe Account, type: :model do


### PR DESCRIPTION
# Summary
This MR makes the content on the homepage full width when the featured researcher/collection sections are toggled to off

## Video

After: How it looks when featured researcher/collection sections are off - 
https://share.getcloudapp.com/8Lu5E0nA

After: How it looks when featured researcher/collection sections are on - 
https://share.getcloudapp.com/2NulemZD

# Acceptance Criteria
- [ ] On the default home page, when featured works and recent uploads are flipped off, and you choose the feature researcher tab, it is aligned to the left and is the full width of the screen (the same alignment as when the explore collections tab is selected).

**_Code Contribution Courtesy of Palni-Palci_**

@samvera/hyku-code-reviewers
