### PR TITLE
Include bulkrax metadata in resource forms and indexers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera/bulkrax.git
-  revision: cd9b58226ef215528a716a761f1d2b47d8c24915
+  revision: b511db6968a12023d74b6e2788947bfe70d5405d
   branch: main
   specs:
     bulkrax (8.1.0)

--- a/app/forms/etd_resource_form.rb
+++ b/app/forms/etd_resource_form.rb
@@ -8,6 +8,7 @@
 class EtdResourceForm < Hyrax::Forms::ResourceForm(EtdResource)
   # Commented out basic_metadata because these terms were added to etd_resource so we can customize it.
   # include Hyrax::FormFields(:basic_metadata)
+  include Hyrax::FormFields(:bulkrax_metadata)
   include Hyrax::FormFields(:etd_resource)
   include Hyrax::FormFields(:with_pdf_viewer)
   include Hyrax::FormFields(:with_video_embed)

--- a/app/forms/oer_resource_form.rb
+++ b/app/forms/oer_resource_form.rb
@@ -8,6 +8,7 @@
 class OerResourceForm < Hyrax::Forms::ResourceForm(OerResource)
   # Commented out basic_metadata because these terms were added to etd_resource so we can customize it.
   # include Hyrax::FormFields(:basic_metadata)
+  include Hyrax::FormFields(:bulkrax_metadata)
   include Hyrax::FormFields(:oer_resource)
   include Hyrax::FormFields(:with_pdf_viewer)
   include Hyrax::FormFields(:with_video_embed)

--- a/app/indexers/etd_resource_indexer.rb
+++ b/app/indexers/etd_resource_indexer.rb
@@ -3,7 +3,8 @@
 # Generated via
 #  `rails generate hyrax:work_resource EtdResource`
 class EtdResourceIndexer < Hyrax::ValkyrieWorkIndexer
-  include Hyrax::Indexer(:basic_metadata)
+  # Commented out basic_metadata because these terms were added to etd_resource so we can customize it.
+  # include Hyrax::Indexer(:basic_metadata)
   include Hyrax::Indexer(:bulkrax_metadata)
   include Hyrax::Indexer(:etd_resource)
   include Hyrax::Indexer(:with_pdf_viewer)

--- a/app/indexers/oer_resource_indexer.rb
+++ b/app/indexers/oer_resource_indexer.rb
@@ -3,7 +3,8 @@
 # Generated via
 #  `rails generate hyrax:work_resource OerResource`
 class OerResourceIndexer < Hyrax::ValkyrieWorkIndexer
-  include Hyrax::Indexer(:basic_metadata)
+  # Commented out basic_metadata because these terms were added to etd_resource so we can customize it.
+  # include Hyrax::Indexer(:basic_metadata)
   include Hyrax::Indexer(:bulkrax_metadata)
   include Hyrax::Indexer(:oer_resource)
   include Hyrax::Indexer(:with_pdf_viewer)


### PR DESCRIPTION
# Summary

Refs https://github.com/scientist-softserv/palni-palci/issues/1010

Bulkrax imports were sometimes not showing as completed on the importer page, because the created object couldn't be found for the link. This error was tracked down to some missing inclusion of the bulkrax metadata on some of the indexers and forms, resulting in the bulkrax_identifier not being saved on the newly created works. 

This change ensures that all models, forms, and indexers have the appropriate metadata included. Additionally bulkrax is updated to bring in the most recent fixes. 

# Expected behavior before

Importers showed error `Error: NoMethodError - undefined method 'persisted?' for false:FalseClass` on certain models, and Item does not link.

<details>
<summary>Screenshot</summary>

![Screenshot 2024-09-07 at 4 44 11 PM](https://github.com/user-attachments/assets/790b89bd-0f73-4ece-a593-b5c151e7d4fe)

</details>

# Expected behavior after

Importer shows successful and links to newly created works.

<details>
<summary>Screenshot</summary>

![Screenshot 2024-09-07 at 4 45 00 PM](https://github.com/user-attachments/assets/63061dc8-27b6-4bf8-95b7-ad8e6e58c045)

</details>