### PR TITLE
♻️ TO MAIN: Introduce Hyku::Application.theme_view_path_roots

### DIFF
--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -505,8 +505,10 @@ module Hyrax
       def inject_show_theme_views
         if show_page_theme && show_page_theme != 'default_show'
           original_paths = view_paths
-          show_theme_view_path = Rails.root.join('app', 'views', "themes", show_page_theme.to_s)
-          prepend_view_path(show_theme_view_path)
+          Hyku::Application.theme_view_path_roots.each do |root|
+            show_theme_view_path = root.join('app', 'views', "themes", show_page_theme.to_s)
+            prepend_view_path(show_theme_view_path)
+          end
           yield
           # rubocop:disable Lint/UselessAssignment, Layout/SpaceAroundOperators, Style/RedundantParentheses
           # Do NOT change this line. This is calling the Rails view_paths=(paths) method and not a variable assignment.

--- a/app/controllers/hyrax/contact_form_controller.rb
+++ b/app/controllers/hyrax/contact_form_controller.rb
@@ -101,8 +101,10 @@ module Hyrax
       def inject_theme_views
         if home_page_theme && home_page_theme != 'default_home'
           original_paths = view_paths
-          home_theme_view_path = Rails.root.join('app', 'views', "themes", home_page_theme.to_s)
-          prepend_view_path(home_theme_view_path)
+          Hyku::Application.theme_view_path_roots.each do |root|
+            home_theme_view_path = root.join('app', 'views', "themes", home_page_theme.to_s)
+            prepend_view_path(home_theme_view_path)
+          end
           yield
           # rubocop:disable Lint/UselessAssignment, Layout/SpaceAroundOperators, Style/RedundantParentheses
           # Do NOT change this line. This is calling the Rails view_paths=(paths) method and not a variable assignment.

--- a/app/controllers/hyrax/pages_controller.rb
+++ b/app/controllers/hyrax/pages_controller.rb
@@ -101,8 +101,10 @@ module Hyrax
       def inject_theme_views
         if home_page_theme && home_page_theme != 'default_home'
           original_paths = view_paths
-          home_theme_view_path = Rails.root.join('app', 'views', "themes", home_page_theme.to_s)
-          prepend_view_path(home_theme_view_path)
+          Hyku::Application.theme_view_path_roots.each do |root|
+            home_theme_view_path = root.join('app', 'views', "themes", home_page_theme.to_s)
+            prepend_view_path(home_theme_view_path)
+          end
           yield
           # rubocop:disable Lint/UselessAssignment, Layout/SpaceAroundOperators, Style/RedundantParentheses
           # Do NOT change this method. This is an override of the view_paths= method and not a variable assignment.

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,6 +34,21 @@ module Hyku
   end
 
   class Application < Rails::Application
+    ##
+    #   @return [Array<String>] an array of strings in which we should be looking for theme view
+    #           candidates.
+    # @see Hyrax::WorksControllerBehavior
+    # @see Hyrax::ContactFormController
+    # @see Hyrax::PagesController
+    # @see https://api.rubyonrails.org/classes/ActionView/ViewPaths.html#method-i-prepend_view_path
+    #
+    # @see .path_for
+    def self.theme_view_path_roots
+      returning_value = [Rails.root.to_s]
+      returning_value.push HykuKnapsack::Engine.root.to_s if defined?(HykuKnapsack)
+      returning_value
+    end
+
     # Add this line to load the lib folder first because we need
     config.autoload_paths.unshift("#{Rails.root}/lib")
 


### PR DESCRIPTION
With the introduction of [HykuKnapsack][1], we are adjusting how we
create instances of Hyku.  Namely we don't clone Hyku but instead we
incorporate Hyku as a submodule into a Knapsack.

The Knapsack is a Rails engine that is mounted in the Hyku application.
What this means is that when we want to

Prior to this commit, the only way to adjust themed views would have
been to add them to the Rails application (e.g. Hyku) directly.  Which
would work in a non-Knapsack ecosystem.

However, with Knapsack we need a means of saying "Hey, for themes we
want to be able to add/adjust views within the knapsack."  Hence this
change.

[1]: https://github.com/samvera-labs/hyku_knapsack