### PR TITLE
🧹 Get model mappings all in place

### DIFF
--- a/app/assets/stylesheets/hyku.scss
+++ b/app/assets/stylesheets/hyku.scss
@@ -16,6 +16,10 @@
   }
 }
 
+.dashboard .form-tab-content label {
+  font-weight: 700;
+}
+
 @media (min-width: 768px) {
   .logo-set {
     display: flex;

--- a/app/forms/generic_work_resource_form.rb
+++ b/app/forms/generic_work_resource_form.rb
@@ -5,7 +5,7 @@
 #
 # @see https://github.com/samvera/hyrax/wiki/Hyrax-Valkyrie-Usage-Guide#forms
 # @see https://github.com/samvera/valkyrie/wiki/ChangeSets-and-Dirty-Tracking
-class GenericWorkResourceForm < Hyrax::Forms::PcdmObjectForm(GenericWorkResource)
+class GenericWorkResourceForm < Hyrax::Forms::ResourceForm(GenericWorkResource)
   include Hyrax::FormFields(:basic_metadata)
   include Hyrax::FormFields(:generic_work_resource)
 

--- a/app/forms/image_resource_form.rb
+++ b/app/forms/image_resource_form.rb
@@ -5,7 +5,7 @@
 #
 # @see https://github.com/samvera/hyrax/wiki/Hyrax-Valkyrie-Usage-Guide#forms
 # @see https://github.com/samvera/valkyrie/wiki/ChangeSets-and-Dirty-Tracking
-class ImageResourceForm < Hyrax::Forms::PcdmObjectForm(ImageResource)
+class ImageResourceForm < Hyrax::Forms::ResourceForm(ImageResource)
   include Hyrax::FormFields(:basic_metadata)
   include Hyrax::FormFields(:image_resource)
 

--- a/config/metadata/basic_metadata.yaml
+++ b/config/metadata/basic_metadata.yaml
@@ -1,0 +1,190 @@
+# OVERRIDE Hyrax v5.0.0rc2 to add bibliographic_citation onto the form
+# this can be removed once https://github.com/samvera/hyrax/pull/6578 is merged
+---
+attributes:
+  abstract:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "abstract_tesim"
+    predicate: http://purl.org/dc/terms/abstract
+  access_right:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "access_right_tesim"
+    predicate: http://purl.org/dc/terms/accessRights
+  alternative_title:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "alternative_title_tesim"
+    predicate: http://purl.org/dc/terms/alternative
+  arkivo_checksum:
+    type: string
+    multiple: false
+    form:
+      primary: false
+    predicate: http://scholarsphere.psu.edu/ns#arkivoChecksum
+  based_near:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "based_near_sim"
+      - "based_near_tesim"
+    predicate: http://xmlns.com/foaf/0.1/based_near
+  bibliographic_citation:
+    type: string
+    multiple: true
+    # OVERRIDE begin
+    form:
+      primary: false
+    index_keys:
+      - "bibliographic_citation_tesim"
+    # OVERRIDE end
+    predicate: http://purl.org/dc/terms/bibliographicCitation
+  contributor:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "contributor_tesim"
+    predicate: http://purl.org/dc/elements/1.1/contributor
+  creator:
+    type: string
+    multiple: true
+    form:
+      required: true
+      primary: true
+    index_keys:
+      - "creator_tesim"
+    predicate: http://purl.org/dc/elements/1.1/creator
+  date_created:
+    type: date_time
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "date_created_tesim"
+    predicate: http://purl.org/dc/terms/created
+  description:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "description_tesim"
+    predicate: http://purl.org/dc/elements/1.1/description
+  identifier:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "identifier_tesim"
+    predicate: http://purl.org/dc/terms/identifier
+  import_url:
+    type: string
+    predicate: http://scholarsphere.psu.edu/ns#importUrl
+  keyword:
+    type: string
+    multiple: true
+    index_keys:
+      - "keyword_sim"
+      - "keyword_tesim"
+    form:
+      primary: false
+    predicate: http://schema.org/keywords
+  publisher:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "publisher_tesim"
+    predicate: http://purl.org/dc/elements/1.1/publisher
+  label:
+    type: string
+    form:
+      primary: false
+    index_keys:
+      - "label_tesim"
+    predicate: info:fedora/fedora-system:def/model#downloadFilename
+  language:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "language_tesim"
+    predicate: http://purl.org/dc/elements/1.1/language
+  license:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "license_tesim"
+    predicate: http://purl.org/dc/terms/license
+  relative_path:
+    type: string
+    predicate: http://scholarsphere.psu.edu/ns#relativePath
+  related_url:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "related_url_tesim"
+    predicate: http://www.w3.org/2000/01/rdf-schema#seeAlso
+  resource_type:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "resource_type_sim"
+      - "resource_type_tesim"
+    predicate: http://purl.org/dc/terms/type
+  rights_notes:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "rights_notes_tesim"
+    predicate: http://purl.org/dc/elements/1.1/rights
+  rights_statement:
+    type: string
+    multiple: true
+    form:
+      primary: true
+    index_keys:
+      - "rights_statement_tesim"
+    predicate: http://www.europeana.eu/schemas/edm/rights
+  source:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "source_tesim"
+    predicate: http://purl.org/dc/terms/source
+  subject:
+    type: string
+    multiple: true
+    index_keys:
+      - "subject_sim"
+      - "subject_tesim"
+    form:
+      primary: false
+    predicate: http://purl.org/dc/elements/1.1/subject

--- a/config/metadata/image_resource.yaml
+++ b/config/metadata/image_resource.yaml
@@ -21,4 +21,13 @@
 # Generated via
 #  `rails generate hyrax:work_resource ImageResource`
 
-attributes: {}
+attributes:
+  extent:
+    type: string
+    multiple: true
+    index_keys:
+      - "extent_tesim"
+    form:
+      required: false
+      primary: false
+      multiple: true


### PR DESCRIPTION
This commit will:
  - add extent to the image resource and form
  - override basic_metadata to show bibliographic_citation on forms
  - change PcdmObjectForm to ResourceForm because it was throwing errors
  - add bolding to labels on forms
 
 Also:
  - Indexers were examined and no changes were needed
  - Presenters don't seem to be a default thing for Valkyrie works
  - Controllers were examined and no changes were needed
  - Views were examined and no changes were needed
  - Localizations don't seem to be a default thing for Valkyrie works

Ref:
  - https://github.com/scientist-softserv/hykuup_knapsack/issues/85
  - https://github.com/scientist-softserv/hykuup_knapsack/issues/87
  - https://github.com/scientist-softserv/hykuup_knapsack/issues/88
  - https://github.com/scientist-softserv/hykuup_knapsack/issues/89
  - https://github.com/scientist-softserv/hykuup_knapsack/issues/90
  - https://github.com/scientist-softserv/hykuup_knapsack/issues/91
  - https://github.com/scientist-softserv/hykuup_knapsack/issues/92