### PR TITLE
🧹 Get Controller specs passing

### DIFF
--- a/app/controllers/hyrax/homepage_controller.rb
+++ b/app/controllers/hyrax/homepage_controller.rb
@@ -12,15 +12,17 @@
 #
 #########################################################################################
 #########################################################################################
-# OVERRIDE: Hyrax v2.9.0 to add home_text content block to the index method - Adding themes
-# OVERRIDE: Hyrax v2.9.0 from Hyrax v2.9.0 to add facets to home page - inheriting from
-# CatalogController rather than ApplicationController
-# OVERRIDE: Hyrax v2.9.0 from Hyrax v2.9.0 to add inject_theme_views method for theming
-# OVERRIDE: Hyrax v2.9.0 to add search_action_url method from Blacklight 6.23.0 to make facet links to go to /catalog
-# OVERRIDE: Hyrax v2.9.0 to add .sort_by to return collections in alphabetical order by title on the homepage
-# OVERRIDE: Hyrax v2.9.0 add all_collections page for IR theme
-# OVERRIDE: Hyrax v2.9.0 to add facet counts for resource types for IR theme
-# OVERRIDE: Hyrax v. 2.9.0 to add @featured_collection_list to index method
+
+# OVERRIDE: Hyrax v5.0.0
+# - add home_text content block to the index method - Adding themes
+# - add inject_theme_views method for theming
+# - add all_collections page for IR theme
+# - add facet counts for resource types for IR theme
+
+# - add facets to home page - inheriting from CatalogController rather than ApplicationController
+# - add search_action_url method from Blacklight 6.23.0 to make facet links to go to /catalog
+# - add .sort_by to return collections in alphabetical order by title on the homepage
+# - add @featured_collection_list to index method
 
 module Hyrax
   # Changed to inherit from CatalogController for home page facets
@@ -61,7 +63,7 @@ module Hyrax
 
       ir_counts if home_page_theme == 'institutional_repository'
 
-      (@response, @document_list) = search_results(params)
+      (@response, @document_list) = search_service.search_results
 
       respond_to do |format|
         format.html { store_preferred_view }
@@ -102,26 +104,28 @@ module Hyrax
 
     private
 
-    # Return 6 collections
+    # Return 6 collections, sorts by title
     def collections(rows: 6)
-      builder = Hyrax::CollectionSearchBuilder.new(self)
-                                              .rows(rows)
-      response = repository.search(builder)
-      # adding .sort_by to return collections in alphabetical order by title on the homepage
-      response.documents.sort_by(&:title)
+    (response, documents) = Hyrax::CollectionsService.new(self).search_results do |builder|
+        builder.rows(rows)
+        builder.merge(sort: "title_ssi")
+      end
     rescue Blacklight::Exceptions::ECONNREFUSED, Blacklight::Exceptions::InvalidRequest
       []
     end
 
-    def recent
-      # grab any recent documents
-      (_, @recent_documents) = search_results(q: '', sort: sort_field, rows: 6)
+    # override to show 6 recent items
+    def recent(rows: 6)
+      (_, @recent_documents) = search_service.search_results do |builder|
+        builder.rows(rows)
+        builder.merge(sort: sort_field)
+      end
     rescue Blacklight::Exceptions::ECONNREFUSED, Blacklight::Exceptions::InvalidRequest
       @recent_documents = []
     end
 
     def ir_counts
-      @ir_counts = get_facet_field_response('resource_type_sim', {}, "f.resource_type_sim.facet.limit" => "-1")
+      @ir_counts = search_service.facet_field_response('resource_type_sim', "f.resource_type_sim.facet.limit" => "-1")
     end
 
     # COPIED from Hyrax::HomepageController
@@ -143,6 +147,16 @@ module Hyrax
       else
         yield
       end
+    end
+
+    # add this method to vary blacklight config and user_params
+    def search_service(*args)
+      Hyrax::SearchService.new(
+        config: ::CatalogController.new.blacklight_config, 
+        user_params: params.except(:q, :page), 
+        scope: self,
+        current_ability: current_ability,
+        search_builder_class: search_builder_class)
     end
   end
 end

--- a/app/views/themes/cultural_repository/layouts/hyrax.html.erb
+++ b/app/views/themes/cultural_repository/layouts/hyrax.html.erb
@@ -40,6 +40,6 @@
     </div><!-- /#content-wrapper -->
     <%= render 'shared/footer' %>
     <%= render '/shared/select_work_type_modal', create_work_presenter: @presenter&.create_work_presenter if @presenter&.draw_select_work_modal? %>
-    <%= render 'shared/ajax_modal' %>
+    <%= render 'shared/modal' %>
   </body>
 </html>

--- a/app/views/themes/institutional_repository/layouts/hyrax.html.erb
+++ b/app/views/themes/institutional_repository/layouts/hyrax.html.erb
@@ -29,6 +29,6 @@
 
     </div><!-- /#content-wrapper -->
     <%= render 'shared/footer' %>
