### PR TITLE
Lock chromedriver version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,9 @@ jobs:
           ruby_version: << parameters.ruby_version >>
           bundler_version: << parameters.bundler_version >>
       - samvera/rubocop
-      - browser-tools/install-chrome
+      - browser-tools/install-chrome:
+          chrome-version: 114.0.5735.90 # see https://github.com/CircleCI-Public/browser-tools-orb/pull/96
+          replace-existing: true
       - browser-tools/install-chromedriver
       - run:
           name: Check Chrome install


### PR DESCRIPTION
Lock chromedriver version

[Orb 1.4.6](https://github.com/CircleCI-Public/browser-tools-orb/pull/96) release was supposed to fix this but we are once again seeing the error, so we are attempting to lock the chrome version to bypass this error. 

The error message in the tools is attempting to use URL: https://chromedriver.storage.googleapis.com/index.html
Newer versions of chrome are not supported at this URL.