### PR TITLE
🐛 Update IiifPrint gem to MAIN

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,16 +40,15 @@ GIT
 
 GIT
   remote: https://github.com/scientist-softserv/iiif_print.git
-  revision: 9e7837ce4bd08bf8fff9126455d0e0e2602f6018
+  revision: 5fb1531c2aa4c4797aea5a83c74797148a9fbc32
   branch: main
   specs:
     iiif_print (1.0.0)
-      blacklight_iiif_search (~> 1.0)
+      blacklight_iiif_search (>= 1.0, < 3.0)
       derivative-rodeo (~> 0.5)
-      dry-monads (~> 1.4.0)
-      hyrax (>= 2.5, < 4)
+      hyrax (>= 2.5, < 6)
       nokogiri (>= 1.13.2)
-      rails (~> 5.0)
+      rails (>= 5.0, < 8.0)
       rdf-vocab (~> 3.0)
 
 GIT
@@ -337,7 +336,7 @@ GEM
     declarative-option (0.1.0)
     deprecation (1.1.0)
       activesupport
-    derivative-rodeo (0.5.0)
+    derivative-rodeo (0.5.1)
       activesupport (>= 5)
       aws-sdk-s3
       aws-sdk-sqs


### PR DESCRIPTION
The log between the previous SHA of IiifPrint and the new one had the
following:

```
❯ git slog 9e7837ce4bd08bf8fff9126455d0e0e2602f6018..5fb1531c2aa4c4797aea5a83c74797148a9fbc32 --no-merges
* 4b4165f — 🎁 Add graceful fallback of preprocessing Jeremy Friesen, (2023-11-06) (origin/i282-gracefully-handling-of-copy-failure, i282-gracefully-handling-of-copy-failure)
* f8f9a90 — increase blacklight_iiif_search window Rob Kaufman, (2023-10-18) (origin/rails_version)
* 7fd53d6 — iiif_print doesnt use monads Rob Kaufman, (2023-10-17)
* b6352fa — loosen up hyrax too Rob Kaufman, (2023-10-17)
* a335c68 — Loosen up rails restriction Rob Kaufman, (2023-10-17)
* b170a57 — 🐛 Handle no file_set_ids property Jeremy Friesen, (2023-08-15) (adding-bug-fix)
* 7f34a12 — :broom: Update method call to new Shana Moore, (2023-08-22)
* 0af836f — 🐛 Fix calling Fedora from view Kirk Wang, (2023-08-22)
* e8e19df — Update app/views/hyrax/base/_representative_media.html.erb Jeremy Friesen, (2023-08-18)
* 95eed39 — 🐛 Render thumbnails when IIIF Print disabled Jeremy Friesen, (2023-08-18) (enable-thumbnails-when-iiif-print-disabled)
```

With adventist-knapsack running, I bashed into the web container and ran:

```
bundle update iiif_print derivative-rodeo --conservative
```

Yes the above `derivative-rodeo` is intentional instead of
`derivative_rodeo` which maps to the repository name; there are rubygems
issues to resolve.

Related to:

- https://github.com/scientist-softserv/derivative_rodeo/pull/70
- https://github.com/scientist-softserv/adventist-dl/pull/643
- https://github.com/samvera/hyku/pull/2035