### PR TITLE
upgrade to hyrax 3.5, make graph indexer on by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 orbs:
   samvera: samvera/circleci-orb@0
+  browser-tools: circleci/browser-tools@1.1
 jobs:
   bundle_lint_test:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
         type: string
         default: '4'
     docker:
-      - image: circleci/ruby:<< parameters.ruby_version >>-browsers
+      - image: cimg/ruby:<< parameters.ruby_version >>-browsers
       - image: ualbertalib/docker-fcrepo4:<< parameters.fcrepo_version>>
         environment:
           CATALINA_OPTS: "-Djava.awt.headless=true -Dfile.encoding=UTF-8 -server -Xms512m -Xmx1024m -XX:NewSize=256m -XX:MaxNewSize=256m -XX:PermSize=256m -XX:MaxPermSize=256m -XX:+DisableExplicitGC"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,10 @@ jobs:
       - samvera/bundle:
           ruby_version: << parameters.ruby_version >>
           bundler_version: << parameters.bundler_version >>
+      - run: |
+            sed -i '/require .enumerator./d' /home/circleci/project/vendor/bundle/gems/oai-1.1.0/lib/oai/provider/resumption_token.rb && \
+            sed -i '/require .enumerator./d' /home/circleci/project/vendor/bundle/gems/edtf-3.0.8/lib/edtf.rb && \
+            sed -i '/require .enumerator./d' /home/circleci/project/vendor/bundle/gems/csl-1.6.0/lib/csl.rb
       - samvera/rubocop
       - run: bundle exec rake db:create db:schema:load
       - run: bin/solrcloud-upload-configset.sh solr/conf

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,6 @@ jobs:
       FCREPO_TEST_PORT: 8080/fcrepo
       SPEC_OPTS: --tag ~ci:skip --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
     steps:
-      - browser-tools/install-browser-tools
       - samvera/cached_checkout
       - samvera/bundle:
           ruby_version: << parameters.ruby_version >>
@@ -81,6 +80,7 @@ jobs:
             sed -i '/require .enumerator./d' ./vendor/bundle/ruby/2.7.0/gems/edtf-3.0.8/lib/edtf.rb && \
             sed -i '/require .enumerator./d' ./vendor/bundle/ruby/2.7.0/gems/csl-1.6.0/lib/csl.rb
       - samvera/rubocop
+      - browser-tools/install-browser-tools
       - run: bundle exec rake db:create db:schema:load
       - run: bin/solrcloud-upload-configset.sh solr/conf
       - samvera/parallel_rspec

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,9 +76,9 @@ jobs:
           ruby_version: << parameters.ruby_version >>
           bundler_version: << parameters.bundler_version >>
       - run: |
-            sed -i '/require .enumerator./d' ./vendor/bundle/ruby/2.7.0/gems/oai-1.1.0/lib/oai/provider/resumption_token.rb && \
-            sed -i '/require .enumerator./d' ./vendor/bundle/ruby/2.7.0/gems/edtf-3.0.8/lib/edtf.rb && \
-            sed -i '/require .enumerator./d' ./vendor/bundle/ruby/2.7.0/gems/csl-1.6.0/lib/csl.rb
+            sed -i '/require .enumerator./d' /home/circleci/project/vendor/bundle/gems/oai-1.1.0/lib/oai/provider/resumption_token.rb && \
+            sed -i '/require .enumerator./d' /home/circleci/project/vendor/bundle/gems/edtf-3.0.8/lib/edtf.rb && \
+            sed -i '/require .enumerator./d' /home/circleci/project/vendor/bundle/gems/csl-1.6.0/lib/csl.rb
       - samvera/rubocop
       - browser-tools/install-browser-tools
       - run: bundle exec rake db:create db:schema:load

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
         type: string
         default: '4'
     docker:
-      - image: circleci/ruby:<< parameters.ruby_version >>-node-browsers-legacy
+      - image: circleci/ruby:<< parameters.ruby_version >>-browsers
       - image: ualbertalib/docker-fcrepo4:<< parameters.fcrepo_version>>
         environment:
           CATALINA_OPTS: "-Djava.awt.headless=true -Dfile.encoding=UTF-8 -server -Xms512m -Xmx1024m -XX:NewSize=256m -XX:MaxNewSize=256m -XX:PermSize=256m -XX:MaxPermSize=256m -XX:+DisableExplicitGC"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     parameters:
       ruby_version:
         type: string
