### PR TITLE
add conditional to account for when iiif print gem is installed

### DIFF
--- a/app/presenters/hyrax/iiif_manifest_presenter_decorator.rb
+++ b/app/presenters/hyrax/iiif_manifest_presenter_decorator.rb
@@ -3,8 +3,23 @@
 # OVERRIDE Hyrax 3.4.0 to check the site's ssl_configured when setting protocols
 module Hyrax
   module IiifManifestPresenterDecorator
+    ##
+    # @note The #search_service method is to help configure the IIIF Manifest gem
+    # @note As of 3.4.2, the Hyrax::IiifManifestPresenter does not implement the
+    #    #search_service.
+    # @todo Write test when we incorporate the IIIF Print gem
     def search_service
-      url = Rails.application.routes.url_helpers.solr_document_url(id, host: hostname)
+      # When Hyku introduces the IIIF Print gem, we will then have a "super" method
+      # which creates a URL based on the IIIF Print gem's implementation.
+      # However, the IIIF Print gem has no knowledge of Site.account and so we need
+      # to massage the URL to be SSL or non-SSL.
+      #
+      # The fallback URL is the previous implementation.
+      url = if defined?(super)
+              super
+            else
+              Rails.application.routes.url_helpers.solr_document_url(id, host: hostname)
+            end
       Site.account.ssl_configured ? url.sub(/\Ahttp:/, 'https:') : url
     end
 


### PR DESCRIPTION
With all the work going in the [IIIF Print](https://github.com/scientist-softserv/iiif_print) gem, we need a way to safely override methods.  Instead of updating the `IiifManifestPresenterDecorator` with a injections from a generator, the safer approach is to check `super` to see if there's another implementation of it, in our case, coming from the IIIF Print gem.  If not then carry on as usual.