### PR TITLE
Styling updates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,7 +61,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: d4e646c7613febd2195f3835d3b801c6aa7b601d
+  revision: b98d6f4f57b3d60cabc1c192e12053a11f93eb8c
   branch: main
   specs:
     hyrax (5.0.1)

--- a/app/assets/stylesheets/hyku.scss
+++ b/app/assets/stylesheets/hyku.scss
@@ -520,16 +520,6 @@ body.public-facing {
   margin-top: 20px;
 }
 
-.navbar-toggler-icon {
-  background: no-repeat center center;
-  background-size: 100% 100%;
-  content: "";
-  display: inline-block;
-  height: 1.5em;
-  vertical-align: middle;
-  width: 1.5em;
-}
-
 // remove a button that appears on the facets menu in the catalog search results
 // clicking this button seemingly does nothing
 .catalog-index .facets-header > button {

--- a/app/assets/stylesheets/hyku.scss
+++ b/app/assets/stylesheets/hyku.scss
@@ -538,7 +538,8 @@ body.public-facing {
 
 // make sure constraints are on only one line, even with markdown
 span.constraint-value p, .facet-values p {
-  display: inline-block;
+  display: flex;
+  justify-content: space-between;
   margin-bottom: 0;
 }
 

--- a/app/assets/stylesheets/hyrax.scss
+++ b/app/assets/stylesheets/hyrax.scss
@@ -25,9 +25,3 @@
     background: #ffff00;
   font-weight: 700;
 }
-
-// break long links in catalog search results
-.catalog-index .caption-area .document-metadata a,
-.catalog-index .search-result-wrapper p a {
-  word-break: break-all;
-}


### PR DESCRIPTION
## Fix facet count styling

15e8b91d3927446682a978220513ee1196a68804

This commit will align the facet count to the end of the flex row.

### Before

<img width="331" alt="image" src="https://github.com/samvera/hyku/assets/19597776/057720e0-6a80-42ce-ac61-d0a483df7749">

### After

<img width="422" alt="image" src="https://github.com/samvera/hyku/assets/19597776/8dbd3728-f306-4229-969b-4e11f76731ba">

## Update Hyrax and remove some overrides

d941cfc988880ae903b058cb9816bd5fd7be87b4

This commit will update Hyrax to include some fixes to the UI that we
overrode in Hyku.  Now that the changes have been merged to Hyrax we can
go ahead and remove the overrides after updating to the latest revision.

