### PR TITLE
Collection Thumbnail Uploads

### DIFF
--- a/app/assets/javascripts/delete_uploaded_thumbnail.js.erb
+++ b/app/assets/javascripts/delete_uploaded_thumbnail.js.erb
@@ -1,0 +1,1 @@
+document.getElementById("uploaded-thumbnail").innerHTML = ("<%= j (render partial: "current_thumbnail") %>")

--- a/app/assets/stylesheets/hyku.scss
+++ b/app/assets/stylesheets/hyku.scss
@@ -414,3 +414,16 @@ nav.navbar.navbar-default.navbar-static-top .container-fluid .row {
     padding-right: 0;
   }
 }
+
+//Styles we need access to in the dashboard
+.mb-40 {
+  margin-bottom: 40px;
+}
+
+.mb-20 {
+  margin-bottom: 20px;
+}
+
+.mt-20 {
+  margin-top: 20px;
+}

--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -1,5 +1,5 @@
 ## Override from hyrax to fix file upload in logo and banner
-## OVERRIDE: Hyrax 2.9 to use work titles for collection thumbnail select
+## OVERRIDE: Hyrax 2.9 to use work titles for collection thumbnail select & to add an option to reset to the default thumbnail
 module Hyrax
   module Dashboard
     ## Shows a list of all collections to the admins
@@ -76,6 +76,18 @@ module Hyrax
 
       def edit
         form
+        # Gets original filename of an uploaded thumbnail. See #update
+        if ::SolrDocument.find(@collection.id).thumbnail_path.include? "uploaded_collection_thumbnails" and uploaded_thumbnail?
+          @thumbnail_filename = File.basename(uploaded_thumbnail_files.reject { |f| File.basename(f).include? @collection.id }.first)
+        end
+      end
+
+      def uploaded_thumbnail?
+        uploaded_thumbnail_files.any?
+      end
+
+      def uploaded_thumbnail_files
+        Dir["#{UploadedCollectionThumbnailPathService.upload_dir(@collection)}/*"]
       end
 
       def after_create
@@ -139,7 +151,8 @@ module Hyrax
           process_banner_input
           process_logo_input
         end
-
+        # Save the thumbnail image in the proper dimensions to public folder
+        process_uploaded_thumbnail(params[:collection][:thumbnail_upload]) if params[:collection][:thumbnail_upload]
         process_member_changes
         @collection.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE unless @collection.discoverable?
         # we don't have to reindex the full graph when updating collection
@@ -148,6 +161,18 @@ module Hyrax
           after_update
         else
           after_update_error
+        end
+      end
+
+      # Deletes any previous thumbnails. The thumbnail indexer (see services/hyrax/indexes_thumbnails)
+      # checks if an uploaded thumbnail exists in the public folder before indexing the thumbnail path.
+      def delete_uploaded_thumbnail
+        FileUtils.rm_rf(uploaded_thumbnail_files)
+        @collection.update_index
+
+        respond_to do |format|
+          format.html
+          format.js # renders delete_uploaded_thumbnail.js.erb, which updates _current_thumbnail.html.erb
         end
       end
 
@@ -186,7 +211,7 @@ module Hyrax
 
       # Renders a JSON response with a list of files in this collection
       # This is used by the edit form to populate the thumbnail_id dropdown
-      # OVERRIDE: Hyrax 2.9 to use work titles for collection thumbnail select
+      # OVERRIDE: Hyrax 2.9 to use work titles for collection thumbnail select & to add an option to reset to the default thumbnail
       def files
         params[:q] = '' unless params[:q]
         builder = Hyrax::CollectionMemberSearchBuilder.new(scope: self, collection: collection, search_includes_models: :works)
@@ -202,6 +227,26 @@ module Hyrax
       end
 
       private
