### PR TITLE
:bug: font inputs rendered twice fix

### DIFF
--- a/app/assets/javascripts/admin_font_select.js
+++ b/app/assets/javascripts/admin_font_select.js
@@ -1,6 +1,0 @@
-Blacklight.onLoad(function() {
-  if($("#admin_appearance_body_font").length > 0){
-    $("#admin_appearance_body_font").fontselect({lookahead: 20});
-    $("#admin_appearance_headline_font").fontselect({lookahead: 20});
-  }
-});

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -25,7 +25,6 @@
 //= require tether
 // Required by Blacklight
 //= require blacklight/blacklight
-//= require admin_font_select
 
 // Moved the Hyku JS *above* the Hyrax JS to resolve #1187 (following
 // a pattern found in ScholarSphere)


### PR DESCRIPTION
In the Settings > Appearance> Font tab, the input fields for body and header fonts were getting rendered twice.  We had duplicate code in two different files that called fontselect() on both elements. Because JS was getting called twice, two input fields were displayed. Removing one of them resolves the issue.

Fixes Issue:
- https://github.com/scientist-softserv/adventist-dl/issues/590

## BEFORE

![image](https://github.com/samvera/hyku/assets/10081604/a4c6aea8-204b-4770-8b02-6503a3aa6161)


## AFTER

<img width="719" alt="Screenshot 2023-10-05 at 8 03 07 AM" src="https://github.com/samvera/hyku/assets/10081604/b165a94d-63bb-480d-baf4-b516198c4beb">

@samvera/hyku-code-reviewers
