### PR TITLE
Collection thumbnail dropdown bugs

### DIFF
--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -190,8 +190,12 @@ module Hyrax
       def files
         params[:q] = '' unless params[:q]
         builder = Hyrax::CollectionMemberSearchBuilder.new(scope: self, collection: collection, search_includes_models: :works)
+        # get the default work image because we do not want to show any works in this dropdown that only have the default work image. this indicates that they have no files attached, and will throw an error if selected.
+        default_work_thumbnail_path = Site.instance.default_work_image&.url.presence || ActionController::Base.helpers.image_path('default.png')
+        work_with_no_files_thumbnail_path = ActionController::Base.helpers.image_path('work.png')
         response = repository.search(builder.where(params[:q]).query)
-        result = response.documents.reject { |document| document["thumbnail_path_ss"].blank? || document["thumbnail_path_ss"].include?('no-files') }.map do |document|
+        # only return the works that have files, because these will be the only ones with a viable thumbnail
+        result = response.documents.reject { |document| document["thumbnail_path_ss"].blank? || document["thumbnail_path_ss"].include?(default_work_thumbnail_path) || document["thumbnail_path_ss"].include?(work_with_no_files_thumbnail_path) }.map do |document|
           { id: document["thumbnail_path_ss"].split('/').last.gsub(/\?.*/, ''), text: document["title_tesim"].first }
         end
         reset_thumbnail_option = {

--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -191,7 +191,7 @@ module Hyrax
         params[:q] = '' unless params[:q]
         builder = Hyrax::CollectionMemberSearchBuilder.new(scope: self, collection: collection, search_includes_models: :works)
         response = repository.search(builder.where(params[:q]).query)
-        result = response.documents.reject { |document| document["thumbnail_path_ss"].blank? }.map do |document|
+        result = response.documents.reject { |document| document["thumbnail_path_ss"].blank? || document["thumbnail_path_ss"].include?('no-files') }.map do |document|
           { id: document["thumbnail_path_ss"].split('/').last.gsub(/\?.*/, ''), text: document["title_tesim"].first }
         end
         render json: result

--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -194,6 +194,11 @@ module Hyrax
         result = response.documents.reject { |document| document["thumbnail_path_ss"].blank? || document["thumbnail_path_ss"].include?('no-files') }.map do |document|
           { id: document["thumbnail_path_ss"].split('/').last.gsub(/\?.*/, ''), text: document["title_tesim"].first }
         end
+        reset_thumbnail_option = {
+          id: '',
+          text: 'Default thumbnail'
+        }
+        result << reset_thumbnail_option
         render json: result
       end
 


### PR DESCRIPTION
# Summary

Selecting works from the collection thumbnail dropdown that do not have images attached will return a `We're sorry, something went wrong.` page. 

example:
![Edit_User_Collection_collection_6_Application_name_2022-03-21_at_10 33 19_AM](https://user-images.githubusercontent.com/73361970/162271841-8c239903-6e41-428f-9ea6-bc14339cc244.png)



# Acceptance Criteria
- [ ] works in the collection thumbnail dropdown only show up as an option if they have an image
- [ ] No option in the dropdown causes a sorry something went wrong error

# Screenshots

| before | after |
| ------ | ------ |
| <img width="914" alt="Screen_Shot_2022-03-23_at_12 00 20_PM" src="https://user-images.githubusercontent.com/73361970/162271489-6107c6ee-79f1-4f43-987a-5ca011467843.png"> | <img width="923" alt="Screen_Shot_2022-03-23_at_12 04 03_PM" src="https://user-images.githubusercontent.com/73361970/162271597-c51f89ae-3b1f-42c7-a58b-acd008acc433.png"> |



# Related
* https://gitlab.com/notch8/britishlibrary/-/issues/314

@samvera/hyku-code-reviewers
