### PR TITLE
🐛 Fix Add Child link

### DIFF
--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -35,13 +35,14 @@
         <div class="btn-group">
           <button type="button" class="btn btn-secondary dropdown-toggle" type="button" id="dropdown-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <%= t('.attach_child') %>
-            <ul class="dropdown-menu">
-              <% presenter.valid_child_concerns.each do |concern| %>
-                <li class="dropdown-item">
-                  <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular.to_sym], parent_id: presenter.id) %>
-                </li>
-              <% end %>
-            </ul>
+          </button>
+          <ul class="dropdown-menu">
+            <% presenter.valid_child_concerns.each do |concern| %>
+              <li class="dropdown-item">
+                <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular.to_sym], parent_id: presenter.id) %>
+              </li>
+            <% end %>
+          </ul>
         </div>
       <% end %>
       <%# OVERRIDE to validate delete permission %>

--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -1,4 +1,4 @@
-<%# OVERRIDE Hyrax v5.0.0rc2 Adjust permission checks for delete and add analytics button and add ENV to control turbolinks %>
+<%# OVERRIDE Hyrax v5.0.1 Adjust permission checks for delete and add analytics button and add ENV to control turbolinks %>
 <div class="row show-actions button-row-top-two-column">
   <div class="col-sm-6">
     <% if !workflow_restriction?(presenter) %>
@@ -36,13 +36,11 @@
           <button type="button" class="btn btn-secondary dropdown-toggle" type="button" id="dropdown-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <%= t('.attach_child') %>
           </button>
-          <ul class="dropdown-menu">
+          <div class="dropdown-menu">
             <% presenter.valid_child_concerns.each do |concern| %>
-              <li class="dropdown-item">
-                <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular.to_sym], parent_id: presenter.id) %>
-              </li>
+              <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular.to_sym], parent_id: presenter.id), class: "dropdown-item" %>
             <% end %>
-          </ul>
+          </div>
         </div>
       <% end %>
       <%# OVERRIDE to validate delete permission %>


### PR DESCRIPTION
The links under the Add Child dropdown was not working because the HTML structure was not correct.  This commit will close the button tag and then open the ul tag which allows the links to be clickable.

Ref:
  - https://github.com/scientist-softserv/palni_palci_knapsack/issues/78

![pals-38](https://github.com/samvera/hyku/assets/19597776/d2a3c535-bb23-45fa-b590-b77f3908d164)
