### PR TITLE
Fix duplicate thumbnails for PDFs

### DIFF
--- a/app/services/hyrax/file_set_derivatives_service_decorator.rb
+++ b/app/services/hyrax/file_set_derivatives_service_decorator.rb
@@ -27,10 +27,10 @@ module Hyrax
 
     def create_pdf_derivatives(filename)
       Hydra::Derivatives::PdfDerivatives.create(filename, outputs: [{ label: :thumbnail,
-                                                                        format: 'jpg',
-                                                                        size: '676x986',
-                                                                        url: derivative_url('thumbnail'),
-                                                                        layer: 0 }])
+                                                                      format: 'jpg',
+                                                                      size: '676x986',
+                                                                      url: derivative_url('thumbnail'),
+                                                                      layer: 0 }])
 
       # @todo: Fix extract_full_text & wrap above in if missing_thumbnail? check
       #        commented out because it is failing resulting in RuntimeError (blank file detected)

--- a/app/services/hyrax/file_set_derivatives_service_decorator.rb
+++ b/app/services/hyrax/file_set_derivatives_service_decorator.rb
@@ -1,27 +1,51 @@
 # frozen_string_literal: true
 
-# OVERRIDE Hyrax v5.0.0rc2 to increase the size of thumbnails
-
+# OVERRIDE Hyrax v5.0.0rc2
+# - to increase the size of thumbnails
+# - add method missing_thumbnail? for methods which do both thumbnail AND another derivative
+#   (We were getting duplicate Hyrax::Metadata for thumbnails due to failing and rerunning derivative jobs.)
+# - comment out failing method extract_full_text for PDF derivatives
 module Hyrax
   module FileSetDerivativesServiceDecorator
     # @see https://github.com/samvera/hydra-derivatives/blob/main/lib/hydra/derivatives/processors/video/config.rb#L59
     DEFAULT_VIDEO_SIZE = '320x240'
 
+    ## Override initialize to add method missing_thumbnail?
+    #  We were getting duplicate Hyrax::Metadata for thumbnails due to failing and rerunning derivative jobs.
+    def initialize(file_set)
+      super
+      @fs = if @file_set.is_a?(Hyrax::FileMetadata)
+              Hyrax.query_service.find_by(id: @file_set.file_set_id)
+            else
+              @file_set
+            end
+    end
+
+    def missing_thumbnail?
+      @fs.thumbnail.nil?
+    end
+
     def create_pdf_derivatives(filename)
       Hydra::Derivatives::PdfDerivatives.create(filename, outputs: [{ label: :thumbnail,
-                                                                      format: 'jpg',
-                                                                      size: '676x986',
-                                                                      url: derivative_url('thumbnail'),
-                                                                      layer: 0 }])
-      extract_full_text(filename, uri)
+                                                                        format: 'jpg',
+                                                                        size: '676x986',
+                                                                        url: derivative_url('thumbnail'),
+                                                                        layer: 0 }])
+
+      # @todo: Fix extract_full_text & wrap above in if missing_thumbnail? check
+      #        commented out because it is failing resulting in RuntimeError (blank file detected)
+      #        in ValkyriePersistDerivatives
+      # extract_full_text(filename, uri)
     end
 
     def create_office_document_derivatives(filename)
-      Hydra::Derivatives::DocumentDerivatives.create(filename, outputs: [{ label: :thumbnail,
-                                                                           format: 'jpg',
-                                                                           size: '600x450>',
-                                                                           url: derivative_url('thumbnail'),
-                                                                           layer: 0 }])
+      if missing_thumbnail?
+        Hydra::Derivatives::DocumentDerivatives.create(filename, outputs: [{ label: :thumbnail,
+                                                                             format: 'jpg',
+                                                                             size: '600x450>',
+                                                                             url: derivative_url('thumbnail'),
+                                                                             layer: 0 }])
+      end
       extract_full_text(filename, uri)
     end
 


### PR DESCRIPTION
When text extraction fails on a PDF, the derivative job resubmits. This was resulting in 5 Hyrax::FileMetadata objects on a file set, all for the same thumbnail file, because jobs automatically resubmit 5 times.

In this PR, I commented out the failing extract_full_text method, but also qualified the thumbnail creation on whether the thumbnail is already there.

<details>
<summary>Screenshots</summary>

## BEFORE
![Screenshot 2024-06-21 at 5 39 48 PM](https://github.com/samvera/hyku/assets/17851674/ffdb42b0-090b-4202-960e-2e8ffc6ee020)

## AFTER
![Screenshot 2024-06-21 at 5 38 59 PM](https://github.com/samvera/hyku/assets/17851674/bef54cb6-6cd3-475e-9bb3-8cdc3e2b7ac4)


</details>

