### PR TITLE
🐛 Use default collection img if one is set

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,12 +18,14 @@ module ApplicationHelper
   #  - fallback to Hyrax's default image
   def collection_thumbnail(document, _image_options = {}, url_options = {})
     view_class = url_options[:class]
-    # The correct thumbnail SHOULD be indexed on the object
-    return image_tag(document['thumbnail_path_ss'], class: view_class, alt: alttext_for(document)) if document['thumbnail_path_ss'].present?
-
-    # If nothing is indexed, we just fall back to site default
+    # use the site's default image if one is set
     return image_tag(Site.instance.default_collection_image&.url, alt: alttext_for(document), class: view_class) if Site.instance.default_collection_image.present?
 
+    # if a site default isn't set, use the application's default img
+    # see thumbnail_path_service.rb#default_collection_image
+    return image_tag(document['thumbnail_path_ss'], class: view_class, alt: alttext_for(document)) if document['thumbnail_path_ss'].present?
+
+    Hyrax::ModelIcon.css_class_for(::Collection)
     # fall back to Hyrax default if no site default
     tag.span("", class: [Hyrax::ModelIcon.css_class_for(::Collection), view_class],
                  alt: alttext_for(document))


### PR DESCRIPTION
# Summary

When a user sets a default image in Settings, it should override the true default image (that comes from Hyrax). Previously, the collection image did not change even after the user set one. The logic needed to be swapped.

Issue:
- https://github.com/scientist-softserv/palni_palci_knapsack/issues/76

# Expected Behavior

### When no default image is set, it'll use the application's default image. (this was tested using Pals knapsack, who've customized their default image to be the blocks instead of a blank file)

![Screenshot 2024-08-28 at 08-02-14 Show Appearance __ Hyku Commons](https://github.com/user-attachments/assets/08ef8e4f-cdd9-4e34-b4f6-23d99dc38706)

![Screenshot 2024-08-28 at 11-32-43 Collections](https://github.com/user-attachments/assets/f160e7ac-6cad-41b0-b50d-169a16dd9036)

### When a default image is set in the settings, it should override the application's default image

![image](https://github.com/user-attachments/assets/cb636821-cc90-4087-9ca3-402109d52999)


![Screenshot 2024-08-28 at 11-37-13 Collections](https://github.com/user-attachments/assets/c681f4f6-c963-4874-b048-f4ca31407352)





# Notes