### PR TITLE
Add alt text for collection banner

### DIFF
--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # OVERRIDE Hyrax v3.4.1: add collection methods to collection presenter and
-#    override to return full banner_file data, rather than only download path to file                   
+#    override to return full banner_file data, rather than only download path to file
 # Terms is the list of fields displayed by app/views/collections/_show_descriptions.html.erb
 # rubocop:disable Metrics/BlockLength
 require_dependency Hyrax::Engine.root.join('app', 'presenters', 'hyrax', 'collection_presenter').to_s

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-# OVERRIDE Hyrax v3.4.0
-# OVERRIDE Hyrax v3.4.0 to add collection methods to collection presenter
+# OVERRIDE Hyrax v3.4.1: add collection methods to collection presenter and
+#    override to return full banner_file data, rather than only download path to file                   
 # Terms is the list of fields displayed by app/views/collections/_show_descriptions.html.erb
 # rubocop:disable Metrics/BlockLength
 require_dependency Hyrax::Engine.root.join('app', 'presenters', 'hyrax', 'collection_presenter').to_s
@@ -26,6 +26,18 @@ Hyrax::CollectionPresenter.class_eval do
       total_items
     else
       solr_document.send key
+    end
+  end
+
+  # override banner_file in hyrax to include all banner information rather than just relative_path
+  def banner_file
+    @banner_file ||= begin
+      # Find Banner filename
+      banner_info = CollectionBrandingInfo.where(collection_id: id, role: "banner")
+      filename = File.split(banner_info.first.local_path).last unless banner_info.empty?
+      alttext = banner_info.first.alt_text unless banner_info.empty?
+      relative_path = "/" + banner_info.first.local_path.split("/")[-4..-1].join("/") unless banner_info.empty?
+      { filename: filename, relative_path: relative_path, alt_text: alttext }
     end
   end
 

--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -4,11 +4,11 @@
 <div class="hyc-container" itemscope itemtype="http://schema.org/CollectionPage">
   <div class="row hyc-header">
     <div class="col-md-12">
-
+    
       <% if @presenter.banner_file.present? %>
-          <div class="hyc-banner" style="background-image:url(<%= @presenter.banner_file %>)">
+        <div class="hyc-banner" style="background-image:url(<%= @presenter.banner_file[:relative_path] %>)" title="<%= @presenter.banner_file[:alt_text] %>">
       <% else %>
-          <div class="hyc-generic">
+        <div class="hyc-generic">
       <% end %>
 
       <div class="hyc-title">

