### PR TITLE
🎁 Add Api-Key auth for WillowSword

### DIFF
--- a/config/initializers/willow_sword.rb
+++ b/config/initializers/willow_sword.rb
@@ -7,5 +7,6 @@ Rails.application.config.after_initialize do
     config.collection_models = [Hyrax.config.collection_model]
     config.file_set_models = [Hyrax.config.file_set_model]
     config.default_work_model = Hyrax.config.curation_concerns.first
+    config.authorize_request = true
   end
 end

--- a/db/migrate/20240530205142_add_api_key_to_users.rb
+++ b/db/migrate/20240530205142_add_api_key_to_users.rb
@@ -1,0 +1,6 @@
+class AddAPIKeyToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :api_key, :string
+    add_index :users, :api_key
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_05_28_232441) do
+ActiveRecord::Schema.define(version: 2024_05_30_205142) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -917,6 +917,8 @@ ActiveRecord::Schema.define(version: 2024_05_28_232441) do
     t.string "uid"
     t.string "batch_email_frequency", default: "never"
     t.datetime "last_emailed_at"
+    t.string "api_key"
+    t.index ["api_key"], name: "index_users_on_api_key"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
This commit will add the api_key column to the user model and turn on authorized requests for WillowSword.  To give a user access, do something like the following:

```rb
u = User.find_by(email: 'some_user@example.com')
u.api_key = SecureRandom.uuid
u.save!
```

To add it in the header, it should look like this:
```sh
curl --request GET \
  --url http://dev.hyku.test/sword/service_document \
  --header 'Content-Type: application/xml' \
  --header 'Api-key: some-api-key'
```

Ref:
  - https://github.com/CottageLabs/willow_sword/wiki/Enabling-Authorization-In-Willow-Sword
  - https://github.com/scientist-softserv/palni-palci/issues/1037
