### PR TITLE
Update WillowSword gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,7 +216,7 @@ GIT
 
 GIT
   remote: https://github.com/scientist-softserv/willow_sword.git
-  revision: 0c1e8afd3bce446005b65bd42067e10d1e991cd9
+  revision: 904313fcb669837b363d7095db8e6b7a818d0e21
   branch: main
   specs:
     willow_sword (0.2.0)


### PR DESCRIPTION
This update will allow the document service query to only return Valkyrie resources instead of also the ones found in ActiveFedora.

Ref:
- https://github.com/scientist-softserv/willow_sword/commit/f401d9254a2b755947f47f588ee139463dcfcf4d