### PR TITLE
adds libreoffice to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ USER root
 ARG EXTRA_APK_PACKAGES="openjdk11-jre ffmpeg"
 RUN apk --no-cache upgrade && \
   apk --no-cache add \
+    libreoffice \
     libxml2-dev \
     mediainfo \
     perl \


### PR DESCRIPTION
Fixes #1869 

When spinning up a new instance of Hyku, filesets are not attaching and thumbnails are not being created.

Changes proposed in this pull request:
* add libreoffice to Dockerfile

@samvera/hyku-code-reviewers
