### PR TITLE
disable-analytics-env-also-dont-error-if-not-enabled

### DIFF
--- a/.env
+++ b/.env
@@ -45,14 +45,14 @@ HYKU_MULTITENANT=true
 
 ##START## Enable Google Analytics
 # Uncomment to enable and configure Google Analytics, see README for instructions.
-HYRAX_ANALYTICS=true
-GOOGLE_ANALYTICS_ID=
-GOOGLE_OAUTH_APP_NAME=hyku-demo
-GOOGLE_OAUTH_APP_VERSION=1.0
-GOOGLE_OAUTH_PRIVATE_KEY_SECRET=notasecret
-GOOGLE_OAUTH_PRIVATE_KEY_PATH=prod-cred.p12
-GOOGLE_OAUTH_CLIENT_EMAIL=hyku-demo@hyku-demo.iam.gserviceaccount.com
+# HYRAX_ANALYTICS=true
+# GOOGLE_ANALYTICS_ID=
+# GOOGLE_OAUTH_APP_NAME=hyku-demo
+# GOOGLE_OAUTH_APP_VERSION=1.0
+# GOOGLE_OAUTH_PRIVATE_KEY_SECRET=notasecret
+# GOOGLE_OAUTH_PRIVATE_KEY_PATH=prod-cred.p12
+# GOOGLE_OAUTH_CLIENT_EMAIL=hyku-demo@hyku-demo.iam.gserviceaccount.com
 
 # AND comment this out
-# HYRAX_ANALYTICS=false
+HYRAX_ANALYTICS=false
 ##END## Enable Google Analytics

--- a/app/views/hyrax/dashboard/sidebar/_activity.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_activity.html.erb
@@ -48,7 +48,7 @@
     <% end %>
   <% end %>
 
-  <% if current_ability.can_create_any_work? %>
+  <% if current_ability.can_create_any_work? && Hyrax.config.analytics? %>
     <li>
       <%= menu.collapsable_section t('hyrax.admin.sidebar.analytics'),
                                         icon_class: "fa fa-pie-chart",

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -1,11 +1,11 @@
 #
 # To integrate your app with Google Analytics, uncomment the lines below and add your API key information.
 #
-analytics:
-  google:
-    analytics_id: <%= ENV['GOOGLE_ANALYTICS_ID'] %>
-    app_name: <%= ENV['GOOGLE_OAUTH_APP_NAME'] %>
-    app_version: <%= ENV['GOOGLE_OAUTH_APP_VERSION'] %>
-    privkey_path: <%= ENV['GOOGLE_OAUTH_PRIVATE_KEY_PATH'] %>
-    privkey_secret: <%= ENV['GOOGLE_OAUTH_PRIVATE_KEY_SECRET'] %>
-    client_email: <%= ENV['GOOGLE_OAUTH_CLIENT_EMAIL'] %>
+# analytics:
+#   google:
+#     analytics_id: <%= ENV['GOOGLE_ANALYTICS_ID'] %>
+#     app_name: <%= ENV['GOOGLE_OAUTH_APP_NAME'] %>
+#     app_version: <%= ENV['GOOGLE_OAUTH_APP_VERSION'] %>
+#     privkey_path: <%= ENV['GOOGLE_OAUTH_PRIVATE_KEY_PATH'] %>
+#     privkey_secret: <%= ENV['GOOGLE_OAUTH_PRIVATE_KEY_SECRET'] %>
+#     client_email: <%= ENV['GOOGLE_OAUTH_CLIENT_EMAIL'] %>


### PR DESCRIPTION
# Summary
rspec spec/features/create_generic_work_spec.rb
Rspec feature test [was failing](https://app.circleci.com/pipelines/github/samvera/hyku/1162/workflows/ceb0f71c-6c6b-49cf-845b-4940bd4e0606/jobs/1250/tests#failed-test-0) due to not being able to access the dashboard because Google Analytics was enabled by default (half-setup) and no p12 file to allow the feature test to access the dashboard so adding a check to see if google analytics is setup and commenting out the analytics env variables in the env file.

- Bringing over [Hyrax fix](https://github.com/samvera/hyrax/commit/73437b8ed8d2441b7fe3bbff14e41e53922d3fdb) for not erroring the dashboard view if analytics isn't enabled yet
- Disables Google analytics in the env file on default