--- a/app/views/hyrax/dashboard/collections/_form_branding.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_branding.html.erb
@@ -1,0 +1,165 @@
+ <!-- OVERRIDE Hyrax v3.4.1 to add text for collection banner image 
+    also added image tags to show logo images... js templates branding to show them seems to be broken
+    uses Hyrax::Forms::CollectionForm -->
+
+<div class="set-access-controls">
+  <h3><%= t('.branding.label') %></h3>
+  <p><%= t('.branding.description') %></p>
+  <label><strong><%= t('.banner.label') %></strong></label>
+  <p><%= t('.banner.description') %>.</p>
+
+  <div id="fileupload">
+    <!-- Redirect browsers with JavaScript disabled to the origin page -->
+    <noscript><input type="hidden" name="redirect" value="<%= main_app.root_path %>" /></noscript>
+    <!-- The table listing the files available for upload/download -->
+
+    <!-- The fileupload-buttonbar contains buttons to add/delete files and start/cancel the upload -->
+    <div class="row fileupload-buttonbar">
+      <div class="col-sm-3">
+        <!-- The fileinput-button span is used to style the file input field as button -->
+        <span class="btn btn-success fileinput-button">
+          <span class="glyphicon glyphicon-plus"></span>
+          <span><%= t('.choose_file') %></span>
+          <input type="file" name="files[]" single />
+        </span>
+      </div> <!-- end col-xs-4 -->
+
+      <!-- The global progress state -->
+      <div class="col-xs-8 fileupload-progress branding-banner-progress fade">
+        <!-- The global progress bar -->
+        <div class="progress progress-striped active" role="progressbar" aria-valuemin="0" aria-valuemax="100">
+          <div class="progress-bar progress-bar-success" style="width:0%;"></div>
+        </div>
+        <!-- The extended global progress state -->
+        <div class="progress-extended">&nbsp;</div>
+      </div> <!-- end col-xs-5 fileupload-progress fade -->
+    </div> <!-- end row fileupload-buttonbar -->
+
+    <div class="row branding-banner-list">
+      <div class="col-xs-12">
+        <div class="container">
+        <% if f.object.banner_info[:file] %>
+          <div id="banner">
+            <div class="row branding-banner-row">
+              <div class="col-sm-3">
+                <span class="name">
+                  <span><%= f.object.banner_info[:file] %></span>
+                  <input type="hidden" name="banner_unchanged" value="true" />
+                </span>
+              </div>
+              <div class="col-sm-4 branding-banner-input">
+                <label for="banner_text"><%= t('.alt_text') %>
+                   <input id="banner_text" class="branding-banner-input" type="text" name="banner_text[]" value="<%= f.object.banner_info[:alttext] %>" />
+                </label>
+              </div>
+
+              <div class="col-sm-2">
+                <button class="btn btn-danger delete branding-banner-remove" data-type="DELETE" data-url="/" onclick=$("#banner").remove();>
+                  <span class="glyphicon glyphicon-remove"></span>
+                  <span class="controls-remove-text"><%= t('.remove') %></span>
+                  <span class="sr-only">
+                    <%= t('.previous') %>
+                    <span class="controls-field-name-text"><%= t('.remove_current_banner') %></span>
+                  </span>
+                </button>
+              </div> <!-- end col-sm-2 -->
+            </div> <!-- row branding-banner-row -->
+
+            <% if f.object.banner_info[:relative_path] %>
+            <div class="banner-image">
+              <i><%= image_tag(f.object.banner_info[:relative_path],
+                               height: "100",
+                               alt: f.object.banner_info[:alttext].presence || f.object.banner_info[:file]) %></i>
+            </div>
+            <% end %>
+          </div> <!-- end banner -->
+          <div role="presentation" class="table table-striped"><span class="files"></span></div>
+        <% else %>
+          <div role="presentation" class="table table-striped"><span class="files"></span></div>
+        <% end %>
+
+          <!-- The global file processing state -->
+          <span class="fileupload-process"></span>
+        </div> <!-- end container -->
+      </div> <!-- end row branding-banner-list -->
+    </div> <!-- end row branding-banner-list -->
+  </div> <!-- fileupload -->
+
+  <%= render 'hyrax/uploads/js_templates_branding' %>
+
+  <label><strong><%= t('.logo.label') %></strong></label>
+  <p><%= t('.logo.description') %></p>
+
+  <div id="fileuploadlogo">
+    <!-- Redirect browsers with JavaScript disabled to the origin page -->
+    <noscript><input type="hidden" name="redirect" value="<%= main_app.root_path %>" /></noscript>
+    <!-- The table listing the files available for upload/download -->
+
+    <!-- The fileupload-buttonbar contains buttons to add/delete files and start/cancel the upload -->
+    <div class="row fileupload-buttonbar">
+      <div class="col-xs-4">
+        <!-- The fileinput-button span is used to style the file input field as button -->
+        <span class="btn btn-success fileinput-button">
+          <span class="glyphicon glyphicon-plus"></span>
+          <span><%= t('.choose_file') %></span>
+          <input type="file" name="files[]" single />
+        </span>
+      </div> <!-- end col-xs-4 -->
+
+      <!-- The global progress state -->
+      <div class="col-xs-8 fileupload-progress branding-logo-progress fade">
+        <!-- The global progress bar -->
+        <div class="progress progress-striped active" role="progressbar" aria-valuemin="0" aria-valuemax="100">
+          <div class="progress-bar progress-bar-success" style="width:0%;"></div>
+        </div>
+        <!-- The extended global progress state -->
+        <div class="progress-extended">&nbsp;</div>
+      </div> <!-- end col-xs-8 fileupload-progress branding-logo-progress fade -->
+    </div> <!-- end row fileupload-buttonbar -->
+
+    <div class="row branding-logo-list">
+      <div class="col-xs-12">
+        <div class="container">
+          <% i = 0 %>
+          <% f.object.logo_info.each_with_index do |linfo, i| %>
+            <div class="row branding-logo-row" id="logorow_<%= i %>">
+              <div class="col-sm-3">
+                <span class="name">
+                  <i><%= image_tag(linfo[:relative_path],
+                       height: "36",
+                       alt: linfo[:alttext].presence || linfo[:file]) %></i>
+                  <span><%= linfo[:file] %></span>
+                <input type="hidden" name="logo_files[]" value="<%= linfo[:full_path] %>" />
+                </span>
+              </div>
+
+              <div class="col-sm-4 branding-logo-input">
+                <label for="linkurl_<%= i %>"><%= t('.link_url') %>
+                  <input id="linkurl_<%= i %>" class="branding-logo-input" type="text" name="linkurl[]" value="<%= linfo[:linkurl] %>" />
+                </label>
+                <label for="alttext_<%= i %>"><%= t('.alt_text') %>
+                  <input id="alttext_<%= i %>" class="branding-logo-input" type="text" name="alttext[]" value="<%= linfo[:alttext] %>" />
+                </label>
+              </div>
+
+              <div class="col-sm-2">
+                <button class="btn btn-danger delete branding-logo-remove" data-type="DELETE" data-url="/" onclick=$("#logorow_<%= i %>").remove();>
+                  <span class="glyphicon glyphicon-remove"></span>
+                  <span class="controls-remove-text"><%= t('.remove') %></span>
+                   <span class="sr-only">
+                    <%= t('.previous') %>
+                    <span class="controls-field-name-text"><%= t('.remove_logo') %> <%= i + 1 %></span>
+                  </span>
+                </button>
+              </div> <!-- end col-sm-2 -->
+            </div> <!-- row logorow -->
+          <% end %>
+          <span class="files"></span>
+        </div> <!-- end container -->
+
+        <!-- The global file processing state -->
+        <span class="fileupload-process"></span>
+      </div> <!-- end col-xs-12 -->
+    </div> <!-- end row branding-logo-list -->
+  </div> <!-- end fileuploadlogo -->
+</div> <!-- end set-access-controls -->

