### PR TITLE
introduce per tenant analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Jump In: [![Slack Status](http://slack.samvera.org/badge.svg)](http://slack.samv
     * [With Vagrant](#with-vagrant)
     * [With Kubernetes](#with-kubernetes)
   * [Single Tenant Mode](#single-tenancy)
+  * [Analytics Feature](#analytics-feature)
+    * [Google](#google)
   * [Switching accounts](#switching-accounts)
   * [Environment Variables](#environment-variables)
   * [Development dependencies](#development-dependencies)
@@ -143,84 +145,59 @@ switch!('myaccount')
 ```
 
 ## Analytics Feature
-Hyku currently only supports the configuration of one Google Analytics account for the basic functionality of this feature. Hyku currently only support Google Analytics with the Universal Analytics property for this feature.
+Hyku currently only supports Google Analytics with the Universal Analytics property for this feature. An account will need to be established per tenant.
 
 Note: Google has announced they will stop processing data using the Universal Analytics property on July 1, 2023  or July 1, 2024 for Analytics 360 properties.
 
-To enable analytics tracking and reporting features within Hyku, please follow the directions below.
+Analytics tracking and reporting features will be turned off by default. To enable them within Hyku, please follow the directions below.
 
-### Setup a Google Analytics Account
-- Create a Service Account: https://cloud.google.com/iam/docs/creating-managing-service-accounts
-  - Note the service account email
-  - When making a service account key, make sure the key type is set to p12
-  - Note the service account private key secret
-- Create an OAuth 2.0 Client ID: https://developers.google.com/identity/protocols/oauth2/web-server#creatingcred
+
+### Google
+#### Create the account
+<!-- TODO: check for updates when we've moved to GA4 -->
 - Create an Analytics account: https://support.google.com/analytics/answer/10269537?hl=en
-  - Note Google Universal Analytics ID number
-- Add service account email  as User, and grant "View" access: https://support.google.com/analytics/answer/1009702?hl=en#Add&zippy=%2Cin-this-article
 - Enable the "Google Analytics API": https://developers.google.com/identity/protocols/oauth2/web-server#enable-apis
-- Enable the "IAM Service Account Credentials API": https://developers.google.com/identity/protocols/oauth2/web-server#enable-apis
+- Create a Service Account:
+  - https://developers.google.com/identity/protocols/oauth2/service-account#creatinganaccount
+  - Please select the p12 format when making your service account key.
+  - Note the private key secret so we can add it to the tenant settings.
+- Configure OAuth 2.0 consent screen: https://support.google.com/cloud/answer/10311615?hl=en&ref_topic=3473162
+- Create an OAuth 2.0 Client ID: https://developers.google.com/identity/protocols/oauth2/web-server#creatingcred
 
-### Set the Environment Variables
-In Hyku there are a few areas to set the environment variables needed for each of your environments development/staging/prodeuction/etc.
+#### Set the Account Settings
+(Uncomment the config/analytics.yml file so that any tenant's without the account level settings referenced below can fallback to the default values in the project level environment variables.)
 
-- Uncomment the config/analytics.yml file where the below mentioned environment variables will connect to our application.
+This applies to each of your environments: development/staging/production/etc.
+Dashboard >> Settings >> Account
 
-```yaml
-analytics:
-  google:
-    analytics_id: <%= ENV['GOOGLE_ANALYTICS_ID'] %>
-    app_name: <%= ENV['GOOGLE_OAUTH_APP_NAME'] %>
-    app_version: <%= ENV['GOOGLE_OAUTH_APP_VERSION'] %>
-    privkey_path: <%= ENV['GOOGLE_OAUTH_PRIVATE_KEY_PATH'] %>
-    privkey_secret: <%= ENV['GOOGLE_OAUTH_PRIVATE_KEY_SECRET'] %>
-    client_email: <%= ENV['GOOGLE_OAUTH_CLIENT_EMAIL'] %>
-```
+| Name | Description | Example |
+| ------------- | ------------- | ------------- |
+| GOOGLE_ANALYTICS_ID | The ID of your Google Analytics account. | UA-123456-12 |
+| GOOGLE_OAUTH_APP_NAME | The name of the Google application in the Google API console. | hyku-demo |
+| GOOGLE_OAUTH_APP_VERSION | The version of the Google application in the Google API console. | 1.0 |
+| GOOGLE_OAUTH_PRIVATE_KEY_VALUE | The value of the p12 file with base64 encryption. | lotsOfCharacters! |
+| GOOGLE_OAUTH_PRIVATE_KEY_PATH | The full path to your p12, key file. | cred.p12 |
+| GOOGLE_OAUTH_PRIVATE_KEY_SECRET | The secret provided when you created the p12 key. | not-a-secret |
+| GOOGLE_OAUTH_CLIENT_EMAIL | OAuth Client email address. | set-me@email.com |
 
-- For local development please see the .env file and see the "Enable Google Analytics" section.
+- You can use the `GOOGLE_OAUTH_PRIVATE_KEY_VALUE` OR `GOOGLE_OAUTH_PRIVATE_KEY_PATH` value. VALUE takes precedence.
+  - To get the `GOOGLE_OAUTH_PRIVATE_KEY_VALUE` value, you need the path to the p12 file you got from setting up your Service Account and run the following in your console locally.
+    - `base64 -i path/to/file.p12 | pbcopy`
+    - Once you run this script the value is on your local computers clipboard. You will need to paste this into the corresponding account setting.
 
-```yaml
-##START## Enable Google Analytics
-# Uncomment to enable and configure Google Analytics, see README for instructions.
-HYRAX_ANALYTICS=true
-GOOGLE_ANALYTICS_ID=UA-123456-12
-GOOGLE_OAUTH_APP_NAME=hyku-demo
-GOOGLE_OAUTH_APP_VERSION=1.0
-GOOGLE_OAUTH_PRIVATE_KEY_SECRET=not-a-secret
-GOOGLE_OAUTH_PRIVATE_KEY_PATH=prod-cred.p12
-GOOGLE_OAUTH_CLIENT_EMAIL=set-me@email.com
+### Matomo
+#### Create the account
+<!-- TODO -->
 
-# AND comment this out
-# HYRAX_ANALYTICS=false
-##END## Enable Google Analytics
-```
+#### Set the Account Settings
+This applies to each of your environments: development/staging/production/etc.
+Dashboard >> Settings >> Account
 
-- For deployment to staging/production please update/add the variables and values to the helm values files located in the ops directory (example: staging-deploy.tmpl.yaml).
-
-```yaml
-  - name: GOOGLE_ANALYTICS_ID
-    value: $GOOGLE_ANALYTICS_ID # Set in GitHub's Environment Secrets
-  - name: GOOGLE_OAUTH_APP_NAME
-    value: hyku-demo
-  - name: GOOGLE_OAUTH_APP_VERSION
-    value: '1.0'
-  - name: GOOGLE_OAUTH_PRIVATE_KEY_SECRET
-    value: $GOOGLE_OAUTH_PRIVATE_KEY_SECRET # Set in GitHub's Environment Secrets
-  - name: GOOGLE_OAUTH_PRIVATE_KEY_PATH
-    value: prod-cred.p12 # The p12 file is in root and named `prod-cred.p12`
-  - name: GOOGLE_OAUTH_PRIVATE_KEY_VALUE
-    value: $GOOGLE_OAUTH_PRIVATE_KEY_VALUE # Set in GitHub's Environment Secrets
-  - name: GOOGLE_OAUTH_CLIENT_EMAIL
-    value: set-me@email.com
-  - name: HYRAX_ANALYTICS
-    value: 'true'
-```
-
-To get the `GOOGLE_OAUTH_PRIVATE_KEY_VALUE` value to set the variable in GitHub's Environment Secrets, you need the path to the p12 file you got from setting up your Google Service Account and run the following in your console locally.
-
-`base64 -i path/to/file.p12 | pbcopy`
-
-Once you run this script the value is on your local computers clipboard. You will need to paste this into GitHubs Environment Secrets or however you/your organization are handling secrets.
+| Name | Description | Example |
+| ------------- | ------------- | ------------- |
+| MATOMO_BASE_URL | | |
+| MATOMO_SITE_ID | | |
+| MATOMO_AUTH_TOKEN | | |
 
 ## Environment Variables
 
@@ -243,13 +220,6 @@ Once you run this script the value is on your local computers clipboard. You wil
 | FCREPO_STAGING_BASE_PATH | Fedora root path used for dev instance | /staging | no
 | FCREPO_TEST_BASE_PATH | Fedora root path used for test instance | /test | yes
 | FCREPO_TEST_PORT | Test port for the fedora repo  8986 | yes |
-| GOOGLE_ANALYTICS_ID | The Google Analytics account id. Disabled if not set | - | no |
-| GOOGLE_OAUTH_APP_NAME | The name of the application. | - | no |
-| GOOGLE_OAUTH_APP_VERSION | The version of application. | - | no |
-| GOOGLE_OAUTH_PRIVATE_KEY_SECRET | The secret provided by Google when you created the key. | - | no |
-| GOOGLE_OAUTH_PRIVATE_KEY_PATH | The full path to your p12, key file. | - | no |
-| GOOGLE_OAUTH_PRIVATE_KEY_VALUE | The value of the p12 file with base64 encryption, only set on deployment as that is how we get the p12 file on the server (see bin/web & bin/worker files) | - | no
-| GOOGLE_OAUTH_CLIENT_EMAIL | OAuth Client email address.  | set-me@email.com | no |
 | HYKU_ADMIN_HOST | URL of the admin / proprietor host in a multitenant environment | hyku.test | no |
 | HYKU_ADMIN_ONLY_TENANT_CREATION | Restrict signing up a new tenant to the admin | false | no | |
 | HYKU_ALLOW_SIGNUP | Can users register themselves on a given Tenant | true  | no |
@@ -287,6 +257,7 @@ Once you run this script the value is on your local computers clipboard. You wil
 | HYKU_WEEKLY_EMAIL_LIST | Not used. Placeholder for upcoming Ubiquity feature | en | no |
 | HYKU_YEARLY_EMAIL_LIST | Not used. Placeholder for upcoming Ubiquity feature | en | no |
 | HYRAX_ACTIVE_JOB_QUEUE | Which Rails background job runner should be used? | sidekiq | no |
+| HYRAX_ANALYTICS | Flag to enable(true)/disable(false) the Google Analytics feature. | 'false' | no
 | HYRAX_FITS_PATH | Where is fits.sh installed on the system. Will try the PATH if not set. | /app/fits/fits.sh | no |
 | HYRAX_REDIS_NAMESPACE | What namespace should the application use by default | hyrax | no |
 | I18N_DEBUG | See [Working with Translations] above | false | yes |

--- a/app/models/concerns/account_settings.rb
+++ b/app/models/concerns/account_settings.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# All settings have a presedence order as follows
+# All settings have a precedence order as follows
 # Per Tenant Setting > ENV['HYKU_SETTING_NAME'] > ENV['HYRAX_SETTING_NAME'] > default
 
 module AccountSettings
@@ -26,10 +26,16 @@ module AccountSettings
     setting :email_subject_prefix, type: 'string'
     setting :enable_oai_metadata, type: 'string', disabled: true
     setting :file_size_limit, type: 'string', default: 5.gigabytes.to_s
-    setting :google_analytics_id, type: 'string'
     setting :google_scholarly_work_types, type: 'array', disabled: true
     setting :geonames_username, type: 'string', default: ''
     setting :gtm_id, type: 'string'
+    setting :google_analytics_id, type: 'string'
+    setting :google_oauth_app_name, type: 'string'
+    setting :google_oauth_app_version, type: 'string'
+    setting :google_oauth_private_key_value, type: 'string'
+    setting :google_oauth_private_key_path, type: 'string'
+    setting :google_oauth_private_key_secret, type: 'string'
+    setting :google_oauth_client_email, type: 'string'
     setting :locale_name, type: 'string', disabled: true
     setting :monthly_email_list, type: 'array', disabled: true
     setting :oai_admin_email, type: 'string', default: 'changeme@example.com'
@@ -62,7 +68,7 @@ module AccountSettings
   class_methods do
     def setting(name, args)
       known_type = ['array', 'boolean', 'hash', 'string'].include?(args[:type])
-      raise "Setting type #{args[:type]} is not supported. Can not laod." unless known_type
+      raise "Setting type #{args[:type]} is not supported. Can not load." unless known_type
 
       send("#{args[:type]}_settings") << name
       all_settings[name] = args
@@ -156,11 +162,11 @@ module AccountSettings
     def reload_library_config
       Hyrax.config do |config|
         config.contact_email = contact_email
-        config.analytics = google_analytics_id.present?
-        config.google_analytics_id = google_analytics_id if google_analytics_id.present?
         config.geonames_username = geonames_username
         config.uploader[:maxFileSize] = file_size_limit
       end
+
+      reload_analytics
 
       Devise.mailer_sender = contact_email
 
@@ -186,5 +192,39 @@ module AccountSettings
       return unless ssl_configured
       ActionMailer::Base.default_url_options ||= {}
       ActionMailer::Base.default_url_options[:protocol] = 'https'
+    end
+
+    def reload_analytics
+      # rubocop:disable Style/RedundantSelf
+      # fall back to the default values if they aren't set in the tenant
+      unless self.google_analytics_id.present? &&
+             self.google_oauth_app_name.present? &&
+             self.google_oauth_app_version.present? &&
+             (self.google_oauth_private_key_value.present? || self.google_oauth_private_key_path.present?) &&
+             self.google_oauth_private_key_secret.present? &&
+             self.google_oauth_client_email.present?
+
+        config = Hyrax::Analytics::Config.load_from_yaml
+        self.google_analytics_id = self.google_analytics_id.presence || config.analytics_id
+        self.google_oauth_app_name = self.google_oauth_app_name.presence || config.app_name
+        self.google_oauth_app_version = self.google_oauth_app_version.presence || config.app_version
+        self.google_oauth_private_key_value = self.google_oauth_private_key_value.presence || config.privkey_value
+        self.google_oauth_private_key_path = self.google_oauth_private_key_path.presence || config.privkey_path
+        self.google_oauth_private_key_secret = self.google_oauth_private_key_secret.presence || config.privkey_secret
+        self.google_oauth_client_email = self.google_oauth_client_email.presence || config.client_email
+      end
+
+      # require the analytics to be set per tenant
+      Hyrax::Analytics.config.analytics_id = self.google_analytics_id
+      Hyrax::Analytics.config.app_name = self.google_oauth_app_name
+      Hyrax::Analytics.config.app_version = self.google_oauth_app_version
+      Hyrax::Analytics.config.privkey_value = self.google_oauth_private_key_value
+      Hyrax::Analytics.config.privkey_path = self.google_oauth_private_key_path
+      Hyrax::Analytics.config.privkey_secret = self.google_oauth_private_key_secret
+      Hyrax::Analytics.config.client_email = self.google_oauth_client_email
+
+      # only show analytics partials if analytics are set on the tenant
+      Hyrax.config.analytics = Hyrax::Analytics.config.valid?
+      # rubocop:enable Style/RedundantSelf
     end
 end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -6,6 +6,7 @@
 #     analytics_id: <%= ENV['GOOGLE_ANALYTICS_ID'] %>
 #     app_name: <%= ENV['GOOGLE_OAUTH_APP_NAME'] %>
 #     app_version: <%= ENV['GOOGLE_OAUTH_APP_VERSION'] %>
+#     privkey_value: <%= ENV['GOOGLE_OAUTH_PRIVATE_KEY_VALUE'] %>
 #     privkey_path: <%= ENV['GOOGLE_OAUTH_PRIVATE_KEY_PATH'] %>
 #     privkey_secret: <%= ENV['GOOGLE_OAUTH_PRIVATE_KEY_SECRET'] %>
 #     client_email: <%= ENV['GOOGLE_OAUTH_CLIENT_EMAIL'] %>

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -12,6 +12,13 @@ en:
           base_path: Fedora base path should begin with a slash AND not end with a slash
           url: Fedora URL should not end with a slash
         name: A single or hyphenated name used for technical aspects of the repository (e.g., "acme" or "acme-library").
+        google_analytics_id: The ID of your Analytics account
+        google_oauth_app_name: The name of the application
+        google_oauth_app_version: The version of application
+        google_oauth_private_key_secret: The secret provided when you created the key
+        google_oauth_private_key_path: The full path to your p12, key file
+        google_oauth_private_key_value: The value of the p12 file with base64 encryption
+        google_oauth_client_email: OAuth Client email address
         gtm_id: The ID of your Google Tag Manager account
         contact_email: Email recipient of messages sent via the contact form
         weekly_email_list: List of email addresses to email the weekly report. Leave a single space between each email


### PR DESCRIPTION
# Story
allow for per tenant analytics. still has a fallback to use the project default values though.
you can establish an analytics account for each tenant, or only some tenants while allowing the others to use the defaults in the environment variables.

related
- https://github.com/scientist-softserv/palni-palci/issues/408
- https://github.com/scientist-softserv/palni-palci/issues/409

@samvera/hyku-code-reviewers
