### PR TITLE
🎁 Superadmins can activate users

### DIFF
--- a/.env
+++ b/.env
@@ -40,6 +40,7 @@ HYKU_ADMIN_ONLY_TENANT_CREATION=false
 HYKU_DEFAULT_HOST=%{tenant}.hyku.test
 HYKU_ROOT_HOST=hyku.test
 HYKU_MULTITENANT=true
+HYKU_USER_DEFAULT_PASSWORD=password
 # Comment out these 2 for multi tenancy / Uncomment for single
 # HYKU_ROOT_HOST=hyku.test
 # HYKU_MULTITENANT=false

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -11,7 +11,18 @@ module Admin
       if @user.present? && @user.roles.destroy_all
         redirect_to hyrax.admin_users_path, notice: t('hyrax.admin.users.destroy.success', user: @user)
       else
-        redirect_to hyrax.admin_users_path flash: { error: t('hyrax.admin.users.destroy.failure', user: @user) }
+        redirect_to hyrax.admin_users_path, flash: { error: t('hyrax.admin.users.destroy.failure', user: @user) }
+      end
+    end
+
+    def activate
+      user = User.find(params[:id])
+      user.password = ENV.fetch('HYKU_USER_DEFAULT_PASSWORD', 'password')
+
+      if user.save && user.accept_invitation!
+        redirect_to hyrax.admin_users_path, notice: t('hyrax.admin.users.activate.success', user: user)
+      else
+        redirect_to hyrax.admin_users_path, flash: { error: t('hyrax.admin.users.activate.failure', user: user) }
       end
     end
 

--- a/app/views/hyrax/admin/users/index.html.erb
+++ b/app/views/hyrax/admin/users/index.html.erb
@@ -25,7 +25,7 @@
                       @invite_roles_options.map { |r| [r.titleize, r ]},
                       { prompt: 'Select a role...' },
                       required: false,
-                      class: 'form-control' %> 
+                      class: 'form-control' %>
           <%= f.submit t('.add'), class: 'btn btn-primary' %>
         </div>
       <% end %>
@@ -87,7 +87,10 @@
               <td><%= user.accepted_or_not_invited? ? t('.status.active') : t('.status.pending') %></td>
               <% if can? :destroy, User %>
                 <td>
-                  <%= link_to t('.delete'),  main_app.admin_user_path(user), class: 'btn btn-danger btn-sm action-delete', method: :delete, data: { confirm: t('hyrax.admin.users.destroy.confirmation', user: user.email) } %>
+                  <%= link_to t('.delete'), main_app.admin_user_path(user), class: 'btn btn-danger btn-sm action-delete', method: :delete, data: { confirm: t('hyrax.admin.users.destroy.confirmation', user: user.email) } %>
+                  <% if user.invited_to_sign_up? %>
+                    <%= link_to t('.activate'), main_app.activate_admin_user_path(user.id), class: 'btn btn-primary btn-sm', method: :post, data: { confirm: t('hyrax.admin.users.activate.confirmation', user: user.email) } %>
+                  <% end %>
                 </td>
               <% end %>
             </tr>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -114,6 +114,14 @@ de:
       work_types: Verfügbare Arbeitstypen
     footer:
       admin_login: Administratorenlogin
+    identity_provider:
+      header: Authentifizierungsidentitätsanbieter
+      label:
+        logo_image: Bild für die SSO-Seite
+        logo_image_alt_text: Alternativtext für Bild
+        name: Name oder Beschreibung
+        optoins: Optionen
+        provider: Anbieter
     proprietor:
       accounts:
         nav: Konten
@@ -210,6 +218,10 @@ de:
         roles_and_permissions: Benutzer und Gruppen
         system_status: Systemstatus
       users:
+        activate:
+          confirmation: Sind Sie sicher, dass Sie den Benutzer „%{user}“ aktivieren möchten?
+          failure: Benutzer „%{user}“ konnte nicht aktiviert werden.
+          success: Benutzer „%{user}“ wurde erfolgreich aktiviert.
         destroy:
           confirmation: Möchten Sie den Benutzer "%{user}" wirklich löschen? Diese Aktion lässt sich nicht rückgängig machen.
           failure: Benutzer "%{user}" konnte nicht gelöscht werden.
@@ -278,6 +290,9 @@ de:
         edit: Bearbeiten
         header: Benutzer verwalten
         update: Aktualisieren
+  single_signon:
+    index:
+      sign_in_with_provider: Melden Sie sich mit %{provider} an
   status:
     index:
       services: Dienste

