### PR TITLE
Wrap willow_sword initializer in after_initialize

### DIFF
--- a/config/initializers/willow_sword.rb
+++ b/config/initializers/willow_sword.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 # Overriding the default config values
-WillowSword.setup do |config|
-  config.work_models = Hyrax.config.registered_curation_concern_types
-  config.collection_models = [Hyrax.config.collection_model]
-  config.file_set_models = [Hyrax.config.file_set_model]
-  config.default_work_model = Hyrax.config.curation_concerns.first
+Rails.application.config.after_initialize do
+  WillowSword.setup do |config|
+    config.work_models = Hyrax.config.registered_curation_concern_types
+    config.collection_models = [Hyrax.config.collection_model]
+    config.file_set_models = [Hyrax.config.file_set_model]
+    config.default_work_model = Hyrax.config.curation_concerns.first
+  end
 end


### PR DESCRIPTION
We had to do this because the willow_sword initializer called Hyrax which created loading issues with the SimpleSchemaLoaderDecorator in HykuKnapsack.
