### PR TITLE
Contribute directory_image_alt_text to Hyku

### DIFF
--- a/app/forms/hyrax/forms/admin/appearance_decorator.rb
+++ b/app/forms/hyrax/forms/admin/appearance_decorator.rb
@@ -206,6 +206,11 @@ module Hyrax
           block_for('directory_image_text')
         end
 
+        # The alt text for the directory image
+        def directory_image_alt_text
+          block_for('directory_image_alt_text')
+        end
+
         # The alt text for the default_collection image
         def default_collection_image_text
           block_for('default_collection_image_text')

--- a/db/migrate/20240528232441_add_directory_image_alt_text_to_sites.rb
+++ b/db/migrate/20240528232441_add_directory_image_alt_text_to_sites.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDirectoryImageAltTextToSites < ActiveRecord::Migration[6.1]
+  def change
+    add_column :sites, :directory_image_alt_text, :string unless column_exists?(:sites, :directory_image_alt_text)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_05_02_230546) do
+ActiveRecord::Schema.define(version: 2024_05_28_232441) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -822,6 +822,7 @@ ActiveRecord::Schema.define(version: 2024_05_02_230546) do
     t.string "show_theme"
     t.string "search_theme"
     t.string "favicon"
+    t.string "directory_image_alt_text"
   end
 
   create_table "subject_local_authority_entries", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
This comes from Palni/Palci as they and possibly other institutions use a custom splash page that shows the logos of each public tenant.  We would have to do some more thinking to contribute back the splash page but at least this sets it up for the future.
