### PR TITLE
🧹 Attempt to resolve ActionView::Template::Error

### DIFF
--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -508,6 +508,8 @@ module Hyrax
       if show_page_theme && show_page_theme != 'default_show'
         original_paths = view_paths
         Hyku::Application.theme_view_path_roots.each do |root|
+          next unless File.exist?(root)
+
           show_theme_view_path = File.join(root, 'app', 'views', "themes", show_page_theme.to_s)
           prepend_view_path(show_theme_view_path)
         end


### PR DESCRIPTION
We're seeing errors of the following.  I'm curious if the CI does not
have the correct paths.

>   73) Work Editor role read permissions with open visibility can see the show page for works deposited by other users
>      Failure/Error: Site.application_name || super
>
>      ActionView::Template::Error:
>        Permission denied @ dir_s_mkdir - /app
>      # /usr/local/lib/ruby/3.2.0/fileutils.rb:406:in `mkdir'
>      # /usr/local/lib/ruby/3.2.0/fileutils.rb:406:in `fu_mkdir'
>      # /usr/local/lib/ruby/3.2.0/fileutils.rb:384:in `block (2 levels) in mkdir_p'
>      # /usr/local/lib/ruby/3.2.0/fileutils.rb:382:in `reverse_each'
>      # /usr/local/lib/ruby/3.2.0/fileutils.rb:382:in `block in mkdir_p'
>      # /usr/local/lib/ruby/3.2.0/fileutils.rb:374:in `each'
>      # /usr/local/lib/ruby/3.2.0/fileutils.rb:374:in `mkdir_p'
>      # ./app/helpers/hyrax_helper.rb:10:in `application_name'
>      # ./app/views/hyrax/base/show.html.erb:5:in `_app_views_hyrax_base_show_html_erb__1109076121543204006_716860'
>      # /usr/local/lib/ruby/3.2.0/benchmark.rb:311:in `realtime'
>      # ./app/controllers/concerns/hyrax/works_controller_behavior.rb:520:in `inject_show_theme_views'
>      # ./lib/omni_auth/strategies/saml_decorator.rb:28:in `other_phase'
>      # ./spec/requests/work_editor_role_spec.rb:53:in `block (5 levels) in <top (required)>'