### PR TITLE
More theme updates

### DIFF
--- a/app/assets/stylesheets/themes/cultural_repository.scss
+++ b/app/assets/stylesheets/themes/cultural_repository.scss
@@ -1,5 +1,10 @@
 .cultural_repository {
   ////// Navbar //////
+  .navbar-header {
+    display: flex;
+    margin-left: -10px;
+  }
+
   .navbar-expand-lg .navbar-collapse {
     @media (min-width: 992px) {
       display: flex !important;

--- a/app/assets/stylesheets/themes/institutional_repository.scss
+++ b/app/assets/stylesheets/themes/institutional_repository.scss
@@ -22,10 +22,19 @@
     padding-bottom: 40px;
   }
 
+  .image-masthead {
+    margin-bottom: 2.25em;
+  }
+
   // removes the blur on the banner image
   .image-masthead .background-container {
     -webkit-filter: none;
     filter: none;
+    top: 1em;
+  }
+
+  .marketing-text-share-button-container {
+    padding-top: 4em;
   }
 
   ////// Navbar //////

--- a/app/assets/stylesheets/themes/neutral_repository.scss
+++ b/app/assets/stylesheets/themes/neutral_repository.scss
@@ -9,6 +9,10 @@
     justify-content: center;
   }
 
+  .site-title-container {
+    padding: 1.5em 0;
+  }
+
   ////// Basic Apperance Styles //////
 
   .mb-40 {

--- a/app/views/themes/cultural_repository/_logo.html.erb
+++ b/app/views/themes/cultural_repository/_logo.html.erb
@@ -1,6 +1,5 @@
 <% if logo_image %>
   <a id="logo" href="<%= hyrax.root_path %>" data-no-turbolink="true">
-    <span class="fa fa-globe" role="img" aria-label="<%= application_name %>" aria-hidden="true"></span>
     <div class="vertical-center-image">
       <%= image_tag logo_image, alt: block_for(name: 'logo_image_text') %>
     </div>

--- a/app/views/themes/institutional_repository/_logo.html.erb
+++ b/app/views/themes/institutional_repository/_logo.html.erb
@@ -1,7 +1,6 @@
 <% # OVERRIDE: Hyrax v5.0.0rc2 - added globe back to logo %>
 <% if logo_image %>
   <a id="logo" class="col-sm-5" href="<%= hyrax.root_path %>" data-no-turbolink="true">
-    <span class="fa fa-globe" role="img" aria-label="<%= application_name %>" aria-hidden="true"></span>
     <%= image_tag logo_image, alt: block_for(name: 'logo_image_text') %>
   </a>
 <% else %>

--- a/app/views/themes/institutional_repository/layouts/homepage.html.erb
+++ b/app/views/themes/institutional_repository/layouts/homepage.html.erb
@@ -5,38 +5,40 @@
     <div class="background-container" title="<%= block_for(name: 'banner_image_text') %>" style="background-image: url('<%= "#{banner_image}?#{Time.now.to_i}" %>')"></div>
 
     <div class="container site-title-container">
-      <div class="site-title h1" style="text-align: center;">
-        <%= render "hyrax/homepage/marketing" if controller_name == 'homepage' || controller_name == 'hyrax_contact_form' || controller_name == 'pages' %>
-      </div>
-      <div class="share-your-work-button">
-        <% if @presenter&.display_share_button? %>
-          <div class="institutional-repository home_share_work row">
-            <div class="col-12 text-center">
-              <% if signed_in? %>
-                <% if @presenter.create_many_work_types? %>
-                  <%= link_to '#',
-                    class: "btn btn-primary btn-lg",
-                    data: { behavior: 'select-work', target: '#worktypes-to-create', 'create-type' => 'single' } do %>
-                    <i class="fa fa-upload" aria-hidden="true"></i> <%= t('hyrax.share_button') %>
+      <div class="marketing-text-share-button-container">
+        <div class="site-title h1" style="text-align: center;">
+          <%= render "hyrax/homepage/marketing" if controller_name == 'homepage' || controller_name == 'hyrax_contact_form' || controller_name == 'pages' %>
+        </div>
+        <div class="share-your-work-button">
+          <% if @presenter&.display_share_button? %>
+            <div class="institutional-repository home_share_work row">
+              <div class="col-12 text-center">
+                <% if signed_in? %>
+                  <% if @presenter.create_many_work_types? %>
+                    <%= link_to '#',
+                      class: "btn btn-primary btn-lg",
+                      data: { behavior: 'select-work', target: '#worktypes-to-create', 'create-type' => 'single' } do %>
+                      <i class="fa fa-upload" aria-hidden="true"></i> <%= t('hyrax.share_button') %>
+                    <% end %>
+                  <% else # simple link to the first work type %>
+                    <%= link_to new_polymorphic_path([main_app, @presenter.first_work_type]),
+                          class: 'btn btn-primary' do %>
+                      <i class="fa fa-upload" aria-hidden="true"></i> <%= t('hyrax.share_button') %>
+                    <% end %>
                   <% end %>
-                <% else # simple link to the first work type %>
-                  <%= link_to new_polymorphic_path([main_app, @presenter.first_work_type]),
-                        class: 'btn btn-primary' do %>
+                <% else %>
+                  <%= link_to hyrax.my_works_path,
+                    class: "btn btn-primary btn-lg" do %>
                     <i class="fa fa-upload" aria-hidden="true"></i> <%= t('hyrax.share_button') %>
                   <% end %>
                 <% end %>
-              <% else %>
-                <%= link_to hyrax.my_works_path,
-                  class: "btn btn-primary btn-lg" do %>
-                  <i class="fa fa-upload" aria-hidden="true"></i> <%= t('hyrax.share_button') %>
-                <% end %>
-              <% end %>
-              <p><%= link_to t(:'hyrax.pages.tabs.terms_page'), hyrax.terms_path %></p>
+                <p><%= link_to t(:'hyrax.pages.tabs.terms_page'), hyrax.terms_path %></p>
+              </div>
             </div>
-          </div>
-        <% end %>
+          <% end %>
 
-        <%= render '/shared/select_work_type_modal', create_work_presenter: @presenter&.create_work_presenter if @presenter&.draw_select_work_modal? %>
+          <%= render '/shared/select_work_type_modal', create_work_presenter: @presenter&.create_work_presenter if @presenter&.draw_select_work_modal? %>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
# Story

## 💄 Give IR theme banner text more room

2e5f98f03fd9266d98fd2889b0dd18de86212dd2

This update will give a little more padding on the top of the text
inside of the banner.

### Before
<img width="1725" alt="image" src="https://github.com/user-attachments/assets/f3a2abd5-6e3a-4ade-926f-0cbeaced388f">

### After
<img width="1726" alt="image" src="https://github.com/user-attachments/assets/7721bd5f-6bec-4a12-a6f8-82020249731d">

## 🧹 Remove globe from logo partial

2cb1b4a274d7a7884ddcbe018c8dc0b1ca6fca85

To align Hyku themes with Hyrax, we remove the globe since they did that
some time ago.

Ref:
  - https://github.com/samvera/hyrax/commit/0d9e361946131ff86dc2bd3682bdbe043bcc587e

### Before
<img width="650" alt="image" src="https://github.com/user-attachments/assets/ecdde467-a86b-41fb-81d7-d13e74336f63">

### After
<img width="464" alt="image" src="https://github.com/user-attachments/assets/9e9235e8-88fb-4d9f-9e7f-922f930d526e">

## 💄 Align cultural_repository logo

528d4b98cebf8105db7c619166563f52962af3f0

This commit will align the logo on the cultural_repository theme better.

### Before
<img width="650" alt="image" src="https://github.com/user-attachments/assets/cbe28a4c-d14d-4243-b02b-4acaa98257ed">

### After
<img width="666" alt="image" src="https://github.com/user-attachments/assets/82383118-6c66-4660-909f-22ea0af67709">

## 💄 Give neutral_repository theme more padding

8dc6eda6c941bc39961fe52b3c41c1cc468f0ef8

This update will give the neutral_repository theme's banner text more
padding and thus increasing the height of the banner area as well to
mimic how it looked previously.

Ref:
  - https://github.com/scientist-softserv/palni_palci_knapsack/issues/56

### Before
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/0b5d82f0-0d03-47be-b81c-308bee678760">


### After
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/e31d7a0f-368e-46bb-a574-5108ce53a5ef">
