### PR TITLE
Update the gitignore with solr_db_initialized so we do not commit it …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ pg_upgrade_*.log
 **.orig
 rerun.txt
 pickle-email-*.html
+solr_db_initialized
 
 ## Environment normalization:
 /.bundle


### PR DESCRIPTION
Adds the solr_db_initialized to the .gitignore file as to not commit it to the repository.

Changes proposed in this pull request:
* .gitignore

@samvera/hyku-code-reviewers
