### PR TITLE
Collection service backport

### DIFF
--- a/app/controllers/hyrax/my/works_controller_decorator.rb
+++ b/app/controllers/hyrax/my/works_controller_decorator.rb
@@ -6,7 +6,7 @@
 module Hyrax
   module My
     module WorksControllerDecorator
-      def collection_service
+      def collections_service
         cloned = clone
         cloned.params = {}
         Hyrax::CollectionsService.new(cloned)

--- a/app/controllers/hyrax/my/works_controller_decorator.rb
+++ b/app/controllers/hyrax/my/works_controller_decorator.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+##
+# OVERRIDE Hyrax 3.5.0; when Hyrax hits v4.0.0 we can remove this.
+# @see https://github.com/samvera/hyrax/pull/5972
+module Hyrax
+  module My
+    module WorksControllerDecorator
+      def collection_service
+        cloned = clone
+        cloned.params = {}
+        Hyrax::CollectionsService.new(cloned)
+      end
+    end
+  end
+end
+
+Hyrax::My::WorksController.prepend(Hyrax::My::WorksControllerDecorator)


### PR DESCRIPTION
## 🐛 Fix Add to Collection for page 2+ of works

b4e2d6a86f5efc49d0d10709fc5323a3d49fe498

Prior to this commit, when you were on page 2 of your works and selected
a work to add to a collection, the query for available collections would
use the page 2 as part of the collection query.  This would mean the
first 100 collections (default page size) that you had access to add
works to were skipped.

With this commit, we omit the query parameters from the works page and
then query collections.

Related to:

- https://github.com/samvera/hyrax/pull/5972
- https://github.com/samvera/hyrax/issues/5969
- https://github.com/scientist-softserv/adventist-dl/issues/625

Co-authored-by: LaRita Robinson <larita@scientist.com>

## 🐛 Fix bad method name

e201df00d26dcd43b2b1be6bef4f49beae7b6c1e

Related to:

- https://github.com/samvera/hyku/pull/2023/files
- https://github.com/scientist-softserv/atla-hyku/pull/198
