### PR TITLE
:bug: subject can't be blank for the contact form

### DIFF
--- a/app/controllers/hyrax/contact_form_controller.rb
+++ b/app/controllers/hyrax/contact_form_controller.rb
@@ -50,7 +50,7 @@ module Hyrax
       # not spam, form is valid, and captcha is valid
       @captcha.values[:category] = params[:contact_form][:category]
       @captcha.values[:contact_method] = params[:contact_form][:contact_method]
-      @captcha.values[:subjects] = params[:contact_form][:subject]
+      @captcha.values[:subject] = params[:contact_form][:subject]
       @contact_form = model_class.new(@captcha.values)
       if @contact_form.valid? && @captcha.valid?
         ContactMailer.contact(@contact_form).deliver_now

--- a/app/controllers/hyrax/contact_form_controller.rb
+++ b/app/controllers/hyrax/contact_form_controller.rb
@@ -50,6 +50,7 @@ module Hyrax
       # not spam, form is valid, and captcha is valid
       @captcha.values[:category] = params[:contact_form][:category]
       @captcha.values[:contact_method] = params[:contact_form][:contact_method]
+      @captcha.values[:subjects] = params[:contact_form][:subject]
       @contact_form = model_class.new(@captcha.values)
       if @contact_form.valid? && @captcha.valid?
         ContactMailer.contact(@contact_form).deliver_now


### PR DESCRIPTION
Previously there was a bug because even if you typed in a subject, the contact form would error saying that it was blank.

<img width="1148" alt="image" src="https://github.com/samvera/hyku/assets/10081604/41a67c73-4371-4661-8916-d4f4939c7091">


Part of issue:
- https://github.com/scientist-softserv/adventist-dl/issues/608