+
+        def process_uploaded_thumbnail(uploaded_file)
+          dir_name = UploadedCollectionThumbnailPathService.upload_dir(@collection)
+          saved_file = Rails.root.join(dir_name, uploaded_file.original_filename)
+          # Create directory if it doesn't already exist
+          unless File.directory?(dir_name)
+            FileUtils.mkdir_p(dir_name)
+          else # clear contents
+          delete_uploaded_thumbnail
+          end
+          File.open(saved_file, 'wb') do |file|
+            file.write(uploaded_file.read)
+          end
+          image = MiniMagick::Image.open(saved_file)
+          # Save two versions of the image: one for homepage feature cards and one for regular thumbnail
+          image.resize('500x900').format("jpg").write("#{dir_name}/#{@collection.id}_card.jpg")
+          image.resize('150x300').format("jpg").write("#{dir_name}/#{@collection.id}_thumbnail.jpg")
+          File.chmod(0664,"#{dir_name}/#{@collection.id}_thumbnail.jpg")
+          File.chmod(0664,"#{dir_name}/#{@collection.id}_card.jpg")
+        end
 
         def default_collection_type
           Hyrax::CollectionType.find_or_create_default_collection_type

--- a/app/middleware/no_cache_middleware.rb
+++ b/app/middleware/no_cache_middleware.rb
@@ -1,0 +1,23 @@
+# Taken from https://codeburst.io/service-workers-rails-middleware-841d0194144d
+class NoCacheMiddleware
+  # pass controllers when we register this middleware.
+  def initialize(app, controllers)
+    @app = app
+    @controllers = controllers
+  end
+
+  def call(env)
+    # Let the next middleware classes & app do their thing first...
+    status, headers, response = @app.call(env)
+    dont_cache = @controllers.any? { |controller_regex| env['REQUEST_PATH'] =~ controller_regex }
+
+    # and modify the response if a controller was fetched.
+    if dont_cache
+      headers["Cache-Control"] = "no-cache, no-store, must-revalidate" # HTTP 1.1.
+      headers["Pragma"] = "no-cache" # HTTP 1.0.
+      headers["Expires"] = "0" # Proxies.
+    end
+
+    [status, headers, response]
+  end
+end

--- a/app/middleware/no_cache_middleware.rb
+++ b/app/middleware/no_cache_middleware.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Taken from https://codeburst.io/service-workers-rails-middleware-841d0194144d
 class NoCacheMiddleware
   # pass controllers when we register this middleware.

--- a/app/services/hyrax/indexes_thumbnails.rb
+++ b/app/services/hyrax/indexes_thumbnails.rb
@@ -1,0 +1,36 @@
+# OVERRIDE Hyrax 2.9.0 to make collection thumbnails uploadable
+
+module Hyrax
+  module IndexesThumbnails
+    extend ActiveSupport::Concern
+
+    included do
+      class_attribute :thumbnail_path_service
+      self.thumbnail_path_service = ThumbnailPathService
+      class_attribute :thumbnail_field
+      self.thumbnail_field = 'thumbnail_path_ss'.freeze
+    end
+
+    # Adds thumbnail indexing to the solr document
+    def generate_solr_document
+      super.tap do |solr_doc|
+        index_thumbnails(solr_doc)
+      end
+    end
+
+    # Write the thumbnail paths into the solr_document
+    # @param [Hash] solr_document the solr document to add the field to
+    def index_thumbnails(solr_document)
+      solr_document[thumbnail_field] = thumbnail_path
+    end
+
+    # Returns the value for the thumbnail path to put into the solr document
+    def thumbnail_path
+      if object.class == Collection && UploadedCollectionThumbnailPathService.uploaded_thumbnail?(object)
+        UploadedCollectionThumbnailPathService.call(object)
+      else
+        self.class.thumbnail_path_service.call(object)
+      end
+    end
+  end
+end

--- a/app/services/hyrax/indexes_thumbnails.rb
+++ b/app/services/hyrax/indexes_thumbnails.rb
@@ -1,5 +1,6 @@
-# OVERRIDE Hyrax 2.9.0 to make collection thumbnails uploadable
+# frozen_string_literal: true
 
+# OVERRIDE Hyrax 2.9.0 to make collection thumbnails uploadable
 module Hyrax
   module IndexesThumbnails
     extend ActiveSupport::Concern
