### PR TITLE
workflow actions header color

### DIFF
--- a/app/assets/stylesheets/themes/cultural_repository.scss
+++ b/app/assets/stylesheets/themes/cultural_repository.scss
@@ -194,6 +194,11 @@
     }
   }
 
+  // prevent cultural repository theme override to the workflow actions header background
+  .panel-default .panel-workflow .panel-heading {
+    background-color: #e6ab5f !important;
+  }
+
   // Note: copied over to override /* line 7, /usr/local/bundle/gems/bootstrap-sass-3.4.1/assets/stylesheets/bootstrap/_panels.scss */
   .panel {
     background-color: #fff !important;

--- a/app/assets/stylesheets/themes/cultural_repository.scss
+++ b/app/assets/stylesheets/themes/cultural_repository.scss
@@ -191,6 +191,7 @@
     .panel-workflow .panel-heading {
       background-color: #e6ab5f !important;
     }
+
     .panel-heading {
       background-color: #ffffff !important;
       border-color: #ddd  !important;

--- a/app/assets/stylesheets/themes/cultural_repository.scss
+++ b/app/assets/stylesheets/themes/cultural_repository.scss
@@ -187,16 +187,14 @@
   // Note: copied over to override * line 254, /usr/local/bundle/gems/bootstrap-sass-3.4.1/assets/stylesheets/bootstrap/_panels.scss */
   .panel-default {
     border-color: transparent !important;
-
+    // prevent cultural repository theme override to the workflow actions header background
+    .panel-workflow .panel-heading {
+      background-color: #e6ab5f !important;
+    }
     .panel-heading {
       background-color: #ffffff !important;
       border-color: #ddd  !important;
     }
-  }
-
-  // prevent cultural repository theme override to the workflow actions header background
-  .panel-default .panel-workflow .panel-heading {
-    background-color: #e6ab5f !important;
   }
 
   // Note: copied over to override /* line 7, /usr/local/bundle/gems/bootstrap-sass-3.4.1/assets/stylesheets/bootstrap/_panels.scss */


### PR DESCRIPTION
Fixes #1863 

In Hyku main, when the Cultural Repository theme is selected, the CSS overrides the workflow actions header to have a white background. The text is also white, so the panel is invisible to the user.

Changes proposed in this pull request:
update the CSS in the Cultural Repository theme so the workflow actions panel does not have a white background with white text

@samvera/hyku-code-reviewers
