### PR TITLE
🐛 Wrap quotes around ENV var

### DIFF
--- a/app/views/shared/_ga4.html.erb
+++ b/app/views/shared/_ga4.html.erb
@@ -7,7 +7,7 @@
   gtag('js', new Date());
 
   gtag('config', '<%= Hyrax::Analytics.config.analytics_id %>');
-  <% if ENV.fetch(GOOGLE_ANALYTICS_ID, Hyrax::Analytics.config.analytics_id) != Hyrax::Analytics.config.analytics_id %>
+  <% if ENV.fetch('GOOGLE_ANALYTICS_ID', Hyrax::Analytics.config.analytics_id) != Hyrax::Analytics.config.analytics_id %>
     gtag('config', '<%= ENV.fetch('GOOGLE_ANALYTICS_ID') %>');
   <% end %>
  window.analytics = gtag;


### PR DESCRIPTION
Not doing so treats the ENV var as a class, and thus throws an error about that class not existing.

## BEFORE
The site was unable to render

![image](https://github.com/samvera/hyku/assets/10081604/cb53cd33-83f6-4f2d-9b24-44f70b909f66)


## AFTER

![image](https://github.com/samvera/hyku/assets/10081604/8bbf474e-2f41-47c3-bea9-8ac75d899cdb)