--- a/config/locales/devise_invitable.de.yml
+++ b/config/locales/devise_invitable.de.yml
@@ -21,9 +21,7 @@ de:
         accept: Die Einladung annehmen
         accept_until: Diese Einladung wird in %{due_date} fällig.
         hello: Hallo %{email}
-        ignore: |-
-          Wenn Sie die Einladung nicht akzeptieren möchten, ignorieren Sie bitte diese E-Mail. 
-          Ihr Konto wird erst dann erstellt, wenn Sie auf den obigen Link zugreifen und Ihr Passwort festlegen.
+        ignore: "Wenn Sie die Einladung nicht akzeptieren möchten, ignorieren Sie bitte diese E-Mail. \nIhr Konto wird erst dann erstellt, wenn Sie auf den obigen Link zugreifen und Ihr Passwort festlegen."
         someone_invited_you: Jemand hat Sie zu %{url} eingeladen, können Sie es über den Link unten akzeptieren.
         subject: Einladungshinweise
   time:

--- a/config/locales/devise_invitable.es.yml
+++ b/config/locales/devise_invitable.es.yml
@@ -21,9 +21,7 @@ es:
         accept: Aceptar la invitacion
         accept_until: Esta invitación será %{due_date}.
         hello: Hola %{email}
-        ignore: |-
-          Si no desea aceptar la invitación, ignore este correo electrónico. 
-          Su cuenta no se creará hasta que acceda al enlace anterior y establezca su contraseña.
+        ignore: "Si no desea aceptar la invitación, ignore este correo electrónico. \nSu cuenta no se creará hasta que acceda al enlace anterior y establezca su contraseña."
         someone_invited_you: Alguien te ha invitado a %{url}, puedes aceptarlo a través del siguiente enlace.
         subject: Instrucciones de invitación
   time:

--- a/config/locales/devise_invitable.fr.yml
+++ b/config/locales/devise_invitable.fr.yml
@@ -21,9 +21,7 @@ fr:
         accept: Accepter l'invitation
         accept_until: Cette invitation sera due en %{due_date}.
         hello: Bonjour %{email}
-        ignore: |-
-          Si vous ne souhaitez pas accepter l'invitation, ignorez ce courriel. 
-          Votre compte ne sera créé que lorsque vous accédez au lien ci-dessus et définissez votre mot de passe.
+        ignore: "Si vous ne souhaitez pas accepter l'invitation, ignorez ce courriel. \nVotre compte ne sera créé que lorsque vous accédez au lien ci-dessus et définissez votre mot de passe."
         someone_invited_you: Quelqu'un vous a invité %{url}, vous pouvez l'accepter par le lien ci-dessous.
         subject: Instructions d'invitation
   time:

--- a/config/locales/devise_invitable.it.yml
+++ b/config/locales/devise_invitable.it.yml
@@ -21,9 +21,7 @@ it:
         accept: Accetta l'invito
         accept_until: Questo invito sarà dovuto in %{due_date}.
         hello: Ciao %{email}
-        ignore: |-
-          Se non desideri accettare l'invito, ignora questa email. 
-          Il tuo account non verrà creato finché non accedi al link precedente e imposta la tua password.
+        ignore: "Se non desideri accettare l'invito, ignora questa email. \nIl tuo account non verrà creato finché non accedi al link precedente e imposta la tua password."
         someone_invited_you: Qualcuno ti ha invitato a %{url}, puoi accettarlo tramite il link qui sotto.
         subject: Istruzioni di invito
   time:

--- a/config/locales/devise_invitable.pt-BR.yml
+++ b/config/locales/devise_invitable.pt-BR.yml
@@ -21,9 +21,7 @@ pt-BR:
         accept: Aceitar convite
         accept_until: Este convite será devido em %{due_date}.
         hello: Olá %{email}
-        ignore: |-
-          Se você não deseja aceitar o convite, ignore este e-mail. 
-          Sua conta não será criada até você acessar o link acima e definir sua senha.
+        ignore: "Se você não deseja aceitar o convite, ignore este e-mail. \nSua conta não será criada até você acessar o link acima e definir sua senha."
         someone_invited_you: Alguém convidou você para %{url}, você pode aceitá-lo através do link abaixo.
         subject: Instruções de convite
   time:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -213,6 +213,10 @@ en:
         repository_activity: Repository Activity
         system_status: System Status
       users:
