### PR TITLE
Accessibility changes

### DIFF
--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -8,6 +8,7 @@ class SitesController < ApplicationController
   def update
     # FIXME: Pull these strings out to i18n locale
     if @site.update(update_params)
+      remove_appearance_text(update_params)
       redirect_to hyrax.admin_appearance_path, notice: 'The appearance was successfully updated.'
     else
       redirect_to hyrax.admin_appearance_path, flash: { error: 'Updating the appearance was unsuccessful.' }
@@ -32,5 +33,21 @@ class SitesController < ApplicationController
 
     def site_theme_params
       params.require(:site).permit(:home_theme, :search_theme, :show_theme)
+    end
+
+    REMOVE_TEXT_MAPS = {
+      "remove_logo_image"               => "logo_image_text",
+      "remove_banner_image"             => "banner_image_text",
+      "remove_directory_image"          => "directory_image_text",
+      "remove_default_collection_image" => "default_collection_image_text",
+      "remove_default_work_image"       => "default_work_image_text"
+    }.freeze
+
+    def remove_appearance_text(update_params)
+      image_text_keys = update_params.keys
+      image_text_keys.each do |image_text_key|
+        block = ContentBlock.find_by(name: REMOVE_TEXT_MAPS[image_text_key])
+        block.delete if block&.value.present?
+      end
     end
 end

--- a/app/forms/hyrax/forms/admin/appearance.rb
+++ b/app/forms/hyrax/forms/admin/appearance.rb
@@ -79,6 +79,31 @@ module Hyrax
           true
         end
 
+        # The alt text for the logo image
+        def logo_image_text
+          block_for('logo_image_text')
+        end
+
+        # The alt text for the banner image
+        def banner_image_text
+          block_for('banner_image_text')
+        end
+
+        # The alt text for the directory image
+        def directory_image_text
+          block_for('directory_image_text')
+        end
+
+        # The alt text for the default_collection image
+        def default_collection_image_text
+          block_for('default_collection_image_text')
+        end
+
+        # The alt text for the default_work image
+        def default_work_image_text
+          block_for('default_work_image_text')
+        end
+
         # The font for the body copy
         def body_font
           block_for('body_font')
@@ -287,20 +312,33 @@ module Hyrax
 
         # @return [Array<Symbol>] a list of fields that are related to the banner
         def self.banner_fields
-          [:banner_image]
+          %i[
+            banner_image banner_label
+          ]
         end
 
-        # @return [Array<Symbol>] a list of fields that are related to the banner
+        # @return [Array<Symbol>] a list of fields that are related to the logo
         def self.logo_fields
-          [:logo_image]
+          %i[
+            logo_image logo_label
+          ]
         end
 
+        # @return [Array<Symbol>] a list of fields that are related to the directory
         def self.directory_fields
-          [:directory_image]
+          %i[
+            directory_image directory_image_label
+          ]
         end
 
+        # @return [Array<Symbol>] a list of fields that are related to default works & collections
         def self.default_image_fields
-          %i[default_collection_image default_work_image]
+          %i[
+            default_collection_image
+            default_work_image
+            default_collection_label
+            default_work_label
+          ]
         end
 
         # Persist the form values
@@ -337,6 +375,11 @@ module Hyrax
             searchbar_text_color
             searchbar_text_hover_color
             custom_css_block
+            logo_image_text
+            banner_image_text
+            directory_image_text
+            default_collection_image_text
+            default_work_image_text
           ]
         end
 

--- a/app/helpers/hyrax_helper.rb
+++ b/app/helpers/hyrax_helper.rb
@@ -25,6 +25,12 @@ module HyraxHelper
     Site.instance.logo_image? ? Site.instance.logo_image.url : false
   end
 
+  def block_for(name:)
+    block = ContentBlock.find_by(name: name)
+    has_value = block&.value.present?
+    has_value ? block.value : false
+  end
+
   def directory_image
     Site.instance.directory_image? ? Site.instance.directory_image.url : false
   end

