### PR TITLE
🐛 Fix PDF.js for Valkyrie

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,10 +147,10 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: a5a0ae9e56df857a92fc53ae86216cbb007db47a
+  revision: 54bb7b22aaf44dcdda76e05fb88b65095b2e899f
   branch: double_combo
   specs:
-    hyrax (5.0.0)
+    hyrax (5.0.1)
       active-fedora (~> 14.0)
       almond-rails (~> 0.1)
       awesome_nested_set (~> 3.1)
@@ -201,7 +201,7 @@ GIT
       sass-rails (~> 6.0)
       select2-rails (~> 3.5)
       signet
-      sprockets (~> 3.7)
+      sprockets (= 3.7.2)
       tinymce-rails (~> 5.10)
       valkyrie (~> 3.1.1)
       view_component (~> 2.74.1)

--- a/app/forms/generic_work_resource_form.rb
+++ b/app/forms/generic_work_resource_form.rb
@@ -10,6 +10,5 @@ class GenericWorkResourceForm < Hyrax::Forms::ResourceForm(GenericWorkResource)
   include Hyrax::FormFields(:generic_work_resource)
   include Hyrax::FormFields(:with_pdf_viewer)
   include Hyrax::FormFields(:with_video_embed)
-  include PdfBehavior
   include VideoEmbedBehavior::Validation
 end

--- a/app/forms/image_resource_form.rb
+++ b/app/forms/image_resource_form.rb
@@ -10,6 +10,5 @@ class ImageResourceForm < Hyrax::Forms::ResourceForm(ImageResource)
   include Hyrax::FormFields(:image_resource)
   include Hyrax::FormFields(:with_pdf_viewer)
   include Hyrax::FormFields(:with_video_embed)
-  include PdfBehavior
   include VideoEmbedBehavior::Validation
 end

--- a/app/helpers/pdf_js_helper.rb
+++ b/app/helpers/pdf_js_helper.rb
@@ -21,16 +21,12 @@ module PdfJsHelper
   end
 
   def render_show_pdf_behavior_checkbox?
-    # we are showing PDF.js based on the FlipFlop value
-    # instead of checking for the property value.
-    # TODO: Valkyrize PDF.js feature
-    false
-    # return unless Flipflop.default_pdf_viewer?
-    # return if params[:id].nil?
+    return unless Flipflop.default_pdf_viewer?
+    return if params[:id].nil?
 
-    # doc = SolrDocument.find params[:id]
+    doc = SolrDocument.find params[:id]
 
-    # presenter = @_controller.show_presenter.new(doc, current_ability)
-    # presenter.file_set_presenters.any?(&:pdf?)
+    presenter = @_controller.show_presenter.new(doc, current_ability)
+    presenter.file_set_presenters.any?(&:pdf?)
   end
 end

--- a/app/listeners/hyrax_listener.rb
+++ b/app/listeners/hyrax_listener.rb
@@ -55,8 +55,9 @@ class HyraxListener
   # def on_collection_membership_update
   # end
 
-  # def on_file_characterized
-  # end
+  def on_file_characterized(event)
+    pdf_viewer_and_download_button(event)
+  end
 
   # def on_file_downloaded
   # end
@@ -99,4 +100,17 @@ class HyraxListener
 
   # def on_object_metadata_updated
   # end
+
+  private
+
+  def pdf_viewer_and_download_button(event)
+    file_set = event[:file_set]
+    return unless file_set.original_file.pdf?
+
+    parent_work = Hyrax.custom_queries.find_parent_work(resource: file_set)
+    parent_work.show_pdf_viewer = '1'
+    parent_work.show_pdf_download_button = '1'
+
+    Hyrax.persister.save(resource: parent_work)
+  end
 end

--- a/app/models/concerns/pdf_behavior.rb
+++ b/app/models/concerns/pdf_behavior.rb
@@ -12,20 +12,19 @@ end
 
 module PdfBehavior
   extend ActiveSupport::Concern
-  # TODO: Valkyrize PDF.js feature
 
   included do
     property :show_pdf_viewer, predicate: RDF::CustomShowPdfViewerTerm.show_pdf_viewer, multiple: false do |index|
-      # index.as :stored_searchable
+      index.as :stored_searchable
     end
 
     # rubocop:disable Metrics/LineLength
     property :show_pdf_download_button, predicate: RDF::CustomShowPdfDownloadButtonTerm.show_pdf_download_button, multiple: false do |index|
-      # index.as :stored_searchable
+      index.as :stored_searchable
     end
     # rubocop:enable Metrics/LineLength
 
