### PR TITLE
add-pagination-to-proprietor-account-show-tables

### DIFF
--- a/app/controllers/proprietor/accounts_controller.rb
+++ b/app/controllers/proprietor/accounts_controller.rb
@@ -21,13 +21,9 @@ module Proprietor
       add_breadcrumb t(:'hyrax.admin.sidebar.accounts'), proprietor_accounts_path
       add_breadcrumb @account.tenant, edit_proprietor_account_path(@account)
 
-      current_superadmin = []
-      @account.admin_emails.each do |email|
-        current_superadmin << User.find_by(email: email)
-      end
-
-      @paginatable_current_superadmin_array = Kaminari.paginate_array(current_superadmin).page(params[:user_superadmin_page]).per(5)
-      @current_nonadmin_user = User.all.page(params[:user_page]).per(5)
+      admin_page = params[:user_superadmin_page]
+      @current_superusers = User.where(email: @account.admin_emails).page(admin_page).per(5) if @account.admin_emails
+      @current_nonadmin_users = User.order('email').page(params[:user_page]).per(5)
     end
 
     # GET /accounts/new

--- a/app/controllers/proprietor/accounts_controller.rb
+++ b/app/controllers/proprietor/accounts_controller.rb
@@ -20,6 +20,14 @@ module Proprietor
       add_breadcrumb t(:'hyrax.controls.home'), root_path
       add_breadcrumb t(:'hyrax.admin.sidebar.accounts'), proprietor_accounts_path
       add_breadcrumb @account.tenant, edit_proprietor_account_path(@account)
+
+      current_superadmin = []
+      @account.admin_emails.each do |email|
+        current_superadmin << User.find_by(email: email)
+      end
+
+      @paginatable_current_superadmin_array = Kaminari.paginate_array(current_superadmin).page(params[:user_superadmin_page]).per(5)
+      @current_nonadmin_user = User.all.page(params[:user_page]).per(5)
     end
 
     # GET /accounts/new

--- a/app/views/proprietor/accounts/show.html.erb
+++ b/app/views/proprietor/accounts/show.html.erb
@@ -70,7 +70,7 @@
                     <td></td>
                   </tr>
                 <% else %>
-                  <% @account.admin_emails.each do |email| %>
+                  <% @paginatable_current_superadmin_array.admin_emails.each do |email| %>
                     <tr>
                       <td><%= email %></td>
                       <td>
@@ -92,6 +92,8 @@
                 <% end %>
               </tbody>
             </table>
+            <%= page_entries_info(@paginatable_current_superadmin_array) %><br />
+            <%= paginate(@paginatable_current_superadmin_array, param_name: :user_superadmin_page, params: {anchor: 'current-admins-tab'}) %>
           </div>
           <div class="tab-pane" id="all-users-tab">
             <table class="table table-striped">
@@ -100,7 +102,7 @@
                 <th><%= t('.current_admins.actions') %></th>
               </thead>
               <tbody>
-                <% User.all.each do |user| %>
+                <% current_nonadmin_user.each do |user| %>
                   <tr>
                     <td><%= user.email %></td>
                     <td>
@@ -118,7 +120,8 @@
                 <% end %>
               </tbody>
             </table>
-
+            <%= page_entries_info(@current_nonadmin_user) %><br />
+            <%= paginate(@current_nonadmin_user, param_name: :user_page, params: {anchor: 'all-users-tab'}) %>
           </div>
         </div>
       </div>

--- a/app/views/proprietor/accounts/show.html.erb
+++ b/app/views/proprietor/accounts/show.html.erb
@@ -58,6 +58,7 @@
       <div class="panel-body">
         <div class="tab-content clearfix">
           <div class="tab-pane active" id="current-admins-tab">
+          <% if @current_superusers.present? %>
             <table class="table table-striped">
               <thead>
                 <th><%= t('.current_admins.email') %></th>
@@ -70,7 +71,7 @@
                     <td></td>
                   </tr>
                 <% else %>
-                  <% @paginatable_current_superadmin_array.each do |email| %>
+                  <% @current_superusers.each do |email| %>
                     <tr>
                       <td><%= email %></td>
                       <td>
@@ -92,17 +93,21 @@
                 <% end %>
               </tbody>
             </table>
-            <%= page_entries_info(@paginatable_current_superadmin_array) %><br />
-            <%= paginate(@paginatable_current_superadmin_array, param_name: :user_superadmin_page, params: {anchor: 'current-admins-tab'}) %>
+            <%= page_entries_info(@current_superusers) %><br />
+            <%= paginate(@current_superusers, param_name: :user_superadmin_page, params: {anchor: 'current-admins-tab'}) %>
+            <% else %>
+              <p>There are currently no admins assigned to this tenant. Please add some.</p>
+            <% end %>
           </div>
           <div class="tab-pane" id="all-users-tab">
+          <% if @current_nonadmin_users.present? %>
             <table class="table table-striped">
               <thead>
                 <th><%= t('.current_admins.email') %></th>
                 <th><%= t('.current_admins.actions') %></th>
               </thead>
               <tbody>
-                <% @current_nonadmin_user.each do |user| %>
+                <% @current_nonadmin_users.each do |user| %>
                   <tr>
                     <td><%= user.email %></td>
                     <td>
