### PR TITLE
resolve-rails-command-servercommand-error

### DIFF
--- a/.regen
+++ b/.regen
@@ -1,0 +1,2 @@
+# When updating CI regen seed, set to current date.
+2023-08-09T14:34:59

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'hyrax/version'
+
+Gem::Specification.new do |spec|
+  spec.authors       = ["Justin Coyne", 'Michael J. Giarlo', "Carolyn Cole", "Matt Zumwalt", 'Jeremy Friesen', 'Trey Pendragon', 'Esmé Cowles']
+  spec.email         = ["jcoyne85@stanford.edu", 'mjgiarlo@stanford.edu', 'cam156@psu.edu', 'matt@databindery.com', "jeremy.n.friesen@gmail.com", 'tpendragon@princeton.edu', 'escowles@ticklefish.org']
+  spec.description   = 'Hyrax is a featureful Samvera front-end based on the latest and greatest Samvera software components.'
+  spec.summary       = <<-SUMMARY
+  Hyrax is a front-end based on the robust Samvera framework, providing a user
+  interface for common repository features. Hyrax offers the ability to create
+  repository object types on demand, to deposit content via multiple workflows,
+  and to describe content with flexible metadata. Numerous optional features may
+  be turned on in the administrative dashboard or added through plugins.
+SUMMARY
+
+  spec.homepage      = "http://github.com/samvera/hyrax"
+
+  spec.files         = `git ls-files`.split($OUTPUT_RECORD_SEPARATOR).select { |f| File.dirname(f) !~ %r{\A"?spec\/?} && f != 'bin/rails' }
+  spec.executables   = spec.files.grep(%r{^bin/}).map { |f| File.basename(f) }
+  spec.name          = "hyrax"
+  spec.require_paths = ["lib"]
+  spec.version       = Hyrax::VERSION
+  spec.license       = 'Apache-2.0'
+  spec.metadata      = { "rubygems_mfa_required" => "true" }
+
+  spec.required_ruby_version = '>= 2.7'
+
+  # NOTE: rails does not follow sem-ver conventions, it's
+  # minor version releases can include breaking changes; see
+  # http://guides.rubyonrails.org/maintenance_policy.html
+  spec.add_dependency 'rails', '~> 6.0'
+
+  spec.add_dependency 'active-fedora', '~> 14.0'
+  spec.add_dependency 'almond-rails', '~> 0.1'
+  spec.add_dependency 'awesome_nested_set', '~> 3.1'
+  spec.add_dependency 'blacklight', '~> 7.29'
+  spec.add_dependency 'blacklight-gallery', '~> 4.0'
+  spec.add_dependency 'breadcrumbs_on_rails', '~> 3.0'
+  spec.add_dependency 'browse-everything', '>= 0.16', '< 2.0'
+  spec.add_dependency 'carrierwave', '~> 1.0'
+  spec.add_dependency 'clipboard-rails', '~> 1.5'
+  spec.add_dependency 'connection_pool', '~> 2.4'
+  spec.add_dependency 'draper', '~> 4.0'
+  spec.add_dependency 'dry-events', '~> 0.2.0'
+  spec.add_dependency 'dry-equalizer', '~> 0.2'
+  spec.add_dependency 'dry-monads', '~> 1.5'
+  spec.add_dependency 'dry-struct', '~> 1.0'
+  spec.add_dependency 'dry-validation', '~> 1.3'
+  spec.add_dependency 'flipflop', '~> 2.3'
+  # Pin more tightly because 0.x gems are potentially unstable
+  spec.add_dependency 'flot-rails', '~> 0.0.6'
+  spec.add_dependency 'font-awesome-rails', '~> 4.2'
+  spec.add_dependency 'hydra-derivatives', '~> 3.3'
+  spec.add_dependency 'hydra-editor', '~> 6.0'
+  spec.add_dependency 'hydra-file_characterization', '~> 1.1'
+  spec.add_dependency 'hydra-head', '~> 12.0'
+  spec.add_dependency 'hydra-works', '>= 0.16'
+  spec.add_dependency 'iiif_manifest', '>= 0.3', '< 2.0'
+  spec.add_dependency 'json-schema' # for Arkivo
+  spec.add_dependency 'legato', '~> 0.3'
+  spec.add_dependency 'linkeddata' # Required for getting values from geonames
+  spec.add_dependency 'mailboxer', '~> 0.12'
+  spec.add_dependency 'nest', '~> 3.1'
+  spec.add_dependency 'noid-rails', '~> 3.0'
+  spec.add_dependency 'oauth'
+  spec.add_dependency 'oauth2', '~> 1.2'
+  spec.add_dependency 'openseadragon'
+  spec.add_dependency 'posix-spawn'
+  spec.add_dependency 'qa', '~> 5.5', '>= 5.5.1' # questioning_authority
+  spec.add_dependency 'rails_autolink', '~> 1.1'
+  spec.add_dependency 'rdf-rdfxml' # controlled vocabulary importer
+  spec.add_dependency 'rdf-vocab', '~> 3.0'
+  spec.add_dependency 'redis', '~> 4.0'
+  spec.add_dependency 'redis-namespace', '~> 1.5'
+  spec.add_dependency 'redlock', '>= 0.1.2', '< 2.0'
+  spec.add_dependency 'reform', '~> 2.3'
+  spec.add_dependency 'reform-rails', '~> 0.2.0'
+  spec.add_dependency 'retriable', '>= 2.9', '< 4.0'
+  spec.add_dependency 'signet'
+  spec.add_dependency 'tinymce-rails', '~> 5.10'
+  spec.add_dependency 'valkyrie', '~> 3.0.1'
+  spec.add_dependency 'view_component', '~> 2.74.1' # Pin until blacklight is updated with workaround for https://github.com/ViewComponent/view_component/issues/1565
+  spec.add_dependency 'sprockets', '~> 3.7'
+  spec.add_dependency 'sass-rails', '~> 6.0'
+  spec.add_dependency 'select2-rails', '~> 3.5'
+
+  spec.add_development_dependency "capybara", '~> 3.29'
+  spec.add_development_dependency 'capybara-screenshot', '~> 1.0'
+  spec.add_development_dependency 'database_cleaner', '~> 1.3'
+  spec.add_development_dependency 'engine_cart', '~> 2.5'
+  spec.add_development_dependency "equivalent-xml", '~> 0.5'
+  spec.add_development_dependency "factory_bot", '~> 4.4'
+  spec.add_development_dependency 'fcrepo_wrapper', '~> 0.5', '>= 0.5.1'
+  spec.add_development_dependency 'mida', '~> 0.3'
+  spec.add_development_dependency 'okcomputer'
+  spec.add_development_dependency 'pg', '~> 1.2'
+  spec.add_development_dependency 'rspec-activemodel-mocks', '~> 1.0'
+  spec.add_development_dependency 'rspec-its', '~> 1.1'
+  spec.add_development_dependency 'rspec-rails', '~> 5.0'
+  spec.add_development_dependency 'rspec_junit_formatter'
+  spec.add_development_dependency "selenium-webdriver", '~> 4.4'
+  spec.add_development_dependency 'i18n-debug'
+  spec.add_development_dependency 'i18n_yaml_sorter'
+  spec.add_development_dependency 'rails-controller-testing', '~> 1'
+  # the hyrax style guide is based on `bixby`. see `.rubocop.yml`
+  spec.add_development_dependency 'bixby', '~> 5.0', '>= 5.0.2' # bixby 5 briefly dropped Ruby 2.5
+  spec.add_development_dependency 'shoulda-callback-matchers', '~> 1.1.1'
+  spec.add_development_dependency 'shoulda-matchers', '~> 3.1'
+  spec.add_development_dependency 'webdrivers', '~> 4.4'
+  spec.add_development_dependency 'webmock'
+end


### PR DESCRIPTION
cherry-pick commit `96a88ab` from hyrax.

when starting the server today I recevied an uninitialized constant Rails::Command::ServerCommand::APP_PATH (NameError) error. a search of the samvera slack returned this message: https://samvera.slack.com/archives/C75LH2VEH/p1691595910445459. @dlpierce responded and I found https://github.com/samvera/hyrax/pull/6146. I cherry picked the merge commit, but I am still unable to start up this app.

we didn't have either of these two files anyway, so I don't think this would have been the solution. but leaving them here as breadcrumbs.

<img width="1440" alt="Screenshot 2023-08-24 at 2 12 55 PM" src="https://github.com/samvera/hyku/assets/29032869/f7793091-9b9b-4517-9416-1482151071ab">

