### PR TITLE
the generate_work_url method from iiif print does not want a hash

### DIFF
--- a/app/views/catalog/_index_gallery_collection_wrapper.html.erb
+++ b/app/views/catalog/_index_gallery_collection_wrapper.html.erb
@@ -2,7 +2,7 @@
 <div class="document col-6 col-md-3">
   <div class="thumbnail">
     <% value = collection_thumbnail(document, {}, counter: document_counter_with_offset(document_counter)) %>
-    <%= link_to value, generate_work_url(document.to_h, request)%>
+    <%= link_to value, generate_work_url(document, request)%>
     <div class="caption">
       <%= render_document_partials document, blacklight_config.view_config(:gallery).partials, :document_counter => document_counter %>
     </div>

--- a/app/views/catalog/_index_header_list_collection.html.erb
+++ b/app/views/catalog/_index_header_list_collection.html.erb
@@ -2,7 +2,7 @@
 
 <div class="search-results-title-row col-12 d-flex flex-row align-items-center pb-2">
   <%# OVERRIDE begin %>
-  <h3 class="search-result-title mb-0 pr-3"><%= link_to document.title_or_label, generate_work_url(document.to_h, request) %></h3>
+  <h3 class="search-result-title mb-0 pr-3"><%= link_to document.title_or_label, generate_work_url(document, request) %></h3>
   <%# OVERRIDE end %>
   <%= Hyrax::CollectionPresenter.new(document, current_ability).collection_type_badge %>
 </div>

--- a/app/views/catalog/_thumbnail_list_collection.html.erb
+++ b/app/views/catalog/_thumbnail_list_collection.html.erb
@@ -1,5 +1,5 @@
 <%# Override Hyrax 3.4.1 to remove thumbnail link supression and use default collection thumbnail %>
 <div class="col-md-3">
   <% value = collection_thumbnail(document, {}, counter: document_counter_with_offset(document_counter)) %>
-  <%= link_to value, generate_work_url(document.to_h, request)%>
+  <%= link_to value, generate_work_url(document, request)%>
 </div>

--- a/app/views/hyrax/homepage/_recent_document.html.erb
+++ b/app/views/hyrax/homepage/_recent_document.html.erb
@@ -5,7 +5,7 @@
         <span class="sr-only"><%= t('hyrax.homepage.recently_uploaded.document.title_label') %></span>
         <h3>
           <%= render_thumbnail_tag recent_document, {}, {suppress_link: true} %>
-          <%= link_to recent_document.title_or_label, generate_work_url(recent_document.to_h, request), data: { turbolinks: block_valkyrie_redirect? } %>
+          <%= link_to recent_document.title_or_label, generate_work_url(recent_document, request), data: { turbolinks: block_valkyrie_redirect? } %>
         </h3>
         <p class="recent-field">
           <span class="recent-label"><%= t('hyrax.homepage.recently_uploaded.document.depositor_label') %>:</span> <%= link_to_profile recent_document.depositor(t('hyrax.homepage.recently_uploaded.document.depositor_missing')) %>

--- a/app/views/themes/cultural_repository/hyrax/homepage/_recent_document.html.erb
+++ b/app/views/themes/cultural_repository/hyrax/homepage/_recent_document.html.erb
@@ -3,6 +3,6 @@
 <div class="recently-uploaded col-6 col-md-2">
   <%= render_thumbnail_tag recent_document, {class: 'img-fluid mx-auto d-block'}, {suppress_link: true} %>
   <div class="recent-doc-title">
-    <%= link_to recent_document.title_or_label, generate_work_url(recent_document.to_h, request) %>
+    <%= link_to recent_document.title_or_label, generate_work_url(recent_document, request) %>
   </div>
 </div>

--- a/app/views/themes/institutional_repository/hyrax/homepage/_recent_document.html.erb
+++ b/app/views/themes/institutional_repository/hyrax/homepage/_recent_document.html.erb
@@ -3,6 +3,6 @@
 <div class="recently-uploaded col-6 col-md-6 pt-3 pb-3">
   <%= render_thumbnail_tag recent_document, {class: 'img-fluid mx-auto d-block'}, {suppress_link: true} %>
   <div class="recent-doc-title">
-    <%= link_to recent_document.title_or_label, generate_work_url(recent_document.to_h, request) %>
+    <%= link_to recent_document.title_or_label, generate_work_url(recent_document, request) %>
   </div>
 </div>

--- a/app/views/themes/neutral_repository/hyrax/homepage/_recent_document.html.erb
+++ b/app/views/themes/neutral_repository/hyrax/homepage/_recent_document.html.erb
@@ -3,6 +3,6 @@
 <div class="recently-uploaded pb-3 col-6 col-md-6">
   <%= render_thumbnail_tag recent_document, {class: 'img-fluid mx-auto d-block'}, {suppress_link: true} %>
   <div class="recent-doc-title">
-    <%= link_to recent_document.title_or_label, generate_work_url(recent_document.to_h, request) %>
+    <%= link_to recent_document.title_or_label, generate_work_url(recent_document, request) %>
   </div>
 </div>


### PR DESCRIPTION
it wants a solr document. lets be consistant about what we give it

This change parallels one from Adventist.

fixes https://github.com/scientist-softserv/adventist-dl/issues/750

@samvera/hyku-code-reviewers
