### PR TITLE
Georgetown conditionally required fields

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -43,6 +43,7 @@
 //= require bulkrax/application
 
 //= require hyrax
+//= require hyrax/conditionally_required_fields
 //= require iiif_print
 
 //= require jquery.flot.pie

--- a/app/assets/javascripts/hyrax/conditionally_required_fields.js
+++ b/app/assets/javascripts/hyrax/conditionally_required_fields.js
@@ -18,12 +18,12 @@ $(document).on('turbolinks:load', function () {
 $(document).on('turbolinks:load', function () {
   return $('body').on('blur', '#generic_work_rights_notes', function () {
     if (this.value === undefined) return;
-    ($('#generic_work_rights_notes').attr('required', true));
+    $('#generic_work_rights_notes').attr('required', true);
 
-    if(this.value === '') {
-      ($('#generic_work_rights_statement').attr('required', true))
+    if (this.value === '') {
+      $('#generic_work_rights_statement').attr('required', true);
     } else {
-      ($('#generic_work_rights_statement').attr('required', false))
+      $('#generic_work_rights_statement').attr('required', false);
     }
   });
 });
@@ -32,12 +32,12 @@ $(document).on('turbolinks:load', function () {
 $(document).on('turbolinks:load', function () {
   return $('body').on('blur', '#generic_work_rights_statement', function () {
     if (this.value === undefined || !this.value) return;
-    ($('#generic_work_rights_statement').attr('required', true))
+    $('#generic_work_rights_statement').attr('required', true);
 
-    if(this.value === '') {
-      ($('#generic_work_rights_notes').attr('required', true))
+    if (this.value === '') {
+      $('#generic_work_rights_notes').attr('required', true);
     } else {
-      ($('#generic_work_rights_notes').attr('required', false))
+      $('#generic_work_rights_notes').attr('required', false);
     }
   });
 });

--- a/app/assets/javascripts/hyrax/conditionally_required_fields.js
+++ b/app/assets/javascripts/hyrax/conditionally_required_fields.js
@@ -1,0 +1,43 @@
+/**
+ * This file is used to conditionally require fields on the edit/new work forms.
+ * At the moment, rights statement is required by default, and rights notes is not.
+ * One or the other must be filled out in order to create/update a work
+ */
+
+// check the value of the rights statement and rights notes fields on page load
+$(document).on('turbolinks:load', function () {
+  $('#generic_work_rights_statement').each(function () {
+    if (this.value || $('#generic_work_rights_notes')[0].value) return;
+
+    $('#generic_work_rights_statement').attr('required', true);
+    $('#generic_work_rights_notes').attr('required', true);
+  });
+});
+
+// check the value of the rights notes field after its focus is removed
+$(document).on('turbolinks:load', function () {
+  return $('body').on('blur', '#generic_work_rights_notes', function () {
+    if (this.value === undefined) return;
+    ($('#generic_work_rights_notes').attr('required', true));
+
+    if(this.value === '') {
+      ($('#generic_work_rights_statement').attr('required', true))
+    } else {
+      ($('#generic_work_rights_statement').attr('required', false))
+    }
+  });
+});
+
+// check the value of the rights statement field after its focus is removed
+$(document).on('turbolinks:load', function () {
+  return $('body').on('blur', '#generic_work_rights_statement', function () {
+    if (this.value === undefined || !this.value) return;
+    ($('#generic_work_rights_statement').attr('required', true))
+
+    if(this.value === '') {
+      ($('#generic_work_rights_notes').attr('required', true))
+    } else {
+      ($('#generic_work_rights_notes').attr('required', false))
+    }
+  });
+});

--- a/app/views/records/edit_fields/_default.html.erb
+++ b/app/views/records/edit_fields/_default.html.erb
@@ -1,0 +1,7 @@
+<% if f.object.multiple? key %>
+  <%= f.input key, as: :multi_value, input_html: { class: 'form-control' }, required: f.object.required?(key) %>
+<% elsif key == :rights_notes %>
+  <%= f.input key, required: f.object.instance_variable_get('@attributes')['rights_statement'].blank? %>
+<% else %>
+  <%= f.input key, required: f.object.required?(key) %>
+<% end %>

--- a/app/views/records/edit_fields/_default.html.erb
+++ b/app/views/records/edit_fields/_default.html.erb
@@ -1,7 +1,0 @@
-<% if f.object.multiple? key %>
-  <%= f.input key, as: :multi_value, input_html: { class: 'form-control' }, required: f.object.required?(key) %>
-<% elsif key == :rights_notes %>
-  <%= f.input key, required: f.object.instance_variable_get('@attributes')['rights_statement'].blank? %>
-<% else %>
-  <%= f.input key, required: f.object.required?(key) %>
-<% end %>

--- a/app/views/records/edit_fields/_rights_statement.html.erb
+++ b/app/views/records/edit_fields/_rights_statement.html.erb
@@ -1,0 +1,7 @@
+<% rights_statements = Hyrax.config.rights_statement_service_class.new %>
+<%= f.input :rights_statement,
+    collection: rights_statements.select_active_options,
+    include_blank: true,
+    item_helper: rights_statements.method(:include_current_value),
+		required: f.object.instance_variable_get('@attributes')['rights_notes'].first.blank?,
+    input_html: { class: 'form-control' } %>

--- a/app/views/records/edit_fields/_rights_statement.html.erb
+++ b/app/views/records/edit_fields/_rights_statement.html.erb
@@ -3,5 +3,5 @@
     collection: rights_statements.select_active_options,
     include_blank: true,
     item_helper: rights_statements.method(:include_current_value),
-		required: f.object.instance_variable_get('@attributes')['rights_notes'].first.blank?,
+		required: false,
     input_html: { class: 'form-control' } %>

--- a/app/views/records/edit_fields/_rights_statement.html.erb
+++ b/app/views/records/edit_fields/_rights_statement.html.erb
@@ -1,3 +1,4 @@
+<%# OVERRIDE: Hyrax 3.5.0 so this is not a required field by default %>
 <% rights_statements = Hyrax.config.rights_statement_service_class.new %>
 <%= f.input :rights_statement,
     collection: rights_statements.select_active_options,


### PR DESCRIPTION
DO NOT MERGE -- this is a pr to show scott at georgetown how an implementation of conditionally requiring fields can be done.
<hr>

# story
require either rights statement or rights notes be filled out on a generic work form

we do this by removing the intiial requirement on the rights statement input. otherwise, [validateMetatdata](https://github.com/samvera/hyrax/blob/main/app/assets/javascripts/hyrax/save_work/save_work_control.es6\#L148-L155) remained false.

instead, on page load we verify if either field has data. if so, we carry on. if neither does, both are marked as required. from there, if one of the two fields is changed then it is marked as required while the other is removed as required.

if neither field has data and the form attempts to be saved (the save button will NOT be disabled), a popup will show up on the rights statement asking for it to be filled out.

# TODO
make this unspecific to the generic work form.