--- a/app/jobs/reindex_admin_sets_job.rb
+++ b/app/jobs/reindex_admin_sets_job.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ReindexAdminSetsJob < ApplicationJob
+  def perform
+    AdminSet.find_each(&:update_index)
+  end
+end

--- a/app/jobs/reindex_collections_job.rb
+++ b/app/jobs/reindex_collections_job.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class ReindexCollectionsJob < ApplicationJob
+  def perform
+    Collection.find_each do |collection|
+      collection.reindex_extent = Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX
+      collection.update_index
+    end
+  end
+end

--- a/app/jobs/reindex_works_job.rb
+++ b/app/jobs/reindex_works_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ReindexWorksJob < ApplicationJob
+  def perform
+    Hyrax.config.registered_curation_concern_types.each do |work_type|
+      work_type.constantize.find_each(&:update_index)
+    end
+  end
+end

--- a/app/views/_logo.html.erb
+++ b/app/views/_logo.html.erb
@@ -1,7 +1,7 @@
   <% if logo_image %>
     <a id="logo" href="<%= hyrax.root_path %>" data-no-turbolink="true">
       <span class="glyphicon glyphicon-globe" role="img" aria-label="<%= application_name %>" aria-hidden="true"></span>
-      <%= image_tag logo_image %>
+      <%= image_tag logo_image, alt_text: block_for(name: 'logo_image_text') %>
     </a>
   <% else %>
     <a id="logo" class="navbar-brand" href="<%= hyrax.root_path %>" data-no-turbolink="true">

--- a/app/views/hyrax/admin/appearances/_banner_image_form.html.erb
+++ b/app/views/hyrax/admin/appearances/_banner_image_form.html.erb
@@ -1,7 +1,9 @@
 <%= simple_form_for @form, url: admin_appearance_path do |f| %>
   <div class="panel-body">
+    <% require_image = @form.banner_image? ? false : true %>
     <%# Upload Banner Image %>
-    <%= f.input :banner_image, as: :file, wrapper: :vertical_file_input, hint: t('hyrax.admin.appearances.show.forms.banner_image.hint') %>
+    <%= f.input :banner_image, as: :file, wrapper: :vertical_file_input, required: require_image, hint: t('hyrax.admin.appearances.show.forms.banner_image.hint') %>
+    <%= f.input :banner_image_text, required: true, as: :text, label: 'Banner image alt text' %>
     <%= image_tag @form.banner_image.url, class: "img-responsive" if @form.banner_image? %>
   </div>
   <div class="panel-footer">

--- a/app/views/hyrax/admin/appearances/_default_images_form.html.erb
+++ b/app/views/hyrax/admin/appearances/_default_images_form.html.erb
@@ -1,9 +1,11 @@
 <%= simple_form_for @form, url: admin_appearance_path do |f| %>
   <div class="panel-body">
     <%= f.input :default_collection_image, as: :file, wrapper: :vertical_file_input, hint: t('hyrax.admin.appearances.show.forms.default_images.hint'), required: false %>
+    <%= f.input :default_collection_image_text, as: :text, label: 'Default collection image alt text', required: false %>
     <%= image_tag @form.default_collection_image.url, class: "img-responsive" if @form.default_collection_image? %>
 
     <%= f.input :default_work_image, as: :file, wrapper: :vertical_file_input, hint: t('hyrax.admin.appearances.show.forms.default_images.hint'), required: false %>
+    <%= f.input :default_work_image_text, as: :text, label: 'Default work image alt text', required: false %>
     <%= image_tag @form.default_work_image.url, class: "img-responsive" if @form.default_work_image? %>
   </div>
   <div class="panel-footer">

--- a/app/views/hyrax/admin/appearances/_directory_image_form.html.erb
+++ b/app/views/hyrax/admin/appearances/_directory_image_form.html.erb
@@ -1,7 +1,9 @@
 <%= simple_form_for @form, url: admin_appearance_path do |f| %>
   <div class="panel-body">
