### PR TITLE
🧹 Ensure feature specs run clean

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -151,7 +151,7 @@ RSpec.configure do |config|
     ActiveFedora::SolrService.reset!
     # Pass `:clean' (or hyrax's convention of :clean_repo) to destroy objects in fedora/solr and
     # start from scratch
-    if example.metadata[:clean] || example.metadata[:clean_repo]
+    if example.metadata[:clean] || example.metadata[:clean_repo] || example.metadata[:type] == :feature
       ## We don't need to do `Hyrax::SolrService.wipe!` so long as we're using `ActiveFedora.clean!`;
       ## but Valkyrie is coming so be prepared.
       # Hyrax::SolrService.wipe!


### PR DESCRIPTION
Prior to this commit, we did not automatically clean the features.  The
below ripgrep (and output) shows that there were some features which did
not start from a clean state.

```
rg "(clean|clean_repo):" spec/features --files-without-match
``

```
spec/features/accounts_spec.rb
spec/features/proprietor_spec.rb
spec/features/featured_collections_spec.rb
spec/features/user_roles_spec.rb
spec/features/oai_pmh_spec.rb
```