### PR TITLE
:bug: incorrect path prevents thumbnails from rendering

### DIFF
--- a/app/services/hyrax/thumbnail_path_service_decorator.rb
+++ b/app/services/hyrax/thumbnail_path_service_decorator.rb
@@ -8,7 +8,7 @@ module Hyrax
       return super unless object.try(:collection?)
 
       collection_thumbnail = CollectionBrandingInfo.where(collection_id: object.id.to_s, role: "thumbnail").first
-      return collection_thumbnail.local_path.gsub(Rails.public_path.to_s, '') if collection_thumbnail
+      return collection_thumbnail.local_path.gsub(Hyrax.config.branding_path.to_s, '/branding') if collection_thumbnail
 
       default_collection_image
     end


### PR DESCRIPTION
# Summary


In Adventist Knapsack we noticed that attaching a thumbnail to a collection would not render the thumbnail. This is part of the necessary fix.

Issue:
- https://github.com/scientist-softserv/adventist_knapsack/issues/763

# Screenshots / Video

## BEFORE

<img width="1169" alt="Screenshot 2024-08-20 at 3 11 07 PM" src="https://github.com/user-attachments/assets/402953fa-3a92-45f0-a639-dbcbc34c86ba">

## AFTER


<img width="1171" alt="Screenshot 2024-08-20 at 3 11 49 PM" src="https://github.com/user-attachments/assets/b49dfb7f-dd1f-48d0-8718-9e418197886e">

