### PR TITLE
remove sentry dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,14 +95,11 @@ GIT
 
 GIT
   remote: https://github.com/samvera-labs/hyku_knapsack.git
-  revision: 5a7c54cace96881a3963ab2fd881ca6ea3f57372
+  revision: cbc6c889ebf52dc03b038afde477c5d9c082e76f
   branch: required_for_knapsack_instances
   specs:
     hyku_knapsack (0.0.1)
       rails (>= 5.2.0)
-      sentry-rails
-      sentry-ruby
-      sentry-sidekiq
 
 GIT
   remote: https://github.com/samvera-labs/hyrax-doi.git
@@ -1513,6 +1510,9 @@ DEPENDENCIES
   scss_lint
   secure_headers
   selenium-webdriver (= 4.8.1)
+  sentry-rails
+  sentry-ruby
+  sentry-sidekiq
   shoulda-matchers (~> 4.0)
   sidekiq (< 7.0)
   simplecov

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,7 +95,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera-labs/hyku_knapsack.git
-  revision: cbc6c889ebf52dc03b038afde477c5d9c082e76f
+  revision: 5a7c54cace96881a3963ab2fd881ca6ea3f57372
   branch: required_for_knapsack_instances
   specs:
     hyku_knapsack (0.0.1)
@@ -1224,15 +1224,6 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
-    sentry-rails (5.17.1)
-      railties (>= 5.0)
-      sentry-ruby (~> 5.17.1)
-    sentry-ruby (5.17.1)
-      bigdecimal
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-    sentry-sidekiq (5.17.1)
-      sentry-ruby (~> 5.17.1)
-      sidekiq (>= 3.0)
     shacl (0.3.0)
       json-ld (~> 3.2)
       rdf (~> 3.2, >= 3.2.8)
@@ -1510,9 +1501,6 @@ DEPENDENCIES
   scss_lint
   secure_headers
   selenium-webdriver (= 4.8.1)
-  sentry-rails
-  sentry-ruby
-  sentry-sidekiq
   shoulda-matchers (~> 4.0)
   sidekiq (< 7.0)
   simplecov


### PR DESCRIPTION
The knapsack will require these gems from bundler.d instead of forcing hyku to care about them. 