### PR TITLE
🧹 Favor Layout/LineLength over Metrics/LineLength

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/LineLength
+# rubocop:disable Layout/LineLength
 source 'https://rubygems.org'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
@@ -106,4 +106,4 @@ gem 'webmock', group: %i[test]
 # and place overrides, themes and deployment code.
 gem 'hyku_knapsack', github: 'samvera-labs/hyku_knapsack', branch: 'upstream_main'
 
-# rubocop:enable Metrics/LineLength
+# rubocop:enable Layout/LineLength

--- a/app/models/featured_collection_list.rb
+++ b/app/models/featured_collection_list.rb
@@ -6,14 +6,14 @@ class FeaturedCollectionList
   # @param [ActionController::Parameters] a collection of nested perameters
   def featured_collections_attributes=(attributes_collection)
     attributes_collection = attributes_collection.to_h if attributes_collection.respond_to?(:permitted?)
-    # rubocop:disable Metrics/LineLength
+    # rubocop:disable Layout/LineLength
     attributes_collection = attributes_collection.sort_by { |i, _| i.to_i }.map { |_, attributes| attributes } if attributes_collection.is_a? Hash
     attributes_collection.each do |attributes|
       raise "Missing id" if attributes['id'].blank?
       existing_record = FeaturedCollection.find(attributes['id'])
       existing_record.update(attributes.except('id'))
     end
-    # rubocop:enable Metrics/LineLength
+    # rubocop:enable Layout/LineLength
   end
 
   def featured_collections

--- a/lib/tasks/tenantize_task.rake
+++ b/lib/tasks/tenantize_task.rake
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/LineLength
+# rubocop:disable Layout/LineLength
 namespace :tenantize do
   desc 'Run given task on all or selected tenants'
   task :task, [:task_name] => :environment do |_cmd, args|
@@ -17,4 +17,4 @@ namespace :tenantize do
     end
   end
 end
-# rubocop:enable Metrics/LineLength
+# rubocop:enable Layout/LineLength

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -49,7 +49,7 @@ FactoryBot.define do
                                                                           evaluator.user,
                                                                           access)
 
-        attributes = evaluator.with_permission_template.merge(attributes) if evaluator.with_permission_template.respond_to?(:merge) # rubocop:disable Metrics/LineLength
+        attributes = evaluator.with_permission_template.merge(attributes) if evaluator.with_permission_template.respond_to?(:merge) # rubocop:disable Layout/LineLength
 
         create(:permission_template, attributes) unless Hyrax::PermissionTemplate.find_by(source_id: collection.id)
         collection.permission_template.reset_access_controls_for(collection:)

--- a/spec/features/admin_set_form_participants_tab_spec.rb
+++ b/spec/features/admin_set_form_participants_tab_spec.rb
@@ -136,9 +136,9 @@ RSpec.describe 'AdminSet form Participants tab', type: :feature, js: true, clean
                            .find(:xpath, '//td[@data-agent="admin"]')
                            .find(:xpath, '..')['innerHTML']
         expect(manager_row_html).to include('<td data-agent="admin">Repository Administrators</td>')
-        # rubocop:disable Metrics/LineLength
+        # rubocop:disable Layout/LineLength
         expect(manager_row_html).to include('<input class="btn btn-sm btn-danger disabled" disabled="disabled" title="The repository administrators group cannot be removed" type="submit" value="Remove">')
-        # rubocop:enable Metrics/LineLength
+        # rubocop:enable Layout/LineLength
       end
 
       it 'shows an enabled remove button next to Repository Administrator group as a Depositor' do

--- a/spec/features/appearance_theme_spec.rb
+++ b/spec/features/appearance_theme_spec.rb
@@ -69,9 +69,9 @@ RSpec.describe 'Admin can select home page theme', type: :feature, js: true, cle
       visit '/admin/appearance'
       click_link('Themes')
       select('Gallery view', from: 'Search Results Page Theme')
-      # rubocop:disable Metrics/LineLength
+      # rubocop:disable Layout/LineLength
       expect(page).to have_content('This will select a default view for the search results page. Users can select their preferred views on the search results page that will override this selection')
-      # rubocop:enable Metrics/LineLength
+      # rubocop:enable Layout/LineLength
       find('body').click
       click_on('Save')
       site = Site.last

