### PR TITLE
♻️ Favor configurable html head title value

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Hyku</title>
+  <title><%= Hyku::Application.html_head_title %></title>
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
   <%= csrf_meta_tags %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,6 +34,15 @@ module Hyku
   end
 
   class Application < Rails::Application
+    ##
+    # @!group Class Attributes
+    #
+    # @!attribute html_head_title
+    #   The title to render for the application's HTML > HEAD > TITLE element.
+    #   @return [String]
+    class_attribute :html_head_title, default: "Hyku", attr_accessor: false
+    # @!endgroup Class Attributes
+
     # Add this line to load the lib folder first because we need
     # IiifPrint::SplitPdfs::AdventistPagesToJpgsSplitter
     config.autoload_paths.unshift("#{Rails.root}/lib")

--- a/spec/config/application_spec.rb
+++ b/spec/config/application_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Hyku::Application do
+  describe '.html_head_title' do
+    it { is_expected.to be_a(String) }
+  end
+end


### PR DESCRIPTION
Prior to this commit, we hard-coded the page title; this is something
that should be far more configurable.  And this refactor is a step
towards that.

This also allows for downstream implementors to not have to override the
view simply to change the title element.