### PR TITLE
:bug: Correct contact_email and contact_email_to descriptions

### DIFF
--- a/config/locales/simple_form.de.yml
+++ b/config/locales/simple_form.de.yml
@@ -9,8 +9,8 @@ de:
         admin_emails: Geben Sie jeweils eine E-Mail-Adresse ein
         allow_signup: Erlauben Sie Benutzern, sich bei Ihrem Repository anzumelden
         cache_api: Aktiviert den Cache für API-Endpunkte. Experimental
-        contact_email: E-Mail-Empfänger von Nachrichten, die über das Kontaktformular gesendet werden
-        contact_email_to: E-Mail-Adresse, die Kontakt-E-Mails erhalten soll
+        contact_email_to: E-Mail-Empfänger von Nachrichten, die über das Kontaktformular gesendet werden
+        contact_email: E-Mail-Adresse, die Kontakt-E-Mails erhalten soll
         doi_reader: Zeigen Sie die Fähigkeit, aus Datacite zu lesen, um Datensätze zu füllen. WIP nicht verwenden
         doi_writer: Schreiben Sie DOIs für Datensätze. WIP nicht verwenden
         email_format: Legen Sie eine Liste von E-Mail-Domains fest, die sich bei diesem Repository anmelden dürfen, z. B. (@ubiquitypress.com @gmail.com). Lassen Sie zwischen jeder Domäne ein einzelnes Leerzeichen.

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -13,7 +13,6 @@ en:
           url: Fedora URL should not end with a slash
         name: A single or hyphenated name used for technical aspects of the repository (e.g., "acme" or "acme-library").
         gtm_id: The ID of your Google Tag Manager account
-        contact_email: The email address that messages submitted via the contact page are sent to
         weekly_email_list: List of email addresses to email the weekly report. Leave a single space between each email
         monthly_email_list: List of email addresses to email the monthly report. Leave a single space between each email
         yearly_email_list: List of email addresses to email the yearly report. Leave a single space between each email
@@ -29,7 +28,8 @@ en:
         doi_writer: Write DOIs for records. WIP do not use
         cache_api: Turns on cache for API endpoints. Experimental
         email_subjet_prefix: String to put in front of system email subjects.
-        contact_email_to: The email address that system notifications will be sent from. Additional configuration is required to add an address from domains other than the site's domain
+        contact_email: The email address that system notifications will be sent from. Additional configuration is required to add an address from domains other than the site's domain
+        contact_email_to: The email address that messages submitted via the contact page are sent to
         geonames_username: Register at http://www.geonames.org/manageaccount
         file_acl: Turn off if using a file system like samba or nfs that does not support setting access control lists
         ssl_configured: Set it true if using https

--- a/config/locales/simple_form.es.yml
+++ b/config/locales/simple_form.es.yml
@@ -9,8 +9,8 @@ es:
         admin_emails: Introduce una dirección de correo electrónico a la vez
         allow_signup: Permita que los usuarios se registren en su repositorio
         cache_api: Activa la memoria caché para los puntos finales de la API. Experimental
-        contact_email: Destinatario de correo electrónico de los mensajes enviados a través del formulario de contacto
-        contact_email_to: Dirección de correo electrónico que debe recibir correos electrónicos de contacto
+        contact_email_to: Destinatario de correo electrónico de los mensajes enviados a través del formulario de contacto
+        contact_email: Dirección de correo electrónico que debe recibir correos electrónicos de contacto
         doi_reader: Mostrar la capacidad de leer de Datacite para completar registros. WIP no usar
         doi_writer: Escriba DOI para los registros. WIP no usar
         email_format: Establezca una lista de dominios de correo electrónico que pueden registrarse en este repositorio, por ejemplo, (@ubiquitypress.com @gmail.com). Deje un solo espacio entre cada dominio.

--- a/config/locales/simple_form.fr.yml
+++ b/config/locales/simple_form.fr.yml
@@ -9,8 +9,8 @@ fr:
         admin_emails: Entrez une adresse e-mail à la fois
         allow_signup: Autoriser les utilisateurs à s'inscrire à votre référentiel
         cache_api: Active le cache pour les points de terminaison d'API. Expérimental
