### PR TITLE
✅ renames namespace due to naming conflicts

### DIFF
--- a/app/presenters/hyku/collection_presenter_decorator.rb
+++ b/app/presenters/hyku/collection_presenter_decorator.rb
@@ -5,7 +5,7 @@
 #   full banner_file data, rather than only download path to file.
 # - Alter permissions-related behavior.
 # Terms is the list of fields displayed by app/views/collections/_show_descriptions.html.erb
-module Hyrax
+module Hyku
   module CollectionPresenterDecorator
     extend ActiveSupport::Concern
 
@@ -131,4 +131,4 @@ module Hyrax
   end
 end
 
-Hyrax::CollectionPresenter.prepend(Hyrax::CollectionPresenterDecorator)
+Hyrax::CollectionPresenter.prepend(Hyku::CollectionPresenterDecorator)

--- a/spec/presenters/hyrax/collection_presenter_decorator_spec.rb
+++ b/spec/presenters/hyrax/collection_presenter_decorator_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Hyrax::CollectionPresenter, type: :decorator do
         def collection_type_badge
           "<span>"
         end
-        prepend Hyrax::CollectionPresenterDecorator
+        prepend Hyku::CollectionPresenterDecorator
       end
     end
     let(:presenter) { base_class.new }


### PR DESCRIPTION
Adventist override was not taking precedence because Hyku had an override with the same name. This PR changes the name space to specify Hyku, so that when Adventist wants to override Hyrax it truly overrides Hyrax. 