### PR TITLE
Create title validator

### DIFF
--- a/app/change_sets/generic_work_change_set.rb
+++ b/app/change_sets/generic_work_change_set.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+require 'title_validator'
+
+class GenericWorkChangeSet < Valkyrie::ChangeSet
+  property :title, multiple: true, required: true
+
+  # validating change_sets => https://github.com/samvera/valkyrie/wiki/Validating-change-sets
+  validates :title, presence: true
+  validates_with TitleValidator
+end

--- a/app/change_sets/image_change_set.rb
+++ b/app/change_sets/image_change_set.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+require 'title_validator'
+
+class ImageChangeSet < Valkyrie::ChangeSet
+  property :title, multiple: true, required: true
+
+  # validating change_sets => https://github.com/samvera/valkyrie/wiki/Validating-change-sets
+  validates :title, presence: true
+  validates_with TitleValidator
+end

--- a/app/validators/title_validator.rb
+++ b/app/validators/title_validator.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+class TitleValidator < ActiveModel::Validator
+  # ensure the property exists and is in the controlled vocabulary
+  def validate(record)
+    record.title.present?
+
+    record.errors.add :title, 'Your work must have a title.'
+  end
+end

--- a/lib/hyrax/solr_service_decorator.rb
+++ b/lib/hyrax/solr_service_decorator.rb
@@ -17,7 +17,7 @@ module Hyrax
 
     # TODO: does Valkyrie Solr Service need to be reset in some way?
     def reset!
-      @old_service.reset! if @old_service
+      @old_service&.reset!
 
       Hyrax.index_adapter&.reset!
     end


### PR DESCRIPTION
Create change set for model resources and a TitleValidator.

```ruby
Enforce the validator with generic_work_resource_cs = GenericWorkChangeSet.new(GenericWorkResource.new). 

generic_work_resource_cs.valid? => false

generic_work_resource_cs.errors.messages => => {:title=>["can't be blank", "Your work must have a title."]}
```

Issue:
- https://github.com/scientist-softserv/hykuup_knapsack/issues/84

Docs:
- https://github.com/samvera/valkyrie/wiki/Persisting-changes-through-synchronization#successfully-change-and-save

