### PR TITLE
Branding fixes

### DIFF
--- a/app/controllers/hyrax/dashboard/collections_controller_decorator.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller_decorator.rb
@@ -5,6 +5,7 @@
 # - ensure user is allowed to change visibility
 # - add the ability to upload a collection thumbnail
 # - add altext to collection banner
+# @TODO clean up of unnecessary methods now that we are using Valkyrie transactions to set branding
 
 module Hyrax
   module Dashboard
@@ -45,7 +46,7 @@ module Hyrax
       def edit
         form
         # Gets original filename of an uploaded thumbnail. See #update
-        return unless ::SolrDocument.find(@collection.id).thumbnail_path.include?("uploaded_collection_thumbnails") && uploaded_thumbnail?
+        return unless ::SolrDocument.find(@collection.id).thumbnail_path&.include?("uploaded_collection_thumbnails") && uploaded_thumbnail?
         @thumbnail_filename = File.basename(uploaded_thumbnail_files.reject { |f| File.basename(f).include? @collection.id }.first)
       end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,15 +12,31 @@ module ApplicationHelper
     @group_navigation_presenter ||= Hyku::Admin::Group::NavigationPresenter.new(params:)
   end
 
-  def collection_thumbnail(document, _image_options = {}, _url_options = {})
-    return image_tag(document['thumbnail_path_ss']) if document['thumbnail_path_ss'].present?
-    return super if Site.instance.default_collection_image.blank?
+  # Return collection thumbnail formatted for display:
+  #  - use collection's branding thumbnail if it exists
+  #  - use site's default collection image if one exists
+  #  - fallback to Hyrax's default image
+  def collection_thumbnail(document, _image_options = {}, url_options = {})
+    view_class = url_options[:class]
+    # The correct thumbnail SHOULD be indexed on the object
+    return image_tag(document['thumbnail_path_ss'], class: view_class, alt: alttext_for(document)) if document['thumbnail_path_ss'].present?
 
-    image_tag(Site.instance.default_collection_image&.url)
+    # If nothing is indexed, we just fall back to site default
+    return image_tag(Site.instance.default_collection_image&.url, alt: alttext_for(document), class: view_class) unless Site.instance.default_collection_image.blank?
+
+    # fall back to Hyrax default if no site default
+    tag.span("", class: [Hyrax::ModelIcon.css_class_for(::Collection), view_class],
+                 alt: alttext_for(document))
   end
 
   def label_for(term:, record_class: nil)
     locale_for(type: 'labels', term:, record_class:)
+  end
+
+  def alttext_for(collection)
+    thumbnail = CollectionBrandingInfo.where(collection_id: collection.id, role: "thumbnail")&.first
+    return thumbnail.alt_text if thumbnail
+    block_for(name: 'default_collection_image_text') || "#{collection.title_or_label} #{t('hyrax.dashboard.my.sr.thumbnail')}"
   end
 
   def hint_for(term:, record_class: nil)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -22,7 +22,7 @@ module ApplicationHelper
     return image_tag(document['thumbnail_path_ss'], class: view_class, alt: alttext_for(document)) if document['thumbnail_path_ss'].present?
 
     # If nothing is indexed, we just fall back to site default
