### PR TITLE
🎁 fixes to unblock deploys

### DIFF
--- a/app/controllers/saved_searches_controller.rb
+++ b/app/controllers/saved_searches_controller.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class SavedSearchesController < ApplicationController
-  include Blacklight::SavedSearches
-
-  helper BlacklightAdvancedSearch::RenderConstraintsOverride
-end

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -1,0 +1,34 @@
+test:
+  service: Disk
+  root: <%= Rails.root.join("tmp/storage") %>
+
+local:
+  service: Disk
+  root: <%= Rails.root.join("storage") %>
+
+# Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
+# amazon:
+#   service: S3
+#   access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
+#   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
+#   region: us-east-1
+#   bucket: your_own_bucket-<%= Rails.env %>
+
+# Remember not to checkin your GCS keyfile to a repository
+# google:
+#   service: GCS
+#   project: your_project
+#   credentials: <%= Rails.root.join("path/to/gcs.keyfile") %>
+#   bucket: your_own_bucket-<%= Rails.env %>
+
+# Use bin/rails credentials:edit to set the Azure Storage secret (as azure_storage:storage_access_key)
+# microsoft:
+#   service: AzureStorage
+#   storage_account_name: your_account_name
+#   storage_access_key: <%= Rails.application.credentials.dig(:azure_storage, :storage_access_key) %>
+#   container: your_container_name-<%= Rails.env %>
+
+# mirror:
+#   service: Mirror
+#   primary: local
+#   mirrors: [ amazon, google, microsoft ]


### PR DESCRIPTION
Removes SaveSearchesController as it is not longer supported. Blacklight::SavedSearched was removed in v7+ Adds storage.yml, a required file to boot up in production.

ref:
- https://github.com/projectblacklight/blacklight/wiki/Saved-Searches
- https://github.com/projectblacklight/blacklight/pull/1736

Issue 
- https://github.com/scientist-softserv/hykuup_knapsack/issues/78