### PR TITLE
Dashboard styling

### DIFF
--- a/app/assets/stylesheets/hyku.scss
+++ b/app/assets/stylesheets/hyku.scss
@@ -673,3 +673,25 @@ tr[data-feature="use-iiif-print"] {
 .carousel-control-next-icon {
   background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='' width='8' height='8' viewBox='0 0 8 8'%3e%3cpath d='M2.75 0L1.25 1.5 3.75 4 1.25 6.5 2.75 8l4-4-4-4z'/%3e%3c/svg%3e");
 }
+
+// OVERRIDE Hyrax v5.0.1 to fix sidebar position
+.sidebar {
+  padding-bottom: calc(2rem + 3rem);
+  position: fixed;
+  height: 100%;
+  overflow-x: hidden;
+
+  &.maximized {
+    .sidebar-toggle {
+      transition: 0.1s;
+      position: fixed;
+      left: 252px;
+    }
+  }
+
+  .sidebar-toggle {
+    position: fixed;
+    left: 32px;
+    transition: 0.1s;
+  }
+}

--- a/app/assets/stylesheets/hyku.scss
+++ b/app/assets/stylesheets/hyku.scss
@@ -3,7 +3,7 @@
     margin-left: 10px;
 
     img {
-      max-height: 50px;
+      max-height: 40px;
     }
   }
 

--- a/app/views/hyrax/dashboard/sidebar/_configuration.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_configuration.html.erb
@@ -1,4 +1,4 @@
-<%# OVERRIDE Hyrax v5.0.0rc2 add account settings and title attributes %>
+<%# OVERRIDE Hyrax v5.0.1 add account settings and title attributes %>
 
 <% if menu.show_configuration? %>
   <li class="h5 nav-item"><%= t('hyrax.admin.sidebar.configuration') %></li>
@@ -30,7 +30,7 @@
           <% end %>
         <% end %>
         <% if can?(:manage, Hyrax::Feature) %>
-	  <%= menu.nav_link(hyrax.edit_pages_path, class: "nav-link", title: t('hyrax.admin.sidebar.pages')) do %>
+          <%= menu.nav_link(hyrax.edit_pages_path, class: "nav-link", title: t('hyrax.admin.sidebar.pages')) do %>
             <span class="fa fa-file-text-o" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.pages') %></span>
           <% end %>
           <%= menu.nav_link(hyrax.edit_content_blocks_path, class: "nav-link", title: t('hyrax.admin.sidebar.content_blocks')) do %>
@@ -43,20 +43,21 @@
             <span class="fa  fa-address-book"></span> <span class="sidebar-action-text"><%= t('hyku.admin.work_types') %></span>
           <% end %>
         <% end %>
-
-	<% if Flipflop.show_workflow_roles_menu_item_in_admin_dashboard_sidebar? && can?(:manage, Sipity::WorkflowResponsibility) %>
-	  <%= menu.nav_link(hyrax.admin_workflow_roles_path, class: "nav-link", title: t('hyrax.admin.sidebar.workflow_roles')) do %>
-	    <span class="fa fa-users" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.workflow_roles') %></span>
-	  <% end %>
-	<% end %>
-
-	<% if can?(:update, RolesService) %>
-	  <%= menu.nav_link(main_app.admin_roles_service_jobs_path, class: "nav-link", title: t('hyrax.admin.sidebar.roles_service_jobs')) do %>
-	    <span class="fa fa-users" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.roles_service_jobs') %></span>
-          <% end %>
-	<% end %>
       <% end %>
     </li>
   <% end %>
+
+  <% if Flipflop.show_workflow_roles_menu_item_in_admin_dashboard_sidebar? && can?(:manage, Sipity::WorkflowResponsibility) %>
+    <%= menu.nav_link(hyrax.admin_workflow_roles_path, class: "nav-link", title: t('hyrax.admin.sidebar.workflow_roles')) do %>
+      <span class="fa fa-users" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.workflow_roles') %></span>
+    <% end %>
+  <% end %>
+
+	<% if can?(:update, RolesService) %>
+    <%= menu.nav_link(main_app.admin_roles_service_jobs_path, class: "nav-link", title: t('hyrax.admin.sidebar.roles_service_jobs')) do %>
+      <span class="fa fa-users" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.roles_service_jobs') %></span>
+    <% end %>
+	<% end %>
+
   <%= render 'hyrax/dashboard/sidebar/menu_partials', menu: menu, section: :configuration %>
 <% end %>


### PR DESCRIPTION
# Story

## 💄 Shrink max height to fit logo

547b01e69b791f8ac4fa6c45e700e8c25eee88e2

If a logo is chosen the height of the masthead in the dashbaord grows
big enough to cover part of the sidebar by a little bit.  This commit
will dial that back to 40px instead of 50px.

## 💄 Make dashboard sidebar fixed

dce334bf3f6b7edd0bf608330eab1daad88d559b

This commit will make the dashboard sidebar fixed so it always stays on
the screen and the user can scroll through it.

## 🐛 Move Workflow Roles and Data Repair out

8706790120f99c4d769e0a40a589da15d8da3fe9

At some point the Workflow Roles and Data Repair options were moved into
the Settings menu fold.  This moves them back out.

# Screenshots / Video

https://github.com/user-attachments/assets/f5599386-827f-488a-bcff-3c9ce6898437

