### PR TITLE
Adjust themes

### DIFF
--- a/app/assets/stylesheets/hyku.scss
+++ b/app/assets/stylesheets/hyku.scss
@@ -695,3 +695,10 @@ tr[data-feature="use-iiif-print"] {
     transition: 0.1s;
   }
 }
+
+// Featured collection
+#featured_collections {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+}

--- a/app/views/hyrax/homepage/_featured_collection_section.html.erb
+++ b/app/views/hyrax/homepage/_featured_collection_section.html.erb
@@ -1,31 +1,33 @@
-<% if @featured_collection_list.empty? %>
-  <p id='no-collections'><%= t('hyrax.homepage.featured_collections.no_collections') %></p>
-<% elsif can? :update, FeaturedCollection %>
-  <%= form_for [main_app, @featured_collection_list] do |f| %>
-    <div class="dd" id="ff">
-      <ol id="featured_works">
-        <%= f.fields_for :featured_collections do |featured| %>
-          <%= render 'sortable_featured_collections', f: featured %>
+<div id="featured_collections" >
+  <% if @featured_collection_list.empty? %>
+    <p id='no-collections'><%= t('hyrax.homepage.featured_collections.no_collections') %></p>
+  <% elsif can? :update, FeaturedCollection %>
+    <%= form_for [main_app, @featured_collection_list] do |f| %>
+      <div class="dd" id="ff">
+        <ol id="featured_works">
+          <%= f.fields_for :featured_collections do |featured| %>
+            <%= render 'sortable_featured_collections', f: featured %>
+          <% end %>
+        </ol>
+      </div>
+      <%= f.submit("Save order", class: 'btn btn-primary') %>
+    <% end %>
+  <% else %>
+    <table class="table table-striped collection-highlights">
+      <tbody>
+        <%= form_for [main_app, @featured_collection_list] do |f| %>
+          <%= f.fields_for :featured_collections do |featured| %>
+            <%= render 'explore_collections', f: featured %>
+          <% end %>
         <% end %>
-      </ol>
-    </div>
-    <%= f.submit("Save order", class: 'btn btn-primary') %>
+      </tbody>
+    </table>
   <% end %>
-<% else %>
-  <table class="table table-striped collection-highlights">
-    <tbody>
-      <%= form_for [main_app, @featured_collection_list] do |f| %>
-        <%= f.fields_for :featured_collections do |featured| %>
-          <%= render 'explore_collections', f: featured %>
-        <% end %>
-      <% end %>
-    </tbody>
-  </table>
-<% end %>
-<ul class="list-inline collection-highlights-list">
-  <li>
-    <%= link_to t('hyrax.homepage.admin_sets.link'),
-                main_app.search_catalog_path(f: { generic_type_sim: ["Collection"]}),
-                class: 'btn btn-primary mt-1' %>
-  </li>
-</ul>
+</div>
+  <ul class="list-inline collection-highlights-list">
+    <li>
+      <%= link_to t('hyrax.homepage.admin_sets.link'),
+                  main_app.search_catalog_path(f: { generic_type_sim: ["Collection"]}),
+                  class: 'btn btn-primary mt-1' %>
+    </li>
+  </ul>

--- a/app/views/themes/cultural_repository/_collections_section.html.erb
+++ b/app/views/themes/cultural_repository/_collections_section.html.erb
@@ -2,6 +2,7 @@
   <div class="row">
     <div class="col-12 cultural-repository collections-container"> <!-- can toggle on/off -->
       <h4>Featured Collections</h4>
+      <h2 class="sr-only">Featured Collections</h2>
       <%= render 'featured_collection_section' %>
     </div>
   </div>

--- a/app/views/themes/institutional_repository/hyrax/homepage/_recent_document.html.erb
+++ b/app/views/themes/institutional_repository/hyrax/homepage/_recent_document.html.erb
@@ -1,10 +1,10 @@
 <%# OVERRIDE Hyrax v5.0.0rc2 template for client theming and shared search %>
 <h3 class="sr-only"><%= t('hyrax.homepage.recently_uploaded.document.title_label') %></h3>