+        activate:
+          confirmation: Are you sure you want to activate the user "%{user}"?
+          failure: User "%{user}" could not be activated.
+          success: User "%{user}" has been successfully activated.
         destroy:
           confirmation: Are you sure you wish to delete the user "%{user}"? This action is irreversible.
           failure: User "%{user}" could not be deleted.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -114,6 +114,14 @@ es:
       work_types: Tipos de trabajo disponibles
     footer:
       admin_login: Acceso del administrador
+    identity_provider:
+      header: Proveedor de identidad de autenticación
+      label:
+        logo_image: Imagen para la página SSO
+        logo_image_alt_text: Texto alternativo para imagen
+        name: Nombre o descripción
+        optoins: Opciones
+        provider: Proveedor
     proprietor:
       accounts:
         nav: Cuentas
@@ -207,6 +215,10 @@ es:
         repository_activity: Actividad del repositorio
         system_status: Estado del sistema
       users:
+        activate:
+          confirmation: ¿Estás seguro de que deseas activar el usuario "%{user}"?
+          failure: No se pudo activar el usuario "%{user}".
+          success: El usuario "%{user}" se ha activado correctamente.
         destroy:
           confirmation: ¿Estás seguro de que deseas eliminar el usuario "%{user}"? Esta acción es irreversible.
           failure: El usuario "%{user}" no pudo ser eliminado.
@@ -275,6 +287,9 @@ es:
         edit: Editar
         header: Administrar usuario
         update: Actualizar
+  single_signon:
+    index:
+      sign_in_with_provider: Iniciar sesión con %{provider}
   status:
     index:
       services: Servicios

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -114,6 +114,14 @@ fr:
       work_types: Types de travail disponibles
     footer:
       admin_login: Connexion Administrateur
+    identity_provider:
+      header: Fournisseur d'identité d'authentification
+      label:
+        logo_image: Image de la page SSO
+        logo_image_alt_text: Texte alternatif pour l'image
+        name: Nom ou description
+        optoins: Possibilités
+        provider: Fournisseur
     proprietor:
       accounts:
         nav: Comptes
@@ -212,6 +220,10 @@ fr:
         system_status: État du système
         technical: Technique
       users:
+        activate:
+          confirmation: Etes-vous sûr de vouloir activer l'utilisateur "%{user}" ?
+          failure: L'utilisateur "%{user}" n'a pas pu être activé.
+          success: L'utilisateur "%{user}" a été activé avec succès.
         destroy:
           confirmation: Voulez-vous vraiment supprimer l'utilisateur "%{user}"? Cette action est irréversible.
           failure: L'utilisateur "%{user}" n'a pas pu être supprimé.
@@ -280,6 +292,9 @@ fr:
         edit: Modifier
         header: Gérer l'utilisateur
         update: Mettre à jour
+  single_signon:
+    index:
+      sign_in_with_provider: Connectez-vous avec %{provider}
   status:
     index:
       services: Prestations de service

--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -202,6 +202,7 @@ de:
         collections: Sammlungen
         configuration: Aufbau
         contact: Kontakt
+        identity_provider: Identitätsanbieter
         notifications: Benachrichtigungen
         pages: Seiten
         profile: Profil

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -203,6 +203,7 @@ es:
         configuration: Configuración
         contact: Contacto
         content_blocks: Bloques de contenido
+        identity_provider: Proveedor de identidad
         notifications: Notificaciones
         pages: Páginas
         profile: Perfil

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -202,6 +202,7 @@ fr:
         collections: Les collections
         configuration: Configuration
         contact: Contact
+        identity_provider: Fournisseur d'identité
         notifications: Notifications
         pages: Pages
         profile: Profil

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -203,6 +203,7 @@ it:
         configuration: Configurazione
         contact: Contatto
         content_blocks: Blocchi di contenuto
+        identity_provider: Fornitore di identità
         notifications: notifiche
         pages: pagine
         profile: Profilo

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -203,6 +203,7 @@ pt-BR:
         configuration: Configuração
         contact: Contato
         content_blocks: Blocos de Conteúdo
+        identity_provider: Provedor de identidade
         notifications: Notificações
         pages: Páginas
         profile: Perfil

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -203,6 +203,7 @@ zh:
         configuration: 组态
         contact: 联系
         content_blocks: 内容块
+        identity_provider: 身份提供者
         notifications: 通知事项
         pages: 页数
         profile: 个人资料

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -114,6 +114,14 @@ it:
       work_types: Tipi di lavoro disponibili
     footer:
       admin_login: Accesso amministratore
