### PR TITLE
🐛 Fix solr endpoint default issue

### DIFF
--- a/lib/hyrax/solr_service_decorator.rb
+++ b/lib/hyrax/solr_service_decorator.rb
@@ -28,6 +28,11 @@ module Hyrax
 
       Hyrax.index_adapter&.reset!
     end
+
+    # Override Hyrax SolrService connection method to always use Hyku's connection method.
+    def connection
+      SolrEndpoint.new.connection
+    end
   end
 end
 

--- a/spec/requests/catalog_controller_spec.rb
+++ b/spec/requests/catalog_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe CatalogController, type: :request, clean: true, multitenant: true
     WebMock.disable!
     allow(AccountElevator).to receive(:switch!).with(cross_search_tenant_account.cname).and_return('public')
     allow(Apartment::Tenant.adapter).to receive(:connect_to_new).and_return('')
-    allow_any_instance_of(Hyrax::SolrService).to receive(:connection).and_return(sample_solr_connection)
+    allow_any_instance_of(Hyrax::SolrServiceDecorator).to receive(:connection).and_return(sample_solr_connection)
 
     Hyrax::SolrService.add(hyku_sample_work.to_solr)
     Hyrax::SolrService.commit


### PR DESCRIPTION
refs https://github.com/samvera/hyku/issues/2177

The failure was happening due to the `post` method in Hyrax's `solr_service`. This method was using Hyrax's connection method, which fell back to `valkyrie_index.connection`, resulting in a url with no core so it used `hyrax-valkyrie`