### PR TITLE
🐛 Addressing Psych::DisallowedClass error with YAML changes

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -54,5 +54,27 @@ module Hyku
 
       Object.include(AccountSwitch)
     end
+
+    ##
+    # Psych Allow YAML Classes
+    #
+    # The following configuration addresses errors of the following form:
+    #
+    # ```
+    # Psych::DisallowedClass: Tried to load unspecified class: ActiveSupport::HashWithIndifferentAccess
+    # ```
+    #
+    # Psych::DisallowedClass: Tried to load unspecified class: <Your Class Name Here>
+    config.after_initialize do
+      config.active_record.yaml_column_permitted_classes = [
+        Symbol,
+        Hash,
+        Array,
+        ActiveSupport::HashWithIndifferentAccess,
+        ActiveModel::Attribute.const_get(:FromDatabase),
+        User,
+        Time
+      ]
+    end
   end
 end


### PR DESCRIPTION
As we're moving through updates to the underlying Psych and Rails we're noticing the following errors happening:

```
Psych::DisallowedClass: Tried to load unspecified class:
  ActiveSupport::HashWithIndifferentAccess
```

This relates to work done in:

- https://github.com/scientist-softserv/palni-palci/blob/02493401e92515832b054aa018332c252b768b0c/config/application.rb#L64
- https://github.com/IU-Libraries-Joint-Development/essi/blob/f187698d57c66f076b933177d481827921d89ac5/config/application.rb#L33

This is the PR for ESSI's fix: https://github.com/IU-Libraries-Joint-Development/essi/commit/c530abab1222c81aa81dc0b63f6752d38f217fae

@samvera/hyku-code-reviewers
