### PR TITLE
♻️ Account for observed customizations

### DIFF
--- a/app/presenters/concerns/hyrax/iiif_av/displays_content_decorator.rb
+++ b/app/presenters/concerns/hyrax/iiif_av/displays_content_decorator.rb
@@ -8,6 +8,47 @@ module Hyrax
     #   request.base_url => hostname
     # also to remove #auth_service since it was not working for now
     module DisplaysContentDecorator
+      extend ActiveSupport::Concern
+
+      included do
+        ##
+        # @!group Class Attributes
+
+        ##
+        # @!attribute iiif_audio_labels_and_mime_types [r|w]
+        #   @return [Hash<String,String>] Hash of valid audio labels and their mime types.
+        class_attribute :iiif_audio_labels_and_mime_types, default: { "ogg" => "audio/ogg", "mp3" => "audio/mpeg" }
+
+        ##
+        # @!attribute iiif_video_labels_and_mime_types [r|w]
+        #   @return [Hash<String,String>] Hash of valid video labels and their mime types.
+        class_attribute :iiif_video_labels_and_mime_types, default: { "mp4" => "video/mpeg", "webm" => "audio/webm" }
+
+        ##
+        # @!attribute iiif_video_url_builder [r|w]
+        #   @param document [SolrDocument]
+        #   @param label [String]
+        #   @param host [String] (e.g. samvera.org)
+        #   @return [String] the fully qualified URL.
+        #
+        #   @example
+        #     # The below example will build a URL taht will download directly from Hyrax as the
+        #     # video resource.  This is a hack to address the processing times of video derivatives;
+        #     # namely in certain setups/configurations of Hyku, video processing is laggy—as in days.
+        #     #
+        #     # The draw back of using this method is that we're pointing to the original video file.
+        #     # This is acceptable if the original file has already been processed out of band (e.g.
+        #     # before uploading to Hyku/Hyrax).  When we're dealing with a raw video, this is likely
+        #     # not ideal for streaming.
+        #     Hyrax::IiifAv::DisplaysContent.iiif_video_url_builder = ->(document:, label:, host:) do
+        #       Hyrax::Engine.routes.url_helpers.download_url(document, host:, protocol: 'https')
+        #     end
+        class_attribute :iiif_video_url_builder,
+                        default: ->(document:, label:, host:) { Hyrax::IiifAv::Engine.routes.url_helpers.iiif_av_content_url(document.id, label:, host:) }
+        # @!endgroup Class Attributes
+        ##
+      end
+
       def solr_document
         defined?(super) ? super : object
       end
@@ -16,13 +57,13 @@ module Hyrax
         defined?(super) ? super : @ability
       end
 
+      Request = Struct.new(:base_url, keyword_init: true)
+
       def request
         Request.new(base_url: hostname)
       end
 
       private
-
-      Request = Struct.new(:base_url, keyword_init: true)
 
       def image_content
         return nil unless latest_file_id
@@ -37,28 +78,50 @@ module Hyrax
         image_content_v3(url)
       end
 
+      ##
+      # @note In the case where we have stream_urls, we'll assume the URL is correct.  In the case
+      #       where we're deferring to the document, we'll use {.iiif_video_labels_and_mime_types}
+      def video_content
+        # @see https://github.com/samvera-labs/iiif_manifest
+        streams = stream_urls
+        if streams.present?
+          streams.collect { |label, url| video_display_content(url, label) }
+        else
+          iiif_video_labels_and_mime_types.map do |label, mime_type|
+            url = iiif_video_url_builder.call(document: solr_document, label:, host: request.base_url)
+            video_display_content(url, label, mime_type:)
+          end
+        end
+      end
+
       # rubocop:disable Metrics/MethodLength
-      def video_display_content(_url, label = '')
+      def video_display_content(url, label = '', mime_type: solr_document.mime_type)
         width = solr_document.width&.try(:to_i) || 320
         height = solr_document.height&.try(:to_i) || 240
         duration = conformed_duration_in_seconds
         IIIFManifest::V3::DisplayContent.new(
-          Hyrax::IiifAv::Engine.routes.url_helpers.iiif_av_content_url(
-            solr_document.id,
-            label:,
-            host: request.base_url
-          ),
+          url,
           label:,
           width:,
           height:,
           duration:,
           type: 'Video',
-          format: solr_document.mime_type
+          format: mime_type
         )
       end
-      # rubocop:enable Metrics/MethodLength
 
-      def audio_display_content(_url, label = '')
+      def audio_content
+        streams = stream_urls
+        if streams.present?
+          streams.collect { |label, url| audio_display_content(url, label) }
+        else
+          iiif_audio_labels_and_mime_types.map do |label, mime_type|
+            audio_display_content(download_path(label), label, mime_type:)
+          end
+        end
+      end
+
+      def audio_display_content(_url, label = '', mime_type: solr_document.mime_type)
         duration = conformed_duration_in_seconds
         IIIFManifest::V3::DisplayContent.new(
           Hyrax::IiifAv::Engine.routes.url_helpers.iiif_av_content_url(
@@ -69,7 +132,7 @@ module Hyrax
           label:,
           duration:,
           type: 'Sound',
-          format: solr_document.mime_type
+          format: mime_type
         )
       end
 

--- a/spec/presenters/concerns/hyrax/iiif_av/displays_content_decorator_spec.rb
+++ b/spec/presenters/concerns/hyrax/iiif_av/displays_content_decorator_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Hyrax::IiifAv::DisplaysContent do
+  describe '.iiif_audio_labels_and_mime_types' do
+    subject { described_class.iiif_audio_labels_and_mime_types }
+    it { is_expected.to be_a(Hash) }
+  end
+
+  describe '.iiif_video_labels_and_mime_types' do
+    subject { described_class.iiif_video_labels_and_mime_types }
+    it { is_expected.to be_a(Proc) }
+  end
+
+  describe '.iiif_video_url_builder' do
+    subject { described_class.iiif_video_url_builder }
+    it { is_expected.to be_a(Proc) }
+  end
+end


### PR DESCRIPTION
Dear reviewer, put on your reading glasses.

This commit looks at the newly refactored
`Hyrax::IiifAv::DisplaysContentDecorator` as well as the current state of [PALS's Hyrax::IiifAv::DisplaysContentDecorator][1] and attempts to account for the variances between the two by introducing configurations.

Yes, we could port this to the hyrax-iiif_av gem, but for now that would not solve the underlying issue of how we've been handling things.

[1]: https://github.com/scientist-softserv/palni-palci/blob/8754556c0225ce9f04674c1ffac6403586fd65f4/app/presenters/concerns/hyrax/iiif_av/displays_content_decorator.rb