### PR TITLE
use safe nav for home page theme modal check

### DIFF
--- a/app/views/themes/cultural_repository/layouts/hyrax.html.erb
+++ b/app/views/themes/cultural_repository/layouts/hyrax.html.erb
@@ -39,7 +39,7 @@
 
     </div><!-- /#content-wrapper -->
     <%= render 'shared/footer' %>
-    <%= render '/shared/select_work_type_modal', create_work_presenter: @presenter.create_work_presenter if @presenter.draw_select_work_modal? %>
+    <%= render '/shared/select_work_type_modal', create_work_presenter: @presenter&.create_work_presenter if @presenter&.draw_select_work_modal? %>
     <%= render 'shared/ajax_modal' %>
   </body>
 </html>

--- a/app/views/themes/institutional_repository/layouts/homepage.html.erb
+++ b/app/views/themes/institutional_repository/layouts/homepage.html.erb
@@ -35,7 +35,7 @@
           </div>
         <% end %>
 
-        <%= render '/shared/select_work_type_modal', create_work_presenter: @presenter.create_work_presenter if @presenter.draw_select_work_modal? %>
+        <%= render '/shared/select_work_type_modal', create_work_presenter: @presenter&.create_work_presenter if @presenter&.draw_select_work_modal? %>
       </div>
     </div>
   </div>

--- a/app/views/themes/neutral_repository/hyrax/homepage/index.html.erb
+++ b/app/views/themes/neutral_repository/hyrax/homepage/index.html.erb
@@ -2,4 +2,4 @@
 
 <%= render 'themes/neutral_repository/theme_container' %>
 
-<%= render '/shared/select_work_type_modal', create_work_presenter: @presenter.create_work_presenter if @presenter.draw_select_work_modal? %>
+<%= render '/shared/select_work_type_modal', create_work_presenter: @presenter&.create_work_presenter if @presenter&.draw_select_work_modal? %>


### PR DESCRIPTION
Fixes #1787 

After submitting Contact Form when a theme is applied, an error message prevents the page from loading
`undefined method 'draw_select_work_modal?' for nil:NilClass`

- This contact form page is rendering and there is no presenter. 
- Safe navigation avoids this error.

Changes proposed in this pull request:
* add safe navigator to the home page themes


@samvera/hyku-code-reviewers