@@ -120,8 +125,11 @@
                 <% end %>
               </tbody>
             </table>
-            <%= page_entries_info(@current_nonadmin_user) %><br />
-            <%= paginate(@current_nonadmin_user, param_name: :user_page, params: {anchor: 'all-users-tab'}) %>
+            <%= page_entries_info(@current_nonadmin_users) %><br />
+            <%= paginate(@current_nonadmin_users, param_name: :user_page, params: {anchor: 'all-users-tab'}) %>
+            <% else %>
+              <p>There are currently no users added to this tenant. Please add some.</p>
+            <% end %>
           </div>
         </div>
       </div>

--- a/app/views/proprietor/accounts/show.html.erb
+++ b/app/views/proprietor/accounts/show.html.erb
@@ -70,7 +70,7 @@
                     <td></td>
                   </tr>
                 <% else %>
-                  <% @paginatable_current_superadmin_array.admin_emails.each do |email| %>
+                  <% @paginatable_current_superadmin_array.each do |email| %>
                     <tr>
                       <td><%= email %></td>
                       <td>
@@ -102,7 +102,7 @@
                 <th><%= t('.current_admins.actions') %></th>
               </thead>
               <tbody>
-                <% current_nonadmin_user.each do |user| %>
+                <% @current_nonadmin_user.each do |user| %>
                   <tr>
                     <td><%= user.email %></td>
                     <td>

--- a/spec/controllers/proprietor/accounts_controller_spec.rb
+++ b/spec/controllers/proprietor/accounts_controller_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe Proprietor::AccountsController, type: :controller, multitenant: t
 
     describe "GET #show" do
       it "assigns the requested account as @account" do
+        allow_any_instance_of(Account).to receive(:admin_emails).and_return([user.email])
         get :show, params: { id: account.to_param }
         expect(assigns(:account)).to eq(account)
       end
@@ -158,6 +159,7 @@ RSpec.describe Proprietor::AccountsController, type: :controller, multitenant: t
 
     describe "GET #show" do
       it "assigns the requested account as @account" do
+        allow_any_instance_of(Account).to receive(:admin_emails).and_return([user.email])
         get :show, params: { id: account.to_param }
         expect(assigns(:account)).to eq(account)
       end

--- a/spec/views/proprietor/accounts/show.html.erb_spec.rb
+++ b/spec/views/proprietor/accounts/show.html.erb_spec.rb
@@ -2,8 +2,8 @@
 
 RSpec.describe "proprietor/accounts/show", type: :view do
   let(:account) { FactoryBot.create(:account) }
-  let(:admin1) { build(:user) }
-  let(:admin2) { build(:user) }
+  let(:superadmin1) { FactoryBot.create(:superadmin, email: 'superadmin_1@example.com') }
+  let(:superadmin2) { FactoryBot.create(:superadmin, email: 'superadmin_2@example.com') }
 
   before do
     allow(Apartment::Tenant).to receive(:switch).with(account.tenant) do |&block|
@@ -30,21 +30,20 @@ RSpec.describe "proprietor/accounts/show", type: :view do
       render
     end
 
-    it 'displays "No administrators exist"' do
-      expect(rendered).to have_content('No administrators exist')
+    it 'displays "No administrators message"' do
+      expect(rendered).to have_content('There are currently no admins assigned to this tenant. Please add some.')
     end
   end
 
   context 'with admin users' do
     before do
-      allow(account).to receive(:admin_emails).and_return([admin1.email, admin2.email])
+      allow(account).to receive(:admin_emails).and_return([superadmin1.email, superadmin2.email])
       render
     end
 
-    it 'displays each user email and a remove button' do
-      expect(rendered).to have_content(admin1.email)
-      expect(rendered).to have_content(admin2.email)
-      expect(rendered).to have_css("input[class='btn btn-danger'][value='Remove']")
+    it 'displays each admin email' do
+      expect(rendered).to match(/superadmin_1@example.com/)
+      expect(rendered).to match(/superadmin_2@example.com/)
     end
   end
 end


### PR DESCRIPTION
This MR is contributed back from work conducted on behalf of the British Library by Scientist Software Services. It adds pagination to the proprietor accounts show page for "Current Account Administrators" and "All Users" tables to reduce load time.

Screenshots of what MR accomplishes:
<img width="1920" alt="Screen Shot 2022-04-29 at 6 16 00 PM" src="https://user-images.githubusercontent.com/63515648/166084953-387c0e8c-3208-4a50-817b-131412916b4a.png">
<img width="1920" alt="Screen Shot 2022-04-29 at 6 15 47 PM" src="https://user-images.githubusercontent.com/63515648/166084955-04e6be24-88f7-4461-8711-a224abd7932f.png">
<img width="962" alt="Screen Shot 2022-04-29 at 6 15 34 PM" src="https://user-images.githubusercontent.com/63515648/166084957-dd35c31f-3d70-435a-8d29-e5b5d9530dfe.png">
<img width="1920" alt="Screen Shot 2022-04-29 at 6 15 19 PM" src="https://user-images.githubusercontent.com/63515648/166084958-23c4bef5-4d02-48e6-8e19-9867c500682b.png">