+    <% require_image = @form.directory_image? ? false : true %>
     <%# Upload Directory Image %>
-    <%= f.input :directory_image, as: :file, wrapper: :vertical_file_input, hint: t('hyrax.admin.appearances.show.forms.directory_image.hint') %>
+    <%= f.input :directory_image, as: :file, wrapper: :vertical_file_input, required: require_image, hint: t('hyrax.admin.appearances.show.forms.directory_image.hint') %>
+    <%= f.input :directory_image_text, required: true, as: :text, label: 'Directory image alt text' %>
     <%= image_tag @form.directory_image.url, class: "img-responsive" if @form.directory_image? %>
   </div>
   <div class="panel-footer">

--- a/app/views/hyrax/admin/appearances/_logo_image_form.html.erb
+++ b/app/views/hyrax/admin/appearances/_logo_image_form.html.erb
@@ -1,7 +1,9 @@
 <%= simple_form_for @form, url: admin_appearance_path do |f| %>
   <div class="panel-body">
+    <% require_image = @form.logo_image? ? false : true %>
     <%# Upload Logo Image %>
-    <%= f.input :logo_image, as: :file, wrapper: :vertical_file_input, hint: t('hyrax.admin.appearances.show.forms.logo_image.hint') %>
+    <%= f.input :logo_image, as: :file, wrapper: :vertical_file_input, required: require_image, hint: t('hyrax.admin.appearances.show.forms.logo_image.hint') %>
+    <%= f.input :logo_image_text, required: true, as: :text, label: 'Logo image alt text' %>
     <%= image_tag @form.logo_image.url, class: "img-responsive" if @form.logo_image? %>
   </div>
   <div class="panel-footer">

--- a/app/views/layouts/homepage.html.erb
+++ b/app/views/layouts/homepage.html.erb
@@ -1,0 +1,21 @@
+<% content_for(:navbar) do %>
+  <div class="image-masthead">
+<!-- default repository homepage -->
+    <div class="background-container"  title="<%= block_for(name: 'banner_image_text') %>" style="background-image: url('<%= banner_image %>')"></div>
+    <span class="background-container-gradient"></span>
+
+    <div class="container site-title-container">
+      <div class="site-title h1" style="text-align: center;">
+        <%= render "hyrax/homepage/marketing" if controller_name == 'homepage' %>
+      </div>
+    </div>
+
+    <%= render '/controls' %>
+  </div>
+<% end %>
+
+<% content_for(:precontainer_content) do %>
+  <%= render 'hyrax/homepage/announcement' if controller_name == 'homepage' %>
+<% end %>
+
+<%= render template: 'layouts/hyrax' %>

--- a/app/views/themes/cultural_repository/_logo.html.erb
+++ b/app/views/themes/cultural_repository/_logo.html.erb
@@ -2,7 +2,7 @@
     <a id="logo" href="<%= hyrax.root_path %>" data-no-turbolink="true">
       <span class="glyphicon glyphicon-globe" role="img" aria-label="<%= application_name %>" aria-hidden="true"></span>
       <div class="vertical-center-image">
-      <%= image_tag logo_image %>
+      <%= image_tag logo_image, alt: block_for(name: 'logo_image_text') %>
       </div>
     </a>
   <% else %>

--- a/app/views/themes/cultural_repository/layouts/homepage.html.erb
+++ b/app/views/themes/cultural_repository/layouts/homepage.html.erb
@@ -1,7 +1,8 @@
 <% # OVERRIDE: Hyrax 2.9 template to remove the render of the /controls partial, removed the background gradient span, and added share your work btn %>
 <% content_for(:navbar) do %>
   <div class="image-masthead cultural-homepage">
-    <div class="background-container" style="background-image: url('<%= banner_image %>')"></div>
+    <!-- cultural repository homepage -->
+    <div class="background-container" style="background-image: url('<%= banner_image %>')" title="<%= block_for(name: 'banner_image_text') %>"></div>
 
     <div class="container">
       <% if controller_name == 'homepage' %>

