### PR TITLE
Resolved mixed content error due to insecure XMLHttpRequest endpoint …

### DIFF
--- a/app/presenters/hyrax/iiif_manifest_presenter_decorator.rb
+++ b/app/presenters/hyrax/iiif_manifest_presenter_decorator.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# OVERRIDE Hyrax 3.4.0 to use site in the search_service method
+module Hyrax
+  module IiifManifestPresenterDecorator
+    def search_service
+      url = Rails.application.routes.url_helpers.solr_document_url(id, host: hostname)
+      Site.account.ssl_configured ? url.sub(/\Ahttp:/, 'https:') : url
+    end
+  end
+end
+
+Hyrax::IiifManifestPresenter.prepend(Hyrax::IiifManifestPresenterDecorator)

--- a/app/presenters/hyrax/iiif_manifest_presenter_decorator.rb
+++ b/app/presenters/hyrax/iiif_manifest_presenter_decorator.rb
@@ -7,6 +7,16 @@ module Hyrax
       url = Rails.application.routes.url_helpers.solr_document_url(id, host: hostname)
       Site.account.ssl_configured ? url.sub(/\Ahttp:/, 'https:') : url
     end
+    
+    ##
+    # @return [String] the URL where the manifest can be found
+    def manifest_url
+      return '' if id.blank?
+
+      protocol = Site.account.ssl_configured ? 'https' : 'http'
+      Rails.application.routes.url_helpers.polymorphic_url([:manifest, model], host: hostname, protocol: protocol)
+    end
+
   end
 end
 

--- a/app/presenters/hyrax/iiif_manifest_presenter_decorator.rb
+++ b/app/presenters/hyrax/iiif_manifest_presenter_decorator.rb
@@ -7,7 +7,7 @@ module Hyrax
       url = Rails.application.routes.url_helpers.solr_document_url(id, host: hostname)
       Site.account.ssl_configured ? url.sub(/\Ahttp:/, 'https:') : url
     end
-    
+
     ##
     # @return [String] the URL where the manifest can be found
     def manifest_url
@@ -16,7 +16,6 @@ module Hyrax
       protocol = Site.account.ssl_configured ? 'https' : 'http'
       Rails.application.routes.url_helpers.polymorphic_url([:manifest, model], host: hostname, protocol: protocol)
     end
-
   end
 end
 

--- a/app/presenters/hyrax/iiif_manifest_presenter_decorator.rb
+++ b/app/presenters/hyrax/iiif_manifest_presenter_decorator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# OVERRIDE Hyrax 3.4.0 to use site in the search_service method
+# OVERRIDE Hyrax 3.4.0 to check the site's ssl_configured when setting protocols
 module Hyrax
   module IiifManifestPresenterDecorator
     def search_service

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,7 +31,12 @@ module Hyku
         config.active_elastic_job.secret_key_base = Rails.application.secrets[:secret_key_base]
       end
     end
-
+    config.to_prepare do
+      # Allows us to use decorator files in the app directory
+      Dir.glob(File.join(File.dirname(__FILE__), "../app/**/*_decorator*.rb")).sort.each do |c|
+        Rails.configuration.cache_classes ? require(c) : load(c)
+      end
+    end
     # resolve reloading issue in dev mode
     config.paths.add 'app/helpers', eager_load: true
 

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -169,15 +169,22 @@ Hyrax.config do |config|
 
   config.iiif_image_server = true
 
-  config.iiif_image_url_builder = lambda do |file_id, base_url, size, format|
+  config.iiif_image_url_builder = lambda do |file_id, base_url, size, _format|
+    # Comment this next line to allow universal viewer to work in development
+    # Issue with Hyrax v 2.9.0 where IIIF has mixed content error when running with SSL enabled
+    # See Samvera Slack thread https://samvera.slack.com/archives/C0F9JQJDQ/p1596718417351200?thread_ts=1596717896.350700&cid=C0F9JQJDQ
+    base_url = base_url.sub(/\Ahttp:/, 'https:')
     Riiif::Engine.routes.url_helpers.image_url(file_id, host: base_url, size: size)
   end
 
   config.iiif_info_url_builder = lambda do |file_id, base_url|
     uri = Riiif::Engine.routes.url_helpers.info_url(file_id, host: base_url)
-    uri.sub(%r{/info\.json\Z}, '')
+    uri = uri.sub(%r{/info\.json\Z}, '')
+    # Comment this next line to allow universal viewer to work in development
+    # Issue with Hyrax v 2.9.0 where IIIF has mixed content error when running with SSL enabled
+    # See Samvera Slack thread https://samvera.slack.com/archives/C0F9JQJDQ/p1596718417351200?thread_ts=1596717896.350700&cid=C0F9JQJDQ
+    uri.sub(/\Ahttp:/, 'https:')
   end
-
 end
 
 Date::DATE_FORMATS[:standard] = "%m/%d/%Y"


### PR DESCRIPTION


Fix issue 77 in UTK https://gitlab.com/notch8/utk-hyku/-/issues/77
**Summary**
- Issue observed: The IIIF viewer in the work's show page keeps spinning and never loads its work.
- Error: Mixed Content: The page at 'https://diem-test.hyku-demo.notch8.cloud/concern/generic_works/e9012684-3f8a-4a7f-ab2f-498c69010066?locale=en' was loaded over HTTPS, but requested an insecure XMLHttpRequest endpoint 'http://diem-test.hyku-demo.notch8.cloud/images/3548763f-6131-412c-b873-666bc9100a95%2Ffiles%2F6b7ab744-e000-4103-9f37-99e238d62965%2Ffcr:versions%2Fversion1/info.json'. This request has been blocked; the content must be served over HTTPS.

**Changes proposed in this pull request:**
- **Hyrax.rb** Add base_url correction in hyrax configuration
- **application.rb** Enable decorations in application configuration
- **iiif_manifest_presenter_decorator.rb** Add override file to implement search_service method

