### PR TITLE
nil check in ir theme

### DIFF
--- a/app/views/themes/institutional_repository/layouts/homepage.html.erb
+++ b/app/views/themes/institutional_repository/layouts/homepage.html.erb
@@ -8,7 +8,7 @@
         <%= render "hyrax/homepage/marketing" if controller_name == 'homepage' || controller_name == 'hyrax_contact_form' || controller_name == 'pages' %>
       </div>
       <div class="share-your-work-button">
-        <% if @presenter.display_share_button? %>
+        <% if @presenter&.display_share_button? %>
           <div class="institutional-repository home_share_work row">
             <div class="col-sm-12 text-center">
               <% if signed_in? %>


### PR DESCRIPTION
Fixes #1787 

After submitting Contact Form when IR theme is applied, an error message prevents the page from loading
undefined method 'display_share_button?' for nil:NilClass

This contact form page is rendering and there is no presenter.
Safe navigation avoids this error.
Changes proposed in this pull request:

add safe navigator to the IR home page themes

@samvera/hyku-code-reviewers