-    return image_tag(Site.instance.default_collection_image&.url, alt: alttext_for(document), class: view_class) unless Site.instance.default_collection_image.blank?
+    return image_tag(Site.instance.default_collection_image&.url, alt: alttext_for(document), class: view_class) if Site.instance.default_collection_image.present?
 
     # fall back to Hyrax default if no site default
     tag.span("", class: [Hyrax::ModelIcon.css_class_for(::Collection), view_class],

--- a/app/presenters/hyrax/collection_presenter_decorator.rb
+++ b/app/presenters/hyrax/collection_presenter_decorator.rb
@@ -81,14 +81,9 @@ module Hyrax
                        end
     end
 
+    # use either the indexed thumbnail or find the branding for the collection
     def thumbnail_file
-      @thumbnail_file ||= CollectionBrandingInfo.where(collection_id: id, role: "thumbnail")
-                                                .select(:local_path, :alt_text, :target_url).map do |thumbnail|
-        { alttext: thumbnail.alt_text,
-          file: File.split(thumbnail.local_path).last,
-          file_location: "/#{thumbnail.local_path.split('/')[-4..-1].join('/')}",
-          linkurl: thumbnail.target_url }
-      end
+      @thumbnail_file ||= collection_thumbnail(solr_document)
     end
 
     # Begin Featured Collections Methods

--- a/app/services/hyrax/thumbnail_path_service_decorator.rb
+++ b/app/services/hyrax/thumbnail_path_service_decorator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# OVERRIDE Hyrax v5.0.0rc2 - use site defaults instead of app wide defaults
+# OVERRIDE Hyrax v5.0.0rc2 - index using site defaults instead of app wide defaults
 
 module Hyrax
   module ThumbnailPathServiceDecorator
@@ -10,7 +10,11 @@ module Hyrax
       collection_thumbnail = CollectionBrandingInfo.where(collection_id: object.id.to_s, role: "thumbnail").first
       return collection_thumbnail.local_path.gsub(Rails.public_path.to_s, '') if collection_thumbnail
 
-      default_image
+      default_collection_image
+    end
+
+    def default_collection_image
+      Site.instance.default_collection_image&.url || ActionController::Base.helpers.image_path('default.png')
     end
 
     def default_image

--- a/app/views/hyrax/collections/_media_display.html.erb
+++ b/app/views/hyrax/collections/_media_display.html.erb
@@ -1,8 +1,3 @@
-<% if presenter.thumbnail_path %>
-  <%= image_tag presenter.thumbnail_path,
-                class: "representative-media",
-                alt: block_for(name: 'default_collection_image_text'),
-                role: "presentation" %>
-<% else %>
-  <%= image_tag(Site.instance.default_collection_image) %>
-<% end %>
+<%# OVERRIDE Hyrax 6.0: %>
+<%# show uploaded thumbnail or default with alttext %>
+<%= collection_thumbnail(presenter.solr_document, "", {class: "representative-media"}) %>

--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -1,4 +1,7 @@
-<%# OVERRIDE Hyrax 5.0.1 add show actions buttons to collection show page %>
+<%# OVERRIDE Hyrax 5.0.1: %>
+<%# add show actions buttons to collection show page %>
+<%# add branding text for banner image %>
+<%# remove duplicate items count originating in Hyrax view %>
 
 <% provide :page_title, construct_page_title(@presenter.title) %>
 <div class="hyc-container" itemscope itemtype="http://schema.org/CollectionPage">
@@ -36,16 +39,15 @@
       <% unless @presenter.total_viewable_items.blank? %>
           <div class="hyc-bugs">
             <div class="hyc-item-count">
-              <b><%= @presenter.total_viewable_items %></b>
               <%= pluralize(@presenter.total_viewable_items, t('.item_count')) %></div>
 
-            <% unless @presenter.creator.blank? %>
-                <div class="hyc-created-by">Created by: <%= @presenter.creator.first %></div>
-            <% end %>
+              <% unless @presenter.creator.blank? %>
+                  <div class="hyc-created-by">Created by: <%= @presenter.creator.first %></div>
+              <% end %>
 
-            <% unless @presenter.modified_date.blank? %>
-                <div class="hyc-last-updated">Last Updated: <%= @presenter.modified_date %></div>
-            <% end %>
+              <% unless @presenter.modified_date.blank? %>
+                  <div class="hyc-last-updated">Last Updated: <%= @presenter.modified_date %></div>
+              <% end %>
           </div>
       <% end %>
 

--- a/app/views/hyrax/dashboard/collections/_list_collections.html.erb
+++ b/app/views/hyrax/dashboard/collections/_list_collections.html.erb
@@ -22,19 +22,13 @@
   <td>
     <div class="thumbnail-title-wrapper">
       <div class="thumbnail-wrapper">
-        <% if (collection_presenter.thumbnail_path == nil) %>
-          <%= image_tag(Site.instance.default_collection_image) %>
-        <% else %>
-          <%# OVERRIDE begin %>
-          <%= image_tag(collection_presenter.thumbnail_path, alt: block_for(name: 'default_collection_image_text') || "#{collection_presenter.title_or_label} #{t('hyrax.dashboard.my.sr.thumbnail')}") %>
-          <%# OVERRIDE end %>
-        <% end %>
+        <%# Use appropriate collection thumbnail + alttext %>
+        <%= collection_thumbnail(collection_presenter.solr_document) %>
       </div>
       <%= link_to collection_presenter.show_path do %>
           <span class="sr-only"><%= t("hyrax.dashboard.my.sr.show_label") %> </span>
           <%= markdown(collection_presenter.title_or_label) %>
       <% end %>
-
       <%# Expand arrow %>
       <a href="#" class="small show-more" title="Click for more details">
         <i id="expand_<%= id %>" class="fa fa-chevron-right" aria-hidden="true"></i>

--- a/app/views/hyrax/my/collections/_list_collections.html.erb
+++ b/app/views/hyrax/my/collections/_list_collections.html.erb
@@ -24,13 +24,8 @@
   <td>
     <div class="thumbnail-title-wrapper">
       <div class="thumbnail-wrapper">
-        <% if (collection_presenter.thumbnail_path == nil) %>
-          <span class="<%= Hyrax::ModelIcon.css_class_for(::Collection) %> collection-icon-small"></span>
-        <% else %>
-          <%# OVERRIDE begin %>
-          <%= image_tag(collection_presenter.thumbnail_path, alt: collection_presenter.thumbnail_file.first&.[](:alttext) || block_for(name: 'default_collection_image_text') || "#{collection_presenter.title_or_label} #{t('hyrax.dashboard.my.sr.thumbnail')}") %>
-          <%# OVERRIDE end %>
-        <% end %>
+        <%# Use appropriate collection thumbnail + alttext %>
+        <%= collection_thumbnail(collection_presenter.solr_document) %>
       </div>
       <%= link_to collection_presenter.show_path, id: "src_copy_link#{id}" do %>
         <span class="sr-only"><%= t("hyrax.dashboard.my.sr.show_label") %></span>

--- a/lib/hyrax/transactions/steps/save_collection_banner_decorator.rb
+++ b/lib/hyrax/transactions/steps/save_collection_banner_decorator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# OVERRIDE Hyrax v5.0.0 to save the collection banner in 'public/uploads'
+# OVERRIDE Hyrax v5.0.0 to save the collection banner in 'public/uploads' and include alttext
 
 module Hyrax
   module Transactions
@@ -8,7 +8,26 @@ module Hyrax
       module SaveCollectionBannerDecorator
         include Hyku::CollectionBrandingBehavior
 
-        def add_new_banner(collection_id:, uploaded_file_ids:)
+        def call(collection_resource, update_banner_file_ids: nil, alttext: nil)
+          collection_id = collection_resource.id.to_s
+          process_banner_input(collection_id: collection_id, update_banner_file_ids: update_banner_file_ids, alttext: alttext)
+          Success(collection_resource)
+        end
+
+        def process_banner_input(collection_id:, update_banner_file_ids:, alttext:)
+          if !update_banner_file_ids && !alttext
+            remove_banner(collection_id: collection_id)
+          elsif update_banner_file_ids
+            remove_banner(collection_id: collection_id)
+            add_new_banner(collection_id: collection_id, uploaded_file_ids: update_banner_file_ids, alttext: alttext)
+          elsif alttext
+            CollectionBrandingInfo
+              .where(collection_id: collection_id, role: "banner")
+              .first.update_column(:alt_text, alttext)
+          end
+        end
+        
+        def add_new_banner(collection_id:, uploaded_file_ids:, alttext:)
           f = uploaded_files(uploaded_file_ids).first
           file_location = process_file_location(f)
 
@@ -16,7 +35,7 @@ module Hyrax
             collection_id:,
             filename: File.split(f.file_url).last,
             role: "banner",
-            alt_txt: "",
+            alt_txt: alttext,
             target_url: ""
           )
           banner_info.save file_location

