### PR TITLE
🐛 Add guards for migrations

### DIFF
--- a/db/migrate/20200513060858_create_domain_names.rb
+++ b/db/migrate/20200513060858_create_domain_names.rb
@@ -1,12 +1,14 @@
 class CreateDomainNames < ActiveRecord::Migration[5.1]
   def change
-    create_table :domain_names do |t|
-      t.references :account
-      t.string :cname
-      t.boolean :is_active, default: true
-      t.boolean :is_ssl_enabled, default: false
+    unless table_exists?(:domain_names)
+      create_table :domain_names do |t|
+        t.references :account
+        t.string :cname
+        t.boolean :is_active, default: true
+        t.boolean :is_ssl_enabled, default: false
 
-      t.timestamps
+        t.timestamps
+      end
     end
   end
 end

--- a/db/migrate/20231215215705_create_hyrax_counter_metrics.hyrax.rb
+++ b/db/migrate/20231215215705_create_hyrax_counter_metrics.hyrax.rb
@@ -1,14 +1,16 @@
 class CreateHyraxCounterMetrics < ActiveRecord::Migration[6.1]
   def change
-    create_table :hyrax_counter_metrics do |t|
-      t.string :worktype
-      t.string :resource_type
-      t.integer :work_id
-      t.date :date
-      t.integer :total_item_investigations
-      t.integer :total_item_requests
+    unless table_exists?(:hyrax_counter_metrics)
+      create_table :hyrax_counter_metrics do |t|
+        t.string :worktype
+        t.string :resource_type
+        t.integer :work_id
+        t.date :date
+        t.integer :total_item_investigations
+        t.integer :total_item_requests
 
-      t.timestamps
+        t.timestamps
+      end
     end
   end
 end

--- a/db/migrate/20231215215707_add_indices_to_hyrax_counter_metrics.hyrax.rb
+++ b/db/migrate/20231215215707_add_indices_to_hyrax_counter_metrics.hyrax.rb
@@ -1,8 +1,8 @@
 class AddIndicesToHyraxCounterMetrics < ActiveRecord::Migration[6.1]
   def change
-    add_index :hyrax_counter_metrics, :worktype
-    add_index :hyrax_counter_metrics, :resource_type
-    add_index :hyrax_counter_metrics, :work_id
-    add_index :hyrax_counter_metrics, :date
+    add_index :hyrax_counter_metrics, :worktype unless index_exists?(:hyrax_counter_metrics, :worktype)
+    add_index :hyrax_counter_metrics, :resource_type unless index_exists?(:hyrax_counter_metrics, :resource_type)
+    add_index :hyrax_counter_metrics, :work_id unless index_exists?(:hyrax_counter_metrics, :work_id)
+    add_index :hyrax_counter_metrics, :date unless index_exists?(:hyrax_counter_metrics, :date)
   end
 end

--- a/db/migrate/20231215215708_add_fields_to_counter_metric.hyrax.rb
+++ b/db/migrate/20231215215708_add_fields_to_counter_metric.hyrax.rb
@@ -1,8 +1,8 @@
 class AddFieldsToCounterMetric < ActiveRecord::Migration[6.1]
   def change
-    add_column :hyrax_counter_metrics, :title, :string
-    add_column :hyrax_counter_metrics, :year_of_publication, :integer, index: true
-    add_column :hyrax_counter_metrics, :publisher, :string, index: true
-    add_column :hyrax_counter_metrics, :author, :string, index: true
+    add_column :hyrax_counter_metrics, :title, :string unless column_exists?(:hyrax_counter_metrics, :title)
+    add_column :hyrax_counter_metrics, :year_of_publication, :integer, index: true unless column_exists?(:hyrax_counter_metrics, :year_of_publication)
+    add_column :hyrax_counter_metrics, :publisher, :string, index: true unless column_exists?(:hyrax_counter_metrics, :publisher)
+    add_column :hyrax_counter_metrics, :author, :string, index: true unless column_exists?(:hyrax_counter_metrics, :author)
   end
 end


### PR DESCRIPTION
We noticed in deploying Pals staging that these changes were needed to run migrations successfully.
