### PR TITLE
Fix Admin Set form to make edit work

### DIFF
--- a/app/forms/admin_set_resource_form.rb
+++ b/app/forms/admin_set_resource_form.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
+Hyrax::Forms::AdministrativeSetForm.include CollectionAccessFiltering
 class AdminSetResourceForm < Hyrax::Forms::AdministrativeSetForm
-  include CollectionAccessFiltering
 end


### PR DESCRIPTION
`include CollectionAccessFiltering` was happening at the wrong time, and a needed method was not found by the edit view. This presented the lazy migration from happening for the admin set in the UI, but saving the resource in the console created a slightly broken valkyrized resource.

This PR fixes the edit, and the converted admin sets appear for use when creating a work via the UI or Bulkrax.
