### PR TITLE
83 datacite endpoint credentials save error

### DIFF
--- a/app/controllers/proprietor/accounts_controller.rb
+++ b/app/controllers/proprietor/accounts_controller.rb
@@ -58,6 +58,7 @@ module Proprietor
     # PATCH/PUT /accounts/1
     # PATCH/PUT /accounts/1.json
     def update
+      @account.data_cite_endpoint = DataCiteEndpoint.new unless @account.data_cite_endpoint.persisted?
       respond_to do |format|
         if @account.update(edit_account_params)
           f = edit_account_params['full_account_cross_searches_attributes'].to_h
@@ -104,7 +105,7 @@ module Proprietor
                                                                                  full_account_attributes: [:id]],
                                         solr_endpoint_attributes: %i[id url],
                                         fcrepo_endpoint_attributes: %i[id url base_path],
-                                        datacite_endpoint_attributes: %i[mode prefix username password])
+                                        data_cite_endpoint_attributes: %i[mode prefix username password])
       end
 
       def account_params

--- a/app/views/proprietor/accounts/edit.html.erb
+++ b/app/views/proprietor/accounts/edit.html.erb
@@ -52,8 +52,8 @@
 
           <% unless @account.search_only? %>
             <h3><%= t(".datacite_endpoint") %></h3>
-					  <%= f.fields_for :datacite_endpoint do |s| %>
-						  <%= s.input :mode, required: false  %>
+					  <%= f.simple_fields_for :data_cite_endpoint do |s| %>
+						  <%= s.input :mode, collection: ['test', 'production'], required: false  %>
 						  <%= s.input :prefix, required: false  %>
 						  <%= s.input :username, required: false  %>
 						  <%= s.input :password, input_html: { value: @account.data_cite_endpoint.password }, required: false  %>


### PR DESCRIPTION
Fix issue 83 in UTK https://gitlab.com/notch8/utk-hyku/-/issues/83
**Summary**

Issue observed: DataCite Endpoint credentials do not save on the global /proprietor/accounts/#/edit form (AKA superadmin tenant account edit form). This blocks testing for DOIs.

Changes proposed in this pull request:

- app/views/proprietor/accounts/**edit.html.erb** -- Corrected `data_cite_endpoint` and added a select input for testing/production. Undecided about select input.
- app/controllers/proprietor/**accounts_controller.rb** -- Current blocker with updating edit_account_params due to "unpermitted parameters".