@@ -8,7 +9,7 @@ module Hyrax
       class_attribute :thumbnail_path_service
       self.thumbnail_path_service = ThumbnailPathService
       class_attribute :thumbnail_field
-      self.thumbnail_field = 'thumbnail_path_ss'.freeze
+      self.thumbnail_field = 'thumbnail_path_ss'
     end
 
     # Adds thumbnail indexing to the solr document

--- a/app/services/uploaded_collection_thumbnail_path_service.rb
+++ b/app/services/uploaded_collection_thumbnail_path_service.rb
@@ -1,0 +1,20 @@
+class UploadedCollectionThumbnailPathService < Hyrax::ThumbnailPathService
+  class << self
+    # @param [Collection] object to get the thumbnail path for an uploaded image
+    def call(object)
+      "/uploads/uploaded_collection_thumbnails/#{object.id}/#{object.id}_card.jpg"
+    end
+
+    # rubocop:disable Rails/FilePath, Lint/StringConversionInInterpolation
+    def uploaded_thumbnail?(collection)
+      File.exist?("#{Rails.root.to_s}/public/uploads/uploaded_collection_thumbnails/#{collection.id}/#{collection.id}_card.jpg")
+    end
+
+    def upload_dir(collection)
+      "#{Rails.root.to_s}/public/uploads/uploaded_collection_thumbnails/#{collection.id}"
+    end
+    # rubocop:enable Rails/FilePath, Lint/StringConversionInInterpolation
+  end
+end
+
+

--- a/app/services/uploaded_collection_thumbnail_path_service.rb
+++ b/app/services/uploaded_collection_thumbnail_path_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class UploadedCollectionThumbnailPathService < Hyrax::ThumbnailPathService
   class << self
     # @param [Collection] object to get the thumbnail path for an uploaded image
@@ -5,7 +7,7 @@ class UploadedCollectionThumbnailPathService < Hyrax::ThumbnailPathService
       "/uploads/uploaded_collection_thumbnails/#{object.id}/#{object.id}_card.jpg"
     end
 
-    # rubocop:disable Rails/FilePath, Lint/StringConversionInInterpolation
+    # rubocop:disable Metrics/LineLength, Rails/FilePath, Lint/StringConversionInInterpolation
     def uploaded_thumbnail?(collection)
       File.exist?("#{Rails.root.to_s}/public/uploads/uploaded_collection_thumbnails/#{collection.id}/#{collection.id}_card.jpg")
     end
@@ -13,8 +15,6 @@ class UploadedCollectionThumbnailPathService < Hyrax::ThumbnailPathService
     def upload_dir(collection)
       "#{Rails.root.to_s}/public/uploads/uploaded_collection_thumbnails/#{collection.id}"
     end
-    # rubocop:enable Rails/FilePath, Lint/StringConversionInInterpolation
+    # rubocop:enable Metrics/LineLength, Rails/FilePath, Lint/StringConversionInInterpolation
   end
 end
-
-

--- a/app/views/hyrax/dashboard/collections/_current_thumbnail.html.erb
+++ b/app/views/hyrax/dashboard/collections/_current_thumbnail.html.erb
@@ -1,0 +1,7 @@
+<% thumbnail_path = SolrDocument.find(@collection.id).thumbnail_path %>
+ <% if thumbnail_path.include?("uploaded_collection_thumbnails") and File.exist? Rails.root.join("public#{::SolrDocument.find(@collection.id).thumbnail_path}") %>
+  <%= image_tag(thumbnail_path, class: "current-thumbnail") %>
+  <p>Current image: <strong><%= @thumbnail_filename %></strong></p>
+<% else %>
+  No image found.
+<% end %>

