### PR TITLE
Themes logic refactor

### DIFF
--- a/app/controllers/concerns/hyku/home_page_themes_behavior.rb
+++ b/app/controllers/concerns/hyku/home_page_themes_behavior.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Hyku
+  module HomePageThemesBehavior
+    extend ActiveSupport::Concern
+
+    included do
+      around_action :inject_theme_views
+    end
+
+    # Needed for decorators
+    prepended do
+      around_action :inject_theme_views
+    end
+
+    # Add this method to prepend the theme views into the view_paths
+    def inject_theme_views
+      if home_page_theme && home_page_theme != 'default_home'
+        original_paths = view_paths
+        Hyku::Application.theme_view_path_roots.each do |root|
+          home_theme_view_path = File.join(root, 'app', 'views', "themes", home_page_theme.to_s)
+          prepend_view_path(home_theme_view_path)
+        end
+        yield
+        # rubocop:disable Lint/UselessAssignment, Layout/SpaceAroundOperators, Style/RedundantParentheses
+        # Do NOT change this line. This is calling the Rails view_paths=(paths) method and not a variable assignment.
+        view_paths=(original_paths)
+        # rubocop:enable Lint/UselessAssignment, Layout/SpaceAroundOperators, Style/RedundantParentheses
+      else
+        yield
+      end
+    end
+  end
+end

--- a/app/controllers/hyrax/contact_form_controller_decorator.rb
+++ b/app/controllers/hyrax/contact_form_controller_decorator.rb
@@ -14,10 +14,9 @@ module Hyrax
     # Adds Hydra behaviors into the application controller
     include Blacklight::SearchContext
     include Blacklight::AccessControls::Catalog
+    include Hyku::HomePageThemesBehavior
 
     prepended do
-      # OVERRIDE: Adding inject theme views method for theming
-      around_action :inject_theme_views
       before_action :setup_negative_captcha, only: %i[new create]
 
       # OVERRIDE: Add for theming
@@ -83,24 +82,6 @@ module Hyrax
       end
     rescue Blacklight::Exceptions::ECONNREFUSED, Blacklight::Exceptions::InvalidRequest
       []
-    end
-
-    # OVERRIDE: Adding to prepend the theme views into the view_paths
-    def inject_theme_views
-      if home_page_theme && home_page_theme != 'default_home'
-        original_paths = view_paths
-        Hyku::Application.theme_view_path_roots.each do |root|
-          home_theme_view_path = File.join(root, 'app', 'views', "themes", home_page_theme.to_s)
-          prepend_view_path(home_theme_view_path)
-        end
-        yield
-        # rubocop:disable Lint/UselessAssignment, Layout/SpaceAroundOperators, Style/RedundantParentheses
-        # Do NOT change this line. This is calling the Rails view_paths=(paths) method and not a variable assignment.
-        view_paths=(original_paths)
-        # rubocop:enable Lint/UselessAssignment, Layout/SpaceAroundOperators, Style/RedundantParentheses
-      else
-        yield
-      end
     end
 
     def setup_negative_captcha

--- a/app/controllers/hyrax/homepage_controller.rb
+++ b/app/controllers/hyrax/homepage_controller.rb
@@ -30,9 +30,7 @@ module Hyrax
     # Adds Hydra behaviors into the application controller
     include Blacklight::SearchContext
     include Blacklight::AccessControls::Catalog
-
-    # OVERRIDE: account for Hyku themes
-    around_action :inject_theme_views
+    include Hyku::HomePageThemesBehavior
 
     # The search builder for finding recent documents
     # Override of Blacklight::RequestBuilders and default CatalogController behavior
@@ -138,22 +136,6 @@ module Hyrax
     # COPIED from Hyrax::HomepageController
     def sort_field
       "date_uploaded_dtsi desc"
-    end
-
-    # Add this method to prepend the theme views into the view_paths
-    def inject_theme_views
-      if home_page_theme && home_page_theme != 'default_home'
-        original_paths = view_paths
-        home_theme_view_path = Rails.root.join('app', 'views', "themes", home_page_theme.to_s)
-        prepend_view_path(home_theme_view_path)
-        yield
-        # rubocop:disable Lint/UselessAssignment, Layout/SpaceAroundOperators, Style/RedundantParentheses
-        # Do NOT change this line. This is calling the Rails view_paths=(paths) method and not a variable assignment.
-        view_paths=(original_paths)
-        # rubocop:enable Lint/UselessAssignment, Layout/SpaceAroundOperators, Style/RedundantParentheses
-      else
-        yield
-      end
     end
 
     # add this method to vary blacklight config and user_params

