### PR TITLE
Hyrax 5 upgrade spec fixing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,6 +71,7 @@ gem 'rack-test', '0.7.0', group: %i[test] # rack-test >= 0.71 does not work with
 gem 'rails-controller-testing', group: %i[test]
 gem 'rdf', '~> 3.2'
 gem 'redlock', '>= 0.1.2', '< 2.0' # lock redlock per https://github.com/samvera/hyrax/pull/5961
+gem 'redis-namespace', '~> 1.10' # Hyrax v5 relies on 1.5; but we'd like to have the #clear method so we need 1.10 or greater.
 gem 'riiif', '~> 2.0'
 gem 'rolify'
 gem 'rsolr', '~> 2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -70,8 +70,8 @@ gem 'puma', '~> 5.6' # Use Puma as the app server
 gem 'rack-test', '0.7.0', group: %i[test] # rack-test >= 0.71 does not work with older Capybara versions (< 2.17). See #214 for more details
 gem 'rails-controller-testing', group: %i[test]
 gem 'rdf', '~> 3.2'
-gem 'redlock', '>= 0.1.2', '< 2.0' # lock redlock per https://github.com/samvera/hyrax/pull/5961
 gem 'redis-namespace', '~> 1.10' # Hyrax v5 relies on 1.5; but we'd like to have the #clear method so we need 1.10 or greater.
+gem 'redlock', '>= 0.1.2', '< 2.0' # lock redlock per https://github.com/samvera/hyrax/pull/5961
 gem 'riiif', '~> 2.0'
 gem 'rolify'
 gem 'rsolr', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1437,6 +1437,7 @@ DEPENDENCIES
   rails (~> 6.0)
   rails-controller-testing
   rdf (~> 3.2)
+  redis-namespace (~> 1.10)
   redlock (>= 0.1.2, < 2.0)
   riiif (~> 2.0)
   rolify

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -111,6 +111,8 @@ class Account < ApplicationRecord
     Hyrax::Engine.routes.default_url_options[:host] = cname
   end
 
+  DEFAULT_FILE_CACHE_STORE = ENV.fetch('HYKU_CACHE_ROOT', '/app/samvera/file_cache')
+
   def setup_tenant_cache(is_enabled)
     Rails.application.config.action_controller.perform_caching = is_enabled
     ActionController::Base.perform_caching = is_enabled
@@ -118,7 +120,7 @@ class Account < ApplicationRecord
     if is_enabled
       Rails.application.config.cache_store = :redis_cache_store, { url: Redis.current.id }
     else
-      Rails.application.config.cache_store = :file_store, ENV.fetch('HYKU_CACHE_ROOT', '/app/samvera/file_cache')
+      Rails.application.config.cache_store = :file_store, DEFAULT_FILE_CACHE_STORE
     end
     # rubocop:enable Style/ConditionalAssignment
     Rails.cache = ActiveSupport::Cache.lookup_store(Rails.application.config.cache_store)

--- a/app/models/fcrepo_endpoint.rb
+++ b/app/models/fcrepo_endpoint.rb
@@ -27,7 +27,7 @@ class FcrepoEndpoint < Endpoint
   def remove!
     switch!
     # Preceding slash must be removed from base_path when calling delete()
-    path = base_path.sub!(%r{^/}, '')
+    path = base_path.sub(%r{^/}, '')
     ActiveFedora.fedora.connection.delete(path)
     destroy
   end

--- a/app/models/redis_endpoint.rb
+++ b/app/models/redis_endpoint.rb
@@ -21,14 +21,8 @@ class RedisEndpoint < Endpoint
   # Remove all the keys in Redis in this namespace, then destroy the record
   def remove!
     switch!
-    # Redis::Namespace currently doesn't support flushall or flushdb.
-    # See https://github.com/resque/redis-namespace/issues/56
-    # So, instead we select all keys in current namespace and delete
-    keys = redis_instance.keys '*'
-    return if keys.empty?
-    # Delete in slices to avoid "stack level too deep" errors for large numbers of keys
-    # See https://github.com/redis/redis-rb/issues/122
-    keys.each_slice(1000) { |key_slice| redis_instance.del(*key_slice) }
+    # redis-namespace v1.10.0 introduced clear https://github.com/resque/redis-namespace/pull/202
+    redis_instance.clear
     destroy
   end
 

--- a/app/models/solr_endpoint.rb
+++ b/app/models/solr_endpoint.rb
@@ -29,6 +29,9 @@ class SolrEndpoint < Endpoint
 
   # Remove the solr collection then destroy this record
   def remove!
