### PR TITLE
revert renaming of env vars for .gitlab-ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,7 +54,6 @@ test:
     DATABASE_NAME: hyku
     DATABASE_URL: postgres://postgres:postgres@db/hyku
     DATABASE_USER: postgres
-    DATABASE_HOST: DATABASE
     DATABASE_PORT: 5432
     FCREPO_HOST: fcrepo
     FCREPO_PORT: 8081

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -50,7 +50,7 @@ test:
     CHROME_HOSTNAME: chrome
     DATABASE_ADAPTER: postgresql
     DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
-    DATABASE_HOST: DATABASE
+    DATABASE_HOST: db
     DATABASE_NAME: hyku
     DATABASE_URL: postgres://postgres:postgres@db/hyku
     DATABASE_USER: postgres

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -52,7 +52,7 @@ test:
     DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
     DATABASE_HOST: DATABASE
     DATABASE_NAME: hyku
-    DATABASE_URL: postgres://postgres:postgres@DATABASE/hyku
+    DATABASE_URL: postgres://postgres:postgres@db/hyku
     DATABASE_USER: postgres
     DATABASE_HOST: DATABASE
     DATABASE_PORT: 5432

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,14 +48,14 @@ test:
     ALLOW_ANONYMOUS_LOGIN: "yes"
     CONFDIR: "/app/samvera/hyrax-webapp/solr/conf"
     CHROME_HOSTNAME: chrome
-    DB_ADAPTER: postgresql
-    DB_CLEANER_ALLOW_REMOTE_DB_URL: "true"
-    DB_HOST: db
-    DB_NAME: hyku
-    DB_URL: postgres://postgres:postgres@db/hyku
-    DB_USER: postgres
-    DB_HOST: db
-    DB_PORT: 5432
+    DATABASE_ADAPTER: postgresql
+    DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
+    DATABASE_HOST: DATABASE
+    DATABASE_NAME: hyku
+    DATABASE_URL: postgres://postgres:postgres@DATABASE/hyku
+    DATABASE_USER: postgres
+    DATABASE_HOST: DATABASE
+    DATABASE_PORT: 5432
     FCREPO_HOST: fcrepo
     FCREPO_PORT: 8081
     FCREPO_URL: http://fcrepo:8081/rest


### PR DESCRIPTION
this file causes merge conflicts when pulling it back into our gitlab projects. This file isn't actually used in github, so let's make it match the env variables that most if not all of our gitlab projects use and reduce the amount of conflicts to resolve.