### PR TITLE
🧹 Add properties to resource yaml

### DIFF
--- a/config/metadata/image_resource.yaml
+++ b/config/metadata/image_resource.yaml
@@ -21,4 +21,13 @@
 # Generated via
 #  `rails generate hyrax:work_resource ImageResource`
 
-attributes: {}
+attributes:
+  extent:
+    type: string
+    multiple: true
+    index_keys:
+      - "extent_tesim"
+    form:
+      required: false
+      primary: false
+      multiple: true


### PR DESCRIPTION
The only extra proprety I found was on the Image which was the :extent property.  GenericWork didn't have anything extra.

Ref:
  - https://github.com/scientist-softserv/hykuup_knapsack/issues/81

