### PR TITLE
remove duplicate JAVA_OPTS env var

### DIFF
--- a/.env
+++ b/.env
@@ -17,7 +17,6 @@ INITIAL_ADMIN_EMAIL=admin@example.com
 INITIAL_ADMIN_PASSWORD=testing123
 JAVA_OPTS=-Xmx4g -Xms1g
 IN_DOCKER=true
-JAVA_OPTS=
 LD_LIBRARY_PATH=/opt/fits/tools/mediainfo/linux
 PASSENGER_APP_ENV=development
 RAILS_LOG_TO_STDOUT=true


### PR DESCRIPTION
The same variable is defined two lines above and has a value, so I assume that is the correct one.

[The commit that added this duplicate](https://github.com/samvera/hyku/commit/ff2888faddd5bd97a5a74dbe532ea46aa97ea5e6) mentions various improvements (Bulkrax, Docker build, etc). Does removing the empty var break any of that? Should the var with a value be removed instead? 