### PR TITLE
Fix gallery and masonry catalog search results

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ gem 'hyrax-doi', github: 'samvera-labs/hyrax-doi', branch: 'rails_hyrax_upgrade'
 gem 'hyrax-iiif_av', github: 'samvera-labs/hyrax-iiif_av', branch: 'rails_hyrax_upgrade'
 gem 'i18n-debug', require: false, group: %i[development test]
 gem 'i18n-tasks', group: %i[development test]
-gem 'iiif_print', '~> 2.0'
+gem 'iiif_print', github: 'scientist-softserv/iiif_print', branch: 'main'
 gem 'jbuilder', '~> 2.5'
 gem 'jquery-rails' # Use jquery as the JavaScript library
 gem 'openssl', '>= 3.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,6 +219,18 @@ GIT
       rack (>= 1.3.6)
 
 GIT
+  remote: https://github.com/scientist-softserv/iiif_print.git
+  revision: 805191e6caedf2b5b91eb4e0aad692d4aff871c1
+  branch: main
+  specs:
+    iiif_print (2.0.0)
+      blacklight_iiif_search (>= 1.0, < 3.0)
+      derivative-rodeo (~> 0.5)
+      hyrax (>= 2.5, < 6)
+      nokogiri (>= 1.13.2)
+      rdf-vocab (~> 3.0)
+
+GIT
   remote: https://github.com/scientist-softserv/willow_sword.git
   revision: 38a0906647fae2020e8b0b08e296f85c457fcb34
   branch: main
@@ -756,12 +768,6 @@ GEM
       json
     iiif_manifest (1.3.1)
       activesupport (>= 4)
-    iiif_print (2.0.0)
-      blacklight_iiif_search (>= 1.0, < 3.0)
-      derivative-rodeo (~> 0.5)
-      hyrax (>= 2.5, < 6)
-      nokogiri (>= 1.13.2)
-      rdf-vocab (~> 3.0)
     iso-639 (0.3.6)
     iso8601 (0.9.1)
     jaro_winkler (1.5.6)
@@ -1499,7 +1505,7 @@ DEPENDENCIES
   hyrax-iiif_av!
   i18n-debug
   i18n-tasks
-  iiif_print (~> 2.0)
+  iiif_print!
   jbuilder (~> 2.5)
   jquery-rails
   json-canonicalization (= 0.3.1)

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -35,17 +35,9 @@ class CatalogController < ApplicationController
   include BlacklightIiifSearch::Controller
 
   configure_blacklight do |config|
-    ##
-    # Blacklight 7.35.0 's default document_component is `nil`, see:
-    #
-    # - https://github.com/projectblacklight/blacklight/blob/ac5fa8b300c5ad5c35b1663ef0f15372ffa2be0f/lib/blacklight/configuration.rb#L213
-    # - https://github.com/projectblacklight/blacklight/blob/ac5fa8b300c5ad5c35b1663ef0f15372ffa2be0f/lib/blacklight/configuration.rb#L186
-    #
-    # Digging around in the wiki, you might find (only found because I cloned the repo):
-    #
-    # - https://github.com/projectblacklight/blacklight/wiki/Configuration---Results-View
-    config.index.document_component = Blacklight::DocumentComponent
-    config.show.document_component = Blacklight::DocumentComponent
+    config.view.gallery(document_component: Blacklight::Gallery::DocumentComponent)
+    config.view.masonry(document_component: Blacklight::Gallery::DocumentComponent)
+    config.view.slideshow(document_component: Blacklight::Gallery::SlideshowComponent)
 
     # IiifPrint index fields
     config.add_index_field 'all_text_timv'
@@ -450,6 +442,14 @@ class CatalogController < ApplicationController
   def show
     _, @document = search_service.fetch(params[:id])
     render json: @document.to_h
+  end
+
+  # The styling is off when the bookmark checkbox renders, plus there's no way for a user to get
+  # to the /bookmarks route anyway.  For now we're following Hyrax's opinion and turning it off.
+  #
+  # https://github.com/samvera/hyrax/blob/abeb5aff99d8ff6a7d32f6e8234538d7bef15fbd/.dassie/app/controllers/catalog_controller.rb#L304-L309
+  def render_bookmarks_control?
+    false
   end
 end
 # rubocop:enable Metrics/ClassLength, Metrics/BlockLength


### PR DESCRIPTION
# Story

Issue: 
- https://github.com/scientist-softserv/hykuup_knapsack/issues/229

## 🐛 Fix gallery and masonry catalog results styling

b39333f9e6973905e14d0b7b53b9ce7be1425635

Previously, when the user looks at the catalog search results page and
sets the view to either gallery or masonry, the styling is really off.
Here this commit should fix that and also hide the bookmarks checkbox.
Hyrax dassie does not show it so we will mimic that until further notice
since the user can't even get to the /bookmarks route.

Ref:
  - https://github.com/scientist-softserv/hykuup_knapsack/issues/229

## Update `iiif_print` gem

e677230d4b8a5ea8861c99a49182c8d854f4cf2e

# Expected Behavior Before Changes

![image](https://github.com/samvera/hyku/assets/19597776/ae0b4846-4742-4417-b285-d5c5c1eafbc8)
![image](https://github.com/samvera/hyku/assets/19597776/d20dbab7-2cb8-4596-b790-a8151b9ae6ab)

# Expected Behavior After Changes

![image](https://github.com/samvera/hyku/assets/19597776/bf0d17bd-9ee9-4fed-a77e-be2f4da2570d)
![image](https://github.com/samvera/hyku/assets/19597776/de2300a1-4378-4306-8fa6-e6e213220d7e)
