### PR TITLE
upgrade hyrax docker image and remove malloc env var.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG HYRAX_IMAGE_VERSION=v4.0.0.beta2
+ARG HYRAX_IMAGE_VERSION=hyrax-v4.0.0.rc1
 FROM ghcr.io/samvera/hyrax/hyrax-base:$HYRAX_IMAGE_VERSION as hyku-base
 
 USER root
@@ -96,5 +96,4 @@ RUN RAILS_ENV=production SECRET_KEY_BASE=`bin/rake secret` DB_ADAPTER=nulldb DB_
 CMD ./bin/web
 
 FROM hyku-web as hyku-worker
-ENV MALLOC_ARENA_MAX=2
 CMD ./bin/worker

--- a/lib/tasks/reset.rake
+++ b/lib/tasks/reset.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :reset do
   desc 'reset work and collection data across all tenants'
   task all_works_and_collections: [:environment] do
@@ -10,10 +12,10 @@ namespace :reset do
   end
 
   desc 'reset work and collection data from a single tenant, any argument that works with switch!() will work here'
-  task :works_and_collections, [:account] => [:environment] do |t, args|
+  task :works_and_collections, [:account] => [:environment] do |_t, args|
     raise "You must speficy a name, cname or id of an account" if args[:account].blank?
-    
-    confirm('You are about to delete all works and collections from #{args[:account]}, this is not reversable!')
+
+    confirm("You are about to delete all works and collections from #{args[:account]}, this is not reversable!")
     switch!(args[:account])
     Rake::Task["hyrax:reset:works_and_collections"].reenable
     Rake::Task["hyrax:reset:works_and_collections"].invoke


### PR DESCRIPTION
This PR updates the hyrax image version to the latest in order to resolve issue where the QA gem requirements (ldpath) needed at least ruby 2.7.5 but the beta2 image was using 2.7.2

This also removes the `malloc arena max` variable from the dockerfile as the new image resolves the issue surrounding this. 

I don't believe there are any formal github issues for either of these things.


Changes proposed in this pull request:
* Upgrade hyrax docker image
* remove unneeded malloc variable

@samvera/hyku-code-reviewers
