### PR TITLE
Update script grants admins manage access to Collections

### DIFF
--- a/app/services/roles_service.rb
+++ b/app/services/roles_service.rb
@@ -108,6 +108,12 @@ class RolesService # rubocop:disable Metrics/ClassLength
         pt.access_grants.find_or_create_by!(
           access: Hyrax::PermissionTemplateAccess::MANAGE,
           agent_type: Hyrax::PermissionTemplateAccess::GROUP,
+          agent_id: Ability.admin_group_name
+        )
+
+        pt.access_grants.find_or_create_by!(
+          access: Hyrax::PermissionTemplateAccess::MANAGE,
+          agent_type: Hyrax::PermissionTemplateAccess::GROUP,
           agent_id: 'collection_manager'
         )
 


### PR DESCRIPTION
Ref https://github.com/scientist-softserv/palni-palci/issues/430 

## Summary

Ensure admin group gets manage access to all Collections when running `rake hyku:roles:create_collection_accesses`

If a Collection did not previously have a permission template, one would have been been created for it when running this script. Since we weren't granting admins any access before this change, admins were not able to do things like deposit works into these "broken" Collections