### PR TITLE
moves share your work button outside of featured works partial

### DIFF
--- a/app/views/themes/neutral_repository/_theme_container.html.erb
+++ b/app/views/themes/neutral_repository/_theme_container.html.erb
@@ -8,7 +8,7 @@
     </div>
   </div>
   <% end %>
-  <%# April todo add featured reserarch/recent doc feature flags %>
+  <%= render 'themes/neutral_repository/layouts/share_your_work_row' if controller_name == 'homepage' %>
   <% if @presenter.display_featured_works? %>
     <div class="col-xs-12">
       <%= render 'themes/neutral_repository/hyrax/homepage/featured_works' %>

--- a/app/views/themes/neutral_repository/hyrax/homepage/_featured_works.html.erb
+++ b/app/views/themes/neutral_repository/hyrax/homepage/_featured_works.html.erb
@@ -1,9 +1,7 @@
 <h2 class="sr-only"><%= t('hyrax.homepage.featured_works.title') %></h2>
 <% if @featured_work_list.empty? %>
-  <%= render 'themes/neutral_repository/layouts/share_your_work_row' if controller_name == 'homepage' %>
   <p><%= t('hyrax.homepage.featured_works.no_works') %></p>
 <% elsif can? :update, FeaturedWork %>
-  <%= render 'themes/neutral_repository/layouts/share_your_work_row' if controller_name == 'homepage' %>
   <%= form_for [hyrax, @featured_work_list] do |f| %>
     <div class="panel-group dd" id="dd">
       <ol id="featured_works">


### PR DESCRIPTION
Fixes #1865 

In Hyku main, when the Neutral Repository theme is selected, and the Featured Work feature flipper is toggled off, the Share your work button is toggled off as a side effect.

Changes proposed in this pull request:
* move share your work partial outside of the featured work partial


@samvera/hyku-code-reviewers
