### PR TITLE
:bug: Fix collection search & facet

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -123,7 +123,7 @@ class CatalogController < ApplicationController
 
     # solr fields that will be treated as facets by the blacklight application
     #   The ordering of the field names is the order of the display
-    config.add_facet_field 'human_readable_type_sim', label: "Type", limit: 5
+    config.add_facet_field 'generic_type_sim', label: "Type", limit: 5
     config.add_facet_field 'resource_type_sim', label: "Resource Type", limit: 5
     config.add_facet_field 'creator_sim', limit: 5
     config.add_facet_field 'contributor_sim', label: "Contributor", limit: 5

--- a/app/views/hyrax/homepage/_featured_collection_section.html.erb
+++ b/app/views/hyrax/homepage/_featured_collection_section.html.erb
@@ -25,7 +25,7 @@
 <ul class="list-inline collection-highlights-list">
   <li>
     <%= link_to t('hyrax.homepage.admin_sets.link'),
-                main_app.search_catalog_path(f: { human_readable_type_sim: ["Collection"]}),
+                main_app.search_catalog_path(f: { generic_type_sim: ["Collection"]}),
                 class: 'btn btn-secondary' %>
   </li>
 </ul>


### PR DESCRIPTION
`human_readable_type` has been replaced by `generic_type`.

Refs https://github.com/scientist-softserv/hykuup_knapsack/issues/226

This fixes
1) the `All Collections` button now finds collections
2) the catalog search now includes collections in the Type section

<details>
<summary>Screenshots</summary>

![Screenshot 2024-06-07 at 2 34 53 PM](https://github.com/samvera/hyku/assets/17851674/77b780dc-2cfe-4fd9-bc56-ad4e622008d0)

![Screenshot 2024-06-07 at 2 35 36 PM](https://github.com/samvera/hyku/assets/17851674/1ca87611-5a32-4da1-94ad-401203930d8f)

</details>