### PR TITLE
DRAFT: add-datatable-proprietor-accounts-show

### DIFF
--- a/app/views/proprietor/accounts/show.html.erb
+++ b/app/views/proprietor/accounts/show.html.erb
@@ -58,7 +58,7 @@
       <div class="panel-body">
         <div class="tab-content clearfix">
           <div class="tab-pane active" id="current-admins-tab">
-            <table class="table table-striped">
+            <table class="table table-striped datatable">
               <thead>
                 <th><%= t('.current_admins.email') %></th>
                 <th><%= t('.current_admins.actions') %></th>
@@ -94,7 +94,7 @@
             </table>
           </div>
           <div class="tab-pane" id="all-users-tab">
-            <table class="table table-striped">
+            <table class="table table-striped datatable">
               <thead>
                 <th><%= t('.current_admins.email') %></th>
                 <th><%= t('.current_admins.actions') %></th>


### PR DESCRIPTION
This MR is contributed back from work conducted on behalf of the British Library by Scientist Software Services. It adds datatables to the proprietor accounts show page to reduce load time.

After MR Screenshots:
<img width="1374" alt="Screen Shot 2022-04-27 at 8 02 10 PM" src="https://user-images.githubusercontent.com/63515648/165668439-1a45e63f-977e-4a33-9abc-322f9ee11a1e.png">
<img width="1368" alt="Screen Shot 2022-04-27 at 8 01 57 PM" src="https://user-images.githubusercontent.com/63515648/165668441-bd3caa23-3562-4f81-91b8-1ba716f45ea4.png">

