### PR TITLE
🧹 Remove deprecated Blacklight code

### DIFF
--- a/app/controllers/hyrax/contact_form_controller.rb
+++ b/app/controllers/hyrax/contact_form_controller.rb
@@ -11,7 +11,6 @@ module Hyrax
     # OVERRIDE: Hyrax v3.4.0 Add for theming
     # Adds Hydra behaviors into the application controller
     include Blacklight::SearchContext
-    include Blacklight::SearchHelper
     include Blacklight::AccessControls::Catalog
     before_action :build_contact_form
     layout 'homepage'

--- a/app/controllers/hyrax/homepage_controller.rb
+++ b/app/controllers/hyrax/homepage_controller.rb
@@ -27,7 +27,6 @@ module Hyrax
   class HomepageController < CatalogController
     # Adds Hydra behaviors into the application controller
     include Blacklight::SearchContext
-    include Blacklight::SearchHelper
     include Blacklight::AccessControls::Catalog
 
     # OVERRIDE: account for Hyku themes

--- a/app/controllers/hyrax/pages_controller.rb
+++ b/app/controllers/hyrax/pages_controller.rb
@@ -15,7 +15,6 @@ module Hyrax
     # OVERRIDE: Hyrax v3.4.0 Add for theming
     # Adds Hydra behaviors into the application controller
     include Blacklight::SearchContext
-    include Blacklight::SearchHelper
     include Blacklight::AccessControls::Catalog
 
     # OVERRIDE: Adding inject theme views method for theming

--- a/app/controllers/search_history_controller.rb
+++ b/app/controllers/search_history_controller.rb
@@ -3,6 +3,5 @@
 class SearchHistoryController < ApplicationController
   include Blacklight::SearchHistory
   helper BlacklightAdvancedSearch::RenderConstraintsOverride
-  helper BlacklightRangeLimit::ViewHelperOverride
   helper RangeLimitHelper
 end


### PR DESCRIPTION
removes the deprecated blacklight code allows the specs to run. We should consider if finding a replacement is necessary in the following ticket:

- https://github.com/scientist-softserv/hykuup_knapsack/issues/54
- 
or the fix may be caught when we resolve failing specs

Issue:
- https://github.com/scientist-softserv/hykuup_knapsack/issues/35