### PR TITLE
run asset build later in process to allow knapsack to run it only one time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,10 +91,9 @@ ONBUILD RUN git config --global --add safe.directory /app/samvera && \
 
 ONBUILD COPY --chown=1001:101 $APP_PATH /app/samvera/hyrax-webapp
 
-ONBUILD RUN RAILS_ENV=production SECRET_KEY_BASE=`bin/rake secret` DB_ADAPTER=nulldb DB_URL='postgresql://fake' bundle exec rake assets:precompile && yarn install
-
-
 FROM hyku-base as hyku-web
+RUN RAILS_ENV=production SECRET_KEY_BASE=`bin/rake secret` DB_ADAPTER=nulldb DB_URL='postgresql://fake' bundle exec rake assets:precompile && yarn install
+
 CMD ./bin/web
 
 FROM hyku-web as hyku-worker


### PR DESCRIPTION
Because assets were done in ONBUILD they always got compiled before the knapsack was mounted. This prevented knapsack assets from getting precompiled properly. 