### PR TITLE
Batch Email Notifications

### DIFF
--- a/app/jobs/batch_email_notification_job.rb
+++ b/app/jobs/batch_email_notification_job.rb
@@ -25,7 +25,7 @@ class BatchEmailNotificationJob < ApplicationJob
         end
       end
 
-      user.update(last_emailed_at: Time.current)
+      user.last_emailed_at = Time.current
     end
     BatchEmailNotificationJob.set(wait_until: Date.tomorrow.midnight).perform_later
   end

--- a/app/models/sushi.rb
+++ b/app/models/sushi.rb
@@ -204,7 +204,9 @@ module Sushi
         raise Sushi::Error::UsageNotReadyForRequestedDatesError.new(data: "Unable to complete the request because the end_date of #{params[:end_date]} is for a month that has incomplete data.  That month's data ends on #{latest_date.iso8601}.")
         # rubocop:enable Metrics/MethodLength
       end
+    # rubocop:disable Lint/ShadowedException
     rescue ActionController::ParameterMissing, KeyError => e
+      # rubocop:enable Lint/ShadowedException
       raise Sushi::Error::InsufficientInformationToProcessRequestError.new(data: e.message)
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,8 @@
 
 # rubocop:disable Metrics/ClassLength
 class User < ApplicationRecord
+  has_one :user_batch_email, dependent: :destroy
+
   # Includes lib/rolify from the rolify gem
   rolify
   # Connects this user object to Hydra behaviors.
@@ -188,6 +190,14 @@ class User < ApplicationRecord
       total_file_downloads:,
       total_work_views:
     }
+  end
+
+  def last_emailed_at
+    UserBatchEmail.find_or_create_by(user: self).last_emailed_at
+  end
+
+  def last_emailed_at=(value)
+    UserBatchEmail.find_or_create_by(user: self).update(last_emailed_at:  value)
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/models/user_batch_email.rb
+++ b/app/models/user_batch_email.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal:true
+
+class UserBatchEmail < ApplicationRecord
+  self.table_name = 'user_batch_emails'
+  belongs_to :user, class_name: '::User'
+end

--- a/db/migrate/20240820195641_remove_last_emailed_at_from_users.rb
+++ b/db/migrate/20240820195641_remove_last_emailed_at_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveLastEmailedAtFromUsers < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :users, :last_emailed_at, :datetime if column_exists?(:users, :last_emailed_at)
+  end
+end

--- a/db/migrate/20240820200440_create_user_batch_emails.rb
+++ b/db/migrate/20240820200440_create_user_batch_emails.rb
@@ -1,0 +1,10 @@
+class CreateUserBatchEmails < ActiveRecord::Migration[6.1]
+  def change
+    create_table :user_batch_emails do |t|
+      t.references :user, unique: true, index: true
+      t.datetime :last_emailed_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -407,12 +407,6 @@ ActiveRecord::Schema.define(version: 2024_08_20_200440) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "hyrax_flexible_schemas", force: :cascade do |t|
-    t.text "profile"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-  end
-
   create_table "hyrax_groups", id: :serial, force: :cascade do |t|
     t.string "name"
     t.text "description"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_08_06_161142) do
+ActiveRecord::Schema.define(version: 2024_08_20_200440) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -405,6 +405,12 @@ ActiveRecord::Schema.define(version: 2024_08_06_161142) do
     t.boolean "enabled", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "hyrax_flexible_schemas", force: :cascade do |t|
+    t.text "profile"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "hyrax_groups", id: :serial, force: :cascade do |t|
@@ -856,6 +862,14 @@ ActiveRecord::Schema.define(version: 2024_08_06_161142) do
     t.index ["user_id"], name: "index_uploaded_files_on_user_id"
   end
 
+  create_table "user_batch_emails", force: :cascade do |t|
+    t.bigint "user_id"
+    t.datetime "last_emailed_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_user_batch_emails_on_user_id"
+  end
+
   create_table "user_stats", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.datetime "date"
@@ -917,7 +931,6 @@ ActiveRecord::Schema.define(version: 2024_08_06_161142) do
     t.string "provider"
     t.string "uid"
     t.string "batch_email_frequency", default: "never"
-    t.datetime "last_emailed_at"
     t.string "api_key"
     t.index ["api_key"], name: "index_users_on_api_key"
     t.index ["email"], name: "index_users_on_email", unique: true

--- a/spec/jobs/batch_email_notification_job_spec.rb
+++ b/spec/jobs/batch_email_notification_job_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe BatchEmailNotificationJob do
 
     context 'when the user has a daily frequency' do
       let(:frequency) { 'daily' }
-      let(:last_emailed) { 1.days.ago }
+      let(:last_emailed) { 1.day.ago }
 
       it 'sends email to users with batch_email_frequency set' do
         expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(1)

--- a/spec/jobs/batch_email_notification_job_spec.rb
+++ b/spec/jobs/batch_email_notification_job_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe BatchEmailNotificationJob do
   let(:receipt) { FactoryBot.create(:mailboxer_receipt, receiver: user) }
   let!(:message) { receipt.notification }
   let!(:user) { FactoryBot.create(:user, batch_email_frequency: frequency) }
-  let(:user_batch_email) { double(last_emailed_at: last_emailed)}
+  let(:user_batch_email) { double(last_emailed_at: last_emailed) }
 
   before do
     allow(Apartment::Tenant).to receive(:switch).and_yield


### PR DESCRIPTION
Refs https://github.com/scientist-softserv/palni_palci_knapsack/issues/121

`last_emailed_at` was previously added to the User table. However User table is not tenant-specific, and this date needed to be unique to each tenant. This moves the `last_emailed_at` date to its own table and modifies the use to match the new location.