### PR TITLE
Downgrade sidekiq until redis is upgraded

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,10 +75,6 @@ jobs:
       - samvera/bundle:
           ruby_version: << parameters.ruby_version >>
           bundler_version: << parameters.bundler_version >>
-      - run: |
-            sed -i '/require .enumerator./d' /home/circleci/project/vendor/bundle/gems/oai-1.1.0/lib/oai/provider/resumption_token.rb && \
-            sed -i '/require .enumerator./d' /home/circleci/project/vendor/bundle/gems/edtf-3.0.8/lib/edtf.rb && \
-            sed -i '/require .enumerator./d' /home/circleci/project/vendor/bundle/gems/csl-1.6.0/lib/csl.rb
       - samvera/rubocop
       - browser-tools/install-browser-tools
       - run: bundle exec rake db:create db:schema:load

--- a/Gemfile
+++ b/Gemfile
@@ -119,7 +119,7 @@ group :aws, :test do
 end
 
 group :aws do
-  gem 'active_elastic_job', git: 'https://github.com/tawan/active-elastic-job.git'
+  gem 'active_elastic_job', git: 'https://github.com/tawan/active-elastic-job.git', branch: 'ec51c5d9dedc4a1b47f2db41f26d5fceb251e979'
   gem 'aws-sdk-sqs'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -109,7 +109,7 @@ gem 'apartment'
 gem 'is_it_working'
 gem 'rolify'
 
-gem 'flipflop', '~> 2.6.0'  # waiting for hyrax 4 upgrade
+gem 'flipflop', '~> 2.6.0' # waiting for hyrax 4 upgrade
 gem 'lograge'
 
 gem 'mods', '~> 2.4'

--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,8 @@ source 'https://rubygems.org'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.5'
 
-gem 'addressable', '2.8.1' # remove once https://github.com/postrank-labs/postrank-uri/issues/49 is fixed
 gem 'activerecord-nulldb-adapter'
+gem 'addressable', '2.8.1' # remove once https://github.com/postrank-labs/postrank-uri/issues/49 is fixed
 # Use sqlite3 as the database for Active Record
 gem 'pg'
 # Use Puma as the app server

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source 'https://rubygems.org'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.5'
 
+gem 'addressable', '2.8.1' # remove once https://github.com/postrank-labs/postrank-uri/issues/49 is fixed
 gem 'activerecord-nulldb-adapter'
 # Use sqlite3 as the database for Active Record
 gem 'pg'

--- a/Gemfile
+++ b/Gemfile
@@ -109,7 +109,7 @@ gem 'apartment'
 gem 'is_it_working'
 gem 'rolify'
 
-gem 'flipflop', '~> 2.3'
+gem 'flipflop', '~> 2.6.0'  # waiting for hyrax 4 upgrade
 gem 'lograge'
 
 gem 'mods', '~> 2.4'
@@ -119,7 +119,8 @@ group :aws, :test do
 end
 
 group :aws do
-  gem 'active_elastic_job', git: 'https://github.com/tawan/active-elastic-job.git', branch: 'ec51c5d9dedc4a1b47f2db41f26d5fceb251e979'
+  gem 'active_elastic_job', git: 'https://github.com/tawan/active-elastic-job.git',
+                            branch: 'ec51c5d9dedc4a1b47f2db41f26d5fceb251e979'
   gem 'aws-sdk-sqs'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -131,7 +131,7 @@ gem 'parser', '~> 2.5.3'
 gem 'rdf', '~> 3.1.15' # rdf 3.2.0 removed SerializedTransaction which ldp requires
 gem 'riiif', '~> 1.1'
 gem 'secure_headers'
-gem 'sidekiq'
+gem 'sidekiq', "< 7.0" # sidekiq 7 requires upgrade to redis 6
 gem 'terser' # to support the Safe Navigation / Optional Chaining operator (?.) and avoid uglifier precompile issue
 gem 'tether-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -434,9 +434,8 @@ GEM
     fcrepo_wrapper (0.9.0)
       ruby-progressbar
     ffi (1.15.5)
-    flipflop (2.7.1)
+    flipflop (2.6.0)
       activesupport (>= 4.0)
-      terminal-table (>= 1.8)
     flot-rails (0.0.7)
       jquery-rails
     flutie (2.2.0)
