### PR TITLE
Remove under construction labels, fixed home page title links on themes

### DIFF
--- a/app/views/hyrax/admin/appearances/show.html.erb
+++ b/app/views/hyrax/admin/appearances/show.html.erb
@@ -28,7 +28,6 @@
           <a href="#css" role="tab" data-toggle="tab"><%= t('.tabs.custom_css') %></a>
         </li>
         <li>
-          <%# TODO: remove icon when themes work is completed %>
           <a href="#themes" role="tab" data-toggle="tab"><%= t('.tabs.themes') %></a>
         </li>
       </ul>

--- a/app/views/hyrax/admin/appearances/show.html.erb
+++ b/app/views/hyrax/admin/appearances/show.html.erb
@@ -28,9 +28,8 @@
           <a href="#css" role="tab" data-toggle="tab"><%= t('.tabs.custom_css') %></a>
         </li>
         <li>
-          <a href="#themes" role="tab" data-toggle="tab">
-            <%= t('.tabs.themes') %>
-          </a>
+          <%# TODO: remove icon when themes work is completed %>
+          <a href="#themes" role="tab" data-toggle="tab"><%= t('.tabs.themes') %></a>
         </li>
       </ul>
       <div class="tab-content">

--- a/app/views/themes/cultural_repository/hyrax/homepage/_explore_collections.html.erb
+++ b/app/views/themes/cultural_repository/hyrax/homepage/_explore_collections.html.erb
@@ -5,11 +5,9 @@
       <%= render_thumbnail_tag(collection, {suppress_link: true}, class: 'img-responsive center-block') %>
     <% end %>
     <div class="collection-item-title">
-      <h3>
-        <%= link_to [hyrax, collection] do %>
-          <%= collection.title_or_label %>
-        <% end %>
-      </h3>
+      <%= link_to [hyrax, collection] do %>
+        <h3><%= collection.title_or_label %></h3>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/app/views/themes/cultural_repository/hyrax/homepage/_featured_fields.html.erb
+++ b/app/views/themes/cultural_repository/hyrax/homepage/_featured_fields.html.erb
@@ -5,11 +5,9 @@
     <% end %>
     <div class="featured-item-title">
       <span class="sr-only"><%= t('hyrax.homepage.featured_works.document.title_label') %></span>
-      <h3>
-        <%= link_to [main_app, featured] do %>
-          <%= featured.title.first %>
-        <% end %>
-      </h3>
+      <%= link_to [main_app, featured] do %>
+        <h3><%= featured.title.first %></h3>
+      <% end %>
     </div>
     <%# Removed featured-item-depositor %>
     <%# Removed item keywords %>

--- a/app/views/themes/cultural_repository/hyrax/homepage/_recent_document.html.erb
+++ b/app/views/themes/cultural_repository/hyrax/homepage/_recent_document.html.erb
@@ -4,10 +4,8 @@
     <%= render_thumbnail_tag(recent_document, {suppress_link: true}, class: 'img-responsive center-block') %>
   <% end %>
   <div class="recent-doc-title">
-    <h3>
-      <%= link_to [main_app, recent_document] do %>
-        <%= recent_document.to_s %>
-      <% end %>
-    </h3>
+    <%= link_to [main_app, recent_document] do %>
+      <h3><%= recent_document.to_s %></h3>
+    <% end %>
   </div>
 </div>

--- a/app/views/themes/neutral_repository/hyrax/homepage/_explore_collections.html.erb
+++ b/app/views/themes/neutral_repository/hyrax/homepage/_explore_collections.html.erb
@@ -5,11 +5,9 @@
       <%= render_thumbnail_tag(collection, {suppress_link: true}, class: 'img-responsive center-block') %>
     <% end %>
     <div class="collection-item-title">
-      <h3>
-        <%= link_to [hyrax, collection] do %>
-          <%= collection.title_or_label %>
-        <% end %>
-      </h3>
+      <%= link_to [hyrax, collection] do %>
+        <h3><%= collection.title_or_label %></h3>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/app/views/themes/neutral_repository/hyrax/homepage/_recent_document.html.erb
+++ b/app/views/themes/neutral_repository/hyrax/homepage/_recent_document.html.erb
@@ -3,11 +3,9 @@
   <div class="recently-uploaded pb-30 col-xs-6 col-md-6">
     <%= render_thumbnail_tag(recent_document, {suppress_link: true}, class: 'img-responsive center-block') %>
       <div class="recent-doc-title">
-      <h3>
         <%= link_to [main_app, recent_document] do %>
-          <%= recent_document.to_s %>
+          <h3><%= recent_document.to_s %></h3>
         <% end %>
-      </h3>
     </div>
   </div>
 <% end %>

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 RSpec.describe Account, type: :model do

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -1,3 +1,4 @@
+
 # frozen_string_literal: true
 
 RSpec.describe Account, type: :model do


### PR DESCRIPTION
Follow up PRs for theming:

- Removes under construction labels on theme selection tab in appearance panel
- Fixes links on Neutral and Cultural repository home pages

References: #379 and #281


**_Code Contribution Courtesy of Palni-Palci_**

@samvera/hyku-code-reviewers
