### PR TITLE
:broom: [i1020] - ga4 follow up

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,7 +142,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: 69f0b81ff7bdbe5dff9620306ee542668ac86425
+  revision: e1160bbbb1b917640515f8db1f3ad3dcdc376c47
   branch: main
   specs:
     hyrax (5.0.1)

--- a/app/assets/stylesheets/hyku.scss
+++ b/app/assets/stylesheets/hyku.scss
@@ -428,7 +428,7 @@ div#collapse-citations {
 }
 
 @media (min-width: 576px) {
-  .citations-button .download-pdf-button {
+  .citations-button .file_download {
     max-width: 300px;
   }
 }
@@ -552,7 +552,7 @@ span.constraint-value p, .facet-values p {
   }
 }
 
-#download-pdf-button {
+#file_download {
   margin: 10px 0 10px 0;
 }
 

--- a/app/jobs/depositor_email_notification_job.rb
+++ b/app/jobs/depositor_email_notification_job.rb
@@ -8,7 +8,6 @@ class DepositorEmailNotificationJob < ApplicationJob
       statistics = user.statistics_for
       next if statistics.nil?
 
-      # Skip if new_work_views and new_file_downloads is 0
       next if statistics[:new_work_views].zero? && statistics[:new_file_downloads].zero?
 
       HykuMailer.depositor_email(user, statistics, current_account).deliver_now

--- a/app/jobs/depositor_email_notification_job.rb
+++ b/app/jobs/depositor_email_notification_job.rb
@@ -8,6 +8,9 @@ class DepositorEmailNotificationJob < ApplicationJob
       statistics = user.statistics_for
       next if statistics.nil?
 
+      # Skip if new_work_views or new_file_downloads is 0
+      next if statistics[:new_work_views].zero? || statistics[:new_file_downloads].zero?
+
       HykuMailer.depositor_email(user, statistics, current_account).deliver_now
     end
     DepositorEmailNotificationJob.set(wait_until: (Time.zone.now + 1.month).beginning_of_month).perform_later

--- a/app/jobs/depositor_email_notification_job.rb
+++ b/app/jobs/depositor_email_notification_job.rb
@@ -8,8 +8,8 @@ class DepositorEmailNotificationJob < ApplicationJob
       statistics = user.statistics_for
       next if statistics.nil?
 
-      # Skip if new_work_views or new_file_downloads is 0
-      next if statistics[:new_work_views].zero? || statistics[:new_file_downloads].zero?
+      # Skip if new_work_views and new_file_downloads is 0
+      next if statistics[:new_work_views].zero? && statistics[:new_file_downloads].zero?
 
       HykuMailer.depositor_email(user, statistics, current_account).deliver_now
     end

--- a/app/mailers/hyku_mailer.rb
+++ b/app/mailers/hyku_mailer.rb
@@ -11,7 +11,7 @@ class HykuMailer < ActionMailer::Base
     @messages = messages || []
     @account = account
     @url = notifications_url_for(@account)