-    # after_initialize :set_default_show_pdf_viewer, :set_default_show_pdf_download_button
+    after_initialize :set_default_show_pdf_viewer, :set_default_show_pdf_download_button
   end
 
   private

--- a/app/presenters/hyku/work_show_presenter.rb
+++ b/app/presenters/hyku/work_show_presenter.rb
@@ -71,13 +71,11 @@ module Hyku
     # End Featured Collections Methods
 
     def show_pdf_viewer?
-      Flipflop.default_pdf_viewer? && file_set_presenters.any?(&:pdf?)
-      # TODO: Valkyrize PDF.js feature
-      # return unless Flipflop.default_pdf_viewer?
-      # return unless show_pdf_viewer
-      # return unless file_set_presenters.any?(&:pdf?)
+      return unless Flipflop.default_pdf_viewer?
+      return unless show_pdf_viewer
+      return unless file_set_presenters.any?(&:pdf?)
 
-      # show_pdf_viewer.first.to_i.positive?
+      show_for_pdf?(show_pdf_viewer)
     end
 
     def show_pdf_download_button?
@@ -85,7 +83,7 @@ module Hyku
       return unless file_set_presenters.any?(&:pdf?)
       return unless show_pdf_download_button
 
-      show_pdf_download_button.first.to_i.positive?
+      show_for_pdf?(show_pdf_download_button)
     end
 
     def viewer?
@@ -127,6 +125,11 @@ module Hyku
 
     def extract_video_embed_presence
       solr_document[:video_embed_tesim]&.first&.present?
+    end
+
+    def show_for_pdf?(field)
+      # With Valkyrie, we store the field as a boolean while AF stores it as an Array
+      valkyrie_presenter? ? field : field.first.to_i.positive?
     end
   end
 end

--- a/app/views/hyrax/file_sets/media_display/_pdf.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_pdf.html.erb
@@ -1,0 +1,23 @@
+<% if display_media_download_link?(file_set: file_set) %>
+  <div>
+      <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
+      <%= image_tag thumbnail_url(file_set),
+                    class: "representative-media",
+                    alt: "",
+                    role: "presentation" %>
+      <% if controller_name == 'file_sets' && @presenter.solr_document.load_parent_docs.any?(&:show_pdf_download_button) %>
+        <%= link_to t('hyrax.file_set.show.downloadable_content.pdf_link'),
+                    hyrax.download_path(file_set),
+                    target: :_blank,
+                    id: "file_download",
+                    data: { label: file_set.id, work_id: @presenter.id, collection_ids: @presenter.member_of_collection_ids } %>
+      <% end %>
+    </div>
+<% else %>
+    <div>
+      <%= image_tag thumbnail_url(file_set),
+                    class: "representative-media",
+                    alt: "",
+                    role: "presentation" %>
+    </div>
+<% end %>

--- a/config/metadata/with_pdf_viewer.yaml
+++ b/config/metadata/with_pdf_viewer.yaml
@@ -7,6 +7,11 @@ attributes:
       - "show_pdf_viewer_bsi"
     # For historic reasons, this is the predicate
     predicate: http://id.loc.gov/vocabulary/identifiers/show_pdf_viewer
+    form:
+      display: true
+      primary: false
+      required: false
+      multiple: false
   show_pdf_download_button:
     # https://dry-rb.org/gems/dry-types/1.7/built-in-types/
     type: bool
@@ -15,3 +20,8 @@ attributes:
       - "show_pdf_download_button_bsi"
     # For historic reasons, this is the predicate
     predicate: http://id.loc.gov/vocabulary/identifiers/show_pdf_download_button
+    form:
+      display: true
+      primary: false
+      required: false
+      multiple: false

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -26,7 +26,7 @@ Hyrax.config.collection_model = "CollectionResource"
 # First find the Hyrax factories; then find the local factories (which extend/modify Hyrax
 # factories).
 FactoryBot.definition_file_paths = [
-  Hyrax::Engine.root.join("spec/factories/").to_s,
+  Hyrax::Engine.root.join("lib/hyrax/specs/shared_specs/factories").to_s,
   File.expand_path("../factories", __FILE__)
 ]
 FactoryBot.find_definitions


### PR DESCRIPTION
# Story

This commit will bring back the full functionality of PDF.js for Valkyrie Hyrax.  This includes:

- toggle the PDF.js viewer
- toggle downlad pdf button

Ref:
  - https://github.com/scientist-softserv/iiif_print/issues/342

# Screenshots

<img width="676" alt="image" src="https://github.com/samvera/hyku/assets/19597776/ceb116bf-52b1-4b12-8544-fff506c6a81a">

![image](https://github.com/samvera/hyku/assets/19597776/07381065-56b6-4928-aa93-f2f42570484e)
