### PR TITLE
🐛 Bring back catalog search constraints

### DIFF
--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -1,0 +1,37 @@
+<%#
+  OVERRIDE Blacklight 7.35.0 to remove content_for(:container_header)
+  The 'search_results_header' and 'constraints' partials were not being rendered.
+  TODO: Figure out why this is happening and apply a proper fix.
+%>
+
+<% @page_title = t('blacklight.search.page_title.title', constraints: render_search_to_page_title(params), application_name: application_name) %>
+
+<% content_for(:head) do -%>
+  <%= render 'catalog/opensearch_response_metadata', response: @response %>
+  <%= rss_feed_link_tag %>
+  <%= atom_feed_link_tag %>
+  <%= json_api_link_tag %>
+<% end %>
+
+<% content_for(:skip_links) do -%>
+    <%= link_to t('blacklight.skip_links.first_result'), '#documents', class: 'element-invisible element-focusable rounded-bottom py-2 px-3', data: { turbolinks: 'false' } %>
+<% end %>
+
+<%# OVERRIDE begin %>
+<%= render 'search_results_header' %>
+<%= render 'constraints' %>
+<%# OVERRIDE end %>
+
+<%= render 'search_header' %>
+
+<h2 class="sr-only visually-hidden"><%= t('blacklight.search.search_results') %></h2>
+
+<%- if @response.empty? %>
+  <%= render "zero_results" %>
+<%- elsif render_grouped_response? %>
+  <%= Deprecation.silence(Blacklight::RenderPartialsHelperBehavior) { render_grouped_document_index } %>
+<%- else %>
+  <%= render_document_index @response.documents %>
+<%- end %>
+
+<%= render 'results_pagination' %>


### PR DESCRIPTION
This commit will override Blacklight to bring back the constraints. This may not be the final solution but it will do for now.  We remove the content_for block because it was not working as expected.

<img width="811" alt="image" src="https://github.com/samvera/hyku/assets/19597776/06601a31-b3be-4880-87bd-87a3275f148a">
