### PR TITLE
add-clause-to-account-settings-for-google_analytics_id

### DIFF
--- a/app/models/concerns/account_settings.rb
+++ b/app/models/concerns/account_settings.rb
@@ -154,22 +154,12 @@ module AccountSettings
     end
 
     def reload_library_config
-
-      if google_analytics_id.present?
-        Hyrax.config do |config|
-          config.contact_email = contact_email
-          config.analytics = google_analytics_id.present?
-          config.google_analytics_id = google_analytics_id
-          config.geonames_username = geonames_username
-          config.uploader[:maxFileSize] = file_size_limit
-        end
-      else
-        Hyrax.config do |config|
-          config.contact_email = contact_email
-          config.analytics = google_analytics_id.present?
-          config.geonames_username = geonames_username
-          config.uploader[:maxFileSize] = file_size_limit
-        end
+      Hyrax.config do |config|
+        config.contact_email = contact_email
+        config.analytics = google_analytics_id.present?
+        config.google_analytics_id = google_analytics_id if google_analytics_id.present?
+        config.geonames_username = geonames_username
+        config.uploader[:maxFileSize] = file_size_limit
       end
       
       Devise.mailer_sender = contact_email

--- a/app/models/concerns/account_settings.rb
+++ b/app/models/concerns/account_settings.rb
@@ -161,7 +161,7 @@ module AccountSettings
         config.geonames_username = geonames_username
         config.uploader[:maxFileSize] = file_size_limit
       end
-      
+
       Devise.mailer_sender = contact_email
 
       if s3_bucket.present?

--- a/app/models/concerns/account_settings.rb
+++ b/app/models/concerns/account_settings.rb
@@ -154,14 +154,24 @@ module AccountSettings
     end
 
     def reload_library_config
-      Hyrax.config do |config|
-        config.contact_email = contact_email
-        config.analytics = google_analytics_id.present?
-        config.google_analytics_id = google_analytics_id
-        config.geonames_username = geonames_username
-        config.uploader[:maxFileSize] = file_size_limit
-      end
 
+      if google_analytics_id.present?
+        Hyrax.config do |config|
+          config.contact_email = contact_email
+          config.analytics = google_analytics_id.present?
+          config.google_analytics_id = google_analytics_id
+          config.geonames_username = geonames_username
+          config.uploader[:maxFileSize] = file_size_limit
+        end
+      else
+        Hyrax.config do |config|
+          config.contact_email = contact_email
+          config.analytics = google_analytics_id.present?
+          config.geonames_username = geonames_username
+          config.uploader[:maxFileSize] = file_size_limit
+        end
+      end
+      
       Devise.mailer_sender = contact_email
 
       if s3_bucket.present?


### PR DESCRIPTION
Adds a check for the presence of the google_analytics_id. In a staging environment, if the google_analytics_id was not available we would receive a routing error for the partials in the admin dashboard locally. I also saw errors in my local logs when account_settings.rb would use the method, `reload_library_config`, on the step of `config.google_analytics_id = google_analytics_id` it didn't matter if google_analytics_id.present? or not, the application would need to look in the analytics.yml file which is commented out, and throws an error. In a staging or production environment it gets caught in the hyrax step of the web deployment process.

Error:
```yaml
Block in reload_library_config at /app/samvera/hyrax-webapp/app/models/concerns/account_settings.rb:160
Unable to fetch any keys from /app/samvera/hyrax-webapp/config/analytics.yml
```

Logs are attached from hyku-demo's staging instance with an error preventing the hyrax stage of the web container during the deployment process. This error is preventing the deployment from completing.
[hyku-demo-hyrax-577d7b66b9-f265x_hyrax.log](https://github.com/samvera/hyku/files/9641484/hyku-demo-hyrax-577d7b66b9-f265x_hyrax.log)


I also am not quick enough to get the file updated live on the server during the deployment process, I only have 30~ish seconds until the pod disconnects. But did test it locally to ensure the errors didn't show in the logs.