### PR TITLE
Valkyrize the reindexer jobs

### DIFF
--- a/app/jobs/reindex_admin_sets_job.rb
+++ b/app/jobs/reindex_admin_sets_job.rb
@@ -2,6 +2,8 @@
 
 class ReindexAdminSetsJob < ApplicationJob
   def perform
-    AdminSet.find_each(&:update_index)
+    AdministrativeSet.find_each do |admin_set|
+      ReindexItemJob.perform_later(admin_set)
+    end
   end
 end

--- a/app/jobs/reindex_collections_job.rb
+++ b/app/jobs/reindex_collections_job.rb
@@ -2,7 +2,7 @@
 
 class ReindexCollectionsJob < ApplicationJob
   def perform
-    Collection.find_each do |collection|
+    PcdmCollection.find_each do |collection|
       ReindexItemJob.perform_later(collection)
     end
   end

--- a/app/jobs/reindex_item_job.rb
+++ b/app/jobs/reindex_item_job.rb
@@ -2,6 +2,6 @@
 
 class ReindexItemJob < ApplicationJob
   def perform(item)
-    item.update_index
+    Hyrax.index_adapter.save(resource: item)
   end
 end


### PR DESCRIPTION
Ref https://github.com/scientist-softserv/hykuup_knapsack/issues/35

The current reindex wouldn't work for Valkyrie resources. However this change only picks up the new collection types, ignoring the ActiveFedora types.

Starting this as a draft to note the need for SOME change, even though this may not be adequate.