### PR TITLE
global user new form 500 error

### DIFF
--- a/app/views/proprietor/users/_form.html.erb
+++ b/app/views/proprietor/users/_form.html.erb
@@ -1,8 +1,8 @@
 <div class="form-inputs">
   <%= f.input :display_name, label: 'Display Name' %>
-  <%= f.input :email, hint: '' %>
+  <%= f.input :email, required: true, hint: '' %>
   <%= f.input :is_superadmin, as: :boolean %>
-  <%= f.input :password, hint: 'Only if creating or changing' %>
+  <%= f.input :password, required: f.object.new_record? ? true : false %>
   <%= f.input :facebook_handle %>
   <%= f.input :twitter_handle %>
   <%= f.input :googleplus_handle %>

--- a/app/views/proprietor/users/new.html.erb
+++ b/app/views/proprietor/users/new.html.erb
@@ -12,7 +12,9 @@
                 <%= pluralize(@user.errors.count, "error") %> prohibited this repository from being saved:
                 <ul>
                   <% @user.errors.messages.each do |key, messages| %>
+                  <% if @user.errors.details[key].present? %>
                     <li><%= key %> &quot;<%= @user.errors.details[key].first[:value] %>&quot; <%= messages.join(' and ') %></li>
+                  <% end %>
                   <% end %>
                 </ul>
               </div>

--- a/spec/features/proprietor_spec.rb
+++ b/spec/features/proprietor_spec.rb
@@ -25,16 +25,5 @@ RSpec.describe 'Proprietor administration', multitenant: true do
       visit '/'
       expect(page).to have_link 'Logout'
     end
-
-    it "has validation for password" do
-      visit '/proprietor/users/new'
-      fill_in "user_email", with: user.email
-      fill_in "user_password", with: ""
-      click_on "Save"
-      byebug
-      message = page.find("#user_password").native.attribute("validationMessage")
-      expect(message).to eq "Please fill out this field."
-    end
-
   end
 end

--- a/spec/features/proprietor_spec.rb
+++ b/spec/features/proprietor_spec.rb
@@ -25,5 +25,16 @@ RSpec.describe 'Proprietor administration', multitenant: true do
       visit '/'
       expect(page).to have_link 'Logout'
     end
+
+    it "has validation for password" do
+      visit '/proprietor/users/new'
+      fill_in "user_email", with: user.email
+      fill_in "user_password", with: ""
+      click_on "Save"
+      byebug
+      message = page.find("#user_password").native.attribute("validationMessage")
+      expect(message).to eq "Please fill out this field."
+    end
+
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.describe User, type: :model do
+  it 'validates email and password' do
+    should validate_presence_of(:email)
+    should validate_presence_of(:password)
+  end
+
   context 'the first created user in global tenant' do
     subject { FactoryBot.create(:base_user) }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,8 +2,8 @@
 
 RSpec.describe User, type: :model do
   it 'validates email and password' do
-    should validate_presence_of(:email)
-    should validate_presence_of(:password)
+    is_expected.to validate_presence_of(:email)
+    is_expected.to validate_presence_of(:password)
   end
 
   context 'the first created user in global tenant' do


### PR DESCRIPTION
Fix issue 74 in UTK https://gitlab.com/notch8/utk-hyku/-/issues/74

**Summary** 
Global User form to create new users triggers a 500 error response when the email and password fields are not populated. The form did not make it clear what fields were required. 

**Changes proposed in this pull request:**
* Add required fields to email and password for `app/views/proprietor/users/_form.html.erb`

@samvera/hyku-code-reviewers
