### PR TITLE
User invite email has html tag

### DIFF
--- a/config/locales/devise_invitable.de.yml
+++ b/config/locales/devise_invitable.de.yml
@@ -22,7 +22,7 @@ de:
         accept_until: Diese Einladung wird in %{due_date} fällig.
         hello: Hallo %{email}
         ignore: |-
-          Wenn Sie die Einladung nicht akzeptieren möchten, ignorieren Sie bitte diese E-Mail. <br />
+          Wenn Sie die Einladung nicht akzeptieren möchten, ignorieren Sie bitte diese E-Mail. 
           Ihr Konto wird erst dann erstellt, wenn Sie auf den obigen Link zugreifen und Ihr Passwort festlegen.
         someone_invited_you: Jemand hat Sie zu %{url} eingeladen, können Sie es über den Link unten akzeptieren.
         subject: Einladungshinweise

--- a/config/locales/devise_invitable.en.yml
+++ b/config/locales/devise_invitable.en.yml
@@ -22,7 +22,7 @@ en:
         accept_until: This invitation will be due in %{due_date}.
         hello: Hello %{email}
         ignore: |-
-          If you don't want to accept the invitation, please ignore this email.<br />
+          If you don't want to accept the invitation, please ignore this email. 
           Your account won't be created until you access the link above and set your password.
         someone_invited_you: Someone has invited you to %{url}, you can accept it through the link below.
         subject: Invitation instructions

--- a/config/locales/devise_invitable.es.yml
+++ b/config/locales/devise_invitable.es.yml
@@ -22,7 +22,7 @@ es:
         accept_until: Esta invitación será %{due_date}.
         hello: Hola %{email}
         ignore: |-
-          Si no desea aceptar la invitación, ignore este correo electrónico.<br />
+          Si no desea aceptar la invitación, ignore este correo electrónico. 
           Su cuenta no se creará hasta que acceda al enlace anterior y establezca su contraseña.
         someone_invited_you: Alguien te ha invitado a %{url}, puedes aceptarlo a través del siguiente enlace.
         subject: Instrucciones de invitación

--- a/config/locales/devise_invitable.fr.yml
+++ b/config/locales/devise_invitable.fr.yml
@@ -22,7 +22,7 @@ fr:
         accept_until: Cette invitation sera due en %{due_date}.
         hello: Bonjour %{email}
         ignore: |-
-          Si vous ne souhaitez pas accepter l'invitation, ignorez ce courriel. <br />
+          Si vous ne souhaitez pas accepter l'invitation, ignorez ce courriel. 
           Votre compte ne sera créé que lorsque vous accédez au lien ci-dessus et définissez votre mot de passe.
         someone_invited_you: Quelqu'un vous a invité %{url}, vous pouvez l'accepter par le lien ci-dessous.
         subject: Instructions d'invitation

--- a/config/locales/devise_invitable.it.yml
+++ b/config/locales/devise_invitable.it.yml
@@ -22,7 +22,7 @@ it:
         accept_until: Questo invito sarà dovuto in %{due_date}.
         hello: Ciao %{email}
         ignore: |-
-          Se non desideri accettare l'invito, ignora questa email. <br />
+          Se non desideri accettare l'invito, ignora questa email. 
           Il tuo account non verrà creato finché non accedi al link precedente e imposta la tua password.
         someone_invited_you: Qualcuno ti ha invitato a %{url}, puoi accettarlo tramite il link qui sotto.
         subject: Istruzioni di invito

--- a/config/locales/devise_invitable.pt-BR.yml
+++ b/config/locales/devise_invitable.pt-BR.yml
@@ -22,7 +22,7 @@ pt-BR:
         accept_until: Este convite será devido em %{due_date}.
         hello: Olá %{email}
         ignore: |-
-          Se você não deseja aceitar o convite, ignore este e-mail. <br />
+          Se você não deseja aceitar o convite, ignore este e-mail. 
           Sua conta não será criada até você acessar o link acima e definir sua senha.
         someone_invited_you: Alguém convidou você para %{url}, você pode aceitá-lo através do link abaixo.
         subject: Instruções de convite

--- a/config/locales/devise_invitable.zh.yml
+++ b/config/locales/devise_invitable.zh.yml
@@ -22,7 +22,7 @@ zh:
         accept_until: 此邀请将到期 %{due_date}.
         hello: 你好 %{email}
         ignore: |-
-          如果您不想接受邀请，请忽略此电子邮件。<br />
+          如果您不想接受邀请，请忽略此电子邮件。
           在您访问以上链接并设置密码之前，您的帐户将不会被创建。
         someone_invited_you: 有人邀请你到 %{url}，您可以通过以下链接接受。
         subject: 邀请说明


### PR DESCRIPTION
Fixes #1998


When a new user receives an email to activate their account, the email has a <br /> tag in it. We have received a lot of reports of these emails going to spam and this could be a contributing factor.


Changes proposed in this pull request:
removes the `<br />` tag from the email text in each of the locale files

@samvera/hyku-code-reviewers