--- a/app/views/themes/institutional_repository/_logo.html.erb
+++ b/app/views/themes/institutional_repository/_logo.html.erb
@@ -2,7 +2,7 @@
   <% if logo_image %>
     <a id="logo" class="col-sm-5" href="<%= hyrax.root_path %>" data-no-turbolink="true">
       <span class="glyphicon glyphicon-globe" role="img" aria-label="<%= application_name %>" aria-hidden="true"></span>
-      <%= image_tag logo_image %>
+      <%= image_tag logo_image, alt: block_for(name: 'logo_image_text') %>
     </a>
   <% else %>
     <a id="logo" class="col-sm-5 navbar-brand" href="<%= hyrax.root_path %>" data-no-turbolink="true">

--- a/app/views/themes/institutional_repository/layouts/homepage.html.erb
+++ b/app/views/themes/institutional_repository/layouts/homepage.html.erb
@@ -1,7 +1,8 @@
 <% # OVERRIDE: Hyrax 2.9 template to remove the gradient overlay span, removed /controls partial, and added the share your work button for themeing %>
 <% content_for(:navbar) do %>
   <div class="image-masthead">
-    <div class="background-container" style="background-image: url('<%= banner_image %>')"></div>
+  <!-- institutional repository homepage -->
+    <div class="background-container" style="background-image: url('<%= banner_image %>')" title="<%= block_for(name: 'banner_image_text') %>"></div>
 
     <div class="container site-title-container">
       <div class="site-title h1" style="text-align: center;">

--- a/app/views/themes/neutral_repository/layouts/homepage.html.erb
+++ b/app/views/themes/neutral_repository/layouts/homepage.html.erb
@@ -1,7 +1,8 @@
 <% # OVERRIDE: Hyrax 2.9 template to remove the render of the removed the background gradient span and add mb-40 class on line 6%>
 <% content_for(:navbar) do %>
   <div class="image-masthead">
-    <div class="background-container" style="background-image: url('<%= banner_image %>')"></div>
+    <!-- neutral repository homepage -->
+    <div class="background-container" title="<%= block_for(name: 'banner_image_text') %>" style="background-image: url('<%= banner_image %>')"></div>
 
     <div class="container site-title-container mb-40">
       <div class="site-title h1" style="text-align: center;">

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -36,7 +36,7 @@ en:
       hyku_group:
         description: A brief summary of the role of the group
       user:
-        email: Enter one email address at a time. You may also resend an invitation via this form. Roles are comma sepearted and only apply to this tenant.
+        email: Enter one email address at a time. You may also resend an invitation via this form. Roles are comma separated and only apply to this tenant.
     labels:
       account:
         admin_emails: Add or invite new administrator (via email)

--- a/spec/controllers/sites_controller_spec.rb
+++ b/spec/controllers/sites_controller_spec.rb
@@ -38,14 +38,17 @@ RSpec.describe SitesController, type: :controller, singletenant: true do
           .at_least(3).times
         f = fixture_file_upload('/images/nypl-hydra-of-lerna.jpg', 'image/jpg')
         Site.instance.update(banner_image: f)
+        ContentBlock.find_or_create_by(name: 'banner_image_text').update!(value: 'Sample text')
       end
 
       it "#update with remove_banner_image deletes a banner image" do
         expect(Site.instance.banner_image?).to be true
+        expect(ContentBlock.find_by(name: 'banner_image_text')).not_to be nil
         post :update, params: { id: Site.instance.id, remove_banner_image: 'Remove banner image' }
         expect(response).to redirect_to('/admin/appearance?locale=en')
         expect(flash[:notice]).to include("The appearance was successfully updated")
         expect(Site.instance.banner_image?).to be false
+        expect(ContentBlock.find_by(name: 'banner_image_text')).to be nil
       end
     end
 