--- a/app/views/hyrax/uploads/_js_templates_branding.html.erb
+++ b/app/views/hyrax/uploads/_js_templates_branding.html.erb
@@ -1,0 +1,128 @@
+ <!-- OVERRIDE Hyrax v3.4.0 to add text for collection banner image -->
+<!-- The template to display files available for upload -->
+<script id="template-upload" type="text/x-tmpl">
+{% for (var i=0, file; file=o.files[i]; i++) { %}
+    <tr class="template-upload fade">
+      <td>
+        <span class="preview"></span>
+      </td>
+      <td>
+        <p class="name">{%=file.name%}</p>
+        <strong class="error text-danger"></strong>
+      </td>
+    </tr>
+{% } %}
+</script>
+
+<!-- function used by the following template -->
+<script type="text/javascript">
+  function setAllResourceTypes(resourceTypeId) {
+    var firstResourceType = $("#resource_type_" + resourceTypeId.toString())[0];
+    var selected_options = [];
+    for (var i = 0; i < firstResourceType.length; i++) {
+      if (firstResourceType.options[i].selected) {
+        selected_options.push(firstResourceType.options[i].value);
+      }
+    }
+    $(".resource_type_dropdown").each(function(index, element) {
+      for(var i=0; i< this.length; i++) {
+        this.options[i].selected =
+            $.inArray(this.options[i].value, selected_options) > -1 ? true : false;
+      }
+    });
+  }
+</script>
+
+<!-- Simpler display of files available for download. Originally from hyrax/base/_form_files -->
+<!-- TODO: further consolidate with template-download above -->
+<!-- The template to display the banner once upload is complete -->
+<script id="template-download" type="text/x-tmpl">
+{% for (var i=0, file; file=o.files[i]; i++) { %}
+        <span class="template-download fade">
+          <div id="banner">
+            <div class="row branding-banner-row">
+              <div class="col-sm-3">
+                <span class="name">
+                  <span>{%=file.name%}</span>
+                  <input type="hidden" name="banner_files[]" value="{%=file.id%}">
+                </span>
+                {% if (file.error) { %}
+                  <span><span class="label label-danger"><%= t('.error') %></span> {%=file.error%}</span>
+                {% } %}
+              </div>
+
+
+              <div class="col-sm-4 branding-banner-input">
+                <label for="banner_text"><%= t('.alt_text') %>
+                  <input id="banner_text" type="text" name="banner_text[]" class="branding-banner-input" single>
+                </label>
+              </div>
+
+              <div class="col-sm-2">
+                <button class="btn btn-link remove branding-banner-remove" data-type="{%=file.deleteType%}" data-url="{%=file.deleteUrl%}" onclick=$("#banner").remove(); {% if (file.deleteWithCredentials) { %} data-xhr-fields='{"withCredentials":true}'{% } %}>
+                  <span class="glyphicon glyphicon-remove"></span>
+                  <span class="controls-remove-text"><%= t('.remove') %></span>
+                  <span class="sr-only">
+                    <%= t('.previous') %>
+                    <span class="controls-field-name-text"><%= t('.remove_new_banner') %></span>
+                  </span>
+                </button>
+              </div> <!-- end col-sm-2 -->
+            </div> <!-- row branding-banner-row -->
+          </div> <!-- end container banner -->
+        </span>
+{% }  $("div#banner").remove(); %}
+</script>
+
+<!-- The template to display logo in the table once upload is complete -->
+<script id="logo-template-download" type="text/x-tmpl">
+{% for (var i=0, file; file=o.files[i]; i++) { %}
+            <span class="template-download fade">
+            <div class="row branding-logo-row">
+              <div class="col-sm-3">
+                <span class="preview">
+                    {% if (file.thumbnailUrl) { %}
+                        <a href="{%=file.url%}" title="{%=file.name%}" download="{%=file.name%}" data-gallery><img src="{%=file.thumbnailUrl%}"></a>
+                    {% } %}
+                </span>
+
+                <span class="name">
+                    {% if (file.url) { %}
+                        <a href="{%=file.url%}" title="{%=file.name%}" download="{%=file.name%}" {%=file.thumbnailUrl?'data-gallery':''%}>{%=file.name%}</a>
+                    {% } else { %}
+                        <span>{%=file.name%}</span>
+                    {% } %}
+                    <input type="hidden" name="logo_files[]" value="{%=file.id%}">
+                </span>
+
+                {% if (file.error) { %}
+                    <span><span class="label label-danger">Error</span> {%=file.error%}</span>
+                {% } %}
+              </div>
+
+              <div class="col-sm-4 branding-logo-input">
+                <label for="linkurl"><%= t('.link_url') %>
+                  <input id="linkurl" class="branding-logo-input" type="text" name="linkurl[]"></input>
+                </label>
+                <label for="alttext"><%= t('.alt_text') %>
+                  <input id="alttext" class="branding-logo-input" type="text" name="alttext[]"></input>
+                </label>
+              </div>
+
+              <div class="col-sm-2 text-right">
+                <span class="input-group-btn field-controls">
+            <button class="btn btn-sm btn-danger delete branding-logo-remove" data-type="{%=file.deleteType%}" data-url="{%=file.deleteUrl%}"{% if (file.deleteWithCredentials) { %} data-xhr-fields='{"withCredentials":true}'{% } %}>
+                    <span class="glyphicon glyphicon-remove"></span>
+                    <span class="controls-remove-text">Remove</span>
+                    <span class="sr-only">
+                      <%= t('.previous') %>
+                      <span class="controls-field-name-text"><%= t('.remove_new_logo') %></span>
+                    </span>
+                  </button>
+                </span>
+              </div>
+
+            </div>
+            </span>
+{% } %}
+</script>


### PR DESCRIPTION
The collection branding table includes a fields for alternative text, but banner doesn't allow entry of the text. The branding tab for the collection should allow entry of custom descriptive text, similarly to the way the logo does. Additionally, background images do not support alt text, so banner image should use this alt text as title rather than alt.

Fixes ticket https://gitlab.com/notch8/utk-hyku/-/issues/60

Changes proposed in this pull request:
* collection banner text can be entered and edited
* collection banner text is used as title text on collection's public view if it has been entered
* modifications to branding view to correct images not appearing

@samvera/hyku-code-reviewers