--- a/app/views/hyrax/dashboard/collections/_form.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form.html.erb
@@ -1,0 +1,125 @@
+<%# OVERRIDE Hyrax 2.9.0 to make it say 'Default thumbnail' in the thumbnail select box instead of 'undefined' %>
+<div class="panel panel-default tabs" id="collection-edit-controls">
+  <ul class="nav nav-tabs" role="tablist">
+    <li class="active">
+      <a href="#description" role="tab" data-toggle="tab"><%= t('.tabs.description') %></a>
+    </li>
+    <% if @form.persisted? %>
+      <% if @collection.brandable? %>
+      <li>
+        <a href="#branding" role="tab" data-toggle="tab"><%= t('.tabs.branding') %></a>
+      </li>
+      <% end %>
+      <% if @collection.discoverable? %>
+      <li>
+        <a href="#discovery" role="tab" data-toggle="tab"><%= t('.tabs.discovery') %></a>
+      </li>
+      <% end %>
+      <% if @collection.sharable? %>
+      <li>
+        <a href="#sharing" role="tab" data-toggle="tab"><%= t('.tabs.sharing') %></a>
+      </li>
+      <% end %>
+    <% end %>
+  </ul>
+
+<%= simple_form_for @form, url: [hyrax, :dashboard, @form], html: { class: 'editor' } do |f| %>
+  <div class="tab-content">
+    <div id="description" class="tab-pane active">
+      <div class="panel panel-default labels">
+        <div class="panel-body">
+          <div id="base-terms">
+            <% f.object.primary_terms.each do |term| %>
+              <%= render_edit_field_partial(term, f: f) %>
+            <% end %>
+            <% if f.object.persisted? %>
+              <%# we're loading these values dynamically to speed page load %>
+              <%# OVERRIDE here to make it say 'Default thumbnail' in the select box instead of 'undefined' %>
+              <%= f.input :thumbnail_id,
+                          input_html: { data: { text: f.object.thumbnail_title || 'Default thumbnail' } } %>
+              <%# option to upload thumbnail %>
+              <%= label_tag(:thumbnail_upload, "Upload a Thumbnail") %>
+              <p class='help-block'>
+                Uploading an image here will replace a thumbnail selected from the above dropdown. For best results, use an image at least 500x500 px. If you would like to use an image from the dropdown above, click the "Clear upload" button below.
+              </p>
+              <%# raise 'hell' %>
+              <div id="uploaded-thumbnail" class="mb-20">
+                <%= render "current_thumbnail" %>
+              </div>
+              <%= f.file_field :thumbnail_upload, class: "thumbnail-upload" %>
+              <%= link_to("Clear upload", main_app.delete_uploaded_thumbnail_path, method: :post, remote: :true, class: "btn btn-danger mb-40 mt-20", id: "clear-upload") %>
+            <% end %>
+          </div>
+          <% if f.object.display_additional_fields? %>
+            <%= link_to t('hyrax.collection.form.additional_fields'),
+                    '#extended-terms',
+                    class: 'btn btn-default additional-fields',
+                    data: { toggle: 'collapse' },
+                    role: "button",
+                    'aria-expanded'=> "false",
+                    'aria-controls'=> "extended-terms" %>
+            <div id="extended-terms" class='collapse'>
+              <% f.object.secondary_terms.each do |term| %>
+                <%= render_edit_field_partial(term, f: f) %>
+              <% end %>
+            </div>
+          <% end %>
+          <%= hidden_field_tag :type, params[:type] %>
+          <%= hidden_field_tag :stay_on_edit, true %>
+          <%= hidden_field_tag :collection_type_gid, @collection.collection_type_gid %>
+          <!-- parent_id may be passed from the nested collections controller to allow a subcollection relationship to be added as collection is created -->
+          <% if params[:parent_id].present? %>
+            <%= hidden_field_tag :parent_id, params[:parent_id] %>
+          <% end %>
+          <% if params[:batch_document_ids].present? %>
+            <% params[:batch_document_ids].each do |batch_item| %>
+              <input type="hidden" name="batch_document_ids[]" value="<%= batch_item %>" />
+            <% end %>
+          <% end %>
+        </div>
+      </div>
+    </div> <!-- end description -->
+    <% if @form.persisted? %>
+      <div id="branding" class="tab-pane">
+        <div class="panel panel-default labels">
+          <div class="panel-body">
+            <%= render 'form_branding', f: f %>
+          </div>
+        </div>
+      </div>
+
+      <div id="discovery" class="tab-pane">
+        <div class="panel panel-default labels">
+          <div class="panel-body">
+            <%= render 'form_discovery', f: f %>
+          </div>
+        </div>
+      </div>
+
+      <div id="sharing" class="tab-pane">
+        <div class="panel panel-default labels" id="collection_permissions" data-param-key="<%= f.object.model_name.param_key %>">
+          <div class="panel-body">
+            <%= render 'form_share', f: f %>
+          </div>
+        </div>
+      </div>
+    <% end %>
+    <div class="panel-footer">
+      <% if @collection.persisted? %>
+        <%= f.submit t(:'hyrax.collection.select_form.update'), class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "update_submit", name: "update_collection" %>
+        <%= link_to t(:'helpers.action.cancel'), hyrax.dashboard_collection_path(@collection), class: 'btn btn-link' %>
+      <% else %>
+        <%= f.submit t(:'hyrax.collection.select_form.create'), class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "create_submit", name: "create_collection" %>
+        <%= link_to t(:'helpers.action.cancel'), hyrax.my_collections_path, class: 'btn btn-link' %>
+      <% end %>
+    </div>
+  </div> <!-- end tab-content -->
+<% end # simple_form_for %>
+
+<script>
+  // loading message
+  $("#clear-upload").click(function() {
+    $("#uploaded-thumbnail").html("Removing uploaded thumbnail...");
+  });
+  $("label[for='collection_thumbnail_id']").html("Select a Thumbnail from Collection");
+</script>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -21,6 +21,7 @@ Rails.application.configure do
     'Cache-Control' => 'public, s-maxage=31536000, maxage=15552000',
     'Expires' => "#{1.year.from_now.to_formatted_s(:rfc822)}"
   }