-        default: 2.7.4
+        default: 2.7.6
       bundler_version:
         type: string
         default: '2.0.1'
@@ -85,6 +85,6 @@ workflows:
   ci:
     jobs:
       - bundle_lint_test:
-          ruby_version: "2.7.4"
-          name: "ruby2-7-4"
+          ruby_version: "2.7.6"
+          name: "ruby2-7-6"
           solr_config_path: 'solr/conf'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,15 +70,15 @@ jobs:
       FCREPO_TEST_PORT: 8080/fcrepo
       SPEC_OPTS: --tag ~ci:skip --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
     steps:
+      - browser-tools/install-browser-tools
       - samvera/cached_checkout
-
       - samvera/bundle:
           ruby_version: << parameters.ruby_version >>
           bundler_version: << parameters.bundler_version >>
       - run: |
-            sed -i '/require .enumerator./d' /home/circleci/project/vendor/bundle/gems/oai-1.1.0/lib/oai/provider/resumption_token.rb && \
-            sed -i '/require .enumerator./d' /home/circleci/project/vendor/bundle/gems/edtf-3.0.8/lib/edtf.rb && \
-            sed -i '/require .enumerator./d' /home/circleci/project/vendor/bundle/gems/csl-1.6.0/lib/csl.rb
+            sed -i '/require .enumerator./d' ./vendor/bundle/ruby/2.7.0/gems/oai-1.1.0/lib/oai/provider/resumption_token.rb && \
+            sed -i '/require .enumerator./d' ./vendor/bundle/ruby/2.7.0/gems/edtf-3.0.8/lib/edtf.rb && \
+            sed -i '/require .enumerator./d' ./vendor/bundle/ruby/2.7.0/gems/csl-1.6.0/lib/csl.rb
       - samvera/rubocop
       - run: bundle exec rake db:create db:schema:load
       - run: bin/solrcloud-upload-configset.sh solr/conf

--- a/Gemfile
+++ b/Gemfile
@@ -88,7 +88,7 @@ gem 'bulkrax', '~> 3.5.0'
 gem 'blacklight', '~> 6.7'
 gem 'blacklight_oai_provider', '~> 6.1', '>= 6.1.1'
 
-gem 'hyrax', '~> 3.4.0'
+gem 'hyrax', '~> 3.5.0'
 
 gem 'bolognese', '>= 1.9.10'
 gem 'hyrax-doi', git: 'https://github.com/samvera-labs/hyrax-doi.git', branch: 'hyrax_upgrade'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -404,7 +404,7 @@ GEM
     geocoder (1.8.1)
     globalid (1.0.1)
       activesupport (>= 5.0)
-    google-apis-core (0.9.1)
+    google-apis-core (0.10.0)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (>= 0.16.2, < 2.a)
       httpclient (>= 2.8.1, < 3.a)
@@ -413,7 +413,7 @@ GEM
       retriable (>= 2.0, < 4.a)
       rexml
       webrick
-    google-apis-drive_v3 (0.32.0)
+    google-apis-drive_v3 (0.33.0)
       google-apis-core (>= 0.9.1, < 2.a)
     googleauth (1.3.0)
       faraday (>= 0.17.3, < 3.a)
@@ -475,7 +475,7 @@ GEM
       hydra-derivatives (~> 3.6)
       hydra-file_characterization (~> 1.0)
       hydra-pcdm (>= 0.9)
-    hyrax (3.4.2)
+    hyrax (3.5.0)
       active-fedora (~> 13.1, >= 13.1.2)
       almond-rails (~> 0.1)
       awesome_nested_set (~> 3.1)
@@ -488,6 +488,7 @@ GEM
       draper (~> 4.0)
       dry-equalizer (~> 0.2)
       dry-events (~> 0.2.0)
+      dry-monads (< 1.5)
       dry-struct (~> 1.0)
       dry-transaction (~> 0.11)
       dry-validation (~> 1.3)
