### PR TITLE
Add release notes template

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -151,6 +151,7 @@ Common checks that may occur in our repositories:
 
 1. Travis CI - where our automated tests are running
 2. Approval Required - Github enforces at least one person approve a pull request. Also, all reviewers that have chimed in must approve.
+3. Required Labels - an appropriate [semver](https://semver.org/) label (see [release.yml](https://github.com/samvera/hyku/blob/main/.github/release.yml))
 
 If one or more of the required checks failed (or are incomplete), the code should not be merged (and the UI will not allow it). If all of the checks have passed, then anyone on the project (including the pull request submitter) may merge the code.
 

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,20 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - major-ver
+    - title: Exciting New Features 🎉
+      labels:
+        - minor-ver
+    - title: Bug Fixes 🐞
+      labels:
+        - patch-ver
+    - title: Database Changes
+      labels:
+        - database-changes
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/release_labels.yml
+++ b/.github/workflows/release_labels.yml
@@ -1,0 +1,25 @@
+name: Verify
+on:
+  pull_request:
+    branches:
+      - '**'
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+
+jobs:
+  check_pr_labels:
+    runs-on: ubuntu-latest
+    name: PR has required labels
+    steps:
+      - uses: actions/checkout@v2
+
+      # https://github.com/marketplace/actions/label-checker-for-pull-requests
+      - name: Check PR for Release Notes labels
+        uses: docker://agilepathway/pull-request-label-checker:latest
+        with:
+          one_of: patch-ver,minor-ver,major-ver,ignore-for-release
+          repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,6 +151,7 @@ Common checks that may occur in our repositories:
 
 1. Travis CI - where our automated tests are running
 2. Approval Required - Github enforces at least one person approve a pull request. Also, all reviewers that have chimed in must approve.
+3. Required Labels - an appropriate [semver](https://semver.org/) label (see [release.yml](https://github.com/samvera/hyku/blob/main/.github/release.yml))
 
 If one or more of the required checks failed (or are incomplete), the code should not be merged (and the UI will not allow it). If all of the checks have passed, then anyone on the project (including the pull request submitter) may merge the code.
 


### PR DESCRIPTION
Borrow changelog config from [Bulkrax](https://github.com/samvera-labs/bulkrax).

This will organize listed PRs when generating release notes by using labels. 

Changes proposed in this pull request:
- Add changelog template 
- Add PR label validating GitHub Action
- Include PR label instructions in contributing guidelines 