### PR TITLE
♻️ TO MAIN: Add handling for Knapsack theme overrides

### DIFF
--- a/app/controllers/hyrax/admin/appearances_controller.rb
+++ b/app/controllers/hyrax/admin/appearances_controller.rb
@@ -16,8 +16,8 @@ module Hyrax
         add_breadcrumbs
         @form = form_class.new
         @fonts = [@form.headline_font, @form.body_font]
-        @home_theme_information = YAML.load_file('config/home_themes.yml')
-        @show_theme_information = YAML.load_file('config/show_themes.yml')
+        @home_theme_information = YAML.load_file(Hyku::Application.path_for('config/home_themes.yml'))
+        @show_theme_information = YAML.load_file(Hyku::Application.path_for('config/show_themes.yml'))
         @home_theme_names = load_home_theme_names
         @show_theme_names = load_show_theme_names
         @search_themes = load_search_themes

--- a/app/services/uploaded_collection_thumbnail_path_service.rb
+++ b/app/services/uploaded_collection_thumbnail_path_service.rb
@@ -9,11 +9,11 @@ class UploadedCollectionThumbnailPathService < Hyrax::ThumbnailPathService
 
     # rubocop:disable Metrics/LineLength, Rails/FilePath, Lint/StringConversionInInterpolation
     def uploaded_thumbnail?(collection)
-      File.exist?("#{Rails.root.to_s}/public/uploads/uploaded_collection_thumbnails/#{collection.id}/#{collection.id}_card.jpg")
+      File.exist?(File.join(upload_dir(collection), "#{collection.id}_card.jpg"))
     end
 
     def upload_dir(collection)
-      "#{Rails.root.to_s}/public/uploads/uploaded_collection_thumbnails/#{collection.id}"
+      Hyku::Application.path_for("public/uploads/uploaded_collection_thumbnails/#{collection.id}")
     end
     # rubocop:enable Metrics/LineLength, Rails/FilePath, Lint/StringConversionInInterpolation
   end

--- a/app/views/hyrax/dashboard/collections/_current_thumbnail.html.erb
+++ b/app/views/hyrax/dashboard/collections/_current_thumbnail.html.erb
@@ -1,5 +1,5 @@
 <% thumbnail_path = SolrDocument.find(@collection.id).thumbnail_path %>
- <% if thumbnail_path.include?("uploaded_collection_thumbnails") and File.exist? Rails.root.join("public#{::SolrDocument.find(@collection.id).thumbnail_path}") %>
+ <% if thumbnail_path.include?("uploaded_collection_thumbnails") and File.exist? Hyky::Application.path_for("public#{::SolrDocument.find(@collection.id).thumbnail_path}") %>
   <%= image_tag(thumbnail_path, class: "current-thumbnail") %>
   <p>Current image: <strong><%= @thumbnail_filename %></strong></p>
 <% else %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,6 +37,22 @@ module Hyku
     # Add this line to load the lib folder first because we need
     config.autoload_paths.unshift("#{Rails.root}/lib")
 
+    ##
+    # @api public
+    #
+    # @param relative_path [String] lookup the relative paths first in the Knapsack then in Hyku.
+    #
+    # @return [String] the path to the file, favoring those found in the knapsack but falling back
+    #         to those in the Rails.root.
+    def self.path_for(relative_path)
+      if defined?(HykuKnapsack)
+        engine_path = HykuKnapsack::Engine.root.join(relative_path)
+        return engine_path.to_s if engine_path.exist?
+      end
+
+      Rails.root.join(relative_path).to_s
+    end
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.


### PR DESCRIPTION
Prior to this commit, we were looking for themes yaml files relative to the directory of the spawning script.  For Hyku that was always the `Rails.root` directory.  However, when running specs in Knapsack, that directory was `Knapsack::Engine.root`.

This unearthed a potential configuration issue; namely that we want Knapsack's to control what themes are available, meaning we don't want to require amending Hyku's themes.

So, we introduce a mechanism for looking up files first in the Knapsack then in Hyku.

I discovered this bug in the specs for knapsack (below is the *Error stack trace*)

<details>
<summary>Error stack trace</summary>

```
2) Hyrax::Admin::AppearancesController with an administrator GET #show assigns the requested site as @site
     Failure/Error: get :show, params: {}

     Errno::ENOENT:
       No such file or directory @ rb_sysopen - config/home_themes.yml
     # /usr/local/bundle/gems/psych-3.3.4/lib/psych.rb:582:in `initialize'
     # /usr/local/bundle/gems/psych-3.3.4/lib/psych.rb:582:in `open'
     # /usr/local/bundle/gems/psych-3.3.4/lib/psych.rb:582:in `unsafe_load_file'
     # ./hyrax-webapp/app/controllers/hyrax/admin/appearances_controller.rb:19:in `show'
     # /usr/local/bundle/gems/rails-controller-testing-1.0.5/lib/rails/controller/testing/template_assertions.rb:62:in `process'
     # /usr/local/bundle/gems/devise-4.9.2/lib/devise/test/controller_helpers.rb:35:in `block in process'
     # /usr/local/bundle/gems/devise-4.9.2/lib/devise/test/controller_helpers.rb:104:in `catch'
     # /usr/local/bundle/gems/devise-4.9.2/lib/devise/test/controller_helpers.rb:104:in `_catch_warden'
     # /usr/local/bundle/gems/devise-4.9.2/lib/devise/test/controller_helpers.rb:35:in `process'
     # /usr/local/bundle/gems/rails-controller-testing-1.0.5/lib/rails/controller/testing/integration.rb:16:in `block (2 levels) in <module:Integration>'
     # ./spec/controllers/hyrax/hyrax/admin/appearances_controller_spec.rb:31:in `block (4 levels) in <top (required)>'
     # /usr/local/bundle/gems/webmock-3.19.1/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'
     # ./hyrax-webapp/spec/support/multitenancy_metadata.rb:50:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:124:in `block in run'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `loop'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `run'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec_ext/rspec_ext.rb:12:in `run_with_retry'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:37:in `block (2 levels) in setup'
     # ./spec/spec_helper.rb:10:in `block (2 levels) in <top (required)>'
```

</details>

Related to:

- https://github.com/samvera/hyku/pull/2007
- https://github.com/samvera/hyku/pull/2008

The above two commits will require some reconciliation once this is incorporated.