### PR TITLE
🐛 Adding conditional when Devise is non-registerable

### DIFF
--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -16,7 +16,9 @@
         <li><%= link_to t("hyrax.toolbar.dashboard.menu"), hyrax.dashboard_path %></li>
 
         <li class="divider"></li>
-        <li><%= link_to t("hyku.toolbar.profile.edit_registration"), main_app.edit_user_registration_path %></li>
+	<% if Devise.mappings[:user]&.registerable? %>
+          <li><%= link_to t("hyku.toolbar.profile.edit_registration"), main_app.edit_user_registration_path %></li>
+        <% end %>
         <li><%= link_to t("hyrax.toolbar.profile.logout"), main_app.destroy_user_session_path %></li>
       </ul>
     </li><!-- /.btn-group -->

--- a/app/views/themes/cultural_repository/_user_util_links.html.erb
+++ b/app/views/themes/cultural_repository/_user_util_links.html.erb
@@ -25,7 +25,9 @@
         <li><%= link_to t("hyrax.toolbar.dashboard.menu"), hyrax.dashboard_path %></li>
 
         <li class="divider"></li>
-        <li><%= link_to t("hyku.toolbar.profile.edit_registration"), main_app.edit_user_registration_path %></li>
+	<% if Devise.mappings[:user]&.registerable? %>
+          <li><%= link_to t("hyku.toolbar.profile.edit_registration"), main_app.edit_user_registration_path %></li>
+        <% end %>
         <li><%= link_to t("hyrax.toolbar.profile.logout"), main_app.destroy_user_session_path %></li>
       </ul>
     </li><!-- /.btn-group -->

--- a/app/views/themes/institutional_repository/_user_util_links.html.erb
+++ b/app/views/themes/institutional_repository/_user_util_links.html.erb
@@ -17,7 +17,9 @@
           <li><%= link_to t("hyrax.toolbar.dashboard.menu"), hyrax.dashboard_path %></li>
 
           <li class="divider"></li>
-          <li><%= link_to t("hyku.toolbar.profile.edit_registration"), main_app.edit_user_registration_path %></li>
+	  <% if Devise.mappings[:user]&.registerable? %>
+            <li><%= link_to t("hyku.toolbar.profile.edit_registration"), main_app.edit_user_registration_path %></li>
+          <% end %>
           <li><%= link_to t("hyrax.toolbar.profile.logout"), main_app.destroy_user_session_path %></li>
         </ul>
       </li><!-- /.btn-group -->


### PR DESCRIPTION
Prior to this commit, if we remove the User's `devise registerable` configuration we would encounter an error with the path methods not existing.  With this change, we allow for disabling of the registerable feature; in a Devise friendly manner.

We could look to the below view and extract a helper method for this. But this seems to be a path of least problem.

From `app/views/devise/shared/_links.html.erb`:

```
<%- if devise_mapping.registerable? && controller_name != 'registrations' && !Account.global_tenant? && current_account.try(:allow_signup) %>
  <%= link_to t(".sign_up"), new_registration_path(resource_name) %><br />
<% end -%>
```

The `devise_mapping` method is `Devise.mappings[<key>]`; and in this case that key is `:user`.  See
https://github.com/heartcombo/devise/blob/ec0674523e7909579a5a008f16fb9fe0c3a71712/app/controllers/devise_controller.rb#L60

Related to:

- https://github.com/scientist-softserv/adventist-dl/issues/492
