### PR TITLE
Update base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN apk --no-cache upgrade && \
     exiftool \
     ffmpeg \
     git \
-    imagemagick \
     less \
     libreoffice \
     libreoffice-lang-uk \
@@ -29,6 +28,17 @@ RUN apk --no-cache upgrade && \
     tesseract-ocr \
     vim \
     yarn \
+    build-base \
+    imagemagick \
+    imagemagick-dev \
+    imagemagick-libs \
+    imagemagick-heic \
+    imagemagick-jpeg \
+    imagemagick-jxl \
+    imagemagick-pdf \
+    imagemagick-svg \
+    imagemagick-tiff \
+    imagemagick-webp \
   && echo "******** Packages Installed *********"
 
 # Build and install ImageMagick


### PR DESCRIPTION
# Summary

This change is necessary because Hyrax main now uses [Ruby 3.2](https://github.com/samvera/hyrax/blob/main/Dockerfile#L2-L4).

Otherwise, building the latest Hyku fails with this error: 

```ruby
29.78 Because every version of hyrax depends on Ruby >= 3.2
29.78   and Gemfile depends on hyrax >= 0,
29.78   Ruby >= 3.2 is required.
29.78 So, because current Ruby version is = 2.7.7,
29.78   version solving has failed.
```

```ruby
docker run -it --rm ghcr.io/samvera/hyku/base:latest bash => ruby 2.7.7p221 (2022-11-24 revision 168ec2b1e5) [aarch64-linux-musl]
```

# Expected Behavior

A dev is able to successfully build and spin up Hyku, with Ruby version 3.2+

![image](https://github.com/user-attachments/assets/95134738-2ecb-454c-b6c1-9b09030cba81)


<img width="1347" alt="image" src="https://github.com/user-attachments/assets/8058d552-ca7e-46c8-83a1-bb45c1c4f1c7">


# Notes

TODO: 

Build a new base image after merger