### PR TITLE
🧹 Favor Sipity::Entity function over to_sipity_entity

### DIFF
--- a/spec/requests/work_approval_permissions_spec.rb
+++ b/spec/requests/work_approval_permissions_spec.rb
@@ -39,11 +39,11 @@ RSpec.describe 'Work approval permissions', type: :request, singletenant: true, 
     end
 
     it 'can approve a work' do
-      expect(work.to_sipity_entity.workflow_state.name).to eq('pending_review')
+      expect(Sipity::Entity(work).workflow_state.name).to eq('pending_review')
 
       put hyrax_workflow_action_path(work), params: { workflow_action: { name: 'approve', comment: '' } }
 
-      expect(work.to_sipity_entity.reload.workflow_state.name).to eq('deposited')
+      expect(Sipity::Entity(work).reload.workflow_state.name).to eq('deposited')
     end
 
     it 'can see works submitted for review in the dashboard' do
@@ -59,11 +59,11 @@ RSpec.describe 'Work approval permissions', type: :request, singletenant: true, 
     end
 
     it 'can approve a work' do
-      expect(work.to_sipity_entity.workflow_state.name).to eq('pending_review')
+      expect(Sipity::Entity(work).workflow_state.name).to eq('pending_review')
 
       put hyrax_workflow_action_path(work), params: { workflow_action: { name: 'approve', comment: '' } }
 
-      expect(work.to_sipity_entity.reload.workflow_state.name).to eq('deposited')
+      expect(Sipity::Entity(work).reload.workflow_state.name).to eq('deposited')
     end
 
     it 'can see works submitted for review in the dashboard' do
@@ -79,12 +79,12 @@ RSpec.describe 'Work approval permissions', type: :request, singletenant: true, 
     end
 
     it 'cannot approve a work' do
-      expect(work.to_sipity_entity.workflow_state.name).to eq('pending_review')
+      expect(Sipity::Entity(work).workflow_state.name).to eq('pending_review')
 
       put hyrax_workflow_action_path(work), params: { workflow_action: { name: 'approve', comment: '' } }
 
       expect(response).to have_http_status(:unauthorized)
-      expect(work.to_sipity_entity.reload.workflow_state.name).to eq('pending_review')
+      expect(Sipity::Entity(work).reload.workflow_state.name).to eq('pending_review')
     end
 
     it 'cannot see works submitted for review in the dashboard' do
@@ -96,12 +96,12 @@ RSpec.describe 'Work approval permissions', type: :request, singletenant: true, 
 
   context 'when signed in as a user with no special access' do
     it 'cannot approve a work' do
-      expect(work.to_sipity_entity.workflow_state.name).to eq('pending_review')
+      expect(Sipity::Entity(work).workflow_state.name).to eq('pending_review')
 
       put hyrax_workflow_action_path(work), params: { workflow_action: { name: 'approve', comment: '' } }
 
       expect(response).to have_http_status(:unauthorized)
-      expect(work.to_sipity_entity.reload.workflow_state.name).to eq('pending_review')
+      expect(Sipity::Entity(work).reload.workflow_state.name).to eq('pending_review')
     end
 
     it 'cannot see works submitted for review in the dashboard' do


### PR DESCRIPTION
The Sipity conversion methods are now explicit functions (much like the `Array()` function).

- https://github.com/samvera/hyrax/blob/5aaa568d348a180add2a1337d9d794b740703df8/app/models/sipity.rb#L20