--- a/app/controllers/hyrax/pages_controller_decorator.rb
+++ b/app/controllers/hyrax/pages_controller_decorator.rb
@@ -15,11 +15,9 @@ module Hyrax
     # Adds Hydra behaviors into the application controller
     include Blacklight::SearchContext
     include Blacklight::AccessControls::Catalog
+    include Hyku::HomePageThemesBehavior
 
     prepended do
-      # OVERRIDE: Adding inject theme views method for theming
-      around_action :inject_theme_views
-
       # OVERRIDE: Hyrax v5.0.0rc2 Add for theming
       class_attribute :presenter_class
       self.presenter_class = Hyrax::HomepagePresenter
@@ -62,24 +60,6 @@ module Hyrax
     # OVERRIDE: Hyrax v5.0.1 to add facet counts for resource types for IR theme
     def ir_counts
       @ir_counts = get_facet_field_response('resource_type_sim', {}, "f.resource_type_sim.facet.limit" => "-1")
-    end
-
-    # OVERRIDE: Adding to prepend the theme views into the view_paths
-    def inject_theme_views
-      if home_page_theme && home_page_theme != 'default_home'
-        original_paths = view_paths
-        Hyku::Application.theme_view_path_roots.each do |root|
-          home_theme_view_path = File.join(root, 'app', 'views', "themes", home_page_theme.to_s)
-          prepend_view_path(home_theme_view_path)
-        end
-        yield
-        # rubocop:disable Lint/UselessAssignment, Layout/SpaceAroundOperators, Style/RedundantParentheses
-        # Do NOT change this method. This is an override of the view_paths= method and not a variable assignment.
-        view_paths=(original_paths)
-        # rubocop:enable Lint/UselessAssignment, Layout/SpaceAroundOperators, Style/RedundantParentheses
-      else
-        yield
-      end
     end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -142,7 +142,7 @@ module Hyku
     # @see
     def self.theme_view_path_roots
       returning_value = [Rails.root.to_s]
-      returning_value.push HykuKnapsack::Engine.root.to_s if defined?(HykuKnapsack)
+      returning_value.unshift HykuKnapsack::Engine.root.to_s if defined?(HykuKnapsack)
       returning_value
     end
 

--- a/spec/controllers/concerns/hyku/home_page_themes_behavior_spec.rb
+++ b/spec/controllers/concerns/hyku/home_page_themes_behavior_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyku::HomePageThemesBehavior do
+  describe '#inject_theme_views' do
+    context 'Hyrax::ContactFormController' do
+      it 'responds to #inject_theme_views' do
+        expect(Hyrax::ContactFormController.new).to respond_to :inject_theme_views
+      end
+
+      it 'adds the around action' do
+        callbacks = Hyrax::ContactFormController._process_action_callbacks.select { |callback| callback.kind == :around }
+        expect(callbacks.any? { |callback| callback.filter == :inject_theme_views }).to be true
+      end
+    end
+
+    context 'Hyrax::HomepageController' do
+      it 'responds to #inject_theme_views' do
+        expect(Hyrax::HomepageController.new).to respond_to :inject_theme_views
+      end
+
+      it 'adds the around action' do
+        callbacks = Hyrax::HomepageController._process_action_callbacks.select { |callback| callback.kind == :around }
+        expect(callbacks.any? { |callback| callback.filter == :inject_theme_views }).to be true
+      end
+    end
+
+    context 'Hyrax::PagesController' do
+      it 'responds to #inject_theme_views' do
+        expect(Hyrax::PagesController.new).to respond_to :inject_theme_views
+      end
+
+      it 'adds the around action' do
+        callbacks = Hyrax::PagesController._process_action_callbacks.select { |callback| callback.kind == :around }
+        expect(callbacks.any? { |callback| callback.filter == :inject_theme_views }).to be true
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Summary

## ♻️ Add `Hyku::HomePageThemesBehavior`

2ba8794749b0dff8fb3ad04104ab66d2f07e02b6

This commit will move the #inject_theme_views method and the
around_action that calls it into a concern.

## 🐛 Use unshift instead of push

94d495664bffa79804aa4c6c75c59671829454f5

In the HykuKnapsack, we want the themes view path to be prioritized over
the Hyku application's themes view path.
