### PR TITLE
:bug: Depositor role cannot deposit into admin set fix

### DIFF
--- a/app/models/concerns/hyrax/ability/work_ability.rb
+++ b/app/models/concerns/hyrax/ability/work_ability.rb
@@ -15,8 +15,23 @@ module Hyrax
             doc = permissions_doc(id)
             all_work_types_and_files.include?(doc.hydra_model)
           end
-        elsif work_depositor?
+        elsif work_depositor? || admin_set_with_deposit?
           can %i[create], all_work_types_and_files
+        end
+
+        # OVERRIDE HYRAX 3.5.0 to return false if no ids are found
+        # @return [Boolean] true if the user has at least one admin set they can deposit into.
+        def admin_set_with_deposit?
+          ids = PermissionTemplateAccess.for_user(ability: self,
+                                                  access: ['deposit', 'manage'])
+                                        .joins(:permission_template)
+                                        .select(:source_id)
+                                        .distinct
+                                        .pluck(:source_id)
+
+          return false if ids.empty?
+
+          Hyrax.custom_queries.find_ids_by_model(model: Hyrax::AdministrativeSet, ids: ids).any?
         end
       end
     end

--- a/spec/features/create_work_spec.rb
+++ b/spec/features/create_work_spec.rb
@@ -18,4 +18,54 @@ RSpec.describe 'Creating a new Work', type: :feature, clean: true do
     click_link "Share Your Work"
     expect(page).to have_button "Create work"
   end
+
+  context 'as a user with no roles' do
+    let(:user) { create(:user) }
+
+    it 'cannot see the add new work button' do
+      visit '/dashboard/my/works'
+      expect(page).not_to have_link "Add New Work"
+    end
+
+    context 'who has deposit access for a specific admin set' do
+      let(:admin_set_2) do
+        create(:admin_set, title: ["Another Admin Set"],
+                           description: ["A description"])
+      end
+
+      before do
+        create(:permission_template_access,
+               :deposit,
+               permission_template: create(:permission_template, source_id: admin_set_2.id, with_admin_set: true, with_active_workflow: true),
+               agent_type: 'user',
+               agent_id: user.user_key)
+      end
+
+      it 'can see the add new work button' do
+        visit '/dashboard/my/works'
+        expect(page).to have_link "Add New Work"
+      end
+    end
+
+    context 'who belongs to a group with deposit access for a specific admin set' do
+      let(:admin_set_3) do
+        create(:admin_set, title: ["Yet Another Admin Set"],
+                           description: ["A description"])
+      end
+      let(:depositors_group) { create(:depositors_group, name: 'deposit', member_users: [user]) }
+
+      before do
+        create(:permission_template_access,
+               :deposit,
+               permission_template: create(:permission_template, source_id: admin_set_3.id, with_admin_set: true, with_active_workflow: true),
+               agent_type: 'group',
+               agent_id: depositors_group.name)
+      end
+
+      it 'can see the add new work button' do
+        visit '/dashboard/my/works'
+        expect(page).to have_link "Add New Work"
+      end
+    end
+  end
 end


### PR DESCRIPTION
We implemented a fix for this bug in PALS and are contributing it back to Hyku.

Ref:
  - https://github.com/scientist-softserv/palni-palci/issues/864

# Expected Behavior Before Changes

Prior to this commit, even if a user was granted the role of depositor to an admin set, they could not add a work.  If they were added in a group that had the depositor role, they still were not able to create a work.

# Expected Behavior After Changes

Now, users who have the depositor role or in a group with the depositor role can deposit to admin sets.

# Screenshots / Video

https://github.com/scientist-softserv/palni-palci/assets/19597776/dcb324fa-02f5-4743-a804-ea18709bce73

# NOTE

By default Hyku doesn’t actually include everyone_can_create_curation_concerns in the ability logic. It’s behind an [ENV-controlled feature flipper](https://github.com/samvera/hyku/blob/main/app/models/ability.rb#L22-L24), which [by default is true](https://github.com/samvera/hyku/blob/776cf9e9cd3d50b480779c78ee1c5cf0496f078b/.env#L52) (true in this case does not include everyone_can_create_curation_concerns since true == more restrictive permissions)
