### PR TITLE
🎁 Upgrade Redis initializer to Hyrax 5's gen version

### DIFF
--- a/config/initializers/redis_config.rb
+++ b/config/initializers/redis_config.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
-config = YAML.safe_load(ERB.new(IO.read(Rails.root + 'config' + 'redis.yml')).result)[Rails.env].with_indifferent_access
-sentinels = config[:sentinel] && config[:sentinel][:host].present? ? { sentinels: [config[:sentinel]] } : {}
-redis_config = config.except(:sentinel).merge(thread_safe: true).merge(sentinels)
 require 'redis'
-Redis.current = begin
-                  Redis.new(redis_config)
-                rescue
-                  nil
-                end
+require 'connection_pool'
+config = YAML.safe_load(ERB.new(IO.read(Rails.root.join('config', 'redis.yml'))).result)[Rails.env].with_indifferent_access
+
+size = ENV.fetch("HYRAX_REDIS_POOL_SIZE", 5)
+timeout = ENV.fetch("HYRAX_REDIS_TIMEOUT", 5)
+
+Hyrax.config.redis_connection =
+  ConnectionPool::Wrapper.new(size: size, timeout: timeout) { Redis.new(config) }

--- a/spec/features/admin_dashboard_spec.rb
+++ b/spec/features/admin_dashboard_spec.rb
@@ -49,10 +49,10 @@ RSpec.describe 'Admin Dashboard', type: :feature, js: true, clean: true do
 
     it 'shows the status page' do
       visit status_path
-      expect(page).to have_content("Fedora\nOK")
-      expect(page).to have_content("Solr\nOK")
-      expect(page).to have_content("Redis\nOK")
-      expect(page).to have_content("Database\nOK")
+      expect(page).to have_selector(".list-group-item-success", text: "Fedora OK")
+      expect(page).to have_selector(".list-group-item-success", text: "Solr OK")
+      expect(page).to have_selector(".list-group-item-success", text: "Redis OK")
+      expect(page).to have_selector(".list-group-item-success", text: "Database OK")
     end
 
     it 'displays the add-users-to-groups page without the hidden form field', js: true do


### PR DESCRIPTION
Prior to this commit, when looking at the
`Hyrax::RedisEventStore.instance` we saw it's connection information as:

`#<Redis client v4.8.1 for redis://localhost:6379/0>`

We were expecting the connection to be the following:

`#<Redis client v4.8.1 for redis://redis:6379/0>`

What we were seeing in tests is when we hit the redis connection we were
getting an error about not being able to connect to 127.0.0.1:6379 (e.g.
localhost).

With this commit, we have a clear connection to Redis.

See Redis Config initializer:

- https://github.com/samvera/hyrax/blob/966951ffaa72524e4a775f8a198bd51a47ece7d9/lib/generators/hyrax/templates/config/initializers/redis_config.rb#L1-L10

Co-authored-by: Kirk Wang <kirk.wang@scientist.com>