@@ -1228,7 +1227,7 @@ DEPENDENCIES
   easy_translate
   factory_bot_rails
   fcrepo_wrapper (~> 0.4)
-  flipflop (~> 2.3)
+  flipflop (~> 2.6.0)
   flutie
   hyrax (~> 3.5.0)
   hyrax-doi!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,7 +111,7 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    addressable (2.8.4)
+    addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
     almond-rails (0.3.0)
       rails (>= 4.2)
@@ -1202,6 +1202,7 @@ DEPENDENCIES
   active-fedora (>= 11.1.4)
   active_elastic_job!
   activerecord-nulldb-adapter
+  addressable (= 2.8.1)
   apartment
   aws-sdk-sqs
   blacklight (~> 6.7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -947,8 +947,6 @@ GEM
     redic (1.5.3)
       hiredis
     redis (4.8.1)
-    redis-client (0.14.1)
-      connection_pool
     redis-namespace (1.10.0)
       redis (>= 4)
     redlock (1.3.2)
@@ -1069,11 +1067,10 @@ GEM
       sxp (~> 1.1)
     shoulda-matchers (4.5.1)
       activesupport (>= 4.2.0)
-    sidekiq (7.1.0)
-      concurrent-ruby (< 2)
-      connection_pool (>= 2.3.0)
-      rack (>= 2.2.4)
-      redis-client (>= 0.14.0)
+    sidekiq (6.5.9)
+      connection_pool (>= 2.2.5, < 3)
+      rack (~> 2.0)
+      redis (>= 4.5.0, < 5)
     signet (0.17.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
@@ -1271,7 +1268,7 @@ DEPENDENCIES
   secure_headers
   selenium-webdriver
   shoulda-matchers (~> 4.0)
-  sidekiq
+  sidekiq (< 7.0)
   simplecov
   solr_wrapper (~> 2.0)
   spring (~> 1.7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,11 +35,12 @@ GIT
 
 GIT
   remote: https://github.com/tawan/active-elastic-job.git
-  revision: 092a8102cd38cffd7203d408fa03998cdff9dc03
+  revision: ec51c5d9dedc4a1b47f2db41f26d5fceb251e979
+  branch: ec51c5d9dedc4a1b47f2db41f26d5fceb251e979
   specs:
-    active_elastic_job (3.2.0)
+    active_elastic_job (2.0.1)
       aws-sdk-sqs (~> 1)
-      rails (>= 5.2.6, < 7.1)
+      rails (>= 4.2)
 
 GEM
   remote: https://rubygems.org/
@@ -128,8 +129,8 @@ GEM
     awesome_nested_set (3.5.0)
       activerecord (>= 4.0.0, < 7.1)
     aws-eventstream (1.2.0)
-    aws-partitions (1.759.0)
-    aws-sdk-core (3.171.0)
+    aws-partitions (1.785.0)
+    aws-sdk-core (3.178.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.651.0)
       aws-sigv4 (~> 1.5)
@@ -141,10 +142,10 @@ GEM
       aws-sdk-core (~> 3, >= 3.165.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.4)
-    aws-sdk-sqs (1.53.0)
-      aws-sdk-core (~> 3, >= 3.165.0)
+    aws-sdk-sqs (1.61.0)
+      aws-sdk-core (~> 3, >= 3.177.0)
       aws-sigv4 (~> 1.1)
-    aws-sigv4 (1.5.2)
+    aws-sigv4 (1.6.0)
       aws-eventstream (~> 1, >= 1.0.2)
     babel-source (5.8.35)
     babel-transpiler (0.7.0)
@@ -577,7 +578,7 @@ GEM
       signet
       tinymce-rails (~> 5.10)
       valkyrie (~> 2, >= 2.1.1)
-    i18n (1.13.0)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     i18n-debug (1.2.0)
       i18n (< 2)
@@ -715,9 +716,9 @@ GEM
       activesupport (>= 4)
       railties (>= 4)
       request_store (~> 1.0)
-    loofah (2.20.0)
+    loofah (2.21.3)
       crass (~> 1.0.2)
-      nokogiri (>= 1.5.9)
+      nokogiri (>= 1.12.0)
     mail (2.8.1)
       mini_mime (>= 0.1.1)
       net-imap
@@ -747,7 +748,7 @@ GEM
     mini_magick (4.12.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.2)
-    minitest (5.18.0)
+    minitest (5.18.1)
     mods (2.4.1)
       edtf
       iso-639
@@ -764,7 +765,7 @@ GEM
       redic
     net-http-persistent (4.0.2)
       connection_pool (~> 2.2)
-    net-imap (0.3.4)
+    net-imap (0.3.6)
       date
       net-protocol
     net-pop (0.1.2)
@@ -839,7 +840,7 @@ GEM
       nokogiri (~> 1.6)
       rails (>= 5.0, < 7.1)
       rdf
-    racc (1.6.2)
+    racc (1.7.1)
     rack (2.2.7)
     rack-test (0.7.0)
       rack (>= 1.0, < 3)
@@ -860,8 +861,9 @@ GEM
       actionpack (>= 5.0.1.rc1)
       actionview (>= 5.0.1.rc1)
       activesupport (>= 5.0.1.rc1)
-    rails-dom-testing (2.0.3)
-      activesupport (>= 4.2.0)
+    rails-dom-testing (2.1.1)
+      activesupport (>= 5.0.0)
+      minitest
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.5.0)
       loofah (~> 2.19, >= 2.19.1)
@@ -1132,11 +1134,11 @@ GEM
       execjs (>= 0.3.0, < 3)
     tether-rails (1.4.0)
       rails (>= 3.1)
-    thor (1.2.1)
+    thor (1.2.2)
     thread (0.2.2)
     thread_safe (0.3.6)
     tilt (2.1.0)
-    timeout (0.3.2)
+    timeout (0.4.0)
     tinymce-rails (5.10.7)
       railties (>= 3.1.1)
     turbolinks (5.2.1)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -62,16 +62,12 @@ Capybara.default_driver = :rack_test
 ENV['WEB_HOST'] ||= `hostname -s`.strip
 
 if ENV['CHROME_HOSTNAME'].present?
-  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chromeOptions: {
-      args: %w[headless disable-gpu no-sandbox whitelisted-ips window-size=1400,1400]
-    }
-  )
+  options = Selenium::WebDriver::Options.chrome(args: ["headless", "disable-gpu", "no-sandbox", "whitelisted-ips", "window-size=1400,1400"])
 
   Capybara.register_driver :chrome do |app|
     d = Capybara::Selenium::Driver.new(app,
                                        browser: :remote,
-                                       desired_capabilities: capabilities,
+                                       capabilities: options,
                                        url: "http://#{ENV['CHROME_HOSTNAME']}:4444/wd/hub")
     # Fix for capybara vs remote files. Selenium handles this for us
     d.browser.file_detector = lambda do |args|
@@ -84,17 +80,13 @@ if ENV['CHROME_HOSTNAME'].present?
   Capybara.server_port = 3001
   Capybara.app_host = "http://#{ENV['WEB_HOST']}:#{Capybara.server_port}"
 else
-  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chromeOptions: {
-      args: %w[headless disable-gpu]
-    }
-  )
+  options = Selenium::WebDriver::Options.chrome(args: ["headless", "disable-gpu"])
 
   Capybara.register_driver :chrome do |app|
     Capybara::Selenium::Driver.new(
       app,
       browser: :chrome,
-      desired_capabilities: capabilities
+      capabilities: options
     )
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -62,7 +62,11 @@ Capybara.default_driver = :rack_test
 ENV['WEB_HOST'] ||= `hostname -s`.strip
 
 if ENV['CHROME_HOSTNAME'].present?
-  options = Selenium::WebDriver::Options.chrome(args: ["headless", "disable-gpu", "no-sandbox", "whitelisted-ips", "window-size=1400,1400"])
+  options = Selenium::WebDriver::Options.chrome(args: ["headless",
+                                                       "disable-gpu",
+                                                       "no-sandbox",
+                                                       "whitelisted-ips",
+                                                       "window-size=1400,1400"])
 
   Capybara.register_driver :chrome do |app|
     d = Capybara::Selenium::Driver.new(app,


### PR DESCRIPTION
The changes of this PR will modify the gemfile to downgrade Sidekiq 7 to version 6 as Redis is currently on version 5. Sidekiq 7 requires Redis version 6, and depends on the redis-client gem. Redis-client does not get introduced until Redis version 6.