--- a/spec/features/collection_editor_role_spec.rb
+++ b/spec/features/collection_editor_role_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'actions permitted by the collection_editor role', type: :feature, js: true, clean: true, ci: 'skip' do # rubocop:disable Metrics/LineLength
+RSpec.describe 'actions permitted by the collection_editor role', type: :feature, js: true, clean: true, ci: 'skip' do # rubocop:disable Layout/LineLength
   let!(:role) { FactoryBot.create(:role, :collection_editor) }
   let!(:collection) { FactoryBot.create(:private_collection_lw, with_permission_template: true) }
   let(:user) { FactoryBot.create(:user) }

--- a/spec/features/collection_manager_role_spec.rb
+++ b/spec/features/collection_manager_role_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'actions permitted by the collection_manager role', type: :feature, js: true, clean: true, ci: 'skip' do # rubocop:disable Metrics/LineLength
+RSpec.describe 'actions permitted by the collection_manager role', type: :feature, js: true, clean: true, ci: 'skip' do # rubocop:disable Layout/LineLength
   let!(:role) { FactoryBot.create(:role, :collection_manager) }
   let!(:collection) { FactoryBot.create(:private_collection_lw, with_permission_template: true) }
   let(:user) { FactoryBot.create(:user) }

--- a/spec/features/collection_reader_role_spec.rb
+++ b/spec/features/collection_reader_role_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'actions permitted by the collection_reader role', type: :feature, js: true, clean: true, ci: 'skip' do # rubocop:disable Metrics/LineLength
+RSpec.describe 'actions permitted by the collection_reader role', type: :feature, js: true, clean: true, ci: 'skip' do # rubocop:disable Layout/LineLength
   let!(:role) { FactoryBot.create(:role, :collection_reader) }
   let!(:collection) { FactoryBot.create(:private_collection_lw, with_permission_template: true) }
   let(:user) { FactoryBot.create(:user) }

--- a/spec/features/create_generic_work_spec.rb
+++ b/spec/features/create_generic_work_spec.rb
@@ -64,9 +64,9 @@ RSpec.describe 'Create a GenericWork', type: :feature, js: true, clean: true do
       select('In Copyright', from: 'Rights statement')
 
       page.choose('generic_work_visibility_open')
-      # rubocop:disable Metrics/LineLength
+      # rubocop:disable Layout/LineLength
       expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
-      # rubocop:enable Metrics/LineLength
+      # rubocop:enable Layout/LineLength
       find('#agreement').click
 
       click_on('Save')

--- a/spec/features/create_image_spec.rb
+++ b/spec/features/create_image_spec.rb
@@ -64,9 +64,9 @@ RSpec.describe 'Create a Image', type: :feature, js: true, clean: true do
       select('In Copyright', from: 'Rights statement')
 
       page.choose('image_visibility_open')
-      # rubocop:disable Metrics/LineLength
+      # rubocop:disable Layout/LineLength
       expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
-      # rubocop:enable Metrics/LineLength
+      # rubocop:enable Layout/LineLength
       find('#agreement').click
 
       click_on('Save')

--- a/spec/features/institutional_repository_theme_spec.rb
+++ b/spec/features/institutional_repository_theme_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Admin can select institutional repository theme', type: :feature, js: true, clean: true do # rubocop:disable Metrics/LineLength
+RSpec.describe 'Admin can select institutional repository theme', type: :feature, js: true, clean: true do # rubocop:disable Layout/LineLength
   let(:account) { FactoryBot.create(:account) }
   let(:admin) { FactoryBot.create(:admin, email: 'admin@example.com', display_name: 'Adam Admin') }
   let(:user) { create :user }

--- a/spec/features/work_editor_role_spec.rb
+++ b/spec/features/work_editor_role_spec.rb
@@ -100,9 +100,9 @@ RSpec.describe 'Work Editor role', type: :feature, js: true, clean: true, ci: 's
       select('In Copyright', from: 'Rights statement')
 
       page.choose('generic_work_visibility_open')
-      # rubocop:disable Metrics/LineLength
+      # rubocop:disable Layout/LineLength
       expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
-      # rubocop:enable Metrics/LineLength
+      # rubocop:enable Layout/LineLength
       find('#agreement').click
 
       expect { click_on('Save') }