+    # NOTE: Other end points first call switch!; is that an oversight?  Perhaps not as we're relying
+    # on a scheduled job to do the destructive work.
+
     # Spin off as a job, so that it can fail and be retried separately from the other logic.
     if account.search_only?
       RemoveSolrCollectionJob.perform_later(collection, connection_options, 'cross_search_tenant')

--- a/spec/jobs/cleanup_account_job_spec.rb
+++ b/spec/jobs/cleanup_account_job_spec.rb
@@ -10,39 +10,29 @@ RSpec.describe CleanupAccountJob do
   end
 
   before do
-    allow(RemoveSolrCollectionJob).to receive(:perform_later)
-    allow(account.fcrepo_endpoint).to receive(:switch!)
-    allow(ActiveFedora.fedora.connection).to receive(:delete)
+    allow(account.solr_endpoint).to receive(:remove!)
+    allow(account.fcrepo_endpoint).to receive(:remove!)
+    allow(account.redis_endpoint).to receive(:remove!)
     allow(Apartment::Tenant).to receive(:drop).with(account.tenant)
   end
 
   it 'destroys the solr collection' do
-    expect(RemoveSolrCollectionJob).to receive(:perform_later).with('x', hash_including('url'))
-    expect(account.solr_endpoint).to receive(:destroy)
+    expect(account.solr_endpoint).to receive(:remove!)
     described_class.perform_now(account)
   end
 
   it 'destroys the fcrepo collection' do
-    expect(ActiveFedora.fedora.connection).to receive(:delete).with('x')
-    expect(account.fcrepo_endpoint).to receive(:destroy)
+    expect(account.fcrepo_endpoint).to receive(:remove!)
     described_class.perform_now(account)
   end
 
   it 'deletes all entries in the redis namespace' do
-    allow(Redis.current).to receive(:keys).and_return(["x:events:x1", "x:events:x2"])
-    allow(Hyrax::RedisEventStore).to receive(:instance).and_return(
-      Redis::Namespace.new(account.redis_endpoint.namespace, redis: Redis.current)
-    )
-    expect(Hyrax::RedisEventStore.instance.namespace).to eq('x')
-    expect(Hyrax::RedisEventStore.instance.keys).to eq(["events:x1", "events:x2"])
-    expect(Hyrax::RedisEventStore.instance).to receive(:del).with('events:x1', 'events:x2')
-    expect(account.redis_endpoint).to receive(:destroy)
+    expect(account.redis_endpoint).to receive(:remove!)
     described_class.perform_now(account)
   end
 
   it 'destroys the tenant database' do
     expect(Apartment::Tenant).to receive(:drop).with(account.tenant)
-
     described_class.perform_now(account)
   end
 

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe Account, type: :model do
       it "reverts to using file store when cache is off" do
         account.settings[:cache_api] = false
         account.switch!
-        expect(Rails.application.config.cache_store).to eq([:file_store, kind_of(String)])
+        expect(Rails.application.config.cache_store).to eq([:file_store, described_class::DEFAULT_FILE_CACHE_STORE])
       end
     end
 
@@ -140,7 +140,7 @@ RSpec.describe Account, type: :model do
       it "uses the file store" do
         expect(Rails.application.config.action_controller.perform_caching).to be_falsey
         expect(ActionController::Base.perform_caching).to be_falsey
-        expect(Rails.application.config.cache_store).to eq([:file_store, kind_of(String)])
+        expect(Rails.application.config.cache_store).to eq([:file_store, described_class::DEFAULT_FILE_CACHE_STORE])
       end
     end
 

--- a/spec/models/fcrepo_endpoint_spec.rb
+++ b/spec/models/fcrepo_endpoint_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe FcrepoEndpoint do
       # What I found is that I could not stub the last receiver in the chain; as it would still
       # attempt a HEAD request.  So here is the "test".
       connection = double(ActiveFedora::CachingConnection, delete: true)
-      fedora = double(ActiveFedora::Fedora, connection: connection)
+      fedora = double(ActiveFedora::Fedora, connection:)
       expect(ActiveFedora).to receive(:fedora).and_return(fedora)
       expect(connection).to receive(:delete).with(base_path)
       expect { subject.remove! }.to change(described_class, :count).by(-1)

--- a/spec/models/fcrepo_endpoint_spec.rb
+++ b/spec/models/fcrepo_endpoint_spec.rb
@@ -2,10 +2,9 @@
 
 RSpec.describe FcrepoEndpoint do
   let(:base_path) { 'foobar' }
+  subject { described_class.new base_path: }
 
   describe '.options' do