+    identity_provider:
+      header: Provider di identità di autenticazione
+      label:
+        logo_image: Immagine per la pagina SSO
+        logo_image_alt_text: Testo alternativo per l'immagine
+        name: Nome o descrizione
+        optoins: Opzioni
+        provider: Fornitore
     proprietor:
       accounts:
         nav: conti
@@ -207,6 +215,10 @@ it:
         repository_activity: Attività di deposito
         system_status: Stato del sistema
       users:
+        activate:
+          confirmation: Sei sicuro di voler attivare l'utente "%{user}"?
+          failure: Impossibile attivare l'utente "%{user}".
+          success: L'utente "%{user}" è stato attivato con successo.
         destroy:
           confirmation: Sei sicuro di voler cancellare l'utente "%{user}"? Questa azione è irreversibile.
           failure: L'utente "%{user}" non può essere cancellato.
@@ -275,6 +287,9 @@ it:
         edit: Modificare
         header: Gestisci utente
         update: Aggiornare
+  single_signon:
+    index:
+      sign_in_with_provider: Accedi con %{provider}
   status:
     index:
       services: Servizi

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -114,6 +114,14 @@ pt-BR:
       work_types: Tipos de trabalho disponíveis
     footer:
       admin_login: Login do administrador
+    identity_provider:
+      header: Provedor de identidade de autenticação
+      label:
+        logo_image: Imagem para página SSO
+        logo_image_alt_text: Texto alternativo para imagem
+        name: Nome ou Descrição
+        optoins: Opções
+        provider: Fornecedor
     proprietor:
       accounts:
         nav: Contas
@@ -207,6 +215,10 @@ pt-BR:
         repository_activity: Atividade do repositório
         system_status: Status do sistema
       users:
+        activate:
+          confirmation: Tem certeza de que deseja ativar o usuário "%{user}"?
+          failure: O usuário "%{user}" não pôde ser ativado.
+          success: O usuário "%{user}" foi ativado com sucesso.
         destroy:
           confirmation: Tem certeza de que deseja excluir o usuário "%{user}"? Esta ação é irreversível.
           failure: O usuário "%{user}" não pôde ser excluído.
@@ -275,6 +287,9 @@ pt-BR:
         edit: Editar
         header: Gerenciar usuário
         update: Atualizar
+  single_signon:
+    index:
+      sign_in_with_provider: Faça login com %{provider}
   status:
     index:
       services: Serviços

--- a/config/locales/simple_form.de.yml
+++ b/config/locales/simple_form.de.yml
@@ -9,8 +9,8 @@ de:
         admin_emails: Geben Sie jeweils eine E-Mail-Adresse ein
         allow_signup: Erlauben Sie Benutzern, sich bei Ihrem Repository anzumelden
         cache_api: Aktiviert den Cache für API-Endpunkte. Experimental
-        contact_email_to: E-Mail-Empfänger von Nachrichten, die über das Kontaktformular gesendet werden
         contact_email: E-Mail-Adresse, die Kontakt-E-Mails erhalten soll
+        contact_email_to: E-Mail-Empfänger von Nachrichten, die über das Kontaktformular gesendet werden
         doi_reader: Zeigen Sie die Fähigkeit, aus Datacite zu lesen, um Datensätze zu füllen. WIP nicht verwenden
         doi_writer: Schreiben Sie DOIs für Datensätze. WIP nicht verwenden
         email_format: Legen Sie eine Liste von E-Mail-Domains fest, die sich bei diesem Repository anmelden dürfen, z. B. (@ubiquitypress.com @gmail.com). Lassen Sie zwischen jeder Domäne ein einzelnes Leerzeichen.

--- a/config/locales/simple_form.es.yml
+++ b/config/locales/simple_form.es.yml
@@ -9,8 +9,8 @@ es:
         admin_emails: Introduce una dirección de correo electrónico a la vez
         allow_signup: Permita que los usuarios se registren en su repositorio
         cache_api: Activa la memoria caché para los puntos finales de la API. Experimental
-        contact_email_to: Destinatario de correo electrónico de los mensajes enviados a través del formulario de contacto
         contact_email: Dirección de correo electrónico que debe recibir correos electrónicos de contacto