--- a/lib/hyrax/transactions/steps/save_collection_banner_decorator.rb
+++ b/lib/hyrax/transactions/steps/save_collection_banner_decorator.rb
@@ -10,23 +10,23 @@ module Hyrax
 
         def call(collection_resource, update_banner_file_ids: nil, alttext: nil)
           collection_id = collection_resource.id.to_s
-          process_banner_input(collection_id: collection_id, update_banner_file_ids: update_banner_file_ids, alttext: alttext)
+          process_banner_input(collection_id:, update_banner_file_ids:, alttext:)
           Success(collection_resource)
         end
 
         def process_banner_input(collection_id:, update_banner_file_ids:, alttext:)
           if !update_banner_file_ids && !alttext
-            remove_banner(collection_id: collection_id)
+            remove_banner(collection_id:)
           elsif update_banner_file_ids
-            remove_banner(collection_id: collection_id)
-            add_new_banner(collection_id: collection_id, uploaded_file_ids: update_banner_file_ids, alttext: alttext)
+            remove_banner(collection_id:)
+            add_new_banner(collection_id:, uploaded_file_ids: update_banner_file_ids, alttext:)
           elsif alttext
             CollectionBrandingInfo
-              .where(collection_id: collection_id, role: "banner")
-              .first.update_column(:alt_text, alttext)
+              .where(collection_id:, role: "banner")
+              .first.update_column(:alt_text, alttext) # rubocop:disable Rails/SkipsModelValidations
           end
         end
