### PR TITLE
♻️ Add option to override devise configuration

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,9 +14,7 @@ class User < ApplicationRecord
   include Blacklight::User
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
-  devise :database_authenticatable, :invitable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable,
-         :omniauthable, omniauth_providers: %i[saml openid_connect cas]
+  devise(*Hyku::Application.user_devise_parameters)
 
   after_create :add_default_group_membership!
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -41,6 +41,21 @@ module Hyku
     #   The title to render for the application's HTML > HEAD > TITLE element.
     #   @return [String]
     class_attribute :html_head_title, default: "Hyku", attr_accessor: false
+
+    # @!attribute user_devise_parameters
+    #   @return [Object]
+    #
+    #   This is a value that you want to set in the before_initialize block.
+    class_attribute :user_devise_parameters, instance_accessor: false, default: [
+                      :database_authenticatable,
+                      :invitable,
+                      :registerable,
+                      :recoverable,
+                      :rememberable,
+                      :trackable,
+                      :validatable,
+                      :omniauthable, { omniauth_providers: %i[saml openid_connect cas] }]
+
     # @!endgroup Class Attributes
 
     # Add this line to load the lib folder first because we need

--- a/spec/config/application_spec.rb
+++ b/spec/config/application_spec.rb
@@ -4,6 +4,24 @@ require 'spec_helper'
 
 RSpec.describe Hyku::Application do
   describe '.html_head_title' do
+    subject { described_class.html_head_title }
+
     it { is_expected.to be_a(String) }
+  end
+
+  describe '.user_devise_parameters' do
+    subject { described_class.user_devise_parameters }
+
+    it do
+      is_expected.to eq([:database_authenticatable,
+                         :invitable,
+                         :registerable,
+                         :recoverable,
+                         :rememberable,
+                         :trackable,
+                         :validatable,
+                         :omniauthable,
+                         { omniauth_providers: %i[saml openid_connect cas] }])
+    end
   end
 end


### PR DESCRIPTION
For Adventist, we wanted to disable registration of accounts as this was
creating a case where folks were creating their own accounts and
tenants.

Related to:

- https://github.com/scientist-softserv/adventist-dl/issues/492
- https://github.com/scientist-softserv/adventist-dl/issues/618
- https://github.com/samvera/hyku/pull/1964
- https://github.com/scientist-softserv/adventist-dl/pull/493