### PR TITLE
make iiif print off by default so we can mark it as an experimental feature

### DIFF
--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -3,9 +3,11 @@
 class GenericWork < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
   include ::Hyrax::BasicMetadata
-  include IiifPrint.model_configuration(
-    pdf_split_child_model: self
-  )
+  if ActiveModel::Type::Boolean.new.cast(ENV.fetch('HYKU_IIIF_PRINT', false))
+    include IiifPrint.model_configuration(
+      pdf_split_child_model: self
+    )
+  end
 
   validates :title, presence: { message: 'Your work must have a title.' }
 

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -4,9 +4,11 @@
 #  `rails generate hyrax:work Image`
 class Image < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
-  include IiifPrint.model_configuration(
-    pdf_split_child_model: self
-  )
+  if ActiveModel::Type::Boolean.new.cast(ENV.fetch('HYKU_IIIF_PRINT', false))
+    include IiifPrint.model_configuration(
+      pdf_split_child_model: self
+    )
+  end
 
   property :extent, predicate: ::RDF::Vocab::DC.extent, multiple: true do |index|
     index.as :stored_searchable


### PR DESCRIPTION
In order to turn IIIF Print on, you need to set HYKU_IIIF_PRINT=true in your environment. This feature should be considered experimental and will be refined and changed significantly in a future release.