@@ -520,6 +521,7 @@ GEM
       rails_autolink (~> 1.1)
       rdf-rdfxml
       rdf-vocab (~> 3.0)
+      redis (~> 4.0)
       redis-namespace (~> 1.5)
       redlock (>= 0.1.2)
       reform (~> 2.3)
@@ -546,7 +548,7 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       terminal-table (>= 1.5.1)
     ice_nine (0.11.2)
-    iiif_manifest (1.2.0)
+    iiif_manifest (1.3.0)
       activesupport (>= 4)
     is_it_working (1.1.0)
     iso-639 (0.3.5)
@@ -583,7 +585,7 @@ GEM
     jsonlint (0.3.0)
       oj (~> 3)
       optimist (~> 3)
-    jwt (2.5.0)
+    jwt (2.7.0)
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.2)
@@ -618,10 +620,11 @@ GEM
       rdf-turtle
       rdf-vocab (>= 0.8)
       slop
-    ldpath (1.1.0)
+    ldpath (1.2.0)
       nokogiri (~> 1.8)
       parslet
       rdf (~> 3.0)
+      rdf-vocab (~> 3.0)
     legato (0.7.0)
       multi_json
     libxml-ruby (3.1.0)
@@ -657,7 +660,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    logger (1.5.2)
+    logger (1.5.3)
     lograge (0.11.2)
       actionpack (>= 4)
       activesupport (>= 4)
@@ -876,7 +879,7 @@ GEM
     redic (1.5.3)
       hiredis
     redis (4.6.0)
-    redis-namespace (1.9.0)
+    redis-namespace (1.10.0)
       redis (>= 4)
     redlock (1.3.2)
       redis (>= 3.0.0, < 6.0)
@@ -1112,7 +1115,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
+    webrick (1.8.1)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -1152,7 +1155,7 @@ DEPENDENCIES
   fcrepo_wrapper (~> 0.4)
   flipflop (~> 2.3)
   flutie
-  hyrax (~> 3.4.0)
+  hyrax (~> 3.5.0)
   hyrax-doi!
   i18n-debug
   i18n-tasks

--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -264,7 +264,7 @@ module Hyrax
 
         @collection.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE unless @collection.discoverable?
         # we don't have to reindex the full graph when updating collection
-        @collection.reindex_extent = Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX
+        @collection.try(:reindex_extent=, Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX)
         if @collection.update(collection_params.except(:members))
           after_update_response
         else

--- a/app/jobs/reindex_collections_job.rb
+++ b/app/jobs/reindex_collections_job.rb
@@ -3,7 +3,7 @@
 class ReindexCollectionsJob < ApplicationJob
   def perform
     Collection.find_each do |collection|
-      collection.reindex_extent = Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX
+      collection.try(:reindex_extent=, Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX)
       collection.update_index
     end
   end

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -1,3 +1,6 @@
+# Set nested indexer to graph by default. Remove after Hyrax 4.0 upgrade
+ENV['HYRAX_USE_SOLR_GRAPH_NESTING'].present? || ENV['HYRAX_USE_SOLR_GRAPH_NESTING'] = "true"
+
 Hyrax.config do |config|
   config.register_curation_concern :generic_work
   # Injected via `rails g hyrax:work Image`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,11 +83,11 @@ services:
     networks:
       internal:
     healthcheck:
-      test: curl -sf http://$$SOLR_ADMIN_USER:$$SOLR_ADMIN_PASSWORD@localhost:8983/solr/admin/cores?action=STATUS || exit 1
-      start_period: 30s
-      interval: 20s
+      test: curl -sf http://$$SOLR_ADMIN_USER:$$SOLR_ADMIN_PASSWORD@solr:8983/solr/admin/cores?action=STATUS || exit 1
+      start_period: 3s
+      interval: 5s
       timeout: 5s
-      retries: 3
+      retries: 6
     depends_on:
       zoo:
         condition: service_healthy


### PR DESCRIPTION
This skips the very slow nested indexing and will be default behavior in Hyrax 4.0. The only downside is it will not work if the Solr Cloud shard count is > 1