### PR TITLE
Valkyrize Reindex jobs

### DIFF
--- a/app/jobs/reindex_admin_sets_job.rb
+++ b/app/jobs/reindex_admin_sets_job.rb
@@ -2,6 +2,17 @@
 
 class ReindexAdminSetsJob < ApplicationJob
   def perform
-    AdminSet.find_each(&:update_index)
+    models = Hyrax::ModelRegistry.admin_set_classes
+    unique_models = []
+    models.each do |model|
+      unique_models << Wings::ModelRegistry.lookup(model)
+    end
+
+    unique_models.uniq.each do |model|
+      admin_sets = Hyrax.query_service.find_all_of_model(model:)
+      admin_sets.each do |as|
+        ReindexItemJob.perform_later(as.id.to_s)
+      end
+    end
   end
 end

--- a/app/jobs/reindex_collections_job.rb
+++ b/app/jobs/reindex_collections_job.rb
@@ -2,8 +2,17 @@
 
 class ReindexCollectionsJob < ApplicationJob
   def perform
-    Collection.find_each do |collection|
-      ReindexItemJob.perform_later(collection)
+    models = Hyrax::ModelRegistry.collection_classes
+    unique_models = []
+    models.each do |model|
+      unique_models << Wings::ModelRegistry.lookup(model)
+    end
+
+    unique_models.uniq.each do |model|
+      collections = Hyrax.query_service.find_all_of_model(model:)
+      collections.each do |coll|
+        ReindexItemJob.perform_later(coll.id.to_s)
+      end
     end
   end
 end

--- a/app/jobs/reindex_file_sets_job.rb
+++ b/app/jobs/reindex_file_sets_job.rb
@@ -2,8 +2,17 @@
 
 class ReindexFileSetsJob < ApplicationJob
   def perform
-    FileSet.find_each do |file_set|
-      ReindexItemJob.perform_later(file_set)
+    models = Hyrax::ModelRegistry.file_set_classes
+    unique_models = []
+    models.each do |model|
+      unique_models << Wings::ModelRegistry.lookup(model)
+    end
+
+    unique_models.uniq.each do |model|
+      file_sets = Hyrax.query_service.find_all_of_model(model:)
+      file_sets.each do |fs|
+        ReindexItemJob.perform_later(fs.id.to_s)
+      end
     end
   end
 end

--- a/app/jobs/reindex_item_job.rb
+++ b/app/jobs/reindex_item_job.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 class ReindexItemJob < ApplicationJob
-  def perform(item)
+  def perform(item_id)
+    item = Hyrax.query_service.find_by(id: item_id)
+
     if item.is_a?(Valkyrie::Resource)
       Hyrax.index_adapter.save(resource: item)
     else

--- a/app/jobs/reindex_works_job.rb
+++ b/app/jobs/reindex_works_job.rb
@@ -9,9 +9,19 @@ class ReindexWorksJob < ApplicationJob
         work.update_index
       end
     else
-      Site.instance.available_works.each do |work_type|
-        work_type.constantize.find_each do |w|
-          ReindexItemJob.perform_later(w)
+      # previously this used models = Site.instance.available_works
+      # however, this means that if we stop allowing a particular work
+      # class for a tenant, we would also not ever reindex it.
+      # It is safer to use all work classes.
+      models = Hyrax::ModelRegistry.work_classes
+      unique_models = []
+      models.each do |model|
+        unique_models << Wings::ModelRegistry.lookup(model)
+      end
+      unique_models.uniq.each do |model|
+        works = Hyrax.query_service.find_all_of_model(model:)
+        works.each do |w|
+          ReindexItemJob.perform_later(w.id.to_s)
         end
       end
     end


### PR DESCRIPTION
- Addresses all reindex jobs to ensure that they will work for either valkyrie or active fedora objects.
- Ensures that works and collections are appropriately reindexed as default work and collection images are added OR removed (previously, reindexing didn't occur with removal of default images, resulting in works displaying with a missing image.)

Refs https://github.com/scientist-softserv/hykuup_knapsack/issues/35

