### PR TITLE
Hyrax 5 fix css

### DIFF
--- a/app/assets/javascripts/hyrax/app.js.erb
+++ b/app/assets/javascripts/hyrax/app.js.erb
@@ -167,25 +167,25 @@ Hyrax = {
     sidebar: function () {
         $('.sidebar-toggle').on('click', function() {
             $('.sidebar').toggleClass('maximized');
-            if ($(window).width() >= 768) {
+            if ($(window).width() >= 992) {
                 $('.main-content').toggleClass('maximized');
             }
         });
 
         $('.sidebar').on('mouseenter', function() {
-            if ($(window).width() < 768) {
+            if ($(window).width() < 992) {
                 $('.sidebar').addClass('maximized');
             }
         });
 
         $('.sidebar').on('mouseleave', function() {
-            if ($(window).width() < 768) {
+            if ($(window).width() < 992) {
                 $('.sidebar').removeClass('maximized');
             }
         });
 
         $(window).on('resize', function() {
-            if ($(window).width() >= 768) {
+            if ($(window).width() >= 992) {
                 $('.sidebar, .main-content').addClass('maximized');
             } else {
                 $('.sidebar, .main-content').removeClass('maximized');

--- a/app/assets/stylesheets/hyku.scss
+++ b/app/assets/stylesheets/hyku.scss
@@ -490,11 +490,11 @@ body.public-facing {
 }
 
 .navbar-toggler-icon {
-  display: inline-block;
-  width: 1.5em;
-  height: 1.5em;
-  vertical-align: middle;
-  content: "";
   background: no-repeat center center;
   background-size: 100% 100%;
+  content: "";
+  display: inline-block;
+  height: 1.5em;
+  vertical-align: middle;
+  width: 1.5em;
 }

--- a/app/assets/stylesheets/hyku.scss
+++ b/app/assets/stylesheets/hyku.scss
@@ -423,6 +423,7 @@ nav.navbar.navbar-default.navbar-static-top .container-fluid .row {
 body.public-facing {
   .btn {
     &.btn-primary,
+    &.btn-secondary,
     &.btn-danger {
       color: #fff;
     }
@@ -486,4 +487,14 @@ body.public-facing {
 
 .mt-20 {
   margin-top: 20px;
+}
+
+.navbar-toggler-icon {
+  display: inline-block;
+  width: 1.5em;
+  height: 1.5em;
+  vertical-align: middle;
+  content: "";
+  background: no-repeat center center;
+  background-size: 100% 100%;
 }

--- a/app/views/hyrax/dashboard/collections/_show_document_list_row.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_document_list_row.html.erb
@@ -8,7 +8,7 @@
   </td>
   <td>
     <div class="media">
-      <%= link_to [main_app, document], "class" => "media-left", "aria-hidden" => "true" do %>
+      <%= link_to [main_app, document], "class" => "mr-2", "aria-hidden" => "true" do %>
         <%= document_presenter(document)&.thumbnail&.thumbnail_tag(
           { class: "d-none d-md-block file_listing_thumbnail", alt: document.title_or_label }, { suppress_link: true }
         ) %>

--- a/app/views/hyrax/dashboard/works/_list_works.html.erb
+++ b/app/views/hyrax/dashboard/works/_list_works.html.erb
@@ -7,7 +7,7 @@
   </td>
   <td>
     <div class='media'>
-      <%= link_to [main_app, document], class: 'media-left' do %>
+      <%= link_to [main_app, document], class: 'mr-2' do %>
         <%# OVERRIDE begin %>
         <%= document_presenter(document)&.thumbnail&.thumbnail_tag(
           { class: 'd-none d-md-block file_listing_thumbnail', alt: block_for(name: 'default_work_image_text') || "#{document.title_or_label} #{t('hyrax.homepage.admin_sets.thumbnail')}" },

--- a/app/views/hyrax/homepage/_home_content.html.erb
+++ b/app/views/hyrax/homepage/_home_content.html.erb
@@ -5,7 +5,7 @@
   also, to render featured collections
 %>
 
-<div class="<%= @presenter.display_featured_works? || @presenter.display_recently_uploaded? ? 'home-tabs-left col-md-6' : '' %>">
+<div class="<%= @presenter.display_featured_works? || @presenter.display_recently_uploaded? ? 'col-md-6' : '' %>">
   <ul id="homeTabs" class="nav nav-tabs" role="list">
     <%# add check for featured works %>
     <% if @presenter.display_featured_works? %>
@@ -41,10 +41,10 @@
   </div>
 </div><!-- /.col-md-6 -->
 
-<div class="home-tabs-right col-md-6">
+<div class="col-md-6">
   <ul class="nav nav-tabs" role="list">
-    <li class="nav-item active">
-      <a class="nav-link" aria-expanded="true" href="#tab-col2-first" data-toggle="tab">
+    <li class="nav-item">
+      <a class="nav-link active" aria-expanded="true" href="#tab-col2-first" data-toggle="tab">
         <%= t('hyrax.homepage.admin_sets.title') %>
       </a>
     </li>

--- a/app/views/hyrax/my/works/_list_works.html.erb
+++ b/app/views/hyrax/my/works/_list_works.html.erb
@@ -10,8 +10,8 @@
   <td>
     <div class='media'>
       <%# OVERRIDE begin %>
-      <%= link_to [main_app, document], class: 'media-left' do %>
-        <%= render_thumbnail_tag document, { class: 'hidden-xs file_listing_thumbnail', alt: block_for(name: 'default_work_image_text') || "#{document.title_or_label} #{t('hyrax.homepage.admin_sets.thumbnail')}" }, { suppress_link: true } %>
+      <%= link_to [main_app, document], class: 'mr-2' do %>
+        <%= render_thumbnail_tag document, { class: 'd-none d-md-block file_listing_thumbnail', alt: block_for(name: 'default_work_image_text') || "#{document.title_or_label} #{t('hyrax.homepage.admin_sets.thumbnail')}" }, { suppress_link: true } %>
       <% end %>
       <%# OVERRIDE end %>
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -65,7 +65,7 @@ if ENV['CHROME_HOSTNAME'].present?
   options = Selenium::WebDriver::Options.chrome(args: ["disable-gpu",
                                                        "no-sandbox",
                                                        "whitelisted-ips",
-                                                       "window-size=1400,1400"])
+                                                       "window-size=1920,1080"])
 
   Capybara.register_driver :chrome do |app|
     d = Capybara::Selenium::Driver.new(app,
@@ -83,7 +83,9 @@ if ENV['CHROME_HOSTNAME'].present?
   Capybara.server_port = 3001
   Capybara.app_host = "http://#{ENV['WEB_HOST']}:#{Capybara.server_port}"
 else
-  options = Selenium::WebDriver::Options.chrome(args: ["headless", "disable-gpu"])
+  options = Selenium::WebDriver::Options.chrome(args: ["headless",
+                                                       "disable-gpu",
+                                                       "window-size=1920,1080"])
 
   Capybara.register_driver :chrome do |app|
     Capybara::Selenium::Driver.new(


### PR DESCRIPTION
## 🧹 Add space between thumbnail and title

f802001ad74461bd19b245f332dccf803f6c8403


## 🧹 Fixing a few styles

e15b2dd5cd5027eea355aaa3ee592b346f7ead6d

This commit will change the maximized size to match Bootstrap 4 break
points.  Also, added btn-secondary to hyku.css so it doesn't get
overriden by appearance styles.  Finally, restructured the homepage to
make it look more like Hyrax 5.

<img width="852" alt="image" src="https://github.com/samvera/hyku/assets/19597776/91a322ac-b6c5-4a68-a3ae-9ae264cd6434">


<img width="1350" alt="image" src="https://github.com/samvera/hyku/assets/19597776/b35d594d-e43d-48da-b5b3-a87895d95507">
