### PR TITLE
fix embargo and lease date time issue

### DIFF
--- a/app/models/hydra/access_controls/embargo_decorator.rb
+++ b/app/models/hydra/access_controls/embargo_decorator.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# OVERRIDE Hydra-access-controls 12.0.1
+# Fix releasing embargos on the day they are expired - this solves a 1 second bug around how
+# midnights are calculated, which causes day of embargos to incorrectly set the permissions to private
+module Hydra
+  module AccessControls
+    module EmbargoDecorator
+      def active?
+        (embargo_release_date.present? && Date.yesterday.end_of_day < embargo_release_date)
+      end
+    end
+  end
+end
+
+Hydra::AccessControls::Embargo.prepend(Hydra::AccessControls::EmbargoDecorator)

--- a/app/models/hydra/access_controls/lease_decorator.rb
+++ b/app/models/hydra/access_controls/lease_decorator.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# OVERRIDE Hydra-access-controls 12.0.1
+# Fix releasing leases on the day they are expired - this solves a 1 second bug around how
+# midnights are calculated, which causes day of leases to incorrectly set the permissions to private
+module Hydra
+  module AccessControls
+    module LeaseDecorator
+      def active?
+        (lease_release_date.present? && Time.zone.today.end_of_day < lease_release_date)
+      end
+    end
+  end
+end
+
+Hydra::AccessControls::Lease.prepend(Hydra::AccessControls::LeaseDecorator)

--- a/app/models/hydra/access_controls/lease_decorator.rb
+++ b/app/models/hydra/access_controls/lease_decorator.rb
@@ -7,7 +7,7 @@ module Hydra
   module AccessControls
     module LeaseDecorator
       def active?
-        (lease_release_date.present? && Time.zone.today.end_of_day < lease_release_date)
+        (lease_expiration_date.present? && Time.zone.today.end_of_day < lease_expiration_date)
       end
     end
   end


### PR DESCRIPTION
Fixes #1871 

When an admin user releases an expired lease/embargo, the lease/embargo does not release to its new visibility. It should release from `Lease`/`Embargo` to `[new visibility]`. Instead, it releases from `Lease`/`Embargo` to `[old visibility]`

Changes proposed in this pull request:
* add embargo decorator to fix timing issue
* add lease decorator to fix timing issue


@samvera/hyku-code-reviewers
