### PR TITLE
add filesets to search for collection show page

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -40,7 +40,7 @@ class CatalogController < ApplicationController
     config.default_solr_params = {
       qt: "search",
       rows: 10,
-      qf: "title_tesim description_tesim creator_tesim keyword_tesim"
+      qf: "title_tesim description_tesim creator_tesim keyword_tesim all_text_timv"
     }
 
     # Specify which field to use in the tag cloud on the homepage.

--- a/app/search_builders/hyrax/collection_member_search_builder_decorator.rb
+++ b/app/search_builders/hyrax/collection_member_search_builder_decorator.rb
@@ -6,7 +6,7 @@ module Hyrax
     Hyrax::CollectionMemberSearchBuilder.default_processor_chain += [:show_works_or_works_that_contain_files]
 
     # These methods include the filesets in the search results
-    def show_works_or_works_that_contain_files(solr_parameters)      
+    def show_works_or_works_that_contain_files(solr_parameters)
       return if blacklight_params[:q].blank?
       solr_parameters[:user_query] = blacklight_params[:q]
       solr_parameters[:q] = new_query

--- a/app/search_builders/hyrax/collection_member_search_builder_decorator.rb
+++ b/app/search_builders/hyrax/collection_member_search_builder_decorator.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# OVERRIDE: Hyrax 3.4.1 adds filesets to search to allow full text search results on the Collection show pages
+module Hyrax
+  module CollectionMemberSearchBuilderDecorator
+    Hyrax::CollectionMemberSearchBuilder.default_processor_chain += [:show_works_or_works_that_contain_files]
+
+    # These methods include the filesets in the search results
+    def show_works_or_works_that_contain_files(solr_parameters)      
+      return if blacklight_params[:q].blank?
+      solr_parameters[:user_query] = blacklight_params[:q]
+      solr_parameters[:q] = new_query
+      solr_parameters[:defType] = 'lucene'
+    end
+
+    # the {!lucene} gives us the OR syntax
+    def new_query
+      "{!lucene}#{interal_query(dismax_query)} #{interal_query(join_for_works_from_files)}"
+    end
+
+    # the _query_ allows for another parser (aka dismax)
+    def interal_query(query_value)
+      "_query_:\"#{query_value}\""
+    end
+
+    # the {!dismax} causes the query to go against the query fields
+    def dismax_query
+      "{!dismax v=$user_query}"
+    end
+
+    # join from file id to work relationship solrized file_set_ids_ssim
+    def join_for_works_from_files
+      "{!join from=#{Hyrax.config.id_field} to=file_set_ids_ssim}#{dismax_query}"
+    end
+  end
+end
+
+Hyrax::CollectionMemberSearchBuilder.prepend(Hyrax::CollectionMemberSearchBuilderDecorator)


### PR DESCRIPTION
Fixes #1875 

When viewing a collection page, the central search bar does not return results for the content or metadata of works or sub-collections, only the titles. Optimally, this search would function just as the main search bar for each tenant does, searching the text of PDFs, and all metadata fields, but only within the collection.

Changes proposed in this pull request:
* adds a decorator the includes methods to add filesets to the search on the collection show pages
* adds all_text_timv to the catalog controller search fields


@samvera/hyku-code-reviewers
