### PR TITLE
fix single tenant catalog links

### DIFF
--- a/app/helpers/shared_search_helper.rb
+++ b/app/helpers/shared_search_helper.rb
@@ -2,7 +2,7 @@
 
 module SharedSearchHelper
   def generate_work_url(model, request)
-    return model if current_account.search_only?
+    return model unless current_account.search_only?
     # needed because some attributes eg id is a symbol 7 others are string
     model = model.to_h.with_indifferent_access
 

--- a/app/helpers/shared_search_helper.rb
+++ b/app/helpers/shared_search_helper.rb
@@ -2,8 +2,9 @@
 
 module SharedSearchHelper
   def generate_work_url(model, request)
+    return model if current_account.search_only?
     # needed because some attributes eg id is a symbol 7 others are string
-    model = model.with_indifferent_access
+    model = model.to_h.with_indifferent_access
 
     cname = model["account_cname_tesim"]
     account_cname = Array.wrap(cname).first

--- a/app/helpers/shared_search_helper.rb
+++ b/app/helpers/shared_search_helper.rb
@@ -3,6 +3,7 @@
 module SharedSearchHelper
   def generate_work_url(model, request)
     return model unless current_account.search_only?
+
     # needed because some attributes eg id is a symbol 7 others are string
     model = model.to_h.with_indifferent_access
 

--- a/app/views/catalog/_index_header_list_default.html.erb
+++ b/app/views/catalog/_index_header_list_default.html.erb
@@ -1,4 +1,4 @@
 <%# OVERRIDE Hyrax 2.9 to support shared search %>
 <div class="search-results-title-row">
-  <h4 class="search-result-title"><%= link_to document.title_or_label, generate_work_url(document.to_h, request) %></h4>
+  <h4 class="search-result-title"><%= link_to document.title_or_label, generate_work_url(document, request) %></h4>
 </div>

--- a/spec/factories/accounts.rb
+++ b/spec/factories/accounts.rb
@@ -47,6 +47,11 @@ FactoryBot.define do
       tenant { 'public' }
     end
 
+    trait(:search_only) do
+      search_only { true }
+    end
+
+    factory :search_only_account, traits: [:search_only]
     factory :account_with_public_schema, traits: [:public_schema]
   end
 

--- a/spec/helpers/shared_search_helper_spec.rb
+++ b/spec/helpers/shared_search_helper_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe SharedSearchHelper do
     let(:request) { instance_double(ActionDispatch::Request, port: 3000, protocol: "https://", host: account.cname) }
     let(:work_hash) { { id: uuid, 'has_model_ssim': ['GenericWork'], 'account_cname_tesim': account.cname } }
 
-    before do 
+    before do
       allow(helper).to receive(:current_account) { account }
     end
 

--- a/spec/helpers/shared_search_helper_spec.rb
+++ b/spec/helpers/shared_search_helper_spec.rb
@@ -5,11 +5,15 @@ RSpec.describe SharedSearchHelper do
 
   context "shared search records" do
     let(:cname) { 'hyku-me.test' }
-    let(:account) { build(:account, cname: cname) }
+    let(:account) { build(:search_only_account, cname: cname) }
 
     let(:uuid) { SecureRandom.uuid }
     let(:request) { instance_double(ActionDispatch::Request, port: 3000, protocol: "https://", host: account.cname) }
     let(:work_hash) { { id: uuid, 'has_model_ssim': ['GenericWork'], 'account_cname_tesim': account.cname } }
+
+    before do 
+      allow(helper).to receive(:current_account) { account }
+    end
 
     it 'returns #generate_work_url for production' do
       allow(Rails.env).to receive(:development?).and_return(false)


### PR DESCRIPTION
Louisville reported issues with links on the catalog pointing to single.tenant.default as the URL. This is because all page views were using the account_cname instead of just on shared search views.