-    @application_name = account.sites.application_name || account.cname
+    @application_name = account.sites.application_name || account.name.humanize
 
     mail(to: @user.email,
          subject: "You have #{@messages.count} new message(s) on #{@application_name}",
@@ -25,7 +25,7 @@ class HykuMailer < ActionMailer::Base
     @statistics = statistics
     @account = account
     @url = dashboard_url_for(@account)
-    @application_name = account.sites.application_name || account.cname
+    @application_name = account.sites.application_name || account.name.humanize
 
     mail(to: @user.email,
          subject: "Monthly Downloads Summary for #{@application_name}",

--- a/app/mailers/hyku_mailer.rb
+++ b/app/mailers/hyku_mailer.rb
@@ -11,7 +11,7 @@ class HykuMailer < ActionMailer::Base
     @messages = messages || []
     @account = account
     @url = notifications_url_for(@account)
-    @application_name = account.sites.application_name
+    @application_name = account.sites.application_name || account.cname
 
     mail(to: @user.email,
          subject: "You have #{@messages.count} new message(s) on #{@application_name}",
@@ -25,7 +25,7 @@ class HykuMailer < ActionMailer::Base
     @statistics = statistics
     @account = account
     @url = dashboard_url_for(@account)
-    @application_name = account.sites.application_name
+    @application_name = account.sites.application_name || account.cname
 
     mail(to: @user.email,
          subject: "Monthly Downloads Summary for #{@application_name}",

--- a/app/views/hyku_mailer/depositor_email.html.erb
+++ b/app/views/hyku_mailer/depositor_email.html.erb
@@ -1,34 +1,34 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <style>
-    body { font-family: Arial, sans-serif; line-height: 1.6; }
-    .email-container { max-width: 600px; margin: auto; padding: 20px; border: 1px solid #ccc; }
-    .footer { font-size: 12px; color: #666; margin-top: 20px; }
-    .highlight { color: #0056b3; }
-    .button {
-      display: inline-block;
-      padding: 10px 20px;
-      margin: 10px 0;
-      background-color: #0056b3;
-      color: white;
-      text-decoration: none;
-      border-radius: 5px;
-    }
-  </style>
-</head>
-<body>
-  <div class="email-container">
-    <p>Dear Author,</p>
-    <p>You had <%= pluralize(@statistics[:new_file_downloads], 'download') %> in <%= Date.today.prev_month.strftime("%B %Y") %> across your <%= pluralize(@statistics[:new_work_views], 'work') %> in <%= @application_name %>. Your current readership:</p>
-    <ul>
-      <li><%= pluralize(@statistics[:total_file_downloads], 'Total File Download') %></li>
-      <li><%= pluralize(@statistics[:total_work_views], 'Total Work View') %></li>
-    </ul>
-    <a href="<%= @url %>" class="button">VISIT MY DASHBOARD</a>
-    <div class="footer">
-      <p>These monthly reports are provided to you on behalf of <%= @application_name %>. For questions, comments, or to add more content and increase your readership and visibility as an author, please contact your repository administrator.</p>
+  <head>
+    <style>
+      body { font-family: Arial, sans-serif; line-height: 1.6; }
+      .email-container { max-width: 600px; margin: auto; padding: 20px; border: 1px solid #ccc; }
+      .footer { font-size: 12px; color: #666; margin-top: 20px; }
+      .highlight { color: #0056b3; }
+      .button {
+        display: inline-block;
+        padding: 10px 20px;
+        margin: 10px 0;
+        background-color: #0056b3;
+        color: white;
+        text-decoration: none;
+        border-radius: 5px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="email-container">
+      <p>Dear Author,</p>
+      <p>You had <%= pluralize(@statistics[:new_file_downloads], 'new download') %> in <%= Date.today.prev_month.strftime("%B %Y") %> across your <%= pluralize(@statistics[:new_work_views], 'new work') %> in <%= @application_name %>. Your current readership:</p>
+      <ul>
+        <li><%= pluralize(@statistics[:total_file_downloads], 'Total File Download') %></li>
+        <li><%= pluralize(@statistics[:total_work_views], 'Total Work View') %></li>
+      </ul>
+      <a href="<%= @url %>" class="button">VISIT MY DASHBOARD</a>
+      <div class="footer">
+        <p>These monthly reports are provided to you on behalf of <%= @application_name %>. For questions, comments, or to add more content and increase your readership and visibility as an author, please contact your repository administrator.</p>
+      </div>
     </div>
-  </div>
-</body>
+  </body>
 </html>

--- a/app/views/hyku_mailer/depositor_email.html.erb
+++ b/app/views/hyku_mailer/depositor_email.html.erb
@@ -20,7 +20,7 @@
   <body>
     <div class="email-container">
       <p>Dear Author,</p>
-      <p>You had <%= pluralize(@statistics[:new_file_downloads], 'new download') %> in <%= Date.today.prev_month.strftime("%B %Y") %> across your <%= pluralize(@statistics[:new_work_views], 'new work') %> in <%= @application_name %>. Your current readership:</p>
+      <p>You had <%= "#{@statistics[:new_file_downloads]} new files downloaded" %> in <%= Date.today.prev_month.strftime("%B %Y") %> and <%= "#{@statistics[:new_work_views]} new works viewed" %> in <%= @application_name %>. Your current readership:</p>
       <ul>
         <li><%= pluralize(@statistics[:total_file_downloads], 'Total File Download') %></li>
         <li><%= pluralize(@statistics[:total_work_views], 'Total Work View') %></li>

--- a/app/views/hyrax/base/_download_pdf.html.erb
+++ b/app/views/hyrax/base/_download_pdf.html.erb
@@ -2,10 +2,10 @@
   <div class="download-pdf-controls">
     <% if @presenter.representative_presenter.present? && presenter.file_set_presenters.any?(&:pdf?) %>
       <%= button_tag type: 'button',
-                     id: "download-pdf-button",
+                     id: "file_download",
                      data: { label: @presenter.representative_presenter.id,
                              path: hyrax.download_path(presenter.representative_presenter) },
-                     class: "btn btn-success btn-block download-pdf-button center-block",
+                     class: "btn btn-success btn-block file_download center-block",
                      onclick: "window.open(this.dataset.path, '_blank');" do %>
         Download PDF
       <% end %>

--- a/spec/jobs/depositor_email_notification_job_spec.rb
+++ b/spec/jobs/depositor_email_notification_job_spec.rb
@@ -35,6 +35,21 @@ RSpec.describe DepositorEmailNotificationJob do
       end
     end
 
+    context 'when the user has zero new counts in statistics' do
+      let(:statistics) { { new_file_downloads: 0, new_work_views: 0, total_file_downloads: 6, total_file_views: 7, total_work_views: 16 } }
+
+      before do
+        allow(User).to receive(:all).and_return([user])
+        allow(user).to receive(:statistics_for).and_return(statistics)
+      end
+
+      it 'does not send emails to users' do
+        switch!(account)
+        described_class.perform_now
+        expect(ActionMailer::Base.deliveries.count).to eq(0)
+      end
+    end
+
     context 'when the user has no new statistics' do
       let(:statistics) { nil }
 


### PR DESCRIPTION
# Summary

This contains the following work needed to support google analytics: 

- [x] update Hyrax to pull in typo changes that prevented download tracking
  - [x] https://github.com/samvera/hyrax/pull/6897
- [x] add fallback for when application name is blank
- [x] don't send email if 0 new counts 
- [x] all download buttons needs 'file_download' as id for tracking 
  - missing from: 

![Image](https://github.com/user-attachments/assets/c3589942-e029-46ae-96d4-866d0d9c1e73)

Issue: 
- https://github.com/scientist-softserv/palni-palci/issues/1020

# TODO: 

- [ ] update palni palci knapsack's submodule after this gets merged


## Notes

## change download-pdf-button => file_download

54168b7ccf1f7e849a1a1194f2a881af2ae4b4f5

ID must be changed so to be consistent with google analytics tracking.

Issue:
- https://github.com/scientist-softserv/palni-palci/issues/1020

## Add fallback for when application_name is nil

fd8bdb741643826e6f80ab84c455fdb4d24e6349

This should avoid sending emails with blank names in the title.

## Skip if new_work_views or new_file_downloads is 0

608faf9b56a21c616a09ecc6eaadbd06d7e30d54


## update hyrax

7c392159ae2be1a3c5255ca08551cf64662b9deb

pulls in ga4 typo fix
- https://github.com/samvera/hyrax/pull/6897
