### PR TITLE
:gift: allow knapsack to override resource metadata

### DIFF
--- a/app/forms/generic_work_resource_form.rb
+++ b/app/forms/generic_work_resource_form.rb
@@ -6,10 +6,13 @@
 # @see https://github.com/samvera/hyrax/wiki/Hyrax-Valkyrie-Usage-Guide#forms
 # @see https://github.com/samvera/valkyrie/wiki/ChangeSets-and-Dirty-Tracking
 class GenericWorkResourceForm < Hyrax::Forms::ResourceForm(GenericWorkResource)
-  include Hyrax::FormFields(:basic_metadata)
-  include Hyrax::FormFields(:bulkrax_metadata)
-  include Hyrax::FormFields(:generic_work_resource)
-  include Hyrax::FormFields(:with_pdf_viewer)
-  include Hyrax::FormFields(:with_video_embed)
+  if "GenericWorkResourceFormDecorator".safe_constantize.nil?
+    include Hyrax::FormFields(:basic_metadata)
+    include Hyrax::FormFields(:bulkrax_metadata)
+    include Hyrax::FormFields(:generic_work_resource)
+    include Hyrax::FormFields(:with_pdf_viewer)
+    include Hyrax::FormFields(:with_video_embed)
+  end
+
   include VideoEmbedBehavior::Validation
 end

--- a/app/forms/image_resource_form.rb
+++ b/app/forms/image_resource_form.rb
@@ -6,10 +6,13 @@
 # @see https://github.com/samvera/hyrax/wiki/Hyrax-Valkyrie-Usage-Guide#forms
 # @see https://github.com/samvera/valkyrie/wiki/ChangeSets-and-Dirty-Tracking
 class ImageResourceForm < Hyrax::Forms::ResourceForm(ImageResource)
-  include Hyrax::FormFields(:basic_metadata)
-  include Hyrax::FormFields(:bulkrax_metadata)
-  include Hyrax::FormFields(:image_resource)
-  include Hyrax::FormFields(:with_pdf_viewer)
-  include Hyrax::FormFields(:with_video_embed)
+  if "ImageResourceFormDecorator".safe_constantize.nil?
+    include Hyrax::FormFields(:basic_metadata)
+    include Hyrax::FormFields(:bulkrax_metadata)
+    include Hyrax::FormFields(:image_resource)
+    include Hyrax::FormFields(:with_pdf_viewer)
+    include Hyrax::FormFields(:with_video_embed)
+  end
+
   include VideoEmbedBehavior::Validation
 end

--- a/app/indexers/generic_work_resource_indexer.rb
+++ b/app/indexers/generic_work_resource_indexer.rb
@@ -3,11 +3,13 @@
 # Generated via
 #  `rails generate hyrax:work_resource GenericWorkResource`
 class GenericWorkResourceIndexer < Hyrax::ValkyrieWorkIndexer
-  include Hyrax::Indexer(:basic_metadata)
-  include Hyrax::Indexer(:bulkrax_metadata)
-  include Hyrax::Indexer(:generic_work_resource)
-  include Hyrax::Indexer(:with_pdf_viewer)
-  include Hyrax::Indexer(:with_video_embed)
+  if "GenericWorkResourceIndexerDecorator".safe_constantize.nil?
+    include Hyrax::Indexer(:basic_metadata)
+    include Hyrax::Indexer(:bulkrax_metadata)
+    include Hyrax::Indexer(:generic_work_resource)
+    include Hyrax::Indexer(:with_pdf_viewer)
+    include Hyrax::Indexer(:with_video_embed)
+  end
 
   include HykuIndexing
   # Uncomment this block if you want to add custom indexing behavior:

--- a/app/indexers/image_resource_indexer.rb
+++ b/app/indexers/image_resource_indexer.rb
@@ -3,11 +3,13 @@
 # Generated via
 #  `rails generate hyrax:work_resource ImageResource`
 class ImageResourceIndexer < Hyrax::ValkyrieWorkIndexer
-  include Hyrax::Indexer(:basic_metadata)
-  include Hyrax::Indexer(:bulkrax_metadata)
-  include Hyrax::Indexer(:image_resource)
-  include Hyrax::Indexer(:with_pdf_viewer)
-  include Hyrax::Indexer(:with_video_embed)
+  if "ImageResourceIndexerDecorator".safe_constantize.nil?
+    include Hyrax::Indexer(:basic_metadata)
+    include Hyrax::Indexer(:bulkrax_metadata)
+    include Hyrax::Indexer(:image_resource)
+    include Hyrax::Indexer(:with_pdf_viewer)
+    include Hyrax::Indexer(:with_video_embed)
+  end
 
   include HykuIndexing
   # Uncomment this block if you want to add custom indexing behavior:

--- a/app/models/generic_work_resource.rb
+++ b/app/models/generic_work_resource.rb
@@ -3,11 +3,14 @@
 # Generated via
 #  `rails generate hyrax:work_resource GenericWorkResource`
 class GenericWorkResource < Hyrax::Work
-  include Hyrax::Schema(:basic_metadata)
-  include Hyrax::Schema(:bulkrax_metadata)
-  include Hyrax::Schema(:generic_work_resource)
-  include Hyrax::Schema(:with_pdf_viewer)
-  include Hyrax::Schema(:with_video_embed)
+  if "GenericWorkResourceDecorator".safe_constantize.nil?
+    include Hyrax::Schema(:basic_metadata)
+    include Hyrax::Schema(:bulkrax_metadata)
+    include Hyrax::Schema(:generic_work_resource)
+    include Hyrax::Schema(:with_pdf_viewer)
+    include Hyrax::Schema(:with_video_embed)
+  end
+
   include Hyrax::ArResource
   include Hyrax::NestedWorks
 

--- a/app/models/image_resource.rb
+++ b/app/models/image_resource.rb
@@ -10,6 +10,7 @@ class ImageResource < Hyrax::Work
     include Hyrax::Schema(:with_pdf_viewer)
     include Hyrax::Schema(:with_video_embed)
   end
+
   include Hyrax::ArResource
   include Hyrax::NestedWorks
 

--- a/app/models/image_resource.rb
+++ b/app/models/image_resource.rb
@@ -3,11 +3,13 @@
 # Generated via
 #  `rails generate hyrax:work_resource ImageResource`
 class ImageResource < Hyrax::Work
-  include Hyrax::Schema(:basic_metadata)
-  include Hyrax::Schema(:bulkrax_metadata)
-  include Hyrax::Schema(:image_resource)
-  include Hyrax::Schema(:with_pdf_viewer)
-  include Hyrax::Schema(:with_video_embed)
+  if "ImageResourceDecorator".safe_constantize.nil?
+    include Hyrax::Schema(:basic_metadata)
+    include Hyrax::Schema(:bulkrax_metadata)
+    include Hyrax::Schema(:image_resource)
+    include Hyrax::Schema(:with_pdf_viewer)
+    include Hyrax::Schema(:with_video_embed)
+  end
   include Hyrax::ArResource
   include Hyrax::NestedWorks
 


### PR DESCRIPTION
In this commit, we wrap the inclusion of metadata in a conditional so that hyku knapsack can override it, if the decorators exists.

