### PR TITLE
Fix shared search links

### DIFF
--- a/app/helpers/blacklight/catalog_helper_behavior_decorator.rb
+++ b/app/helpers/blacklight/catalog_helper_behavior_decorator.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# OVERRIDE blacklight 6 to allow full url for show links for shared search thumbnail
+Blacklight::CatalogHelperBehavior.module_eval do
+  def render_thumbnail_tag(document, image_options = {}, url_options = {})
+    value = if blacklight_config.view_config(document_index_view_type).thumbnail_method
+              send(blacklight_config.view_config(document_index_view_type).thumbnail_method, document, image_options)
+            elsif blacklight_config.view_config(document_index_view_type).thumbnail_field
+              url = thumbnail_url(document)
+              image_tag url, image_options if url.present?
+            end
+
+    # rubocop:disable Style/GuardClause
+    if value
+      if url_options == false
+        # rubocop:disable Metrics/LineLength
+        Deprecation.warn(self, "passing false as the second argument to render_thumbnail_tag is deprecated. Use suppress_link: true instead. This behavior will be removed in Blacklight 7")
+        # rubocop:enable Metrics/LineLength
+        url_options = { suppress_link: true }
+      end
+      if url_options[:suppress_link]
+        value
+      elsif url_options[:full_url]
+        link_to generate_work_url(document, request) do
+          value
+        end
+      else
+        link_to_document document, value, url_options
+      end
+    end
+    # rubocop:enable Style/GuardClause
+  end
+end

--- a/app/indexers/collection_indexer.rb
+++ b/app/indexers/collection_indexer.rb
@@ -6,9 +6,9 @@ class CollectionIndexer < Hyrax::CollectionIndexer
   include Hyrax::IndexesBasicMetadata
 
   # Uncomment this block if you want to add custom indexing behavior:
-  # def generate_solr_document
-  #  super.tap do |solr_doc|
-  #    solr_doc['my_custom_field_ssim'] = object.my_custom_property
-  #  end
-  # end
+  def generate_solr_document
+    super.tap do |solr_doc|
+      solr_doc["account_cname_tesim"] = Site.instance&.account&.cname
+    end
+  end
 end

--- a/app/views/catalog/_index_header_list_collection.html.erb
+++ b/app/views/catalog/_index_header_list_collection.html.erb
@@ -1,0 +1,4 @@
+<div class="search-results-title-row">
+  <h4 class="search-result-title"><%= link_to document.title_or_label, generate_work_url(document.to_h, request) %></h4>
+  <%= Hyrax::CollectionPresenter.new(document, current_ability).collection_type_badge %>
+</div>

--- a/app/views/catalog/_thumbnail_list_collection.html.erb
+++ b/app/views/catalog/_thumbnail_list_collection.html.erb
@@ -1,0 +1,3 @@
+<div class="col-md-2">
+  <%= render_thumbnail_tag document, {}, { full_url: true } %>
+</div>

--- a/app/views/catalog/_thumbnail_list_default.html.erb
+++ b/app/views/catalog/_thumbnail_list_default.html.erb
@@ -1,0 +1,5 @@
+<div class="col-md-2">
+  <div class="list-thumbnail">
+    <%= render_thumbnail_tag document, {}, {full_url: true} %>
+  </div>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,6 +32,12 @@ module Hyku
       end
     end
 
+    config.to_prepare do
+      Dir.glob(File.join(File.dirname(__FILE__), "../app/**/*_decorator*.rb")).sort.each do |c|
+        Rails.configuration.cache_classes ? require(c) : load(c)
+      end
+    end
+
     # resolve reloading issue in dev mode
     config.paths.add 'app/helpers', eager_load: true
 


### PR DESCRIPTION
Closes utk issue 63 - homepage no longer has collection list
Fixes utk issue 69 - Find all collections button works correctly

## Changes:
Fixes:
- homepage `View All Collections` button
- catalog Collection title links
- catalog Work thumbnail links
Activates:
- catalog Collection thumbnail links

## To test: 
- [ ] "View all collections" button from homepage opens list of only collections
- [ ] Titles and thumbnails of both works and collections on the catalog list link to the work or collection in the appropriate tenant

Related tickets - these are known bugs to be fixed separately:
- utk issue 80 will fix the links from other themes
- utk issue 85 will fix the featured collection list on the shared search tenant's home page.

@samvera/hyku-code-reviewers
