### PR TITLE
Hyrax 5 update ingress

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ gem 'fcrepo_wrapper', '~> 0.4', group: %i[development test]
 gem 'flutie'
 gem 'good_job', '~> 2.99'
 gem 'googleauth', '= 1.8.1' # 1.9.0 got yanked from rubygems, hard pinning until we can upgrade
-gem 'hyrax', github: 'samvera/hyrax', branch: 'double_combo'
+gem 'hyrax', github: 'samvera/hyrax', branch: 'double-combo-ingress'
 gem 'hyrax-doi', github: 'samvera-labs/hyrax-doi', branch: 'rails_hyrax_upgrade'
 gem 'hyrax-iiif_av', github: 'samvera-labs/hyrax-iiif_av', branch: 'rails_hyrax_upgrade'
 gem 'i18n-debug', require: false, group: %i[development test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,7 +125,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: 25066985be7bdc39b21b3ab5a8a0ac9927a745b1
+  revision: 65c69160486aaaee8b07894e4b531c1b9766adef
   branch: double-combo-ingress
   specs:
     hyrax (5.0.0.rc2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,8 +125,8 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: b7891b758411c59f71ff54212e0d250fcc47e35f
-  branch: double_combo
+  revision: 25066985be7bdc39b21b3ab5a8a0ac9927a745b1
+  branch: double-combo-ingress
   specs:
     hyrax (5.0.0.rc2)
       active-fedora (~> 14.0)


### PR DESCRIPTION
Will this fix allow for deploys to demo/staging?

Previous error: 

Error: UPGRADE FAILED: unable to build kubernetes objects from current release manifest: resource mapping not found for name: "hyku-***-hyrax" namespace: "" from "": no matches for kind "Ingress" in version "networking.k8s.io/v1beta1"