### PR TITLE
🐛 Fix duplicating slider icons in IR theme

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,7 @@
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
   <%= csrf_meta_tags %>
+  <%= yield :head %>
 </head>
 <body>
 

--- a/app/views/themes/institutional_repository/hyrax/homepage/_resource_type_slider.html.erb
+++ b/app/views/themes/institutional_repository/hyrax/homepage/_resource_type_slider.html.erb
@@ -1,3 +1,8 @@
+<%# Add content_for block to clear caching so IR icons don't duplicate unintentionally %>
+<% content_for :head do %>
+  <meta name="turbolinks-cache-control" content="no-cache">
+<% end %>
+
 <div class="carousel institutional-repository-carousel slide" id="carousel-tilenav" data-interval="false">
   <div class="carousel-inner">
     <% resource_types.each.with_index do |(k,v), i| %>

--- a/app/views/themes/institutional_repository/hyrax/homepage/_resource_type_slider.html.erb
+++ b/app/views/themes/institutional_repository/hyrax/homepage/_resource_type_slider.html.erb
@@ -10,9 +10,11 @@
       <div class="item <%= i.zero? ? 'active' : '' %>">
         <div class="col-xs-12 col-sm-3 col-md-2">
           <div class="text-center">
-            <i class='<%= "#{v[1]}" %>' aria-hidden="true"></i>
-            <h5><%= k %></h5>
-            <p><%= v[0] %></p>
+            <%= link_to "/catalog?f[resource_type_sim][]=#{k}", style: "color: inherit;" do %>
+              <i class='<%= "#{v[1]}" %>' aria-hidden="true"></i>
+              <h5><%= k %></h5>
+              <p><%= v[0] %></p>
+            <% end %>
           </div>
         </div>
       </div>


### PR DESCRIPTION
# Story

Before this commit, when the user is at the homepage, then navigating away from it, then back to it, the slider icons would duplicate.  This PR will disable turbolinks caching for the slider partial to fix it.

Additionally this PR makes the icons clickable, which provides an intuitive action for the user. When you click on the links it will perform a facet search.

Ref:
  - https://github.com/scientist-softserv/palni-palci/issues/277
  - https://github.com/scientist-softserv/palni-palci/issues/842

# Screenshots / Video

## BEFORE

DEMO: https://share.zight.com/E0um94El

![image (36)](https://github.com/scientist-softserv/palni-palci/assets/10081604/aa78a622-2af3-4cd5-af18-a34aebdd1bb8)

## AFTER
Duplicate icon fixed: 
![pals-277](https://github.com/scientist-softserv/palni-palci/assets/19597776/dc08af9e-8ed9-4670-9d0c-d2377ba1f7eb)

Icons perform facet search on click: 
![Screen Recording 2023-10-11 at 04 01 28 PM](https://github.com/samvera/hyku/assets/10081604/27442516-b53b-4b7e-9c47-0d1d6d83ee33)


# Notes
The duplicate icons were only occurring when the carousel was activated by adding more icons in there.