### PR TITLE
⚙️ Turn off autocomplete in Rails console

### DIFF
--- a/.irbrc
+++ b/.irbrc
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+IRB.conf[:USE_AUTOCOMPLETE] = false
+IRB.conf[:SAVE_HISTORY] = false

--- a/spec/models/featured_collection_list_spec.rb
+++ b/spec/models/featured_collection_list_spec.rb
@@ -2,13 +2,13 @@
 
 require 'rails_helper'
 
-RSpec.describe FeaturedCollectionList, type: :model do
+RSpec.describe FeaturedCollectionList, :clean_repo, type: :model do
   subject { described_class.new }
 
   let(:user) { create(:user).tap { |u| u.add_role(:admin, Site.instance) } }
   let(:account) { create(:account) }
-  let(:collection1) { create(:collection, user:) }
-  let(:collection2) { create(:collection, user:) }
+  let(:collection1) { create(:collection, user:, title: ["Collection Title 1"]) }
+  let(:collection2) { create(:collection, user:, title: ["Collection Title 2"]) }
 
   describe 'featured_collections' do
     before do


### PR DESCRIPTION
This commit will turn off the arguably annoying autocomplete when in Rails console.  Also, not keeping a save history.

Before:

https://github.com/user-attachments/assets/3052a178-5c10-40d5-be4b-6ffc66b5b24b

After:

https://github.com/user-attachments/assets/116aa8c5-e75a-402a-9378-261f4523bf5e