--- a/spec/features/work_search_institution_visibility_spec.rb
+++ b/spec/features/work_search_institution_visibility_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe 'Users trying to search for an Institution Work', type: :feature, clean: true, js: true do # rubocop:disable Metrics/LineLength
+RSpec.describe 'Users trying to search for an Institution Work', type: :feature, clean: true, js: true do # rubocop:disable Layout/LineLength
   let(:fake_solr_document) do
     {
       'has_model_ssim': ['GenericWork'],

--- a/spec/features/work_show_institution_visibility_spec.rb
+++ b/spec/features/work_show_institution_visibility_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Users trying to access an Institution Work's show page", type: :feature, clean: true, js: true do # rubocop:disable Metrics/LineLength
+RSpec.describe "Users trying to access an Institution Work's show page", type: :feature, clean: true, js: true do # rubocop:disable Layout/LineLength
   let(:fake_solr_document) do
     {
       'has_model_ssim': ['GenericWork'],

--- a/spec/features/work_show_open_visibility_spec.rb
+++ b/spec/features/work_show_open_visibility_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Users trying to access a Public Work's show page", type: :feature, clean: true, js: true do # rubocop:disable Metrics/LineLength
+RSpec.describe "Users trying to access a Public Work's show page", type: :feature, clean: true, js: true do # rubocop:disable Layout/LineLength
   let(:fake_solr_document) do
     {
       'has_model_ssim': ['GenericWork'],

--- a/spec/features/work_show_private_visibility_spec.rb
+++ b/spec/features/work_show_private_visibility_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Users trying to access a Private Work's show page", type: :feature, clean: true, js: true do # rubocop:disable Metrics/LineLength
+RSpec.describe "Users trying to access a Private Work's show page", type: :feature, clean: true, js: true do # rubocop:disable Layout/LineLength
   let(:fake_solr_document) do
     {
       'has_model_ssim': ['GenericWork'],

--- a/spec/models/uploaded_file_spec.rb
+++ b/spec/models/uploaded_file_spec.rb
@@ -3,7 +3,7 @@
 # Much of this testing is the complex configurable stuff underneath UploadedFile
 # and simulating the AWS configuration that would be in production.
 
-# rubocop:disable Metrics/LineLength
+# rubocop:disable Layout/LineLength
 RSpec.describe 'Hyrax::UploadedFile' do # rubocop:disable RSpec/DescribeClass
   let(:file) { File.open(fixture_path + '/images/world.png') }
   let(:upload) { Hyrax::UploadedFile.create(file:) }
@@ -110,4 +110,4 @@ RSpec.describe 'Hyrax::UploadedFile' do # rubocop:disable RSpec/DescribeClass
     end
   end
 end
-# rubocop:enable Metrics/LineLength
+# rubocop:enable Layout/LineLength

--- a/spec/requests/work_show_institution_visibility_spec.rb
+++ b/spec/requests/work_show_institution_visibility_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Users trying to access an Institution Work's show page", type: :request, clean: true, multitenant: true do # rubocop:disable Metrics/LineLength
+RSpec.describe "Users trying to access an Institution Work's show page", type: :request, clean: true, multitenant: true do # rubocop:disable Layout/LineLength
   let(:account) { create(:account) }
   let(:work) { create(:work, visibility: 'authenticated') }
   let(:tenant_user_attributes) { attributes_for(:user) }

--- a/spec/routing/featured_collections_route_spec.rb
+++ b/spec/routing/featured_collections_route_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe "file routes", type: :routing do
   routes { Rails.application.routes }
 
-  # rubocop:disable Metrics/LineLength
+  # rubocop:disable Layout/LineLength
   it 'creates a featured_collection' do
     expect(post: '/collections/7/featured_collection').to route_to(controller: 'hyrax/featured_collections', action: 'create', id: '7')
   end
@@ -15,5 +15,5 @@ RSpec.describe "file routes", type: :routing do
     expect(featured_collection_lists_path).to eq '/featured_collections'
     expect(post: '/featured_collections').to route_to(controller: 'hyrax/featured_collection_lists', action: 'create')
   end
-  # rubocop:enable Metrics/LineLength
+  # rubocop:enable Layout/LineLength
 end


### PR DESCRIPTION
Rubocop seams to prefer the Layout namespace for LineLength.