-<%= link_to generate_work_url(recent_document, request) do %>
-  <div class="recently-uploaded col-6 col-md-6 pt-3 pb-3">
+<div class="recently-uploaded col-6 col-md-6 pt-3 pb-3">
+  <%= link_to generate_work_url(recent_document, request) do %>
     <%= render_thumbnail_tag recent_document, {class: 'img-fluid mx-auto d-block'}, {suppress_link: true} %>
     <div class="recent-doc-title">
       <h3><%= markdown(recent_document.title_or_label) %></h3>
     </div>
-  </div>
-<% end %>
+  <% end %>
+</div>

--- a/app/views/themes/institutional_repository/hyrax/homepage/_recently_uploaded.html.erb
+++ b/app/views/themes/institutional_repository/hyrax/homepage/_recently_uploaded.html.erb
@@ -5,7 +5,9 @@
       <p><%= t('.no_public') %></p>
     <% else %>
       <h3>Recent Uploads</h3>
-      <%= render partial: "themes/institutional_repository/hyrax/homepage/recent_document", collection: recent_documents %>
+      <div class="d-flex flex-wrap justify-content-between">
+        <%= render partial: "themes/institutional_repository/hyrax/homepage/recent_document", collection: recent_documents %>
+      <div>
     <% end %>
   </div>
 </div>

--- a/app/views/themes/neutral_repository/hyrax/homepage/_recent_document.html.erb
+++ b/app/views/themes/neutral_repository/hyrax/homepage/_recent_document.html.erb
@@ -1,9 +1,9 @@
 <h3 class="sr-only"><%= t('hyrax.homepage.recently_uploaded.document.title_label') %></h3>
-<%= link_to(generate_work_url(recent_document, request)) do %>
-  <div class="recently-uploaded pb-3 col-6 col-md-6">
+<div class="recently-uploaded pb-3 col-6 col-md-6">
+  <%= link_to(generate_work_url(recent_document, request)) do %>
     <%= render_thumbnail_tag recent_document, {class: 'img-fluid mx-auto d-block'}, {suppress_link: true} %>
     <div class="recent-doc-title">
       <h3><%= markdown(recent_document.title_or_label) %></h3>
     </div>
-  </div>
-<% end %>
+  <% end %>
+</div>

--- a/app/views/themes/neutral_repository/hyrax/homepage/_recently_uploaded.html.erb
+++ b/app/views/themes/neutral_repository/hyrax/homepage/_recently_uploaded.html.erb
@@ -5,7 +5,9 @@
       <p><%= t('.no_public') %></p>
     <% else %>
       <h3>Recent Uploads</h3>
-      <%= render partial: "themes/neutral_repository/hyrax/homepage/recent_document", collection: recent_documents %>
+      <div class="d-flex flex-wrap justify-content-between">
+        <%= render partial: "themes/neutral_repository/hyrax/homepage/recent_document", collection: recent_documents %>
+      </div>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
# Story
## 💄 Adjust featured collection section

74e4e0a4f63b9219179c73e28185a967ea8b4ec5

This commit will adjust the featured colleciton section so it wraps and
doesn't clip anything else.

## 💄 Adjust Recently Uploaded section

1af17b4236bf466a097a01f810daa1a036684d67

In the Institutional Repository and Neutral Repository themes, the
Recently Uploaded section was only showing one column, this commit makes
it show two.

# Screenshots / Video

<img width="1241" alt="image" src="https://github.com/user-attachments/assets/2bbe9090-5190-49e7-8d42-417e41f089b0">

<img width="682" alt="image" src="https://github.com/user-attachments/assets/58166205-0f5f-4908-a993-8ba0310a08da">
