### PR TITLE
:bug: [i37] - Fix syntax error on contact page

### DIFF
--- a/app/views/hyrax/contact_form/new.html.erb
+++ b/app/views/hyrax/contact_form/new.html.erb
@@ -6,7 +6,7 @@
 </div>
 
 <h1>
-    <%= t('hyrax.contact_form.header') %>
+  <%= t('hyrax.contact_form.header') %>
 </h1>
 
 <% if user_signed_in? %>
@@ -39,8 +39,8 @@
   </div>
 
   <div class="form-group row">
-    <%= negative_label_tag(@captcha, :subject, t('hyrax.contact_form.subject_label'), class: "col-sm-2 col-form-label" %>
-    <div class="col-sm-10"><%= negative_text_field_tag(@captcha, :subject, class: 'form-control', required: true %></div>
+    <%= negative_label_tag(@captcha, :subject, t('hyrax.contact_form.subject_label'), class: "col-sm-2 col-form-label") %>
+    <div class="col-sm-10"><%= negative_text_field_tag(@captcha, :subject, class: 'form-control', required: true) %></div>
   </div>
 
   <div class="form-group row">


### PR DESCRIPTION
This commit fixes the reason why the contact page would throw an error. There was a syntax error.

Issue: 
- https://github.com/scientist-softserv/palni_palci_knapsack/issues/37

## BEFORE

<img width="1350" alt="image" src="https://github.com/samvera/hyku/assets/10081604/216f0cd6-1c9e-4d52-802b-e7ed9cc17f7a">



## AFTER

<img width="1347" alt="image" src="https://github.com/samvera/hyku/assets/10081604/6e517314-cad2-4b2a-b543-76d10abf2519">
