### PR TITLE
🐛 Fix video thumbnail generation

### DIFF
--- a/app/services/hyrax/file_set_derivatives_service_decorator.rb
+++ b/app/services/hyrax/file_set_derivatives_service_decorator.rb
@@ -4,6 +4,9 @@
 
 module Hyrax
   module FileSetDerivativesServiceDecorator
+    # @see https://github.com/samvera/hydra-derivatives/blob/main/lib/hydra/derivatives/processors/video/config.rb#L59
+    DEFAULT_VIDEO_SIZE = '320x240'
+
     def create_pdf_derivatives(filename)
       Hydra::Derivatives::PdfDerivatives.create(filename, outputs: [{ label: :thumbnail,
                                                                       format: 'jpg',
@@ -29,6 +32,23 @@ module Hyrax
                                                                         size: '600x450>',
                                                                         url: derivative_url('thumbnail'),
                                                                         layer: 0 }])
+    end
+
+    # Ensures the video dimensions do not get altered when it is ingested
+    def create_video_derivatives(filename)
+      width = Array(file_set.width).first
+      height = Array(file_set.height).first
+      original_size = "#{width}x#{height}"
+      size = width.nil? || height.nil? ? DEFAULT_VIDEO_SIZE : original_size
+
+      Hydra::Derivatives::Processors::Video::Processor.config.size_attributes = size
+      Hydra::Derivatives::VideoDerivatives.create(filename,
+                                                  outputs: [{ label: :thumbnail, format: 'jpg',
+                                                              url: derivative_url('thumbnail') },
+                                                            { label: 'webm', format: 'webm',
+                                                              url: derivative_url('webm') },
+                                                            { label: 'mp4', format: 'mp4',
+                                                              url: derivative_url('mp4') }])
     end
   end
 end


### PR DESCRIPTION
In a previous commit we created the
`Hyrax::FileSetDerivativesServiceDecorator` to override the default thumbnails that Hyrax uses but I forgot to add the video thumbnail, which is fixed here.

Ref
  - https://github.com/scientist-softserv/hykuup_knapsack/issues/69

<img width="1135" alt="image" src="https://github.com/samvera/hyku/assets/19597776/1891ce94-8e3c-4147-ae4d-3b81463e58c4">
