### PR TITLE
🐛 Bring back footer for splash page

### DIFF
--- a/app/views/layouts/hyrax.html.erb
+++ b/app/views/layouts/hyrax.html.erb
@@ -31,7 +31,7 @@
       <%= render 'shared/read_only' if Flipflop.read_only? %>
       <%= content_for?(:content) ? yield(:content) : yield %>
     </div><!-- /#content-wrapper -->
-    <% unless controller.controller_name == 'splash' %>
+    <% if controller.controller_name == 'splash' || controller.controller_name == 'homepage' %>
       <%= render 'shared/footer' %>
     <% end %>
     <%= render 'shared/modal' %>


### PR DESCRIPTION
This commit will bring the footer back for the splash page as well as retain the footer display on the homepage.

ref:
  - https://github.com/scientist-softserv/hykuup_knapsack/issues/211

### Logged out
![image](https://github.com/samvera/hyku/assets/19597776/1e0f47ed-bc8a-4650-a82f-8e368eb408ac)

### Logged in
![image](https://github.com/samvera/hyku/assets/19597776/e89375ca-6f5b-4437-a931-dc72c506b400)

### In a tenant
![image](https://github.com/samvera/hyku/assets/19597776/60928e3d-e4af-4b2d-8671-6ea3783c1a8b)