+  config.middleware.insert_before ActionDispatch::Static, NoCacheMiddleware, [/dashboard\/collections\/.*\/edit/, /uploaded_collection_thumbnails/]
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = Uglifier.new(harmony: true)
   # config.assets.css_compressor = :sass

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -540,6 +540,9 @@ en:
           logo:
             description: One or more images to be displayed at the top of the collection page.  For best results, upload an image (JPG, GIF or PNG) that is 40 pixels in height.  Larger images will be resized to 40 pixels in height.
             label: Logo
+          thumbnail:
+            description: An image to be displayed in the search results and on the homepage if you decide to feature this collection. Image will be cropped and resized in various ways throughout the app, but for best results use an image (JPG, GIF or PNG) with a landscape orientation.
+            label: Thumbnail
         form_discovery:
           para1: These settings determine who is able to discover and view this collection's landing page; they do not affect the visibility of items in the collection.
           para2: If you chose not to make this collection open access, you can still share the collection with specific users and groups using the Sharing tab.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,4 +87,8 @@ Rails.application.routes.draw do
   end
 
   get 'all_collections' => 'hyrax/homepage#all_collections', as: :all_collections
+
+  # Upload a collection thumbnail
+  post "/dashboard/collections/:id/delete_uploaded_thumbnail", to: "hyrax/dashboard/collections#delete_uploaded_thumbnail", as: :delete_uploaded_thumbnail
+
 end


### PR DESCRIPTION
CoAuthors: @eltiffster from uVic & @sephirothkod

Related: https://gitlab.com/notch8/britishlibrary/-/issues/260

# Summary
Currently there is only a convoluted way of adding an image to the collection. Ideally would just upload an image to the collection edit page rather than be forced to created a mock work and add the image as a file to that work.

# Requirements
Add the ability to upload a custom thumbnail/image to a collection page

# Video

Shows the uploaded collection thumbnails saving and showing up on home page:

https://share.getcloudapp.com/GGullKPJ


# Acceptance Criteria
- [ ] as a user I can return to the default collection thumbnail
- [ ] as a user I can upload a thumbnail from the edit collection form and see it on the collection dashboard page, home page, and search results page.
- [ ] as a user, I can still set the collection thumbnail to one of the work thumbnails
- [ ] as a user, I can clear the uploaded thumbnail to use one of the thumbnails from a work

@samvera/hyku-code-reviewers
