### PR TITLE
Able to remove Current Account Administrators

### DIFF
--- a/app/views/proprietor/accounts/show.html.erb
+++ b/app/views/proprietor/accounts/show.html.erb
@@ -71,13 +71,13 @@
                     <td></td>
                   </tr>
                 <% else %>
-                  <% @current_superusers.each do |email| %>
+                  <% @current_superusers.each do |current_superuser| %>
                     <tr>
-                      <td><%= email %></td>
+                      <td><%= current_superuser %></td>
                       <td>
                         <%# For the remove button form, add all admin emails *except this one* as hidden inputs %>
-                        <%= simple_form_for @account, url: [:proprietor, @account], namespace: "remove_#{email}_form", html: { class: 'form' } do |f| %>
-                          <% keep_emails = @account.admin_emails - [ email ] %>
+                        <%= simple_form_for @account, url: [:proprietor, @account], namespace: "remove_#{current_superuser}_form", html: { class: 'form' } do |f| %>
+                          <% keep_emails = @account.admin_emails - [current_superuser.email] %>
                           <% if keep_emails.empty? %>
                             <%= f.input_field :admin_emails, multiple: true, hidden: true, value: '' %>
                           <% else %>


### PR DESCRIPTION
Fixes [UTK-77](https://gitlab.com/notch8/utk-hyku/-/issues/75)

Able to remove Current Account Administrators from Manage Account show page

- rename variable for clarity
- fix array logic

![utk-75-loop](https://user-images.githubusercontent.com/19597776/177573346-b34f72de-ab63-4d62-bc5a-f1b4c0ac2c59.gif)
