### PR TITLE
🧹 Fix `./spec/requests/admin_dashboard_spec.rb` spec

### DIFF
--- a/app/forms/hyrax/forms/workflow_responsibility_form_decorator.rb
+++ b/app/forms/hyrax/forms/workflow_responsibility_form_decorator.rb
@@ -5,13 +5,21 @@
 module Hyrax
   module Forms
     module WorkflowResponsibilityFormDecorator
+      ##
+      # @note We introduced this little crease in the code to allow for conditional switching; and
+      #       thus avoid copying a very large controller
+      #       (e.g. Hyrax::Admin::WorkflowRolesController)
+      # @see Hyrax::Forms::WorkflowResponsibilityGroupForm
       module ClassMethods
-        # Determine which form it is, user or group
+        ##
+        # Determine which form it is, user or group.  By default, it will be a user
+        # (e.g. {Hyrax::Forms::WorkflowResponsibilityForm}); however when you provide a :group_id it
+        # will be a group form (e.g. {Hyrax::Forms::WorkflowResponsibilityGroupForm}.
         def new(params = {})
-          if params[:user_id].present?
-            super
-          else
+          if params[:group_id].present?
             Forms::WorkflowResponsibilityGroupForm.new(params)
+          else
+            super
           end
         end
       end

--- a/app/forms/hyrax/forms/workflow_responsibility_group_form.rb
+++ b/app/forms/hyrax/forms/workflow_responsibility_group_form.rb
@@ -10,6 +10,11 @@ module Hyrax
         model_instance.agent = group.to_sipity_agent
       end
 
+      ##
+      # This method is necessary for the HTML form fields to have the correct name (e.g. `<input
+      # name="sipity_workflow_responsibility[group_id]">`).
+      #
+      # @see ActiveModel::Naming
       def model_instance
         @model ||= Sipity::WorkflowResponsibility.new
       end


### PR DESCRIPTION
Prior to this commit, the specs failed because of the introduction of
the WorkflowResponsibilityFormDecorator.  The decorator extracted prior
logic from Hyrax::Admin::WorkflowRolesController.

In copying that logic we introduced a subtle bug.  Namely, we favored
the original `.new` behavior if and only if you provided a `:user_id`.
This broke places where we instantiated the form in a
view (e.g. `./app/views/hyrax/admin/workflow_roles/index.html.erb`).

With this change, we make the behavior of `.new` fail towards its
"normal" implementation and instead rely on the presence of an attribute
to switch to a different form instantatior.

See Commit:

- https://github.com/samvera/hyku/commit/095edca9a50e647eb1b3ee31a34711c32151912e

Related to:

- https://github.com/samvera/hyku/pull/2079

Co-authored-by: LaRita Robinson <larita@scientist.com>
Co-authored-by: Kirk Wang <kirk.wang@scientist.com>