-        contact_email: Email destinataire des messages envoyés via le formulaire de contact
-        contact_email_to: Adresse e-mail qui doit recevoir les e-mails de contact
+        contact_email_to: Email destinataire des messages envoyés via le formulaire de contact
+        contact_email: Adresse e-mail qui doit recevoir les e-mails de contact
         doi_reader: Afficher la possibilité de lire à partir de Datacite pour remplir les enregistrements. WIP ne pas utiliser
         doi_writer: Rédigez des DOI pour les enregistrements. WIP ne pas utiliser
         email_format: Définissez une liste de domaines de messagerie autorisés à s'inscrire à ce référentiel, par exemple (@ubiquitypress.com @gmail.com). Laissez un seul espace entre chaque domaine.

--- a/config/locales/simple_form.it.yml
+++ b/config/locales/simple_form.it.yml
@@ -9,8 +9,8 @@ it:
         admin_emails: Inserisci un indirizzo email alla volta
         allow_signup: Consenti agli utenti di registrarsi al tuo repository
         cache_api: Attiva la cache per gli endpoint API. Sperimentale
-        contact_email: Email destinatario dei messaggi inviati tramite il modulo di contatto
-        contact_email_to: Indirizzo e-mail che dovrebbe ricevere le e-mail di contatto
+        contact_email_to: Email destinatario dei messaggi inviati tramite il modulo di contatto
+        contact_email: Indirizzo e-mail che dovrebbe ricevere le e-mail di contatto
         doi_reader: Mostra la capacità di leggere da Datacite per popolare i record. WIP non utilizzare
         doi_writer: Scrivi DOI per i record. WIP non utilizzare
         email_format: Impostare un elenco di domini di posta elettronica a cui è consentito registrarsi a questo repository, ad esempio (@ubiquitypress.com @gmail.com). Lascia un singolo spazio tra ogni dominio.

--- a/config/locales/simple_form.pt-BR.yml
+++ b/config/locales/simple_form.pt-BR.yml
@@ -9,8 +9,8 @@ pt-BR:
         admin_emails: Digite um endereço de email de cada vez
         allow_signup: Permitir que os usuários se inscrevam em seu repositório
         cache_api: Ativa o cache para terminais de API. Experimental
-        contact_email: Destinatário de e-mail de mensagens enviadas por meio do formulário de contato
-        contact_email_to: Endereço de e-mail que deve receber e-mails de contato
+        contact_email_to: Destinatário de e-mail de mensagens enviadas por meio do formulário de contato
+        contact_email: Endereço de e-mail que deve receber e-mails de contato
         doi_reader: Mostrar capacidade de ler do Datacite para preencher registros. WIP não use
         doi_writer: Escreva DOIs para registros. WIP não use
         email_format: Defina uma lista de domínios de e-mail que podem se inscrever neste repositório, por exemplo (@ubiquitypress.com @gmail.com). Deixe um único espaço entre cada domínio.

--- a/config/locales/simple_form.zh.yml
+++ b/config/locales/simple_form.zh.yml
@@ -9,8 +9,8 @@ zh:
         admin_emails: 一次输入一个电子邮件地址
         allow_signup: 允许用户注册到您的存储库
         cache_api: 为 API 端点打开缓存。实验性的
-        contact_email: 通过联系表发送的邮件的电子邮件收件人
-        contact_email_to: 应接收联系电子邮件的电子邮件地址
+        contact_email_to: 通过联系表发送的邮件的电子邮件收件人
+        contact_email: 应接收联系电子邮件的电子邮件地址
         doi_reader: 显示从 Datacite 读取数据以填充记录的能力。 WIP 不使用
         doi_writer: 为记录写 DOI。 WIP 不使用
         email_format: 设置允许注册此存储库的电子邮件域列表，例如 (@ubiquitypress.com @gmail.com)。在每个域之间留一个空格。


### PR DESCRIPTION
I previously mixed up the descriptions between the two which introduced a bug. This commit corrects that mistake.

![image](https://github.com/samvera/hyku/assets/10081604/02ba6a31-c2ba-4d9b-9e20-4f303e974ca4)