+        contact_email_to: Destinatario de correo electrónico de los mensajes enviados a través del formulario de contacto
         doi_reader: Mostrar la capacidad de leer de Datacite para completar registros. WIP no usar
         doi_writer: Escriba DOI para los registros. WIP no usar
         email_format: Establezca una lista de dominios de correo electrónico que pueden registrarse en este repositorio, por ejemplo, (@ubiquitypress.com @gmail.com). Deje un solo espacio entre cada dominio.

--- a/config/locales/simple_form.fr.yml
+++ b/config/locales/simple_form.fr.yml
@@ -9,8 +9,8 @@ fr:
         admin_emails: Entrez une adresse e-mail à la fois
         allow_signup: Autoriser les utilisateurs à s'inscrire à votre référentiel
         cache_api: Active le cache pour les points de terminaison d'API. Expérimental
-        contact_email_to: Email destinataire des messages envoyés via le formulaire de contact
         contact_email: Adresse e-mail qui doit recevoir les e-mails de contact
+        contact_email_to: Email destinataire des messages envoyés via le formulaire de contact
         doi_reader: Afficher la possibilité de lire à partir de Datacite pour remplir les enregistrements. WIP ne pas utiliser
         doi_writer: Rédigez des DOI pour les enregistrements. WIP ne pas utiliser
         email_format: Définissez une liste de domaines de messagerie autorisés à s'inscrire à ce référentiel, par exemple (@ubiquitypress.com @gmail.com). Laissez un seul espace entre chaque domaine.

--- a/config/locales/simple_form.it.yml
+++ b/config/locales/simple_form.it.yml
@@ -9,8 +9,8 @@ it:
         admin_emails: Inserisci un indirizzo email alla volta
         allow_signup: Consenti agli utenti di registrarsi al tuo repository
         cache_api: Attiva la cache per gli endpoint API. Sperimentale
-        contact_email_to: Email destinatario dei messaggi inviati tramite il modulo di contatto
         contact_email: Indirizzo e-mail che dovrebbe ricevere le e-mail di contatto
+        contact_email_to: Email destinatario dei messaggi inviati tramite il modulo di contatto
         doi_reader: Mostra la capacità di leggere da Datacite per popolare i record. WIP non utilizzare
         doi_writer: Scrivi DOI per i record. WIP non utilizzare
         email_format: Impostare un elenco di domini di posta elettronica a cui è consentito registrarsi a questo repository, ad esempio (@ubiquitypress.com @gmail.com). Lascia un singolo spazio tra ogni dominio.

--- a/config/locales/simple_form.pt-BR.yml
+++ b/config/locales/simple_form.pt-BR.yml
@@ -9,8 +9,8 @@ pt-BR:
         admin_emails: Digite um endereço de email de cada vez
         allow_signup: Permitir que os usuários se inscrevam em seu repositório
         cache_api: Ativa o cache para terminais de API. Experimental
-        contact_email_to: Destinatário de e-mail de mensagens enviadas por meio do formulário de contato
         contact_email: Endereço de e-mail que deve receber e-mails de contato
+        contact_email_to: Destinatário de e-mail de mensagens enviadas por meio do formulário de contato
         doi_reader: Mostrar capacidade de ler do Datacite para preencher registros. WIP não use
         doi_writer: Escreva DOIs para registros. WIP não use
         email_format: Defina uma lista de domínios de e-mail que podem se inscrever neste repositório, por exemplo (@ubiquitypress.com @gmail.com). Deixe um único espaço entre cada domínio.

--- a/config/locales/simple_form.zh.yml
+++ b/config/locales/simple_form.zh.yml
@@ -9,8 +9,8 @@ zh:
         admin_emails: 一次输入一个电子邮件地址
         allow_signup: 允许用户注册到您的存储库
         cache_api: 为 API 端点打开缓存。实验性的
-        contact_email_to: 通过联系表发送的邮件的电子邮件收件人
         contact_email: 应接收联系电子邮件的电子邮件地址
+        contact_email_to: 通过联系表发送的邮件的电子邮件收件人
         doi_reader: 显示从 Datacite 读取数据以填充记录的能力。 WIP 不使用
         doi_writer: 为记录写 DOI。 WIP 不使用
         email_format: 设置允许注册此存储库的电子邮件域列表，例如 (@ubiquitypress.com @gmail.com)。在每个域之间留一个空格。

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -114,6 +114,14 @@ zh:
       work_types: 可用的工作类型
     footer:
       admin_login: 管理员登录
