### PR TITLE
🧹 Booststrap cleanup

### DIFF
--- a/app/assets/javascripts/hyrax/app.js.erb
+++ b/app/assets/javascripts/hyrax/app.js.erb
@@ -167,25 +167,25 @@ Hyrax = {
     sidebar: function () {
         $('.sidebar-toggle').on('click', function() {
             $('.sidebar').toggleClass('maximized');
-            if ($(window).width() >= 768) {
+            if ($(window).width() >= 992) {
                 $('.main-content').toggleClass('maximized');
             }
         });
 
         $('.sidebar').on('mouseenter', function() {
-            if ($(window).width() < 768) {
+            if ($(window).width() < 992) {
                 $('.sidebar').addClass('maximized');
             }
         });
 
         $('.sidebar').on('mouseleave', function() {
-            if ($(window).width() < 768) {
+            if ($(window).width() < 992) {
                 $('.sidebar').removeClass('maximized');
             }
         });
 
         $(window).on('resize', function() {
-            if ($(window).width() >= 768) {
+            if ($(window).width() >= 992) {
                 $('.sidebar, .main-content').addClass('maximized');
             } else {
                 $('.sidebar, .main-content').removeClass('maximized');

--- a/app/assets/stylesheets/hyku.scss
+++ b/app/assets/stylesheets/hyku.scss
@@ -423,6 +423,7 @@ nav.navbar.navbar-default.navbar-static-top .container-fluid .row {
 body.public-facing {
   .btn {
     &.btn-primary,
+    &.btn-secondary,
     &.btn-danger {
       color: #fff;
     }


### PR DESCRIPTION
This commit will change the breakpoint for the sidebar to the Bootstrap 4 size.  Also the btn-secondary class will no longer be affected by the appearance changes.
