### PR TITLE
🐛 Add custom rendering for license

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -127,3 +127,7 @@ Metrics/BlockLength:
     - 'spec/**/*.rb'
     - 'lib/tasks/*.rake'
     - 'app/controllers/catalog_controller.rb'
+
+RSpec/FilePath:
+  Exclude:
+    - 'spec/config/application_spec.rb'

--- a/app/services/uploaded_collection_thumbnail_path_service.rb
+++ b/app/services/uploaded_collection_thumbnail_path_service.rb
@@ -7,7 +7,6 @@ class UploadedCollectionThumbnailPathService < Hyrax::ThumbnailPathService
       "/uploads/uploaded_collection_thumbnails/#{object.id}/#{object.id}_card.jpg"
     end
 
-    # rubocop:disable Metrics/LineLength, Rails/FilePath
     def uploaded_thumbnail?(collection)
       File.exist?(File.join(upload_dir(collection), "#{collection.id}_card.jpg"))
     end
@@ -15,6 +14,5 @@ class UploadedCollectionThumbnailPathService < Hyrax::ThumbnailPathService
     def upload_dir(collection)
       Hyku::Application.path_for("public/uploads/uploaded_collection_thumbnails/#{collection.id}")
     end
-    # rubocop:enable Metrics/LineLength, Rails/FilePath
   end
 end

--- a/app/views/records/show_fields/_license.html.erb
+++ b/app/views/records/show_fields/_license.html.erb
@@ -1,0 +1,4 @@
+<% service = Hyrax::LicenseService.new %>
+<% record.license.each do |r| %>
+  <%= link_to_field('license', r, service.label(r)) %> <%= iconify_auto_link(r, false) %><br />
+<% end %>


### PR DESCRIPTION
Prior to this commit, the License would render as a plain URL.  With
this change, we are now coercing the license into a URL that is labeled
and titled with the name of the license.

This is copied and modified based on [Rights show partial][1]

Related to:

- https://github.com/scientist-softserv/adventist-dl/issues/620

<details aria-hidden="true"><summary>Screenshot of Before Changes</summary>
<img width="443" alt="" src="https://github.com/samvera/hyku/assets/2130/69563360-cb45-44d1-ab0b-80c21e8f1944">

</details>

<details aria-hidden="true"><summary>Screenshot of After Changes</summary>
<img width="405" alt="after-changes" src="https://github.com/samvera/hyku/assets/2130/324f19cf-7cdc-48a3-87b4-ca4fa51bf08f">
</details>

[1]: https://github.com/samvera/hyrax/blob/b334e186e77691d7da8ed59ff27f091be1c2a700/app/views/records/show_fields/_rights.html.erb