### PR TITLE
♻️ Favor class_attribute over constant

### DIFF
--- a/app/forms/hyrax/forms/admin/appearance.rb
+++ b/app/forms/hyrax/forms/admin/appearance.rb
@@ -17,12 +17,21 @@ module Hyrax
         delegate :default_collection_image, :default_collection_image?, to: :site
         delegate :default_work_image, :default_work_image?, to: :site
 
-        DEFAULT_FONTS = {
+        ##
+        # @!group Class Attributes
+        #
+        # @!attribute default_fonts
+        #   @return [Hash<String, String>] there should be at least the key "body_font" and
+        #           "headline_font"
+        class_attribute :default_fonts, default: {
           'body_font'     => 'Helvetica Neue, Helvetica, Arial, sans-serif;',
           'headline_font' => 'Helvetica Neue, Helvetica, Arial, sans-serif;'
-        }.freeze
+        }
 
-        DEFAULT_COLORS = {
+        ##
+        # @!attribute default_colors
+        #   @return [Hash<String, String>]
+        class_attribute :default_colors, default: {
           'header_and_footer_background_color' => '#3c3c3c',
           'header_and_footer_text_color'       => '#dcdcdc',
           'navbar_background_color'            => '#000000',
@@ -40,7 +49,8 @@ module Hyrax
           # 'active_tabs_background_color'     => '#337ab7',
           'facet_panel_background_color'       => '#f5f5f5',
           'facet_panel_text_color'             => '#333333'
-        }.freeze
+        }
+        # @!endgroup Class Attributes
 
         # @param [Hash] attributes the list of parameters from the form
         def initialize(attributes = {})

--- a/app/services/uploaded_collection_thumbnail_path_service.rb
+++ b/app/services/uploaded_collection_thumbnail_path_service.rb
@@ -7,7 +7,7 @@ class UploadedCollectionThumbnailPathService < Hyrax::ThumbnailPathService
       "/uploads/uploaded_collection_thumbnails/#{object.id}/#{object.id}_card.jpg"
     end
 
-    # rubocop:disable Metrics/LineLength, Rails/FilePath, Lint/StringConversionInInterpolation
+    # rubocop:disable Metrics/LineLength, Rails/FilePath
     def uploaded_thumbnail?(collection)
       File.exist?(File.join(upload_dir(collection), "#{collection.id}_card.jpg"))
     end
@@ -15,6 +15,6 @@ class UploadedCollectionThumbnailPathService < Hyrax::ThumbnailPathService
     def upload_dir(collection)
       Hyku::Application.path_for("public/uploads/uploaded_collection_thumbnails/#{collection.id}")
     end
-    # rubocop:enable Metrics/LineLength, Rails/FilePath, Lint/StringConversionInInterpolation
+    # rubocop:enable Metrics/LineLength, Rails/FilePath
   end
 end

--- a/app/views/hyrax/admin/appearances/_default_colors_form.html.erb
+++ b/app/views/hyrax/admin/appearances/_default_colors_form.html.erb
@@ -1,6 +1,6 @@
 <%= simple_form_for @form, url: admin_appearance_path do |f| %>
   <div class="panel-body defaultable-colors">
-    <% @form.class::DEFAULT_COLORS.each do |color_name, hex| %>
+    <% @form.default_colors.each do |color_name, hex| %>
       <%= render 'color_input', f: f, color_name: color_name, hex: hex %>
     <% end %>
   </div>

--- a/app/views/hyrax/admin/appearances/_default_fonts_form.html.erb
+++ b/app/views/hyrax/admin/appearances/_default_fonts_form.html.erb
@@ -1,6 +1,6 @@
 <%= simple_form_for @form, url: admin_appearance_path do |f| %>
   <div class="panel-body defaultable-fonts">
-    <% df = @form.class::DEFAULT_FONTS %>
+    <% df = @form.default_fonts %>
     <% font = f.object.body_font %>
 
     <%= f.input :body_font, label: 'Select Body Font', required: false, input_html: { class: 'font-fields', data: { default_value: df['body_font'] } } %>

--- a/spec/forms/hyrax/forms/admin/appearance_spec.rb
+++ b/spec/forms/hyrax/forms/admin/appearance_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Hyrax::Forms::Admin::Appearance do
+  describe '.default_fonts' do
+    subject { described_class.default_fonts }
+
+    it { is_expected.to be_a(Hash) }
+
+    it "has the 'body_font' and 'headline_font' keys" do
+      expect(subject.keys).to match_array(['body_font', 'headline_font'])
+    end
+  end
+
+  describe '.default_colors' do
+    subject { described_class.default_colors }
+
+    it { is_expected.to be_a(Hash) }
+  end
+end


### PR DESCRIPTION
In Adventist, we're needing to override the constant's values.  By
making this a class_attribute we can more readily do the override via
configuration instead of obliteration of a constant.