### PR TITLE
Upgrade bulkrax to 5.4.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -258,7 +258,7 @@ GEM
       signet (~> 0.8)
       typhoeus
     builder (3.2.4)
-    bulkrax (5.3.0)
+    bulkrax (5.4.1)
       bagit (~> 0.4)
       coderay
       dry-monads (~> 1.4.0)


### PR DESCRIPTION
A new version of bulkrax has been released that fixes a bug. Previously we couldn't import a fileset as a row.

ref:
- https://github.com/samvera-labs/bulkrax/pull/865
- https://github.com/samvera-labs/bulkrax/releases/tag/v5.4.1

@samvera/hyku-code-reviewers
