### PR TITLE
update color labels and help text

### DIFF
--- a/app/assets/stylesheets/hyku.scss
+++ b/app/assets/stylesheets/hyku.scss
@@ -360,6 +360,10 @@ a.restore-default-color {
   margin-bottom: 2em;
 }
 
+a.btn.btn-default.restore-default-color.with-color-hint {
+  margin-top: 4em;
+}
+
 .defaultable-colors div[class$="_color"] {
   margin-bottom: 0.75em;
 }

--- a/app/forms/hyrax/forms/admin/appearance.rb
+++ b/app/forms/hyrax/forms/admin/appearance.rb
@@ -23,23 +23,23 @@ module Hyrax
         }.freeze
 
         DEFAULT_COLORS = {
-          'header_background_color'          => '#3c3c3c',
-          'header_text_color'                => '#dcdcdc',
-          'searchbar_background_color'       => '#000000',
-          'searchbar_background_hover_color' => '#ffffff',
-          'searchbar_text_color'             => '#eeeeee',
-          'searchbar_text_hover_color'       => '#eeeeee',
-          'link_color'                       => '#2e74b2',
-          'link_hover_color'                 => '#215480',
-          'footer_link_color'                => '#ffebcd',
-          'footer_link_hover_color'          => '#ffffff',
-          'primary_button_background_color'  => '#286090',
-          'default_button_background_color'  => '#ffffff',
-          'default_button_border_color'      => '#cccccc',
-          'default_button_text_color'        => '#333333',
-          'active_tabs_background_color'     => '#337ab7',
-          'facet_panel_background_color'     => '#f5f5f5',
-          'facet_panel_text_color'           => '#333333'
+          'header_and_footer_background_color' => '#3c3c3c',
+          'header_and_footer_text_color'       => '#dcdcdc',
+          'navbar_background_color'            => '#000000',
+          'navbar_link_background_hover_color' => '#ffffff',
+          'navbar_link_text_color'             => '#eeeeee',
+          'navbar_link_text_hover_color'       => '#eeeeee',
+          'link_color'                         => '#2e74b2',
+          'link_hover_color'                   => '#215480',
+          'footer_link_color'                  => '#ffebcd',
+          'footer_link_hover_color'            => '#ffffff',
+          'primary_button_hover_color'         => '#286090',
+          'default_button_background_color'    => '#ffffff',
+          'default_button_border_color'        => '#cccccc',
+          'default_button_text_color'          => '#333333',
+          # 'active_tabs_background_color'     => '#337ab7',
+          'facet_panel_background_color'       => '#f5f5f5',
+          'facet_panel_text_color'             => '#333333'
         }.freeze
 
         DEFAULT_VALUES = DEFAULT_FONTS.merge(DEFAULT_COLORS).freeze
@@ -116,42 +116,42 @@ module Hyrax
         end
 
         # The color for the background of the header and footer bars
-        def header_background_color
-          block_for('header_background_color')
+        def header_and_footer_background_color
+          block_for('header_and_footer_background_color')
         end
 
         # The color for the text in the header bar
-        def header_text_color
-          block_for('header_text_color')
+        def header_and_footer_text_color
+          block_for('header_and_footer_text_color')
         end
 
         # The color for the background of the search navbar
-        def searchbar_background_color
-          block_for('searchbar_background_color')
+        def navbar_background_color
+          block_for('navbar_background_color')
         end
 
-        def searchbar_background_color_alpha
-          convert_to_rgba(searchbar_background_color, 0.4)
+        def navbar_background_color_alpha
+          convert_to_rgba(navbar_background_color, 0.4)
         end
 
-        def searchbar_background_color_active
-          darken_color(searchbar_background_color, 0.35)
+        def navbar_background_color_active
+          darken_color(navbar_background_color, 0.35)
         end
 
-        def searchbar_background_hover_color
-          block_for('searchbar_background_hover_color')
+        def navbar_link_background_hover_color
+          block_for('navbar_link_background_hover_color')
         end
 
-        def searchbar_background_hover_color_alpha
-          convert_to_rgba(searchbar_background_hover_color, 0.15)
+        def navbar_link_background_hover_color_alpha
+          convert_to_rgba(navbar_link_background_hover_color, 0.15)
         end
 
-        def searchbar_text_color
-          block_for('searchbar_text_color')
+        def navbar_link_text_color
+          block_for('navbar_link_text_color')
         end
 
-        def searchbar_text_hover_color
-          block_for('searchbar_text_hover_color')
+        def navbar_link_text_hover_color
+          block_for('navbar_link_text_hover_color')
         end
 
         # The color links
@@ -175,19 +175,19 @@ module Hyrax
         end
 
         # PRIMARY BUTTON COLORS
-        # The background color for "primary" buttons
-        def primary_button_background_color
-          block_for('primary_button_background_color')
+        # The background hover color for "primary" buttons
+        def primary_button_hover_color
+          block_for('primary_button_hover_color')
         end
 
         # The border color for "primary" buttons
         def primary_button_border_color
-          @primary_button_border ||= darken_color(primary_button_background_color, 0.05)
+          @primary_button_border ||= darken_color(primary_button_hover_color, 0.05)
         end
 
         # The mouse over color for "primary" buttons
         def primary_button_hover_background_color
-          darken_color(primary_button_background_color, 0.1)
+          darken_color(primary_button_hover_color, 0.1)
         end
 
         # The mouse over color for the border of "primary" buttons
