### PR TITLE
Disabling a work type causes errors

### DIFF
--- a/app/services/hyrax/quick_classification_query.rb
+++ b/app/services/hyrax/quick_classification_query.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # OVERRIDE FILE from Hryax v2.9.0
 require_dependency Hyrax::Engine.root.join('app', 'services', 'hyrax', 'quick_classification_query').to_s
 

--- a/spec/services/hyrax/quick_classification_query_spec.rb
+++ b/spec/services/hyrax/quick_classification_query_spec.rb
@@ -1,5 +1,6 @@
-# OVERRIDE FILE from Hyrax v2.9.0
+# frozen_string_literal: true
 
+# OVERRIDE FILE from Hyrax v2.9.0
 RSpec.describe Hyrax::QuickClassificationQuery do
   let(:user) { create(:user) }
 


### PR DESCRIPTION
## Summary

Disabling any Work Type in the Dashboard > Settings > Available Work Types page causes Dashboard > Works to throw errors.

Changes proposed in this pull request:

- Override the `Hyrax::QuickClassificationQuery` to use `Site.instance.available_works` to refer to all available work types in a tenant instead of `Hyrax.config.registered_curation_concern_types` (which does not respect disabling Work Types in Hyku's settings) 
- Bring over spec for `Hyrax::QuickClassificationQuery` from Hyrax and expand to cover overrides 
- Only override methods we touch in `Hyrax::QuickClassificationQuery` as opposed to the entire file 

## Steps to Reproduce / Testing Instructions

1. Sign into a tenant as an admin
1. Navigate to Dashboard > Settings > Available Work Types
1. Disable any Work Type and click Save changes 
1. Navigate to Dashboard > My > Works and observe error 
1. Navigate to Dashboard > Works and observe error 
1. Navigate to the tenant's homepage (**NOTE:** for error to be thrown on this page, the "Show share button" Feature must be enabled in Dashboard > Settings > Features) 

### _Code Contribution Courtesy of Palni-Palci_

@samvera/hyku-code-reviewers
