### PR TITLE
🧹 Avoid `#present?` in non-Rails situations

### DIFF
--- a/bin/web
+++ b/bin/web
@@ -1,5 +1,5 @@
 #!/usr/local/bin/ruby
 # frozen_string_literal: true
-`echo "$GOOGLE_OAUTH_PRIVATE_KEY_VALUE" | base64 -d > prod-cred.p12` if ENV['GOOGLE_OAUTH_PRIVATE_KEY_VALUE'].present?
+`echo "$GOOGLE_OAUTH_PRIVATE_KEY_VALUE" | base64 -d > prod-cred.p12` unless ENV['GOOGLE_OAUTH_PRIVATE_KEY_VALUE'].to_s.strip.empty?
 
 exec "bundle exec puma -v -b tcp://0.0.0.0:3000"

--- a/bin/worker
+++ b/bin/worker
@@ -1,11 +1,11 @@
 #!/usr/local/bin/ruby
 # frozen_string_literal: true
-`echo "$GOOGLE_OAUTH_PRIVATE_KEY_VALUE" | base64 -d > prod-cred.p12` if ENV['GOOGLE_OAUTH_PRIVATE_KEY_VALUE'].present?
+`echo "$GOOGLE_OAUTH_PRIVATE_KEY_VALUE" | base64 -d > prod-cred.p12` unless ENV['GOOGLE_OAUTH_PRIVATE_KEY_VALUE'].to_s.strip.empty?
 
-if ENV['DATABASE_URL'].present?
-  ENV['DATABASE_URL'] = ENV['DATABASE_URL'].gsub('pool=5', 'pool=30')
-else
+if ENV['DATABASE_URL'].to_s.strip.empty?
   puts 'DATABASE_URL not set, no pool change needed'
+else
+  ENV['DATABASE_URL'] = ENV['DATABASE_URL'].gsub('pool=5', 'pool=30')
 end
 
 queue = ENV.fetch('HYRAX_ACTIVE_JOB_QUEUE', 'sidekiq')


### PR DESCRIPTION
Rails provides [`Object#present?`][1], which is a method that is not
generally available in Ruby.  However in the changed context, the
scripts do not have access to Rails methods.

By using this adjusted approach we favor baseline Ruby methods.

[1]: https://api.rubyonrails.org/classes/Object.html#method-i-present-3F