### PR TITLE
rename fedora_url to fcrepo_url for consistency

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,7 +58,7 @@ test:
     DB_PORT: 5432
     FCREPO_HOST: fcrepo
     FCREPO_PORT: 8081
-    FEDORA_URL: http://fcrepo:8081/rest
+    FCREPO_URL: http://fcrepo:8081/rest
     FF_NETWORK_PER_BUILD: 1
     GIT_STRATEGY: none
     JAVA_OPTIONS: -Djetty.port=8081

--- a/app/models/endpoint.rb
+++ b/app/models/endpoint.rb
@@ -4,7 +4,7 @@ class Endpoint < ApplicationRecord
   has_one :account
 
   # if an option is blank on an endpoint, the whole app process will crash
-  # when going to that tenant as fedora_url becomes blank. This code
+  # when going to that tenant as fcrepo_url becomes blank. This code
   # prevents that and other nastiness in the event of added or removed
   # options or when data gets converted from one format to another between
   # JSON and a Ruby hash


### PR DESCRIPTION
FEDORA_URL has been renamed to FCREPO_URL, however we missed a few. This MR updates all instances for consistency.