### PR TITLE
an update to fix the way #fetch evaluates env variables

### DIFF
--- a/.env
+++ b/.env
@@ -37,3 +37,6 @@ HYKU_MULTITENANT=true
 # Comment out these 2 for multi tenancy / Uncomment for single
 # HYKU_ROOT_HOST=hyku.test
 # HYKU_MULTITENANT=false
+
+# Uncomment this line to disable Bulkrax
+# HYKU_BULKRAX_ENABLED=false

--- a/app/views/hyrax/dashboard/sidebar/_repository_content.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_repository_content.html.erb
@@ -13,7 +13,7 @@
   <span class="fa fa-file" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.works') %></span>
 <% end %>
 
-<% if ENV.fetch('HYKU_BULKRAX_ENABLED', true) %>
+<% if ENV.fetch('HYKU_BULKRAX_ENABLED', 'true') == 'true' %>
   <%= menu.nav_link(bulkrax.importers_path) do %>
     <span class="fa fa-cloud-upload" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('bulkrax.admin.sidebar.importers') %></span>
   <% end %>

--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-if ENV.fetch('HYKU_BULKRAX_ENABLED', true)
+if ENV.fetch('HYKU_BULKRAX_ENABLED', 'true') == 'true'
 
   Bulkrax.setup do |config|
     # Add local parsers

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -187,7 +187,7 @@ Qa::Authorities::Local.register_subauthority('languages', 'Qa::Authorities::Loca
 Qa::Authorities::Local.register_subauthority('genres', 'Qa::Authorities::Local::TableBasedAuthority')
 
 # set bulkrax default work type to first curation_concern if it isn't already set
-if ENV.fetch('HYKU_BULKRAX_ENABLED', true) && Bulkrax.default_work_type.blank?
+if ENV.fetch('HYKU_BULKRAX_ENABLED', 'true') == 'true' && Bulkrax.default_work_type.blank?
   Bulkrax.default_work_type = Hyrax.config.curation_concerns.first.to_s
 end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,7 +42,7 @@ Rails.application.routes.draw do
 
   mount Blacklight::Engine => '/'
   mount Hyrax::Engine, at: '/'
-  if ENV.fetch('HYKU_BULKRAX_ENABLED', true)
+  if ENV.fetch('HYKU_BULKRAX_ENABLED', 'true') == 'true'
     mount Bulkrax::Engine, at: '/'
   end
 


### PR DESCRIPTION
Fixes https://gitlab.com/notch8/utk-hyku/-/issues/76

Environment variables are strings so the conditional was not working.

Changes proposed in this pull request:
* Include a commented out line for ease of use in `.env`
* rework `ENV.fetch` conditional