### PR TITLE
pin-json-canonicalization-0.3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,8 @@ gem 'i18n-tasks', group: %i[development test]
 gem 'iiif_print', github: 'scientist-softserv/iiif_print', branch: 'main'
 gem 'jbuilder', '~> 2.5'
 gem 'jquery-rails' # Use jquery as the JavaScript library
+# The maintainers yanked 0.3.2 version (see https://github.com/dryruby/json-canonicalization/issues/2)
+gem 'json-canonicalization', "0.3.1"
 gem 'launchy', group: %i[test]
 gem 'listen', '>= 3.0.5', '< 3.2', group: %i[development]
 gem 'lograge'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -653,7 +653,7 @@ GEM
     jquery-ui-rails (6.0.1)
       railties (>= 3.2.16)
     json (2.6.3)
-    json-canonicalization (0.3.2)
+    json-canonicalization (0.3.1)
     json-jwt (1.15.3)
       activesupport (>= 4.2)
       aes_key_wrap
@@ -1330,6 +1330,7 @@ DEPENDENCIES
   iiif_print!
   jbuilder (~> 2.5)
   jquery-rails
+  json-canonicalization (= 0.3.1)
   launchy
   listen (>= 3.0.5, < 3.2)
   lograge

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,7 +13,10 @@
 ActiveRecord::Schema.define(version: 2023_08_04_073106) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "hstore"
+  enable_extension "pgcrypto"
   enable_extension "plpgsql"
+  enable_extension "uuid-ossp"
 
   create_table "account_cross_searches", force: :cascade do |t|
     t.bigint "search_account_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,10 +13,7 @@
 ActiveRecord::Schema.define(version: 2023_08_04_073106) do
 
   # These are extensions that must be enabled in order to support this database
-  enable_extension "hstore"
-  enable_extension "pgcrypto"
   enable_extension "plpgsql"
-  enable_extension "uuid-ossp"
 
   create_table "account_cross_searches", force: :cascade do |t|
     t.bigint "search_account_id"


### PR DESCRIPTION
Pinning the json-canonicalization to 0.3.1

# The maintainers yanked 0.3.2 version (see https://github.com/dryruby/json-canonicalization/issues/2)
gem 'json-canonicalization', "0.3.1"