### PR TITLE
Fix modal functionality for collection public show

### DIFF
--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -33,9 +33,7 @@
       <% unless @presenter.total_viewable_items.blank? %>
           <div class="hyc-bugs">
             <div class="hyc-item-count">
-              <b><%= @presenter.total_viewable_items %></b>
               <%= pluralize(@presenter.total_viewable_items, t('.item_count')) %></div>
-
             <% unless @presenter.creator.blank? %>
                 <div class="hyc-created-by">Created by: <%= @presenter.creator.first %></div>
             <% end %>
@@ -51,7 +49,17 @@
   </div>
   <%# OVERRIDE here to add admin actions buttons to show page %>
   <div class='show-actions-container'>
-    <%= render "hyrax/dashboard/collections/show_actions", presenter: @presenter %>
+    <% id = @presenter.id %>
+    <section class="collection-title-row-wrapper"
+      data-source="show"
+      data-id="<%= id %>"
+      data-colls-hash="<%= available_parent_collections_data(collection: @presenter) %>"
+      data-post-url="<%= hyrax.dashboard_create_nest_collection_within_path(id) %>"
+      data-post-delete-url="<%= hyrax.dashboard_collection_path(id) %>">
+      <div class="collection-title-row-content">
+        <%= render 'hyrax/dashboard/collections/show_actions', presenter: @presenter %>
+      </div>
+    </section>
   </div>
   <%# end OVERRIDE %>
   <div class="row hyc-body">

--- a/app/views/hyrax/dashboard/collections/_show_actions.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_actions.html.erb
@@ -8,6 +8,7 @@
                 class: 'btn btn-primary' %>
 <% end %>
 <% if presenter.collection_type_is_nestable? && presenter.user_can_nest_collection? %>
+    <%= render 'hyrax/my/collections/modal_add_to_collection', source: 'show' %>
 <!-- The user should have deposit access to the parent and read access to the child (the collection we are already showing, so no test is necessary). -->
     <%= button_tag '',
                   class: 'btn btn-primary add-to-collection',


### PR DESCRIPTION
Fixes [UTK #78: Hyku upgrade - collection's public show page's "Add to collection" button does nothing](https://gitlab.com/notch8/utk-hyku/-/issues/78)

- Corrects javascript functionality of `Add to Collection` button on the public show page. 
- Also removes duplicated count of items under title.
- Completion of function routes to the collection's show page on the dashboard. 

**Screen Shots:**

![Screen Shot 2022-07-06 at 3 05 39 PM](https://user-images.githubusercontent.com/17851674/177628590-4c286619-d78e-4a27-bcd0-1392645a0ccd.png)
![Screen Shot 2022-07-06 at 3 24 10 PM](https://user-images.githubusercontent.com/17851674/177628659-26b18ef0-b1b5-452a-842c-a53e85b8df91.png)

@samvera/hyku-code-reviewers