-        
+
         def add_new_banner(collection_id:, uploaded_file_ids:, alttext:)
           f = uploaded_files(uploaded_file_ids).first
           file_location = process_file_location(f)

--- a/spec/tasks/rake_spec.rb
+++ b/spec/tasks/rake_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe "Rake tasks" do
   end
 
   describe 'tenantize:task' do
+    let(:accounts) { [Account.new(name: 'first'), Account.new(name: 'second')] }
     let(:task) { double('task') }
 
     before do
@@ -59,26 +60,22 @@ RSpec.describe "Rake tasks" do
       allow(Account).to receive(:tenants).and_return(accounts)
     end
 
-    context 'when run against all tenants' do
-      let(:accounts) { [Account.new(name: 'first'), Account.new(name: 'second')] }
+    it 'requires at least one argument' do
+      expect { run_task('tenantize:task') }.to raise_error(ArgumentError, /rake task name is required/)
+    end
 
-      it 'requires at least one argument' do
-        expect { run_task('tenantize:task') }.to raise_error(ArgumentError, /rake task name is required/)
-      end
+    it 'requires first argument to be a valid rake task' do
+      expect { run_task('tenantize:task', 'foobar') }.to raise_error(ArgumentError, /Rake task not found\: foobar/)
+    end
 
-      it 'requires first argument to be a valid rake task' do
-        expect { run_task('tenantize:task', 'foobar') }.to raise_error(ArgumentError, /Rake task not found\: foobar/)
+    it 'runs against all tenants' do
+      accounts.each do |account|
+        expect(account).to receive(:switch).once.and_call_original
       end
