### PR TITLE
✅ Fix QuickClassificationQuery leaky spec

### DIFF
--- a/spec/services/hyrax/quick_classification_query_spec.rb
+++ b/spec/services/hyrax/quick_classification_query_spec.rb
@@ -2,6 +2,8 @@
 
 # OVERRIDE Hyrax v2.9.0
 RSpec.describe Hyrax::QuickClassificationQuery, clean_repo: true do
+  # Ensure Hyrax::ModelRegistry.work_classes is loaded so this spec doesn't leak into other specs
+  let!(:work_classes) { Hyrax::ModelRegistry.work_classes }
   # OVERRIDE: add :work_depositor role -- proper testing requires create permission
   let(:user) { create(:user, roles: [:work_depositor]) }
 


### PR DESCRIPTION
The Hyrax::QuickClassificationQuery spec was leaking into other specs because the user ability was being loaded with just the GenericWork. Loading Hyrax::ModelRegistry.work_classes seems to ensure things are loaded correctly.