-    <%= render 'shared/ajax_modal' %>
+    <%= render 'shared/modal' %>
   </body>
 </html>

--- a/spec/controllers/hyrax/homepage_controller_spec.rb
+++ b/spec/controllers/hyrax/homepage_controller_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
-
-# Copied from Hyrax v2.9.0 to add home_text content block to the index method - Adding themes
-RSpec.describe Hyrax::HomepageController, type: :controller, clean: true do
-  let(:routes) { Hyrax::Engine.routes }
+RSpec.describe Hyrax::HomepageController, type: :controller do
+  routes { Hyrax::Engine.routes }
 
   describe "#index" do
     let(:user) { create(:user) }
@@ -12,17 +10,11 @@ RSpec.describe Hyrax::HomepageController, type: :controller, clean: true do
     end
 
     context 'with existing featured researcher' do
-      let!(:frodo) do
-        ContentBlock.create!(
-          name: ContentBlock::NAME_REGISTRY[:researcher],
-          value: 'Frodo Baggins',
-          created_at: Time.zone.now
-        )
-      end
+      let!(:frodo) { ContentBlock.create!(name: ContentBlock::NAME_REGISTRY[:researcher], value: 'Frodo Baggins', created_at: Time.zone.now) }
 
       it 'finds the featured researcher' do
         get :index
-        expect(response).to be_success
+        expect(response).to be_successful
         expect(assigns(:featured_researcher)).to eq frodo
       end
     end
@@ -30,7 +22,7 @@ RSpec.describe Hyrax::HomepageController, type: :controller, clean: true do
     context 'with no featured researcher' do
       it "sets featured researcher" do
         get :index
-        expect(response).to be_success
+        expect(response).to be_successful
         assigns(:featured_researcher).tap do |researcher|
           expect(researcher).to be_kind_of ContentBlock
           expect(researcher.name).to eq 'featured_researcher'
@@ -40,56 +32,41 @@ RSpec.describe Hyrax::HomepageController, type: :controller, clean: true do
 
     it "sets marketing text" do
       get :index
-      expect(response).to be_success
+      expect(response).to be_successful
       assigns(:marketing_text).tap do |marketing|
         expect(marketing).to be_kind_of ContentBlock
         expect(marketing.name).to eq 'marketing_text'
       end
     end
 
-    # override hyrax v2.9.0 added @home_text - Adding Themes
-    it "sets home page text" do
-      get :index
-      expect(response).to be_success
-      assigns(:home_text).tap do |home|
-        expect(home).to be_kind_of ContentBlock
-        expect(home.name).to eq 'home_text'
-      end
-    end
-
     it "does not include other user's private documents in recent documents" do
       get :index
-      expect(response).to be_success
+      expect(response).to be_successful
       titles = assigns(:recent_documents).map { |d| d['title_tesim'][0] }
       expect(titles).not_to include('Test Private Document')
     end
 
-    it "includes only GenericWork objects in recent documents" do
+    it "includes only Work objects in recent documents" do
       get :index
-      assigns(:recent_documents).each do |doc|
-        expect(doc["has_model_ssim"]).to eql ["GenericWork"]
-      end
+      expect(assigns(:recent_documents).all?(&:work?)).to eq true
     end
 
     context "with a document not created this second", clean_repo: true do
+      let(:work_1) { { id: 'work_1', has_model_ssim: 'GenericWork', read_access_person_ssim: user.user_key, date_uploaded_dtsi: 2.days.ago.iso8601 } }
+      let(:work_2) { { id: 'work_2', has_model_ssim: 'GenericWork', read_access_person_ssim: user.user_key, date_uploaded_dtsi: 4.days.ago.iso8601 } }
+      let(:work_3) { { id: 'work_3', has_model_ssim: 'Image', read_access_person_ssim: user.user_key, date_uploaded_dtsi: 3.days.ago.iso8601 } }
+
       before do
-        gw3 = GenericWork.new(title: ['Test 3 Document'], read_groups: ['public'])
-        gw3.apply_depositor_metadata('mjg36')
-        # stubbing to_solr so we know we have something that didn't create in the current second
-        old_to_solr = gw3.method(:to_solr)
-        allow(gw3).to receive(:to_solr) do
-          old_to_solr.call.merge(
-            "system_create_dtsi" => 1.day.ago.iso8601,
-            "date_uploaded_dtsi" => 1.day.ago.iso8601
-          )
+        [work_1, work_2, work_3].each do |obj|
+          Hyrax::SolrService.add(obj)
         end
-        gw3.save
+        Hyrax::SolrService.commit
       end
 
       it "sets recent documents in the right order" do
         get :index
-        expect(response).to be_success
-        expect(assigns(:recent_documents).length).to be <= 4
+        expect(response).to be_successful
+        expect(assigns(:recent_documents).length).to eq 3
         create_times = assigns(:recent_documents).map { |d| d['date_uploaded_dtsi'] }
         expect(create_times).to eq create_times.sort.reverse
       end