@@ -54,14 +57,17 @@ RSpec.describe SitesController, type: :controller, singletenant: true do
         expect(Hyrax::AvatarUploader).to receive(:storage).and_return(CarrierWave::Storage::File).at_least(3).times
         f = fixture_file_upload('/images/nypl-hydra-of-lerna.jpg', 'image/jpg')
         Site.instance.update(directory_image: f)
+        ContentBlock.find_or_create_by(name: 'directory_image_text').update!(value: 'Sample text')
       end
 
       it "#update with remove_directory_image deletes a directory image" do
         expect(Site.instance.directory_image?).to be true
+        expect(ContentBlock.find_by(name: 'directory_image_text')).not_to be nil
         post :update, params: { id: Site.instance.id, remove_directory_image: 'Remove directory image' }
         expect(response).to redirect_to('/admin/appearance?locale=en')
         expect(flash[:notice]).to include("The appearance was successfully updated")
         expect(Site.instance.directory_image?).to be false
+        expect(ContentBlock.find_by(name: 'directory_image_text')).to be nil
       end
 
       context 'when update fails' do
@@ -74,11 +80,35 @@ RSpec.describe SitesController, type: :controller, singletenant: true do
 
         it "#update with remove_directory_image sets error flash" do
           expect(Site.instance.directory_image?).to be true
+          expect(ContentBlock.find_by(name: 'directory_image_text')).not_to be nil
           post :update, params: { id: Site.instance.id, remove_directory_image: 'Remove directory image' }
           expect(response).to redirect_to('/admin/appearance?locale=en')
           expect(flash[:error]).to include("Updating the appearance was unsuccessful")
           expect(Site.instance.directory_image?).to be true
+          expect(ContentBlock.find_by(name: 'directory_image_text')).not_to be nil
         end
+      end
+    end
+
+    context "site with existing logo image and logo text" do
+      before do
+        expect(Hyrax::AvatarUploader)
+          .to receive(:storage)
+          .and_return(CarrierWave::Storage::File)
+          .at_least(3).times
+        f = fixture_file_upload('/images/nypl-hydra-of-lerna.jpg', 'image/jpg')
+        Site.instance.update(logo_image: f)
+        ContentBlock.find_or_create_by(name: 'logo_image_text').update!(value: 'Sample text')
+      end
+
+      it "#update with remove_logo_image deletes both image and text" do
+        expect(ContentBlock.find_by(name: 'logo_image_text')).not_to be nil
+        expect(Site.instance.logo_image?).to be true
+        post :update, params: { id: Site.instance.id, remove_logo_image: 'Remove logo image' }
+        expect(response).to redirect_to('/admin/appearance?locale=en')
+        expect(flash[:notice]).to include("The appearance was successfully updated")
+        expect(Site.instance.logo_image?).to be false
+        expect(ContentBlock.find_by(name: 'logo_image_text')).to be nil
       end
     end
   end

--- a/spec/helpers/hyrax_helper_spec.rb
+++ b/spec/helpers/hyrax_helper_spec.rb
@@ -38,4 +38,28 @@ RSpec.describe HyraxHelper, type: :helper do
       end
     end
   end
+
+  describe "#block_for" do
+    let(:key_name) { 'some_key' }
+
+    context "when ContentBlock is found" do
+      let(:content_block) { FactoryBot.create(:content_block, name: key_name, value: a_value) }
+      let(:a_value) { 'some returned text' }
+
+      before do
+        content_block
+      end
+      it "returns text" do
+        expect(helper.block_for(name: key_name)).to eq(a_value)
+      end
+    end
+
+    context "when ContentBlock is not found" do
+      let(:a_value) { nil }
+
+      it "returns false" do
+        expect(helper.block_for(name: key_name)).to be false
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #[utk-hyku #54](https://gitlab.com/notch8/utk-hyku/-/issues/54)

Adds:
* ability to add alternate text for images added via Appearance admin menu.
* use of alternate text for main page logo
* use of alternate text via title attribute for main page banner image
* missing reindex jobs (referenced when adding default images)
* default logo view (pulled up from hyrax) to allow use of alt text

@samvera/hyku-code-reviewers