+    identity_provider:
+      header: 身份验证身份提供商
+      label:
+        logo_image: SSO 页面的图像
+        logo_image_alt_text: 图像的替代文本
+        name: 名称或描述
+        optoins: 选项
+        provider: 提供者
     proprietor:
       accounts:
         nav: 帐号
@@ -207,6 +215,10 @@ zh:
         repository_activity: 存储库活动
         system_status: 系统状态
       users:
+        activate:
+          confirmation: 您确定要激活用户“%{user}”吗？
+          failure: 无法激活用户“%{user}”。
+          success: 用户“%{user}”已成功激活。
         destroy:
           confirmation: 您确定要删除用户“%{user}”吗？这一行动是不可逆转的。
           failure: 无法删除用户“%{user}”。
@@ -275,6 +287,9 @@ zh:
         edit: 編輯
         header: 管理用户
         update: 更新
+  single_signon:
+    index:
+      sign_in_with_provider: 使用 %{provider} 登录
   status:
     index:
       services: 服务

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -100,7 +100,9 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   namespace :admin do
     resource :account, only: %i[edit update]
     resource :work_types, only: %i[edit update]
-    resources :users, only: [:destroy]
+    resources :users, only: [:index, :destroy] do
+      post 'activate', on: :member
+    end
     resources :groups do
       member do
         get :remove

--- a/ops/demo-deploy.tmpl.yaml
+++ b/ops/demo-deploy.tmpl.yaml
@@ -132,6 +132,8 @@ extraEnvVars: &envVars
     value: "true"
   - name: HYKU_ROOT_HOST
     value: hyku-demo.$BASE_URL
+  - name: HYKU_USER_DEFAULT_PASSWORD
+    value: password
   - name: SMTP_ENABLED
     value: "true"
   - name: SMTP_USER_NAME

--- a/ops/iiif-deploy.tmpl.yaml
+++ b/ops/iiif-deploy.tmpl.yaml
@@ -132,6 +132,8 @@ extraEnvVars: &envVars
     value: "true"
   - name: HYKU_ROOT_HOST
     value: hyku-iiif.$BASE_URL
+  - name: HYKU_USER_DEFAULT_PASSWORD
+    value: password
   - name: SMTP_ENABLED
     value: "true"
   - name: SMTP_USER_NAME

--- a/ops/iiif.tmpl.yaml
+++ b/ops/iiif.tmpl.yaml
@@ -132,6 +132,8 @@ extraEnvVars: &envVars
     value: "true"
   - name: HYKU_ROOT_HOST
     value: hyku-iiif.$BASE_URL
+  - name: HYKU_USER_DEFAULT_PASSWORD
+    value: password
   - name: SMTP_ENABLED
     value: "true"
   - name: SMTP_USER_NAME

--- a/ops/review-deploy.tmpl.yaml
+++ b/ops/review-deploy.tmpl.yaml
@@ -76,6 +76,8 @@ extraEnvVars: &envVars
     value: "true"
   - name: HYKU_ROOT_HOST
     value: hyku-$CI_MERGE_REQUEST_ID.example.com
+  - name: HYKU_USER_DEFAULT_PASSWORD
+    value: password
   - name: HYRAX_ACTIVE_JOB_QUEUE
     value: sidekiq
   - name: HYRAX_FITS_PATH

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -132,6 +132,8 @@ extraEnvVars: &envVars
     value: "true"
   - name: HYKU_ROOT_HOST
     value: hyku-staging.$BASE_URL
+  - name: HYKU_USER_DEFAULT_PASSWORD
+    value: password
   - name: NEGATIVE_CAPTCHA_SECRET
     value: $NEGATIVE_CAPTCHA_SECRET
   - name: SMTP_ENABLED
@@ -152,7 +154,7 @@ extraEnvVars: &envVars
     value: admin
   - name: SOLR_ADMIN_PASSWORD
     value: $SOLR_ADMIN_PASSWORD
- - name: SOLR_COLLECTION_NAME
+  - name: SOLR_COLLECTION_NAME
     value: hyku-staging
   - name: SOLR_CONFIGSET_NAME
     value: hyku-staging


### PR DESCRIPTION
This commit will allow superadmins to activate users from the dashboard. The default password for an activated user is set to `password`.  The activate button shows up for users who have permissions to destroy users.  The assumption is that superadmins will be the only ones with this permission.

Also the locales have been updated to include the new strings.

Ref:
  - https://github.com/scientist-softserv/palni-palci/issues/904

https://github.com/samvera/hyku/assets/19597776/9615e86c-cc49-4667-9834-cdf7d963c7ca

