### PR TITLE
Draft: add feature flipper to render pdfs in uv

### DIFF
--- a/app/actors/hyrax/actors/create_with_files_actor.rb
+++ b/app/actors/hyrax/actors/create_with_files_actor.rb
@@ -12,7 +12,7 @@ module Hyrax
         files = uploaded_files(uploaded_file_ids)
         next_actor.create(env)
         # OVERRIDE: Hyrax 2.5.1 Split PDF into jpg for each page and sent to attach files method
-        if display_pdfs_in_uv? && files.present?
+        if Flipflop.show_pdfs_in_uv? && files.present?
           ConvertPdfToJpgJob.perform_later(files, env.curation_concern, env.attributes, env.user.id)
         end
         validate_files(files, env) && attach_files(files, env)

--- a/app/actors/hyrax/actors/create_with_files_actor.rb
+++ b/app/actors/hyrax/actors/create_with_files_actor.rb
@@ -26,7 +26,7 @@ module Hyrax
         files = uploaded_files(uploaded_file_ids)
         next_actor.update(env)
         # OVERRIDE: Hyrax 2.5.1 Split PDF into jpg for each page and sent to attach files method
-        if display_pdfs_in_uv? && files.present?
+        if Flipflop.show_pdfs_in_uv? && files.present?
           ConvertPdfToJpgJob.perform_later(files, env.curation_concern, env.attributes, env.user.id)
         end
         validate_files(files, env) && attach_files(files, env)

--- a/app/actors/hyrax/actors/create_with_files_actor.rb
+++ b/app/actors/hyrax/actors/create_with_files_actor.rb
@@ -12,7 +12,9 @@ module Hyrax
         files = uploaded_files(uploaded_file_ids)
         next_actor.create(env)
         # OVERRIDE: Hyrax 2.5.1 Split PDF into jpg for each page and sent to attach files method
-        ConvertPdfToJpgJob.perform_later(files, env.curation_concern, env.attributes, env.user.id) if files.present?
+        if display_pdfs_in_uv? && files.present?
+          ConvertPdfToJpgJob.perform_later(files, env.curation_concern, env.attributes, env.user.id)
+        end
         validate_files(files, env) && attach_files(files, env)
         true
       end
@@ -24,7 +26,9 @@ module Hyrax
         files = uploaded_files(uploaded_file_ids)
         next_actor.update(env)
         # OVERRIDE: Hyrax 2.5.1 Split PDF into jpg for each page and sent to attach files method
-        ConvertPdfToJpgJob.perform_later(files, env.curation_concern, env.attributes, env.user.id) if files.present?
+        if display_pdfs_in_uv? && files.present?
+          ConvertPdfToJpgJob.perform_later(files, env.curation_concern, env.attributes, env.user.id)
+        end
         validate_files(files, env) && attach_files(files, env)
         true
       end

--- a/app/actors/hyrax/actors/create_with_remote_files_actor.rb
+++ b/app/actors/hyrax/actors/create_with_remote_files_actor.rb
@@ -79,7 +79,9 @@ module Hyrax
             end
             auth_header = file_info.fetch(:auth_header, {})
             create_file_from_url(env, uri, file_info[:file_name], auth_header)
-            ConvertRemotePdfToJpgJob.perform_now(uri.to_s, env.curation_concern, env.attributes, env.user)
+            if display_pdfs_in_uv?
+              ConvertRemotePdfToJpgJob.perform_now(uri.to_s, env.curation_concern, env.attributes, env.user)
+            end
           end
 
           works_that_need_pdfs = [Image, GenericWork]

--- a/app/actors/hyrax/actors/create_with_remote_files_actor.rb
+++ b/app/actors/hyrax/actors/create_with_remote_files_actor.rb
@@ -85,7 +85,7 @@ module Hyrax
           end
 
           works_that_need_pdfs = [Image, GenericWork]
-          make_pdfs(env) if works_that_need_pdfs.include?(env.curation_concern.class)
+          make_pdfs(env) if works_that_need_pdfs.include?(env.curation_concern.class) && Flipflop.show_pdfs_in_uv?
           true
         end
         # rubocop:enable Metrics/PerceivedComplexity

--- a/app/actors/hyrax/actors/create_with_remote_files_actor.rb
+++ b/app/actors/hyrax/actors/create_with_remote_files_actor.rb
@@ -79,13 +79,13 @@ module Hyrax
             end
             auth_header = file_info.fetch(:auth_header, {})
             create_file_from_url(env, uri, file_info[:file_name], auth_header)
-            if display_pdfs_in_uv?
+            if Flipflop.show_pdfs_in_uv??
               ConvertRemotePdfToJpgJob.perform_now(uri.to_s, env.curation_concern, env.attributes, env.user)
             end
           end
 
           works_that_need_pdfs = [Image, GenericWork]
-          make_pdfs(env) if works_that_need_pdfs.include?(env.curation_concern.class) && Flipflop.show_pdfs_in_uv?
+          make_pdfs(env) if works_that_need_pdfs.include?(env.curation_concern.class)
           true
         end
         # rubocop:enable Metrics/PerceivedComplexity

--- a/app/actors/hyrax/actors/create_with_remote_files_actor.rb
+++ b/app/actors/hyrax/actors/create_with_remote_files_actor.rb
@@ -79,7 +79,7 @@ module Hyrax
             end
             auth_header = file_info.fetch(:auth_header, {})
             create_file_from_url(env, uri, file_info[:file_name], auth_header)
