### PR TITLE
⚙️ Pinning DerivativeRodeo to a better version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ gem 'cocoon'
 gem 'codemirror-rails'
 gem 'coffee-rails', '~> 4.2' # Use CoffeeScript for .coffee assets and views
 gem 'database_cleaner', group: %i[test]
+gem 'derivative-rodeo', '~>0.5', '>= 0.5.3'
 gem 'devise'
 gem 'devise-guests', '~> 0.3'
 gem 'devise-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1440,6 +1440,7 @@ DEPENDENCIES
   codemirror-rails
   coffee-rails (~> 4.2)
   database_cleaner
+  derivative-rodeo (~> 0.5, >= 0.5.3)
   devise
   devise-guests (~> 0.3)
   devise-i18n


### PR DESCRIPTION
I'm struggling with getting IIIF Print to build with the committed constraint for DR.  Why? Because IIIF Print is installing Hyku in it's build and Hyku was previously requiring v0.5.2.

There's some twisted logic inversion that's happening.