### PR TITLE
Propagate locale between group form tabs

### DIFF
--- a/app/presenters/hyku/admin/group/navigation_presenter.rb
+++ b/app/presenters/hyku/admin/group/navigation_presenter.rb
@@ -29,7 +29,7 @@ module Hyku
             name: I18n.t('hyku.admin.groups.nav.attributes'),
             controller: 'admin/groups',
             action: 'edit',
-            path: Rails.application.routes.url_helpers.edit_admin_group_path(group_id),
+            path: Rails.application.routes.url_helpers.edit_admin_group_path(group_id, locale: I18n.locale),
             context: params
           )
         end
@@ -39,7 +39,7 @@ module Hyku
             name: I18n.t('hyku.admin.groups.nav.members'),
             controller: 'admin/group_users',
             action: 'index',
-            path: Rails.application.routes.url_helpers.admin_group_users_path(group_id),
+            path: Rails.application.routes.url_helpers.admin_group_users_path(group_id, locale: I18n.locale),
             context: params
           )
         end
@@ -49,7 +49,7 @@ module Hyku
             name: I18n.t('hyku.admin.groups.nav.roles'),
             controller: 'admin/group_roles',
             action: 'index',
-            path: Rails.application.routes.url_helpers.admin_group_roles_path(group_id),
+            path: Rails.application.routes.url_helpers.admin_group_roles_path(group_id, locale: I18n.locale),
             context: params
           )
         end
@@ -59,7 +59,7 @@ module Hyku
             name: I18n.t('hyku.admin.groups.nav.delete'),
             controller: 'admin/groups',
             action: 'remove',
-            path: Rails.application.routes.url_helpers.remove_admin_group_path(group_id),
+            path: Rails.application.routes.url_helpers.remove_admin_group_path(group_id, locale: I18n.locale),
             context: params
           )
         end


### PR DESCRIPTION
Ref:
- https://github.com/scientist-softserv/palni-palci/issues/1040
- https://github.com/scientist-softserv/palni-palci/pull/1041 

This is a UX improvement. However, it also fixes a bug where some users were getting an error message on these pages for the locale param being an empty string (`?locale=`). Strangely, this only appeared to be affecting users using Windows, but that may not be causation.

![Edit Group Administration Hyku Commons 2024-06-27 at 5 21 28 PM](https://github.com/scientist-softserv/palni-palci/assets/32469930/8174c361-1e11-4bf1-b0b9-c2e6639a2692)

--- 

Originally implemented in PALNI/PALCI's Hyku:
- https://github.com/scientist-softserv/palni-palci/pull/1041/commits/6bb1f07ca5b7fcac760177a811decf0c87a48d29

@samvera/hyku-code-reviewers
