### PR TITLE
1837 better user error handling

### DIFF
--- a/app/views/proprietor/users/new.html.erb
+++ b/app/views/proprietor/users/new.html.erb
@@ -12,9 +12,8 @@
                 <%= pluralize(@user.errors.count, "error") %> prohibited this repository from being saved:
                 <ul>
                   <% @user.errors.messages.each do |key, messages| %>
-                  <% if @user.errors.details[key].present? %>
-                    <li><%= key %> &quot;<%= @user.errors.details[key].first[:value] %>&quot; <%= messages.join(' and ') %></li>
-                  <% end %>
+                    <% next unless messages.present? %>
+                    <li><%= key %> <%= messages.join(' and ') %></li>
                   <% end %>
                 </ul>
               </div>


### PR DESCRIPTION
# expected behavior
- stop checking for `@user.errors.details[key].first[:value]` because it does not exist

# related
- https://gitlab.com/notch8/britishlibrary/-/issues/372

@samvera/hyku-code-reviewers