@@ -97,23 +74,21 @@ RSpec.describe Hyrax::HomepageController, type: :controller, clean: true do
 
     context "with collections" do
       let(:presenter) { double }
-      let(:repository) { double }
-      let(:collection) { create(:collection) }
-      let(:collection_results) { double(documents: [collection]) }
+      # let(:repository) { double }
+      let(:collection_results) { double(documents: ['collection results']) }
 
       before do
-        allow(controller).to receive(:repository).and_return(repository)
+        # allow(controller).to receive(:repository).and_return(repository)
         allow(controller).to receive(:search_results).and_return([nil, ['recent document']])
-        allow(controller.repository).to receive(:search).with(an_instance_of(Hyrax::CollectionSearchBuilder))
-                                                        .and_return(collection_results)
+        allow_any_instance_of(Hyrax::CollectionsService).to receive(:search_results).and_return(collection_results.documents)
       end
 
       it "initializes the presenter with ability and a list of collections" do
-        expect(Hyrax::HomepagePresenter).to receive(:new).with(Ability,
-                                                               [collection])
-                                                         .and_return(presenter)
+        expect(Hyrax::HomepagePresenter).to receive(:new)
+                                        .with(controller.current_ability, ["collection results"])
+                                        .and_return(presenter)
         get :index
-        expect(response).to be_success
+        expect(response).to be_successful
         expect(assigns(:presenter)).to eq presenter
       end
     end
@@ -127,51 +102,63 @@ RSpec.describe Hyrax::HomepageController, type: :controller, clean: true do
 
       it "sets featured works" do
         get :index
-        expect(response).to be_success
+        expect(response).to be_successful
         expect(assigns(:featured_work_list)).to be_kind_of FeaturedWorkList
       end
     end
 
     it "sets announcement content block" do
       get :index
-      expect(response).to be_success
+      expect(response).to be_successful
       assigns(:announcement_text).tap do |announcement|
         expect(announcement).to be_kind_of ContentBlock
         expect(announcement.name).to eq 'announcement_text'
       end
     end
 
-    xcontext "without solr" do # skip until and fix with ticket #301 https://gitlab.com/notch8/palni-palci/-/issues/301
+    xcontext "without solr" do # skip: see https://github.com/scientist-softserv/palni-palci/issues/154
       before do
-        allow(controller).to receive(:repository).and_return(instance_double(Blacklight::Solr::Repository))
-        allow(controller.repository).to receive(:search).and_raise Blacklight::Exceptions::InvalidRequest
+        allow_any_instance_of(Hyrax::SearchService).to receive(:search_results).and_raise Blacklight::Exceptions::InvalidRequest
       end
 
       it "errors gracefully" do
         get :index
-        expect(response).to be_success
+        expect(response).to be_successful
         expect(assigns(:admin_sets)).to be_blank
         expect(assigns(:recent_documents)).to be_blank
       end
     end
 
-    context 'with theming' do
-      it { is_expected.to use_around_action(:inject_theme_views) }
-    end
-
-    context 'with ir stats' do
-      before do
-        allow(controller).to receive(:home_page_theme).and_return('institutional_repository')
-      end
-      # rubocop:disable RSpec/LetSetup
-      let!(:work_with_resource_type) { create(:work, user: user, resource_type: ['Article']) }
-
-      # rubocop:enable RSpec/LetSetup
-
-      it 'gets the stats' do
+    # specs for Hyku-only features
+    # override added @home_text - Adding Themes
+    describe 'Hyku exclusive features' do
+      it "sets home page text" do
         get :index
-        expect(response).to be_success
-        expect(assigns(:ir_counts)['facet_counts']['facet_fields']['resource_type_sim']).to include('Article', 1)
+        expect(response).to be_successful
+        assigns(:home_text).tap do |home|
+          expect(home).to be_kind_of ContentBlock
+          expect(home.name).to eq 'home_text'
+        end
+      end
+
+      context 'with theming' do
+        it { is_expected.to use_around_action(:inject_theme_views) }
+      end
+
+      context 'with ir stats' do
+        before do
+          allow(controller).to receive(:home_page_theme).and_return('institutional_repository')
+        end
+        # rubocop:disable RSpec/LetSetup
+        let!(:work_with_resource_type) { create(:work, user: user, resource_type: ['Article']) }
+
+        # rubocop:enable RSpec/LetSetup
+
+        it 'gets the stats' do
+          get :index
+          expect(response).to be_successful
+          expect(assigns(:ir_counts)['facet_counts']['facet_fields']['resource_type_sim']).to include('Article', 1)
+        end
       end
     end
   end


### PR DESCRIPTION
## Homepage controller specs

Refactor homepage controller to more closely align with Hyrax's homepage controller.
Adjust theme views to render `modal` instead of `ajax_modal`.

refs: https://github.com/scientist-softserv/hykuup_knapsack/issues/56