### PR TITLE
🐛 Ensure `Hyku::Transactions` is loaded

### DIFF
--- a/lib/hyrax/transactions/container_decorator.rb
+++ b/lib/hyrax/transactions/container_decorator.rb
@@ -2,6 +2,8 @@
 
 # OVERRIDE Hyrax v5.0.0 to add custom relations to the change_set
 
+require_dependency 'hyku/transactions/steps/add_custom_relations'
+
 module Hyrax
   module Transactions
     module ContainerDecorator


### PR DESCRIPTION
In Bulkrax we are noticing that sometimes `Hyku::Transactions` isn't loaded.  This commit will ensure it's loaded.
