### PR TITLE
🎁 Add `ActiveJob::Scheduler`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'rails', '~> 6.0', github: 'rails/rails', branch: '6-1-stable'
 
 gem 'active_elastic_job', github: 'active-elastic-job/active-elastic-job', ref: 'ec51c5d9dedc4a1b47f2db41f26d5fceb251e979', group: %i[aws]
 gem 'active-fedora', '~> 14.0'
+gem 'activejob-scheduler', git: 'https://github.com/tubbo/activejob-scheduler.git'
 gem 'activerecord-nulldb-adapter'
 gem 'addressable', '2.8.1' # remove once https://github.com/postrank-labs/postrank-uri/issues/49 is fixed
 gem 'apartment', github: 'scientist-softserv/apartment', branch: 'development'
@@ -74,6 +75,7 @@ gem 'order_already'
 gem 'parser', '>= 3.1.0.0'
 gem 'pg'
 gem 'postrank-uri', '>= 1.0.24'
+gem 'progress_bar'
 gem 'pry-byebug', group: %i[development test]
 gem 'puma', '~> 5.6' # Use Puma as the app server
 gem 'rack-test', '0.7.0', group: %i[test] # rack-test >= 0.71 does not work with older Capybara versions (< 2.17). See #214 for more details

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -249,6 +249,17 @@ GIT
       nokogiri (~> 1.5)
       omniauth (>= 1.2, < 3)
 
+GIT
+  remote: https://github.com/tubbo/activejob-scheduler.git
+  revision: efe54965e08252da5232412df5bae98732cd045c
+  specs:
+    activejob-scheduler (1.0.0.pre)
+      actionmailer (> 5, < 7)
+      activejob (> 5, < 7)
+      activesupport (> 5, < 7)
+      fugit (~> 1.3)
+      travis-release (~> 0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -971,6 +982,7 @@ GEM
     openseadragon (0.6.0)
       rails (> 3.2.0)
     optimist (3.1.0)
+    options (2.3.2)
     order_already (0.3.1)
       rails-html-sanitizer (~> 1.4)
     orm_adapter (0.5.0)
@@ -988,6 +1000,9 @@ GEM
       addressable (>= 2.4.0)
       nokogiri (>= 1.8.0)
       public_suffix (>= 4.0.0, < 5)
+    progress_bar (1.3.3)
+      highline (>= 1.6, < 3)
+      options (~> 2.3.0)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -1344,6 +1359,9 @@ GEM
     tinymce-rails (5.10.9)
       railties (>= 3.1.1)
     trailblazer-option (0.1.2)
+    travis-release (0.0.4)
+      bundler
+      rake
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
@@ -1429,6 +1447,7 @@ PLATFORMS
 DEPENDENCIES
   active-fedora (~> 14.0)
   active_elastic_job!
+  activejob-scheduler!
   activerecord-nulldb-adapter
   addressable (= 2.8.1)
   apartment!
@@ -1486,6 +1505,7 @@ DEPENDENCIES
   parser (>= 3.1.0.0)
   pg
   postrank-uri (>= 1.0.24)
+  progress_bar
   pry-byebug
   puma (~> 5.6)
   rack-test (= 0.7.0)


### PR DESCRIPTION
The deploy was not working because it was missing the `repeat` method which is provided by the `ActiveJob::Scheduler` gem.
