### PR TITLE
update-bin-web-script-for-analytics

### DIFF
--- a/bin/web
+++ b/bin/web
@@ -1,6 +1,6 @@
 #!/usr/local/bin/ruby
 if ENV['GOOGLE_OAUTH_PRIVATE_KEY_VALUE'] && !ENV['GOOGLE_OAUTH_PRIVATE_KEY_VALUE'].empty?
-  %x{echo #{ENV['GOOGLE_OAUTH_PRIVATE_KEY_VALUE']} | base64 --decode > prod-cred.p12}
+  %x{echo "$GOOGLE_OAUTH_PRIVATE_KEY_VALUE" | base64 -d > prod-cred.p12}
 end
 
 exec "bundle exec puma -v -b tcp://0.0.0.0:3000"


### PR DESCRIPTION
On setup of ATLA-Hyku, we noted that there was. failure in the web script making Google Analytics implementation fail with a `PKCS12_parse: mac verify failure`. On review of the prod-cred.p12 file on the server that is supposed to get created from the ./bin/worker script, but was an empty file. 

Adding implementation of the ./bin/worker script which is different than the ./bin/web script, succeeded when ran in both the web and worker pods.

Sentry error: https://scientist-inc.sentry.io/issues/4092424464/?project=4505008236396544&referrer=project-issue-stream

Site where analytics is now working with the new implementation: https://demo.atla-hyku.notch8.cloud/works/7fdcfe46-6c9d-4eeb-8394-b7c236b363d3/stats?locale=en

<details><summary>CLICK ME Screenshot</summary>
<img width="1209" alt="Screenshot 2023-04-15 at 00 54 52" src="https://user-images.githubusercontent.com/63515648/232197552-f6f37a7e-f866-44dd-9394-70780b144edd.png">

</details>