### PR TITLE
🐛 Fix Add to Collection for page 2+ of works

### DIFF
--- a/app/controllers/hyrax/my/works_controller_decorator.rb
+++ b/app/controllers/hyrax/my/works_controller_decorator.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+##
+# OVERRIDE Hyrax 3.5.0; when Hyrax hits v4.0.0 we can remove this.
+# @see https://github.com/samvera/hyrax/pull/5972
+module Hyrax
+  module My
+    module WorksControllerDecorator
+      def collection_service
+        cloned = clone
+        cloned.params = {}
+        Hyrax::CollectionsService.new(cloned)
+      end
+    end
+  end
+end
+
+Hyrax::My::WorksController.prepend(Hyrax::My::WorksControllerDecorator)


### PR DESCRIPTION
Prior to this commit, when you were on page 2 of your works and selected
a work to add to a collection, the query for available collections would
use the page 2 as part of the collection query.  This would mean the
first 100 collections (default page size) that you had access to add
works to were skipped.

With this commit, we omit the query parameters from the works page and
then query collections.

Related to:

- https://github.com/samvera/hyrax/pull/5972
- https://github.com/samvera/hyrax/issues/5969
- https://github.com/scientist-softserv/adventist-dl/issues/625

Co-authored-by: LaRita Robinson <larita@scientist.com>