@@ -197,7 +197,7 @@ module Hyrax
 
         # The color for the background of active "primary" buttons
         def primary_button_active_background_color
-          darken_color(primary_button_background_color, 0.1)
+          darken_color(primary_button_hover_color, 0.1)
         end
 
         # The color for the border of active "primary" buttons
@@ -207,7 +207,7 @@ module Hyrax
 
         # The color for the background of focused "primary" buttons
         def primary_button_focus_background_color
-          darken_color(primary_button_background_color, 0.1)
+          darken_color(primary_button_hover_color, 0.1)
         end
 
         # The color for the border of focused "primary" buttons
@@ -275,7 +275,7 @@ module Hyrax
 
         # The color for the border of navbar-inverse
         def header_background_border_color
-          darken_color(header_background_color, 0.25)
+          darken_color(header_and_footer_background_color, 0.25)
         end
 
         # The color for the facet panel header background color
@@ -367,23 +367,23 @@ module Hyrax
           %i[
             body_font
             headline_font
-            header_background_color
-            header_text_color
+            header_and_footer_background_color
+            header_and_footer_text_color
             link_color
             link_hover_color
             footer_link_color
             footer_link_hover_color
-            primary_button_background_color
+            primary_button_hover_color
             default_button_background_color
             default_button_border_color
             default_button_text_color
             active_tabs_background_color
             facet_panel_background_color
             facet_panel_text_color
-            searchbar_background_color
-            searchbar_background_hover_color
-            searchbar_text_color
-            searchbar_text_hover_color
+            navbar_background_color
+            navbar_link_background_hover_color
+            navbar_link_text_color
+            navbar_link_text_hover_color
             custom_css_block
             logo_image_text
             banner_image_text

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,4 +5,26 @@ module ApplicationHelper
   include Hyrax::OverrideHelperBehavior
   include GroupNavigationHelper
   include SharedSearchHelper
+
+  def hint_for(term:, record_class: nil)
+    hint = locale_for(type: 'hints', term: term, record_class: record_class)
+
+    return hint unless missing_translation(hint)
+  end
+
+  def locale_for(type:, term:, record_class:)
+    @term              = term.to_s
+    @record_class      = record_class.to_s.downcase
+    work_or_collection = @record_class == 'collection' ? 'collection' : 'defaults'
+    default_locale     = t("simple_form.#{type}.#{work_or_collection}.#{@term}").html_safe
+    locale             = t("hyrax.#{@record_class}.#{type}.#{@term}").html_safe
+
+    return default_locale if missing_translation(locale)
+
+    locale
+  end
+
+  def missing_translation(value)
+    value.include?('translation missing')
+  end
 end

--- a/app/views/hyrax/admin/appearances/_color_input.html.erb
+++ b/app/views/hyrax/admin/appearances/_color_input.html.erb
@@ -1,8 +1,15 @@
 <div class='row'>
   <div class='col-lg-10'>
-    <%= f.input color_name, required: false, input_html: { type: 'color', data: { default_value: hex } } %>
+    <% hint = t("hyrax.admin.appearances.show.forms.#{color_name}.hint") %>
+    <%= f.input color_name,
+        required: false,
+        input_html: { type: 'color', data: { default_value: hex } },
+        hint: !missing_translation(hint) && hint %>
   </div>
   <div class='col-lg-2'>
-    <%= link_to 'Restore Default', '#color', class: 'btn btn-default restore-default-color', data: { default_target: color_name } %>
+    <%= link_to 'Restore Default',
+        '#color',
+        class: "btn btn-default restore-default-color #{'with-color-hint' if !missing_translation(hint)}",
+        data: { default_target: color_name } %>
   </div>
 </div>

--- a/app/views/shared/_appearance_styles.html.erb
+++ b/app/views/shared/_appearance_styles.html.erb
@@ -26,31 +26,31 @@ body.public-facing #per_page-dropdown .dropdown-toggle { color: <%= appearance.l
 /* MAIN NAV */
 body.public-facing .navbar-inverse .navbar-link { color: <%= appearance.footer_link_color %>; }
 body.public-facing .navbar-inverse .navbar-link:hover { color: <%= appearance.footer_link_hover_color %> }
-body.public-facing .navbar-inverse { background-color: <%= appearance.header_background_color %>; }
+body.public-facing .navbar-inverse { background-color: <%= appearance.header_and_footer_background_color %>; }
 body.public-facing .navbar-inverse .navbar-nav > .open > a,
 body.public-facing .navbar-inverse .navbar-nav > .open > a:hover,
-body.public-facing .navbar-inverse .navbar-nav > .open > a:focus { background-color: <%= appearance.header_background_color %>; }
+body.public-facing .navbar-inverse .navbar-nav > .open > a:focus { background-color: <%= appearance.header_and_footer_background_color %>; }
 body.public-facing .navbar-inverse .navbar-nav > li > a,
 body.public-facing .navbar-inverse .navbar-text,
-body.public-facing .navbar-inverse .navbar-brand { color: <%= appearance.header_text_color %>; }
+body.public-facing .navbar-inverse .navbar-brand { color: <%= appearance.header_and_footer_text_color %>; }
 body.public-facing .navbar-inverse { border-color: <%= appearance.header_background_border_color %>; }
 
 /* HOME PAGE SEARCH BAR NAV */
-body.public-facing .image-masthead .navbar { background-color: <%= appearance.searchbar_background_color_alpha %>; }
+body.public-facing .image-masthead .navbar { background-color: <%= appearance.navbar_background_color_alpha %>; }
 body.public-facing .image-masthead .navbar .active > a,
 body.public-facing .image-masthead .navbar .active > a:hover,
 body.public-facing .image-masthead .navbar .active > a:focus {
-    background-color: <%= appearance.searchbar_background_color_active %>;
-    color: <%= appearance.searchbar_text_color %>;
+    background-color: <%= appearance.navbar_background_color_active %>;
+    color: <%= appearance.navbar_link_text_color %>;
 }
 body.public-facing .image-masthead .navbar .navbar-nav a {
-    color: <%= appearance.searchbar_text_color %>;
+    color: <%= appearance.navbar_link_text_color %>;
 }
 
 body.public-facing .image-masthead .navbar .navbar-nav a:hover,
 body.public-facing .image-masthead .navbar .navbar-nav a:focus {
-    background-color: <%= appearance.searchbar_background_hover_color_alpha %>;
-    color: <%= appearance.searchbar_text_hover_color %>;
+    background-color: <%= appearance.navbar_link_background_hover_color_alpha %>;
+    color: <%= appearance.navbar_link_text_hover_color %>;
 }
 
 /* HOME PAGE NAV-PILL TABS */
@@ -62,7 +62,7 @@ body.public-facing .nav-pills > li.active > a:focus {
 
 /* PRIMARY BUTTON STYLES */
 body.public-facing .btn-primary {
-  background-color: <%= appearance.primary_button_background_color %>;
+  background-color: <%= appearance.primary_button_hover_color %>;
   border-color: <%= appearance.primary_button_border_color %>;
 }
 body.public-facing .btn-primary:focus,
@@ -76,7 +76,7 @@ body.public-facing .btn-primary:hover {
 }
 body.public-facing .btn-primary:active,
 body.public-facing .btn-primary.active {
-  background-color: <%= appearance.primary_button_background_color %>;
+  background-color: <%= appearance.primary_button_hover_color %>;
   border-color: <%= appearance.primary_button_border_color %>;
 }
 body.public-facing .btn-primary:active:hover,
@@ -85,7 +85,7 @@ body.public-facing .btn-primary:active.focus,
 body.public-facing .btn-primary.active:hover,
 body.public-facing .btn-primary.active:focus,
 body.public-facing .btn-primary.active.focus{
-  background-color: <%= appearance.primary_button_background_color %>;
+  background-color: <%= appearance.primary_button_hover_color %>;
   border-color: <%= appearance.primary_button_border_color %>;
 }
 body.public-facing .btn-primary.disabled:hover,
@@ -94,7 +94,7 @@ body.public-facing .btn-primary.disabled.focus,
 body.public-facing .btn-primary[disabled]:hover,
 body.public-facing .btn-primary[disabled]:focus,
 body.public-facing .btn-primary[disabled].focus {
-  background-color: <%= appearance.primary_button_background_color %>;
+  background-color: <%= appearance.primary_button_hover_color %>;
   border-color: <%= appearance.primary_button_border_color %>;
 }
 

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -157,15 +157,28 @@ de:
             custom_css:
               confirm: Benutzerdefiniertes CSS überschreibt immer andere Themenauswahlen. Vorgehen?
               warning: Wenn Ihre Themenanpassungen nicht korrekt angewendet werden, stellen Sie sicher, dass sie nicht von benutzerdefiniertem CSS überschrieben werden.
+            default_button_background_color:
+              hint: Schaltflächen für die Arbeitsinteraktion (Bearbeiten, Funktionen usw.); Arbeitsansichten auf der Sammlungsseite und Suchfilterschaltfläche.
             default_images:
               alert: Bitte laden Sie vor dem Absenden mindestens eine Datei hoch.
               hint: Für Standardbilder sollten Sie ein Bild (JPG, GIF oder PNG) verwenden, das die gleichen Abmessungen für Höhe und Breite aufweist (100 Pixel breit und 100 Pixel hoch).
             directory_image:
-              hint: Um ein Bild als Verzeichnisbild zu verwenden, sollten Sie ein Bild (JPG, GIF oder PNG) verwenden, das nicht höher als der Header und nicht breiter als 400 Pixel ist.
+            facet_panel_background_color:
+              hint: Gilt für Facetten und zusätzliche Abschnittsüberschriften auf den Arbeitsseiten einiger Themen.
+            facet_panel_text_color:
+              hint: Gilt bei einigen Themen auch für die Farbe des Caretzeichens neben dem Text und den Werktitel.
             favicon:
               hint: Favicons müssen PNG-Dateien und quadratisch sein. Die maximal verwendete Größe beträgt 228 x 228 Pixel.
+            link_color:
+              hint: 'Betrifft Links auf der Startseite und der Arbeitsseite, einschließlich: Breadcrumbs, Tabs, Titel und Nutzungsbedingungen.'
             logo_image:
               hint: Um ein Bild als Logo zu verwenden, sollten Sie ein Bild (JPG, GIF oder PNG) verwenden, das nicht höher als der Header und nicht breiter als 400 Pixel ist.
+            navbar_background_color:
+              hint: Bei 40 % Deckkraft.
+            navbar_link_background_hover_color:
+              hint: Gilt nur für die Schaltflächen „Startseite“, „Info“, „Kontakt“ und „Hilfe“ auf diesen spezifischen Seiten (bei 15 % Deckkraft).
+            primary_button_hover_color:
+              hint: Schaltflächen zum Teilen, Suchen und Sammeln von Interaktionen (Bearbeiten, Funktionen usw.). Der Rand dieser Schaltflächen wird ebenfalls diese Farbe haben.
             themes:
               confirm: Wenn Ihr Thema nicht richtig angewendet wird, stellen Sie sicher, dass es nicht von benutzerdefiniertem CSS überschrieben wird.
           hints:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -170,6 +170,20 @@ en:
               confirm: "If your theme doesn't appear to be applying correctly, verify that it isn't being overwritten by Custom CSS."
             favicon:
               hint: "Favicons need to be png files and must be square. The max size used is 228px x 228px."
+            navbar_background_color:
+              hint: 'At 40% opacity.'
+            navbar_link_background_hover_color:
+              hint: 'Applies to the Home, About, Contact and Help buttons on those specific pages only (at 15% opacity).'
+            link_color:
+              hint: 'Affects links on the home and work pages including: breadcrumbs, tabs, titles and terms of service.'
+            primary_button_hover_color:
+              hint: 'Share, search and collection interaction (edit, feature, etc.) buttons. The border of these buttons will also be this color.'
+            default_button_background_color:
+              hint: 'Work interaction (edit, feature, etc.) buttons; work views on collection page and search filter button.'
+            facet_panel_background_color:
+              hint: 'Applies to facets and additional section headers on the work pages in some themes.'
+            facet_panel_text_color:
+              hint: 'Also applies to the color of the caret next to the text and the work title on some themes.'
           tabs:
             banner_image: "Banner Image"
             directory_image: "Directory Image"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -158,15 +158,28 @@ es:
             custom_css:
               confirm: CSS personalizado siempre anulará otras selecciones de temas. ¿Continuar?
               warning: Si sus personalizaciones de temas no parecen aplicarse correctamente, verifique que CSS personalizado no las sobrescriba.
+            default_button_background_color:
+              hint: Botones de interacción de trabajo (editar, función, etc.); vistas de trabajo en la página de colección y botón de filtro de búsqueda.
             default_images:
               alert: Cargue al menos un archivo antes de enviarlo.
               hint: Para las imágenes predeterminadas, debe usar una imagen (JPG, GIF o PNG) que tenga las mismas dimensiones de alto y ancho (100 píxeles de ancho y 100 píxeles de alto)
             directory_image:
-              hint: Para usar una imagen como imagen de directorio, debe usar una imagen (JPG, GIF o PNG) que no sea más alta que el encabezado ni más ancha que 400 píxeles de ancho.
+            facet_panel_background_color:
+              hint: Se aplica a facetas y encabezados de sección adicionales en las páginas de trabajo en algunos temas.
+            facet_panel_text_color:
+              hint: También se aplica al color del símbolo de intercalación junto al texto y al título de la obra en algunos temas.
             favicon:
               hint: Los favicons deben ser archivos png y deben ser cuadrados. El tamaño máximo utilizado es 228px x 228px.
+            link_color:
+              hint: 'Afecta a los enlaces en las páginas de inicio y trabajo, incluidos: migas de pan, pestañas, títulos y términos de servicio.'
             logo_image:
               hint: Para usar una imagen como logotipo, debe usar una imagen (JPG, GIF o PNG) que no sea más alta que el encabezado ni más ancha que 400 píxeles de ancho.
+            navbar_background_color:
+              hint: Al 40% de opacidad.
+            navbar_link_background_hover_color:
+              hint: Se aplica a los botones Inicio, Acerca de, Contacto y Ayuda solo en esas páginas específicas (al 15 % de opacidad).
+            primary_button_hover_color:
+              hint: Botones para compartir, buscar e interactuar con la colección (editar, presentar, etc.). El borde de estos botones también será de este color.
             themes:
               confirm: Si su tema no parece aplicarse correctamente, verifique que no esté siendo sobrescrito por CSS personalizado.
           hints:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -158,15 +158,28 @@ fr:
             custom_css:
               confirm: Le CSS personnalisé remplacera toujours les autres sélections de thèmes. Procéder?
               warning: Si vos personnalisations de thème ne semblent pas s'appliquer correctement, vérifiez qu'elles ne sont pas écrasées par CSS personnalisé.
+            default_button_background_color:
+              hint: Boutons d'interaction de travail (édition, fonctionnalité, etc.) ; vues de travail sur la page de collection et le bouton de filtre de recherche.
             default_images:
               alert: Veuillez télécharger au moins un fichier avant de soumettre.
               hint: Pour les images par défaut, vous devez utiliser une image (JPG, GIF ou PNG) qui a des dimensions de hauteur et de largeur égales (100 pixels de large et 100 pixels de haut)
             directory_image:
-              hint: Pour utiliser une image comme image de répertoire, vous devez utiliser une image (JPG, GIF ou PNG) qui n'est pas plus haute que l'en-tête et pas plus large que 400 pixels de large.
+            facet_panel_background_color:
+              hint: S'applique aux facettes et aux en-têtes de section supplémentaires sur les pages de travail dans certains thèmes.
+            facet_panel_text_color:
+              hint: S'applique également à la couleur du caret à côté du texte et du titre de l'ouvrage sur certains thèmes.
             favicon:
               hint: Les favicons doivent être des fichiers png et doivent être carrés. La taille maximale utilisée est de 228px x 228px.
+            link_color:
+              hint: 'Affecte les liens sur les pages d''accueil et de travail, notamment : les fils d''Ariane, les onglets, les titres et les conditions d''utilisation.'
             logo_image:
               hint: Pour utiliser une image comme logo, vous devez utiliser une image (JPG, GIF ou PNG) qui n'est pas plus haute que l'en-tête et pas plus large que 400 pixels de large.
+            navbar_background_color:
+              hint: À 40% d'opacité.
+            navbar_link_background_hover_color:
+              hint: S'applique aux boutons Accueil, À propos, Contact et Aide de ces pages spécifiques uniquement (à 15 % d'opacité).
+            primary_button_hover_color:
+              hint: Boutons de partage, de recherche et d'interaction de collecte (édition, fonctionnalité, etc.). La bordure de ces boutons sera également de cette couleur.
             themes:
               confirm: Si votre thème ne semble pas s'appliquer correctement, vérifiez qu'il n'est pas écrasé par le CSS personnalisé.
           hints:

--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -1160,13 +1160,29 @@ de:
         based_near: Ort
         creator: Schöpfer
         date_created: Datum erstellt
+        default_button_background_color: Standardhintergrundfarbe der Schaltfläche
+        default_button_border_color: Standardfarbe des Schaltflächenrahmens
+        default_button_text_color: Standardfarbe für den Schaltflächentext
         description: Beschreibung
         embargo_release_date: bis um
+        facet_panel_background_color: Hintergrundfarbe des Facettenfelds
+        facet_panel_text_color: Textfarbe des Facettenbereichs
         files: Eine Datei hochladen
+        footer_link_color: Farbe des Fußzeilenlinks
+        footer_link_hover_color: Hover-Farbe des Fußzeilen-Links
+        header_and_footer_background_color: Hintergrundfarbe für Kopf- und Fußzeile
+        header_and_footer_text_color: Textfarbe für Kopf- und Fußzeile
         keyword: Stichwort
         lease_expiration_date: bis um
         license: Lizenz
+        link_color: Verknüpfungsfarbe
+        link_hover_color: Link-Hover-Farbe
         member_of_collection_ids: Zur Sammlung hinzufügen
+        navbar_background_color: Hintergrundfarbe der Navigationsleiste
+        navbar_link_background_hover_color: Hintergrundfarbe des Navigationsleisten-Links
+        navbar_link_text_color: Textfarbe für Navigationsleisten-Links
+        navbar_link_text_hover_color: Hover-Farbe des Navigationsleisten-Linktextes
+        primary_button_hover_color: Hover-Farbe der primären Schaltfläche
         related_url: Verwandte URL
         rights_statement: Rechteerklärung
         title: Titel

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1164,13 +1164,29 @@ en:
         based_near: Location
         creator: Creator
         date_created: Date Created
+        default_button_background_color: Default button background color
+        default_button_border_color: Default button border color
+        default_button_text_color: Default button text color
         description: Description
         embargo_release_date: until
+        facet_panel_background_color: Facet panel background color
+        facet_panel_text_color: Facet panel text color
         files: Upload a file
+        footer_link_color: Footer link color
+        footer_link_hover_color: Footer link hover color
+        header_and_footer_background_color: Header and footer background color
+        header_and_footer_text_color: Header and footer text color
         keyword: Keyword
         lease_expiration_date: until
         license: License
+        link_color: Link color
+        link_hover_color: Link hover color
         member_of_collection_ids: Add to collection
+        navbar_background_color: Navbar background color
+        navbar_link_background_hover_color: Navbar link background hover color
+        navbar_link_text_color: Navbar link text color
+        navbar_link_text_hover_color: Navbar link text hover color
+        primary_button_hover_color: Primary button hover color
         related_url: Related URL
         rights_statement: Rights statement
         title: Title

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -1161,13 +1161,29 @@ es:
         based_near: Ubicación
         creator: Creador
         date_created: fecha de creacion
+        default_button_background_color: Color de fondo predeterminado del botón
+        default_button_border_color: Color predeterminado del borde del botón
+        default_button_text_color: Color de texto de botón predeterminado
         description: Descripción
         embargo_release_date: hasta
+        facet_panel_background_color: Color de fondo del panel de facetas
+        facet_panel_text_color: Color del texto del panel de facetas
         files: Cargar un archivo
+        footer_link_color: Color del enlace de pie de página
+        footer_link_hover_color: Color de desplazamiento del enlace de pie de página
+        header_and_footer_background_color: Color de fondo de encabezado y pie de página
+        header_and_footer_text_color: Color de texto de encabezado y pie de página
         keyword: Palabra clave
         lease_expiration_date: hasta
         license: Licencia
+        link_color: Color de enlace
+        link_hover_color: Color de desplazamiento del enlace
         member_of_collection_ids: Añadir a la colección
+        navbar_background_color: Color de fondo de la barra de navegación
+        navbar_link_background_hover_color: Color de desplazamiento del fondo del vínculo de la barra de navegación
+        navbar_link_text_color: Color del texto del enlace de la barra de navegación
+        navbar_link_text_hover_color: Color de desplazamiento del texto del vínculo de la barra de navegación
+        primary_button_hover_color: Color de desplazamiento del botón principal
         related_url: URL relacionada
         rights_statement: Declaración de derechos
         title: Título

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -1159,13 +1159,29 @@ fr:
         based_near: Emplacement
         creator: Créateur
         date_created: date créée
+        default_button_background_color: Couleur d'arrière-plan du bouton par défaut
+        default_button_border_color: Couleur de bordure de bouton par défaut
+        default_button_text_color: Couleur du texte du bouton par défaut
         description: Descripción
         embargo_release_date: jusqu'à ce que
+        facet_panel_background_color: Couleur d'arrière-plan du panneau de facettes
+        facet_panel_text_color: Couleur du texte du panneau des facettes
         files: Télécharger un fichier
+        footer_link_color: Couleur du lien de pied de page
+        footer_link_hover_color: Couleur de survol du lien de pied de page
+        header_and_footer_background_color: Couleur d'arrière-plan de l'en-tête et du pied de page
+        header_and_footer_text_color: Couleur du texte de l'en-tête et du pied de page
         keyword: Mot-clé
         lease_expiration_date: jusqu'à ce que
         license: Licence
+        link_color: Couleur du lien
+        link_hover_color: Couleur de survol du lien
         member_of_collection_ids: Ajouter à la collection
+        navbar_background_color: Couleur d'arrière-plan de la barre de navigation
+        navbar_link_background_hover_color: Couleur de survol de l'arrière-plan du lien de la barre de navigation
+        navbar_link_text_color: Couleur du texte du lien de la barre de navigation
+        navbar_link_text_hover_color: Couleur de survol du texte du lien de la barre de navigation
+        primary_button_hover_color: Couleur de survol du bouton principal
         related_url: URL associée
         rights_statement: Déclaration des droits
         title: Titre

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -1161,13 +1161,29 @@ it:
         based_near: Posizione
         creator: Creatore
         date_created: data di creazione
+        default_button_background_color: Colore di sfondo del pulsante predefinito
+        default_button_border_color: Colore predefinito del bordo del pulsante
+        default_button_text_color: Colore predefinito del testo del pulsante
         description: Descrizione
         embargo_release_date: fino a
+        facet_panel_background_color: Colore di sfondo del pannello facet
+        facet_panel_text_color: Colore del testo del pannello facet
         files: Caricare un file
+        footer_link_color: Colore del collegamento a piè di pagina
+        footer_link_hover_color: Colore al passaggio del mouse del collegamento a piè di pagina
+        header_and_footer_background_color: Colore di sfondo dell'intestazione e del piè di pagina
+        header_and_footer_text_color: Colore del testo dell'intestazione e del piè di pagina
         keyword: Parola chiave
         lease_expiration_date: fino a
         license: Licenza
+        link_color: Colore del collegamento
+        link_hover_color: Colore del collegamento al passaggio del mouse
         member_of_collection_ids: Aggiungere alla collezione
+        navbar_background_color: Colore di sfondo della barra di navigazione
+        navbar_link_background_hover_color: Colore di sfondo del collegamento della barra di navigazione al passaggio del mouse
+        navbar_link_text_color: Colore del testo del collegamento alla barra di navigazione
+        navbar_link_text_hover_color: Colore al passaggio del mouse del testo del collegamento della barra di navigazione
+        primary_button_hover_color: Colore del pulsante principale al passaggio del mouse
         related_url: URL correlato
         rights_statement: Dichiarazione dei diritti
         title: Titolo

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -1161,13 +1161,29 @@ pt-BR:
         based_near: Localização
         creator: O Criador
         date_created: Data Criada
+        default_button_background_color: Cor de fundo do botão padrão
+        default_button_border_color: Cor padrão da borda do botão
+        default_button_text_color: Cor padrão do texto do botão
         description: Descrição
         embargo_release_date: até
+        facet_panel_background_color: Cor de fundo do painel de facetas
+        facet_panel_text_color: Cor do texto do painel de facetas
         files: Enviar um arquivo
+        footer_link_color: Cor do link do rodapé
+        footer_link_hover_color: Cor do foco do link do rodapé
+        header_and_footer_background_color: Cor de fundo do cabeçalho e rodapé
+        header_and_footer_text_color: Cor do texto do cabeçalho e rodapé
         keyword: Palavra-chave
         lease_expiration_date: até
         license: Licença
+        link_color: Cor do link
+        link_hover_color: Cor do foco do link
         member_of_collection_ids: Adicionar a coleção
+        navbar_background_color: Cor de fundo da barra de navegação
+        navbar_link_background_hover_color: Cor de foco do plano de fundo do link da barra de navegação
+        navbar_link_text_color: Cor do texto do link da barra de navegação
+        navbar_link_text_hover_color: Cor do foco do texto do link da barra de navegação
+        primary_button_hover_color: Cor principal do foco do botão
         related_url: URL relacionado
         rights_statement: Declaração de direitos
         title: Título

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -1161,13 +1161,28 @@ zh:
         based_near: 位置
         creator: 创作者
         date_created: 创建日期
-        description: 描述
+        default_button_background_color: 默认按钮背景颜色
+        default_button_border_color: 默认按钮边框颜色
+        default_button_text_color: 默认按钮文字颜色
         embargo_release_date: 直到
+        facet_panel_background_color: 分面面板背景色
+        facet_panel_text_color: 构面面板文本颜色
         files: 上传一个文件
+        footer_link_color: 页脚链接颜色
+        footer_link_hover_color: 页脚链接悬停颜色
+        header_and_footer_background_color: 页眉和页脚背景颜色
+        header_and_footer_text_color: 页眉和页脚文本颜色
         keyword: 关键词
         lease_expiration_date: 直到
         license: 执照
+        link_color: 链接颜色
+        link_hover_color: 链接悬停颜色
         member_of_collection_ids: 添加到收藏
+        navbar_background_color: 导航栏背景颜色
+        navbar_link_background_hover_color: 导航栏链接背景悬停颜色
+        navbar_link_text_color: 导航栏链接文字颜色
+        navbar_link_text_hover_color: 导航栏链接文本悬停颜色
+        primary_button_hover_color: 主按钮悬停颜色
         related_url: 相关网址
         rights_statement: 权利声明
         title: 标题

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -158,15 +158,28 @@ it:
             custom_css:
               confirm: I CSS personalizzati sostituiranno sempre altre selezioni di temi. Procedere?
               warning: Se le personalizzazioni dei temi non sembrano essere applicate correttamente, verifica che non vengano sovrascritte dal CSS personalizzato.
+            default_button_background_color:
+              hint: Pulsanti di interazione con il lavoro (modifica, funzionalità, ecc.); viste di lavoro sulla pagina di raccolta e sul pulsante del filtro di ricerca.
             default_images:
               alert: Carica almeno un file prima di inviarlo.
               hint: Per le immagini predefinite, è necessario utilizzare un'immagine (JPG, GIF o PNG) che abbia le stesse dimensioni in altezza e larghezza (100 pixel in larghezza e 100 pixel in altezza)
             directory_image:
-              hint: Per utilizzare un'immagine come immagine di directory, è necessario utilizzare un'immagine (JPG, GIF o PNG) non più alta dell'intestazione e non più larga di 400 pixel.
+            facet_panel_background_color:
+              hint: Si applica ai facet e alle intestazioni di sezione aggiuntive nelle pagine di lavoro in alcuni temi.
+            facet_panel_text_color:
+              hint: Vale anche per il colore del cursore accanto al testo e al titolo dell'opera su alcuni temi.
             favicon:
               hint: Le favicon devono essere file png e devono essere quadrate. La dimensione massima utilizzata è 228px x 228px.
+            link_color:
+              hint: 'Influisce sui collegamenti nelle pagine di casa e di lavoro, inclusi: breadcrumb, schede, titoli e termini di servizio.'
             logo_image:
               hint: Per utilizzare un'immagine come logo, è necessario utilizzare un'immagine (JPG, GIF o PNG) non più alta dell'intestazione e non più larga di 400 pixel.
+            navbar_background_color:
+              hint: Al 40% di opacità.
+            navbar_link_background_hover_color:
+              hint: Si applica ai pulsanti Home, Informazioni, Contatti e Guida solo su quelle pagine specifiche (con un'opacità del 15%).
+            primary_button_hover_color:
+              hint: Pulsanti di interazione di condivisione, ricerca e raccolta (modifica, funzionalità, ecc.). Anche il bordo di questi pulsanti sarà di questo colore.
             themes:
               confirm: Se il tuo tema non sembra essere applicato correttamente, verifica che non venga sovrascritto dal CSS personalizzato.
           hints:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -158,15 +158,28 @@ pt-BR:
             custom_css:
               confirm: CSS personalizado sempre substituirá outras seleções de temas. Continuar?
               warning: Se suas personalizações de temas não parecem estar sendo aplicadas corretamente, verifique se elas não estão sendo substituídas pelo CSS personalizado.
+            default_button_background_color:
+              hint: Botões de interação do trabalho (editar, recurso, etc.); exibições de trabalho na página de coleção e botão de filtro de pesquisa.
             default_images:
               alert: Faça upload de pelo menos um arquivo antes de enviar.
               hint: Para imagens padrão, você deve usar uma imagem (JPG, GIF ou PNG) que tenha dimensões iguais de altura e largura (100 pixels de largura e 100 pixels de altura)
             directory_image:
-              hint: Para usar uma imagem como imagem do diretório, use uma imagem (JPG, GIF ou PNG) que não seja mais alta que o cabeçalho e que não tenha mais que 400 pixels de largura.
+            facet_panel_background_color:
+              hint: Aplica-se a facetas e cabeçalhos de seção adicionais nas páginas de trabalho em alguns temas.
+            facet_panel_text_color:
+              hint: Aplica-se também à cor do cursor ao lado do texto e ao título da obra em alguns temas.
             favicon:
               hint: Os favicons precisam ser arquivos png e devem ser quadrados. O tamanho máximo usado é 228px x 228px.
+            link_color:
+              hint: 'Afeta links nas páginas inicial e de trabalho, incluindo: breadcrumbs, guias, títulos e termos de serviço.'
             logo_image:
               hint: Para usar uma imagem como logotipo, use uma imagem (JPG, GIF ou PNG) que não seja mais alta que o cabeçalho e que não tenha mais que 400 pixels de largura.
+            navbar_background_color:
+              hint: Com 40% de opacidade.
+            navbar_link_background_hover_color:
+              hint: Aplica-se apenas aos botões Início, Sobre, Contato e Ajuda nessas páginas específicas (com 15% de opacidade).
+            primary_button_hover_color:
+              hint: Botões de compartilhamento, pesquisa e interação de coleção (editar, recurso, etc.). A borda desses botões também será dessa cor.
             themes:
               confirm: Se o seu tema não parece estar sendo aplicado corretamente, verifique se ele não está sendo substituído pelo CSS personalizado.
           hints:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -158,15 +158,28 @@ zh:
             custom_css:
               confirm: 自定义CSS将始终覆盖其他主题选择。继续？
               warning: 如果您的主题自定义设置似乎无法正确应用，请确认自定义CSS不会覆盖它们。
+            default_button_background_color:
+              hint: 工作交互（编辑、功能等）按钮；收藏页面和搜索过滤器按钮上的工作视图。
             default_images:
               alert: 请至少上传一个文件，然后再提交。
               hint: 对于默认图像，您应该使用高度和宽度尺寸（宽度为100像素，高度为100像素）的图像（JPG，GIF或PNG）
             directory_image:
-              hint: 要将图像用作目录图像，应使用不大于标题且宽度不超过400像素的图像（JPG，GIF或PNG）。
+            facet_panel_background_color:
+              hint: 适用于某些主题中工作页面上的分面和附加节标题。
+            facet_panel_text_color:
+              hint: 也适用于文本旁边插入符号的颜色和某些主题的作品标题。
             favicon:
               hint: Favicons 需要是 png 文件并且必须是方形的。使用的最大尺寸为 228px x 228px
+            link_color:
+              hint: 影响主页和工作页面上的链接，包括：面包屑、标签、标题和服务条款。
             logo_image:
               hint: 要将图像用作徽标，应使用不大于标题且宽度不超过400像素的图像（JPG，GIF或PNG）。
+            navbar_background_color:
+              hint: 不透明度为 40%。
+            navbar_link_background_hover_color:
+              hint: 仅适用于这些特定页面上的“主页”、“关于”、“联系方式”和“帮助”按钮（不透明度为 15%）。
+            primary_button_hover_color:
+              hint: 共享、搜索和收藏交互（编辑、功能等）按钮。这些按钮的边框也将是这种颜色。
             themes:
               confirm: 如果您的主题似乎没有正确应用，请确认该主题未被Custom CSS覆盖。
           hints:

--- a/spec/views/hyrax/admin/appearances/show.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/appearances/show.html.erb_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "hyrax/admin/appearances/show", type: :view do
       # default work image
       assert_select "input#admin_appearance_default_work_image[name=?]", "admin_appearance[default_work_image]"
       # colors
-      assert_select "input#admin_appearance_primary_button_background_color[type=?]", "color"
+      assert_select "input#admin_appearance_primary_button_hover_color[type=?]", "color"
       # fonts
       assert_select "input#admin_appearance_body_font[name=?]", "admin_appearance[body_font]"
       # custom css


### PR DESCRIPTION
# summary
bring over the changes from the issue below
- https://github.com/scientist-softserv/palni-palci/issues/449

# Expected Behavior Before Changes
<details>
<summary> color form BEFORE</summary>

![Screenshot 2023-05-09 at 3 18 57 PM](https://github.com/scientist-softserv/palni-palci/assets/29032869/8507161a-d019-4b92-ae99-3a4af946dab0)
![Screenshot 2023-05-09 at 3 19 16 PM](https://github.com/scientist-softserv/palni-palci/assets/29032869/e0e43d5d-ad5b-488a-9fc9-e43a04c5f717)

</details>

# Expected Behavior After Changes
- better named color labels
- help text where useful

# Screenshots / Video

<details>
<summary>color form AFTER</summary>

![image](https://github.com/scientist-softserv/palni-palci/assets/29032869/24efa57d-7d32-4ca8-a801-f898c56a3283)
![image](https://github.com/scientist-softserv/palni-palci/assets/29032869/42a5bd56-0b38-4cc8-bbdf-879ccd39852c)
</details>

# Notes
<details>
<summary> fuller notes </summary>

# COLORS
color changes only apply to the public page, not the admin dashboard

## Header background color >> header_and_footer_background_color
- header and footer background color on every public page

## Header text color >> header_and_footer_text_color
- text color of all text/links in the header
- notification bell
- user icon
- color of all non linked text in the footer

## Searchbar background color >> navbar_background_color
- nav bar background (40% opacity of the color chosen)
- active link background on the navbar color ONLY. darker version of the chosen color. it's a hex and not an rgba so I can't figure out how it's set
- does not affect the bg color of the other navbar links. those are blue unless overridden with css

## Searchbar background hover color >> navbar_link_background_hover_color
- bg color of nav links on hover at 15% opacity

## Searchbar text color >> searchbar_text_color
- text color of the navbar links

## Searchbar text hover color
- text color of the navbar links on hover

## Link color
- dashboard: works/collections tab colors and titles of the works/collections in each tab, terms of use
- work show page: breadcrumbs, metadata text (but not the metadata labels), title of files
- "browse by" link colors on cultural theme home page

## Link hover color
- hover for the above selections

## Footer link color
- color of all linked text in the footer

## Footer link hover color
- hover color of all linked text in the footer

## Primary button background color (looks more like a border, changes to full color on hover) >> primary_button_hover_color
- share button
- search button
- edit, add to collection, feature - collection buttons
- contact form "send" button

## Default button background color
- edit, add to collection, attach child, feature, citations, actions - work buttons
- refresh or change view of works on collection page
- filter by button next to nav bar search icon

## Default button border color
- border color of the above

## Default button text color
- text color of the above

## Active tabs background color
- ??

## Facet panel background color
- facet bg color
- work show page additional sections (facets?) bg color

## Facet panel text color
- text color of the above
- color of caret next to facet title
- title color of work on show page in cultural theme
</details>

@samvera/hyku-code-reviewers
