### PR TITLE
🧹 Narrow specificity of CSS selector

### DIFF
--- a/app/views/themes/institutional_repository/_masthead.html.erb
+++ b/app/views/themes/institutional_repository/_masthead.html.erb
@@ -1,6 +1,6 @@
 <% # OVERRIDE: Hyrax v5.0.0rc2 - added the search bar and removed the /login and locale nav menu and moved to the /controls partial for theming %>
 <header aria-label="header" class="top-header">
-  <nav id="masthead" class="navbar navbar-expand-lg navbar-dark bg-dark justify-content-between cultural-repository-nav <%= placement_class %>" role="navigation" aria-label="masthead">
+  <nav id="masthead" class="navbar navbar-expand-lg navbar-dark bg-dark justify-content-between institutional-repository-nav <%= placement_class %>" role="navigation" aria-label="masthead">
     <div class="container-fluid">
       <!-- Brand and toggle get grouped for better mobile display -->
       <div class="navbar-header">

--- a/spec/features/appearance_theme_spec.rb
+++ b/spec/features/appearance_theme_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe 'Admin can select home page theme', type: :feature, js: true, cle
       allow_any_instance_of(ApplicationController).to receive(:current_account).and_return(account)
       visit '/'
       expect(page).to have_css('body.cultural_repository')
-      expect(page).to have_css('nav.navbar.navbar-inverse.navbar-static-top.cultural-repository-nav')
+      expect(page).to have_css('nav.navbar.cultural-repository-nav')
     end
 
     it 'updates the home theme when the theme is changed' do # rubocop:disable RSpec/ExampleLength
@@ -154,7 +154,7 @@ RSpec.describe 'Admin can select home page theme', type: :feature, js: true, cle
       allow_any_instance_of(ApplicationController).to receive(:current_account).and_return(account)
       visit '/'
       expect(page).to have_css('body.cultural_repository')
-      expect(page).to have_css('nav.navbar.navbar-inverse.navbar-static-top.cultural-repository-nav')
+      expect(page).to have_css('nav.navbar.cultural-repository-nav')
       visit '/admin/appearance'
       click_link('Themes')
       select('Default home', from: 'Home Page Theme')
@@ -174,7 +174,7 @@ RSpec.describe 'Admin can select home page theme', type: :feature, js: true, cle
       visit '/'
       expect(page).to have_css('body.missing_theme')
       expect(page).not_to have_css('nav.cultural-repsitory-nav')
-      expect(page).to have_css('nav.navbar.navbar-inverse.navbar-static-top')
+      expect(page).to have_css('nav.navbar.navbar-expand-lg')
     end
   end
 end

--- a/spec/features/cultural_repository_theme_spec.rb
+++ b/spec/features/cultural_repository_theme_spec.rb
@@ -47,9 +47,9 @@ RSpec.describe 'Admin can select cultural repository theme', type: :feature, js:
       allow_any_instance_of(ApplicationController).to receive(:current_account).and_return(account)
       visit '/'
       expect(page).to have_css('body.cultural_repository')
-      expect(page).to have_css('nav.navbar.navbar-inverse.navbar-static-top.cultural-repository-nav')
+      expect(page).to have_css('nav.navbar.cultural-repository-nav')
       expect(page).to have_css('form#search-form-header.cultural-repository.form-horizontal.search-form')
-      expect(page).to have_css('ul#user_utility_links.cultural-repository.nav.navbar-nav.navbar-right')
+      expect(page).to have_css('ul#user_utility_links.cultural-repository.nav.navbar-nav')
       expect(page).to have_css('div.cultural-repository.facets')
       expect(page).to have_css('div.cultural-repository.featured-works-container')
       expect(page).to have_css('div.cultural-repository.recent-works-container')

--- a/spec/features/institutional_repository_theme_spec.rb
+++ b/spec/features/institutional_repository_theme_spec.rb
@@ -44,14 +44,14 @@ RSpec.describe 'Admin can select institutional repository theme', type: :feature
       allow_any_instance_of(ApplicationController).to receive(:current_account).and_return(account)
       visit '/'
       expect(page).to have_css('body.institutional_repository')
-      expect(page).to have_css('nav.navbar.navbar-inverse.navbar-static-top.institutional-repsitory-nav')
+      expect(page).to have_css('nav#masthead.navbar.institutional-repository-nav')
       expect(page).to have_css('div.ir-stats')
       expect(page).to have_css('div.institutional-repository-featured-researcher')
       expect(page).to have_css('div.institutional-repository-recent-uploads')
-      expect(page).to have_css('div.col-xs-12.col-md-8.institutional-repository.collections-container')
+      expect(page).to have_css('div.col-12.col-md-8.institutional-repository.collections-container')
       expect(page).not_to have_css('ul#homeTabs')
       expect(page).not_to have_css('ul.nav.nav-pills')
-      expect(page).not_to have_css('nav.navbar.navbar-inverse.navbar-static-top.cultural-repository-nav')
+      expect(page).not_to have_css('nav.navbar.cultural-repository-nav')
       expect(page).not_to have_css('background-container-gradient')
     end
 


### PR DESCRIPTION
The selector was *very* specific, and with the HTML class changes for
Bootstrap 3 to 4, this almost certainly broke.

Note, there are still underlying issues with two other specs; there
errors are listed below:

```
1) Admin can select home page theme when a search results theme is
selected updates the search results page with the selected layout view

Failure/Error: super

     ActionView::Template::Error:
       undefined method `with_collection' for nil:NilClass
```