### PR TITLE
🤖 Specify Cache Root

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,7 @@ jobs:
       BUNDLE_PATH: vendor/bundle
       BUNDLE_JOBS: 4
       BUNDLE_RETRY: 3
+      HYKU_CACHE_ROOT: /tmp/hyku-cache
       HYKU_RESTRICT_CREATE_AND_DESTROY_PERMISSIONS: 'true'
       SOLR_ADMIN_USER: admin
       SOLR_ADMIN_PASSWORD: admin


### PR DESCRIPTION
Prior to this commit, we were seeing the following failure:

> Failure/Error: Site.application\_name || super
>
> ActionView::Template::Error:
>  Permission denied @ dir\_s\_mkdir - /app

The `Account#setup_tenant_cache` sets the cache\_store to be `ENV.fetch('HYKU_CACHE_ROOT', '/app/samvera/file_cache')`.  When I locally chanced it to `/blorg/samvera/file_cache` I could repeat the error.

With this commit, we're setting the cache value for the CircleCI run.

Why was it previously working?  Perhaps because
`Account#setup_tenant_cache` never got called due to other configurations?  There is a guard clause around the method call.

