### PR TITLE
🐛 Ensure :maxFileSize is integer

### DIFF
--- a/app/models/concerns/account_settings.rb
+++ b/app/models/concerns/account_settings.rb
@@ -162,7 +162,7 @@ module AccountSettings
     Hyrax.config do |config|
       config.contact_email = contact_email
       config.geonames_username = geonames_username
-      config.uploader[:maxFileSize] = file_size_limit
+      config.uploader[:maxFileSize] = file_size_limit.to_i
     end
 
     Devise.mailer_sender = contact_email


### PR DESCRIPTION
Prior to this commit, we were casting the value to string.  However Hyrax attempts to do division on that string.

See https://github.com/samvera/hyrax/blob/b7891b758411c59f71ff54212e0d250fcc47e35f/app/views/hyrax/base/_form_files.html.erb#L6-L15
