### PR TITLE
🤖 Fix spec/features/collection_type_spec.rb

### DIFF
--- a/spec/features/collection_type_spec.rb
+++ b/spec/features/collection_type_spec.rb
@@ -376,11 +376,7 @@ RSpec.describe 'collection_type', type: :feature, js: true, clean: true do
 
     context 'when collections exist of this type' do
       before do
-        create(
-          :public_collection_lw,
-          user: build(:user),
-          collection_type_gid: exhibit_collection_type.gid
-        )
+        FactoryBot.create(:public_collection_lw, user: build(:user), collection_type: exhibit_collection_type)
 
         exhibit_collection_type
         login_as admin_user
@@ -388,7 +384,7 @@ RSpec.describe 'collection_type', type: :feature, js: true, clean: true do
       end
 
       it 'all settings are disabled', :js do
-        expect(exhibit_collection_type.collections?).to be true
+        expect(exhibit_collection_type.collections.any?).to be true
 
         click_link('Settings', href: '#settings')
 
@@ -446,7 +442,7 @@ RSpec.describe 'collection_type', type: :feature, js: true, clean: true do
         create(
           :public_collection_lw,
           user: admin_user,
-          collection_type_gid: not_empty_collection_type.gid
+          collection_type: not_empty_collection_type
         )
       end
       # OVERRIDE: split deny_delete_modal_text into two variables since the test was failing over the newline character
@@ -474,7 +470,7 @@ RSpec.describe 'collection_type', type: :feature, js: true, clean: true do
         end
 
         # forwards to Dashboard -> Collections -> All Collections
-        within('li.active') do
+        within('.nav-tabs li.nav-item') do
           expect(page).to have_link('All Collections')
         end
 
@@ -492,7 +488,6 @@ RSpec.describe 'collection_type', type: :feature, js: true, clean: true do
   end
 
   # OVERRIDE: new (non-hyrax) test cases below
-
   describe 'default collection type participants', ci: 'skip' do
     let(:title) { 'Title Test' }
 


### PR DESCRIPTION
There are three major changes:

1. Favor setting `collection_type` attribute instead of
   `collection_type_gid`
2. Change `#collections?` to `#collections#any?`
3. Change CSS selector based on Bootstrap upgrade

The above changes are related to work done in:

- https://github.com/samvera/hyrax/pull/5730
- https://github.com/samvera/hyrax/pull/5742
- https://github.com/samvera/hyrax/pull/4701

See:
- https://github.com/samvera/hyrax/commit/eb6e04e312b039a65ef58b1781fa112fd93f2c0c
- https://github.com/samvera/hyrax/commit/237c0c63297df05b9d483a15b212900c2323a455
- https://github.com/samvera/hyrax/commit/280664bd6b0e59c2e10795151f0afcec91b9c15b