-            if Flipflop.show_pdfs_in_uv??
+            if Flipflop.show_pdfs_in_uv?
               ConvertRemotePdfToJpgJob.perform_now(uri.to_s, env.curation_concern, env.attributes, env.user)
             end
           end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,8 +6,4 @@ module ApplicationHelper
   include GroupNavigationHelper
 
   include SharedSearchHelper
-
-  def display_pdfs_in_uv?
-    Flipflop.show_pdfs_in_uv?
-  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,4 +6,8 @@ module ApplicationHelper
   include GroupNavigationHelper
 
   include SharedSearchHelper
+
+  def display_pdfs_in_uv?
+    Flipflop.show_pdfs_in_uv?
+  end
 end

--- a/config/features.rb
+++ b/config/features.rb
@@ -15,7 +15,7 @@ Flipflop.configure do
           default: true,
           description: "Shows the Recently Uploaded tab on the homepage."
 
-  feature :show_pdfs_in_uv,
+  feature :process_pdfs_for_uv,
           default: false,
           description: "Process PDF to show in the Universal Viewer."
 end

--- a/config/features.rb
+++ b/config/features.rb
@@ -17,5 +17,5 @@ Flipflop.configure do
 
   feature :process_pdfs_for_uv,
           default: false,
-          description: "Process PDF to show in the Universal Viewer."
+          description: "Processes PDF to show in the Universal Viewer. PDFs will only render in the UV if they're created when this feature is enabled."
 end

--- a/config/features.rb
+++ b/config/features.rb
@@ -17,5 +17,5 @@ Flipflop.configure do
 
   feature :process_pdfs_for_uv_rendering,
           default: false,
-          description: "Processes PDFs to show in the Universal Viewer (UV). PDFs will only render in the UV if they're created with this feature enabled."
+          description: "Processes PDFs for display in the Universal Viewer (UV). PDFs will only render in the UV if they're created with this feature enabled."
 end

--- a/config/features.rb
+++ b/config/features.rb
@@ -15,7 +15,7 @@ Flipflop.configure do
           default: true,
           description: "Shows the Recently Uploaded tab on the homepage."
 
-  feature :process_pdfs_for_uv,
+  feature :process_pdfs_for_uv_rendering,
           default: false,
           description: "Processes PDF to show in the Universal Viewer. PDFs will only render in the UV if they're created when this feature is enabled."
 end

--- a/config/features.rb
+++ b/config/features.rb
@@ -17,5 +17,5 @@ Flipflop.configure do
 
   feature :process_pdfs_for_uv_rendering,
           default: false,
-          description: "Processes PDF to show in the Universal Viewer (UV). PDFs will only render in the UV if they're created with this feature is enabled."
+          description: "Processes PDF to show in the Universal Viewer (UV). PDFs will only render in the UV if they're created with this feature enabled."
 end

--- a/config/features.rb
+++ b/config/features.rb
@@ -14,4 +14,8 @@ Flipflop.configure do
   feature :show_recently_uploaded,
           default: true,
           description: "Shows the Recently Uploaded tab on the homepage."
+
+  feature :show_pdfs_in_uv,
+          default: false,
+          description: "Renders PDFs in the Universal Viewer."
 end

--- a/config/features.rb
+++ b/config/features.rb
@@ -17,5 +17,5 @@ Flipflop.configure do
 
   feature :process_pdfs_for_uv_rendering,
           default: false,
-          description: "Processes PDF to show in the Universal Viewer (UV). PDFs will only render in the UV if they're created when this feature is enabled."
+          description: "Processes PDF to show in the Universal Viewer (UV). PDFs will only render in the UV if they're created with this feature is enabled."
 end

--- a/config/features.rb
+++ b/config/features.rb
@@ -17,5 +17,5 @@ Flipflop.configure do
 
   feature :process_pdfs_for_uv_rendering,
           default: false,
-          description: "Processes PDF to show in the Universal Viewer. PDFs will only render in the UV if they're created when this feature is enabled."
+          description: "Processes PDF to show in the Universal Viewer (UV). PDFs will only render in the UV if they're created when this feature is enabled."
 end

--- a/config/features.rb
+++ b/config/features.rb
@@ -17,5 +17,5 @@ Flipflop.configure do
 
   feature :show_pdfs_in_uv,
           default: false,
-          description: "Renders PDFs in the Universal Viewer."
+          description: "Process PDF to show in the Universal Viewer."
 end

--- a/config/features.rb
+++ b/config/features.rb
@@ -17,5 +17,5 @@ Flipflop.configure do
 
   feature :process_pdfs_for_uv_rendering,
           default: false,
-          description: "Processes PDF to show in the Universal Viewer (UV). PDFs will only render in the UV if they're created with this feature enabled."
+          description: "Processes PDFs to show in the Universal Viewer (UV). PDFs will only render in the UV if they're created with this feature enabled."
 end


### PR DESCRIPTION
- [ ]  Adds feature flipper wrapper around converting pdfs into jpgs so that the user can choose whether or not they want them to render in the UV.
- [ ] PDFs are shown in the UV only if they get converted to Images. 
- [ ] Therefore, this solution would handle whether or not the pdf shows in the uv on a work by work basis. If the work was created w the setting off, they will not create images/show in the UV and vice versa. 
- [ ] **Is there a way to have them ALL show in the uv if the setting is turned on, regardless of the setting's state at the time they were created?**
- [ ] what happens when there are mixed types of file sets (pdfs and jpegs)
<img width="1430" alt="Screen Shot 2022-06-20 at 1 36 02 PM" src="https://user-images.githubusercontent.com/10081604/174674572-de23de4c-87e1-46c0-89e6-0fe5cbe02266.png">

