### PR TITLE
add checked option to radio button

### DIFF
--- a/app/views/hyrax/dashboard/collections/_form_discovery.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_discovery.html.erb
@@ -6,19 +6,19 @@
   <div class="form-group">
     <label class="radio">
       <%# OVERRIDE BEGIN: added check if true %>
-      <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, checked: @collection.open_access? %>
+      <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, checked: @collection&.open_access? %>
       <%# OVERRIDE END %>
       <strong><%= t('hyrax.visibility.open.text') %></strong> - <%= t('hyrax.visibility.open.note_html') %>
     </label>
     <label class="radio">
       <%# OVERRIDE BEGIN: added check if true %>
-      <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED, checked: @collection.authenticated_only_access? %>
+      <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED, checked: @collection&.authenticated_only_access? %>
       <%# OVERRIDE END %>
       <strong><%= t('hyrax.visibility.authenticated.text', institution: institution_name) %></strong> - <%= t('hyrax.visibility.authenticated.note_html', institution: institution_name) %>
     </label>
     <label class="radio">
       <%# OVERRIDE BEGIN: added check if true %>
-      <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE, checked: @collection.private_access? %>
+      <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE, checked: @collection&.private_access? %>
       <%# OVERRIDE END %>
       <strong><%= t('hyrax.visibility.restricted.text') %></strong>- <%= t('hyrax.visibility.restricted.note_html') %>
     </label>

--- a/app/views/hyrax/dashboard/collections/_form_discovery.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_discovery.html.erb
@@ -1,0 +1,27 @@
+<%# OVERRIDE HYRAX 3.4.1 to indicate what the current collection visibility is %>
+<div class="set-access-controls">
+  <p><%= t('.para1') %></p>
+  <p><%= t('.para2') %></p>
+
+  <div class="form-group">
+    <label class="radio">
+      <%# OVERRIDE BEGIN: added check if true %>
+      <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, checked: @collection.open_access? %>
+      <%# OVERRIDE END %>
+      <strong><%= t('hyrax.visibility.open.text') %></strong> - <%= t('hyrax.visibility.open.note_html') %>
+    </label>
+    <label class="radio">
+      <%# OVERRIDE BEGIN: added check if true %>
+      <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED, checked: @collection.authenticated_only_access? %>
+      <%# OVERRIDE END %>
+      <strong><%= t('hyrax.visibility.authenticated.text', institution: institution_name) %></strong> - <%= t('hyrax.visibility.authenticated.note_html', institution: institution_name) %>
+    </label>
+    <label class="radio">
+      <%# OVERRIDE BEGIN: added check if true %>
+      <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE, checked: @collection.private_access? %>
+      <%# OVERRIDE END %>
+      <strong><%= t('hyrax.visibility.restricted.text') %></strong>- <%= t('hyrax.visibility.restricted.note_html') %>
+    </label>
+  </div>
+
+</div>


### PR DESCRIPTION
Fixes [UTK 94](https://gitlab.com/notch8/utk-hyku/-/issues/94)

## Summary
Through radio buttons, give indicator what visibility the collection is currently set to.

Changes proposed in this pull request:
* overwrite hyrax view
* add checked option to radio button

## Screenshot
![utk-94](https://user-images.githubusercontent.com/19597776/181366215-fbc1c00b-f59a-4556-bfe7-6548752bd8fd.gif)