-    subject { described_class.new base_path: }
-
     it 'uses the configured application settings' do
       expect(subject.options[:base_path]).to eq base_path
     end
@@ -26,6 +25,24 @@ RSpec.describe FcrepoEndpoint do
         ActiveFedora::Fedora.instance.connection.connection.http.url_prefix.to_s
       ).and_raise(RuntimeError)
       expect(subject.ping).to be_falsey
+    end
+  end
+
+  describe '#remove!' do
+    it 'removes the base node in fedora and deletes this endpoint' do
+      subject.save!
+      # All of this stubbing doesn't tell us much; except that the method chain is valid.  Which is perhaps better than the two options:
+      #
+      # 1. Creating the Fedora node then tearing it down.
+      # 2. Not testing this at all.
+      #
+      # What I found is that I could not stub the last receiver in the chain; as it would still
+      # attempt a HEAD request.  So here is the "test".
+      connection = double(ActiveFedora::CachingConnection, delete: true)
+      fedora = double(ActiveFedora::Fedora, connection: connection)
+      expect(ActiveFedora).to receive(:fedora).and_return(fedora)
+      expect(connection).to receive(:delete).with(base_path)
+      expect { subject.remove! }.to change(described_class, :count).by(-1)
     end
   end
 end

--- a/spec/models/redis_endpoint_spec.rb
+++ b/spec/models/redis_endpoint_spec.rb
@@ -2,26 +2,36 @@
 
 RSpec.describe RedisEndpoint do
   let(:namespace) { 'foobar' }
+  let(:faux_redis_instance) { double(Hyrax::RedisEventStore, ping: 'PONG', clear: true) }
+  before { allow(subject).to receive(:redis_instance).and_return(faux_redis_instance) }
+  subject { described_class.new(namespace:) }
 
   describe '.options' do
-    subject { described_class.new(namespace:) }
-
     it 'uses the configured application settings' do
       expect(subject.options[:namespace]).to eq namespace
     end
   end
 
   describe '#ping' do
-    let(:faux_redis_instance) { double(Hyrax::RedisEventStore, ping: 'PONG') }
     it 'checks if the service is up' do
-      allow(subject).to receive(:redis_instance).and_return(faux_redis_instance)
+      allow(faux_redis_instance).to receive(:ping).and_return("PONG")
       expect(subject.ping).to be_truthy
     end
 
     it 'is false if the service is down' do
       allow(faux_redis_instance).to receive(:ping).and_raise(RuntimeError)
-      allow(subject).to receive(:redis_instance).and_return(faux_redis_instance)
       expect(subject.ping).to eq false
+    end
+  end
+
+  describe '#remove!' do
+    subject { described_class.create! }
+
+    it 'clears the namespace and deletes itself' do
+      expect(faux_redis_instance).to receive(:clear)
+      expect do
+        subject.remove!
+      end.to change(described_class, :count).by(-1)
     end
   end
 end

--- a/spec/models/solr_endpoint_spec.rb
+++ b/spec/models/solr_endpoint_spec.rb
@@ -61,4 +61,13 @@ RSpec.describe SolrEndpoint do
       expect(subject.ping).to eq false
     end
   end
+
+  describe '#remove!' do
+    it 'schedules the removal and deletes the end point' do
+      instance = described_class.create!
+      allow(instance).to receive(:account).and_return(double(Account, search_only?: true))
+      expect(RemoveSolrCollectionJob).to receive(:perform_later)
+      expect { instance.remove! }.to change(described_class, :count).by(-1)
+    end
+  end
 end


### PR DESCRIPTION
## 🤖 Extract constant to ease testing

13775d6c2e1c5d80c135316e4760abc994668f8e

We're not concerned with where the cached file is for testing purposes;
so instead of hard-coding a value that can change in the ENV, let's
compare the constant that we use in the code.

tl;dr - Don't rely on magic strings

## 🤖 Re-arrange CleanupAccountJob specs

0dbddad8acb132e40b8c72405c69ef74bed0bb8e

The `CleanupAccountJob` was stubbing very nosily; needing to know too
much about implementation details of the end-points.  Instead this
preserves the over-view spec (e.g. what all the cleanup spec actually
cleans up) while moving that nosy logic to the constituent endpoint.

Most of these specs are testing that the method chains work; which is
perhaps adequate as the other option is far more expensive tests (e.g.
make a new Fedora node only to then immediately destroy it)

I'm also leveraging the new `Redis::Namespace#clear` method.

Related to:

- https://github.com/resque/redis-namespace/pull/202
