### PR TITLE
♻️ Favor Hyku::Application.path_for over Rails.root

### DIFF
--- a/app/services/uploaded_collection_thumbnail_path_service.rb
+++ b/app/services/uploaded_collection_thumbnail_path_service.rb
@@ -9,11 +9,11 @@ class UploadedCollectionThumbnailPathService < Hyrax::ThumbnailPathService
 
     # rubocop:disable Metrics/LineLength, Rails/FilePath, Lint/StringConversionInInterpolation
     def uploaded_thumbnail?(collection)
-      File.exist?("#{Rails.root.to_s}/public/uploads/uploaded_collection_thumbnails/#{collection.id}/#{collection.id}_card.jpg")
+      File.exist?(File.join(upload_dir(collection), "#{collection.id}_card.jpg"))
     end
 
     def upload_dir(collection)
-      "#{Rails.root.to_s}/public/uploads/uploaded_collection_thumbnails/#{collection.id}"
+      Hyku::Application.path_for("public/uploads/uploaded_collection_thumbnails/#{collection.id}")
     end
     # rubocop:enable Metrics/LineLength, Rails/FilePath, Lint/StringConversionInInterpolation
   end

--- a/app/views/hyrax/dashboard/collections/_current_thumbnail.html.erb
+++ b/app/views/hyrax/dashboard/collections/_current_thumbnail.html.erb
@@ -1,5 +1,5 @@
 <% thumbnail_path = SolrDocument.find(@collection.id).thumbnail_path %>
- <% if thumbnail_path.include?("uploaded_collection_thumbnails") and File.exist? Rails.root.join("public#{::SolrDocument.find(@collection.id).thumbnail_path}") %>
+ <% if thumbnail_path.include?("uploaded_collection_thumbnails") and File.exist? Hyky::Application.path_for("public#{::SolrDocument.find(@collection.id).thumbnail_path}") %>
   <%= image_tag(thumbnail_path, class: "current-thumbnail") %>
   <p>Current image: <strong><%= @thumbnail_filename %></strong></p>
 <% else %>


### PR DESCRIPTION
Given the existence of Knapsack we need to consider how overrides in Knapsack will take precedence over Hyku files.  This change handles cases where we want to use the Knapsack's uploaded thumbnails.

Related to:

- #2010
