### PR TITLE
🤖 Fix stub methods to pass tests

### DIFF
--- a/spec/models/redis_endpoint_spec.rb
+++ b/spec/models/redis_endpoint_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RedisEndpoint do
   let(:namespace) { 'foobar' }
 
   describe '.options' do
-    subject { described_class.new namespace: }
+    subject { described_class.new(namespace:) }
 
     it 'uses the configured application settings' do
       expect(subject.options[:namespace]).to eq namespace
@@ -12,13 +12,15 @@ RSpec.describe RedisEndpoint do
   end
 
   describe '#ping' do
+    let(:faux_redis_instance) { double(Hyrax::RedisEventStore, ping: 'PONG') }
     it 'checks if the service is up' do
-      allow(Hyrax::RedisEventStore.instance).to receive(:ping).and_return('PONG')
+      allow(subject).to receive(:redis_instance).and_return(faux_redis_instance)
       expect(subject.ping).to be_truthy
     end
 
     it 'is false if the service is down' do
-      allow(Hyrax::RedisEventStore.instance).to receive(:ping).and_raise(RuntimeError)
+      allow(faux_redis_instance).to receive(:ping).and_raise(RuntimeError)
+      allow(subject).to receive(:redis_instance).and_return(faux_redis_instance)
       expect(subject.ping).to eq false
     end
   end


### PR DESCRIPTION
These tests weren't verifying that we could reach Redis; they were
testing the interface of the `RedisEndpoint#ping` by mocking the
instance.

This commit changes the mocking by avoiding a call to
`Hyrax::RedisEventStore.instance` which was raising a Redis connection
error.

Again, this test is not is redis connecting but "assume we are trying to
connect to redis now demonstrate ping."