### PR TITLE
🐛 Fix collection membership bug

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,6 +41,7 @@ Metrics/BlockLength:
     - 'lib/tasks/*.rake'
     - 'spec/**/*.rb'
     - 'tasks/benchmark.rake'
+    - 'config/application.rb'
 
 Style/AsciiComments:
   Enabled: false

--- a/app/controllers/hyrax/dashboard/collections_controller_decorator.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller_decorator.rb
@@ -145,18 +145,6 @@ module Hyrax
         logo_info
       end
 
-      def collection_params
-        if Hyrax.config.collection_class < ActiveFedora::Base
-          @participants = extract_old_style_permission_attributes(params[:collection])
-          form_class.model_attributes(params[:collection])
-        else
-          params.permit(collection: {})[:collection]
-                .merge(params.permit(:collection_type_gid)
-              .with_defaults(collection_type_gid: default_collection_type_gid))
-                .merge(member_of_collection_ids: Array(params[:parent_id]))
-        end
-      end
-
       # rubocop:disable Metrics/MethodLength
       def process_uploaded_thumbnail(uploaded_file)
         dir_name = UploadedCollectionThumbnailPathService.upload_dir(@collection)


### PR DESCRIPTION
A hyrax bug made it into Hyku via the collections controller decorator. This removes the unnecessary `collection_params method`.

Refs
- https://github.com/scientist-softserv/hykuup_knapsack/issues/183
- https://github.com/samvera/hyrax/commit/7add21367fb551174b07ba13803c16e5bd132458
