### PR TITLE
🧹 Update contact email descriptions

### DIFF
--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -6,7 +6,7 @@ Hyrax.config do |config|
   # Injected via `rails g hyrax:work Image`
   config.register_curation_concern :image
 
-  # Email recipient of messages sent via the contact form
+  # The email address that messages submitted via the contact page are sent to
   # This is set by account settings
   # config.contact_email = 'changeme@example.com'
 

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -13,7 +13,7 @@ en:
           url: Fedora URL should not end with a slash
         name: A single or hyphenated name used for technical aspects of the repository (e.g., "acme" or "acme-library").
         gtm_id: The ID of your Google Tag Manager account
-        contact_email: Email recipient of messages sent via the contact form
+        contact_email: The email address that messages submitted via the contact page are sent to
         weekly_email_list: List of email addresses to email the weekly report. Leave a single space between each email
         monthly_email_list: List of email addresses to email the monthly report. Leave a single space between each email
         yearly_email_list: List of email addresses to email the yearly report. Leave a single space between each email
@@ -29,7 +29,7 @@ en:
         doi_writer: Write DOIs for records. WIP do not use
         cache_api: Turns on cache for API endpoints. Experimental
         email_subjet_prefix: String to put in front of system email subjects.
-        contact_email_to: Email address that should receive contact emails
+        contact_email_to: The email address that system notifications will be sent from. Additional configuration is required to add an address from domains other than the site's domain
         geonames_username: Register at http://www.geonames.org/manageaccount
         file_acl: Turn off if using a file system like samba or nfs that does not support setting access control lists
         ssl_configured: Set it true if using https


### PR DESCRIPTION
# Summary 
The account setting's descriptions for contact_email and contact_email_to are confusing. This PR adds clarity to these configuration options. c/o Palni-Palci

TODO: run translations

## BEFORE

<img width="549" alt="image" src="https://github.com/samvera/hyku/assets/10081604/6d02b9f2-eb68-42d6-ba14-d51939a627bc">


## AFTER

<img width="1071" alt="image" src="https://github.com/samvera/hyku/assets/10081604/02cabfc7-5f3c-43dc-92fe-c2f2e52b31a5">