-
-      it 'runs against all tenants' do
-        accounts.each do |account|
-          expect(account).to receive(:switch).once.and_call_original
-        end
-        allow(Rake::Task).to receive(:[]).with('hyrax:count').and_return(task)
-        expect(task).to receive(:invoke).exactly(accounts.count).times
-        expect(task).to receive(:reenable).exactly(accounts.count).times
-        run_task('tenantize:task', 'hyrax:count')
-      end
+      allow(Rake::Task).to receive(:[]).with('hyrax:count').and_return(task)
+      expect(task).to receive(:invoke).exactly(accounts.count).times
+      expect(task).to receive(:reenable).exactly(accounts.count).times
+      run_task('tenantize:task', 'hyrax:count')
     end
 
     context 'when run against specified tenants' do

--- a/spec/tasks/rake_spec.rb
+++ b/spec/tasks/rake_spec.rb
@@ -52,7 +52,6 @@ RSpec.describe "Rake tasks" do
   end
 
   describe 'tenantize:task' do
-    let(:accounts) { [Account.new(name: 'first'), Account.new(name: 'second')] }
     let(:task) { double('task') }
 
     before do
@@ -60,22 +59,26 @@ RSpec.describe "Rake tasks" do
       allow(Account).to receive(:tenants).and_return(accounts)
     end
 
-    it 'requires at least one argument' do
-      expect { run_task('tenantize:task') }.to raise_error(ArgumentError, /rake task name is required/)
-    end
+    context 'when run against all tenants' do
+      let(:accounts) { [Account.new(name: 'first'), Account.new(name: 'second')] }
 
-    it 'requires first argument to be a valid rake task' do
-      expect { run_task('tenantize:task', 'foobar') }.to raise_error(ArgumentError, /Rake task not found\: foobar/)
-    end
-
-    it 'runs against all tenants' do
-      accounts.each do |account|
-        expect(account).to receive(:switch).once.and_call_original
+      it 'requires at least one argument' do
+        expect { run_task('tenantize:task') }.to raise_error(ArgumentError, /rake task name is required/)
       end
-      allow(Rake::Task).to receive(:[]).with('hyrax:count').and_return(task)
-      expect(task).to receive(:invoke).exactly(accounts.count).times
-      expect(task).to receive(:reenable).exactly(accounts.count).times
-      run_task('tenantize:task', 'hyrax:count')
+
+      it 'requires first argument to be a valid rake task' do
+        expect { run_task('tenantize:task', 'foobar') }.to raise_error(ArgumentError, /Rake task not found\: foobar/)
+      end
+
+      it 'runs against all tenants' do
+        accounts.each do |account|
+          expect(account).to receive(:switch).once.and_call_original
+        end
+        allow(Rake::Task).to receive(:[]).with('hyrax:count').and_return(task)
+        expect(task).to receive(:invoke).exactly(accounts.count).times
+        expect(task).to receive(:reenable).exactly(accounts.count).times
+        run_task('tenantize:task', 'hyrax:count')
+      end
     end
 
     context 'when run against specified tenants' do


### PR DESCRIPTION
# Story
Fixes https://github.com/scientist-softserv/hykuup_knapsack/issues/205

# Expected Behavior Before Changes

Alt text did not work correctly for collection thumbnails and banner.
Default collection image did not get used... default work image was used instead.

# Expected Behavior After Changes

- [ ] Setting Branding
    - [ ] Images and text can be set and will appear on collection's branding tab
    - [ ] Images and text can be removed and disappear from collection's branding tab
    - [ ] Branding shows appropriately on collection's public show page
    - [ ] Branding reverts to standard when removed from collection's branding tab
- [ ] Setting Default thumbnails
    - [ ] Default thumbnails and alt text are saved and appear on Settings/Appearance default images tab
    - [ ] Default thumbnails and text can be removed and disappear from Settings/Appearance default images tab
    - [ ] Setting a default thumbnail or text reindexes all works &/or collections
    - [ ] Removing a collection's default thumbnail does not affect works
    - [ ] Removing a work's default thumbnail does not affect collections
- [ ] Thumbnails show appropriately on all views:
    - [ ] catalog search results view
    - [ ] dashboard index views
    - [ ] collection public show
    - [ ] collection dashboard show
    - [ ] homepage featured collections

# Notes