### PR TITLE
Fix sign up link not rendering

### DIFF
--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -2,7 +2,7 @@
   <%= link_to t(".sign_in"), new_session_path(resource_name) %><br />
 <% end -%>
 
-<%- if devise_mapping.registerable? && controller_name != 'registrations' && !Account.global_tenant? && current_account.try(:allow_signup) == "true"  %>
+<%- if devise_mapping.registerable? && controller_name != 'registrations' && !Account.global_tenant? && current_account.try(:allow_signup) == true  %>
   <%= link_to t(".sign_up"), new_registration_path(resource_name) %><br />
 <% end -%>
 


### PR DESCRIPTION
Fixes #1879 

`Account#allow_signup` returns a boolean, not a string. This conditional would always return `false` due to this data type mismatch.

@samvera/hyku-code-reviewers 