### PR TITLE
🐛 Break long links in catalog search

### DIFF
--- a/app/assets/stylesheets/hyrax.scss
+++ b/app/assets/stylesheets/hyrax.scss
@@ -25,3 +25,9 @@
     background: #ffff00;
   font-weight: 700;
 }
+
+// break long links in catalog search results
+.catalog-index .caption-area .document-metadata a,
+.catalog-index .search-result-wrapper p a {
+  word-break: break-all;
+}


### PR DESCRIPTION
This will make any long links break.  Prior to this commit any links that didn't have a `-` or a character that would create a natural word break would push the UI until it looked weird.

## Before:
![image](https://github.com/samvera/hyku/assets/19597776/ae903ca4-811e-457e-bf31-0903ad8cdef6)

## After:
![image](https://github.com/samvera/hyku/assets/19597776/03d68e94-5d06-4dc9-889e-64e4e984da70)

## Before:
![image](https://github.com/samvera/hyku/assets/19597776/d1e5ca08-13c8-4aad-bbab-29315ffc1a10)

## After:
![image](https://github.com/samvera/hyku/assets/19597776/c0c6a6cd-8103-47e8-92f2-aca4648f48f9)
