### PR TITLE
🐛 Fix "Sort by: Published Date"

### DIFF
--- a/app/indexers/concerns/hyku_indexing.rb
+++ b/app/indexers/concerns/hyku_indexing.rb
@@ -24,10 +24,19 @@ module HykuIndexing
         # TODO: Reinstate once valkyrie fileset work is complete - https://github.com/scientist-softserv/hykuup_knapsack/issues/34
         solr_doc['all_text_tsimv'] = full_text(object.file_sets.first&.id) if object.kind_of?(ActiveFedora::Base)
         # rubocop:enable Style/ClassCheck
+        solr_doc['title_ssim'] = SortTitle.new(object.title.first).alphabetical
+        solr_doc['depositor_ssi'] = object.depositor
+        solr_doc['creator_ssim'] = object.creator&.first
+        if object.respond_to?(:date_created)
+          solr_doc[CatalogController.created_field] =
+            Array(object.date_created).first
+        end
         add_date(solr_doc)
       end
     end
   end
+
+  private
 
   def full_text(file_set_id)
     return if !Flipflop.default_pdf_viewer? || file_set_id.blank?
@@ -36,12 +45,23 @@ module HykuIndexing
   end
 
   def add_date(solr_doc)
-    # The allowed date formats are either YYYY, YYYY-MM, or YYYY-MM-DD
-    # the date must be formatted as a 4 digit year in order to be sorted.
-    valid_date_formats = /\A(\d{4})(?:-\d{2}(?:-\d{2})?)?\z/
     date_string = solr_doc['date_created_tesim']&.first
-    year = date_string&.match(valid_date_formats)&.captures&.first
-    solr_doc['date_tesi'] = year if year
-    solr_doc['date_ssi'] = year if year
+    return unless date_string
+
+    date_string = pad_date_with_zero(date_string) if date_string.include?('-')
+
+    # The allowed date formats are either YYYY, YYYY-MM, or YYYY-MM-DD
+    valid_date_formats = /\A(\d{4}(?:-\d{2}(?:-\d{2})?)?)\z/
+    date = date_string&.match(valid_date_formats)&.captures&.first
+
+    # If the date is not in the correct format, index the original date string
+    date ||= date_string
+
+    solr_doc['date_tesi'] = date if date
+    solr_doc['date_ssi'] = date if date
+  end
+
+  def pad_date_with_zero(date_string)
+    date_string.split('-').map { |d| d.rjust(2, '0') }.join('-')
   end
 end

--- a/app/models/sort_title.rb
+++ b/app/models/sort_title.rb
@@ -6,6 +6,8 @@ class SortTitle
   end
 
   def alphabetical
+    return if @title.blank?
+
     title = @title.downcase
     title = title.gsub(/^an(?:[[:space:]])/, '')
                  .gsub(/^a(?:[[:space:]])/, '')


### PR DESCRIPTION
Issue: 
- https://github.com/scientist-softserv/adventist_knapsack/issues/185

This commit fixes a bug in the ability to sort works by "Published date", "Upload date", and "Title" in the catalog search page and the collection show page reported in Adventist Knapsack.

Adds sorting to Solr doc in `HykuIndexing` module.  

Ascending sort:
![image](https://github.com/user-attachments/assets/794593ad-896d-45e5-b7ab-1660d6bfd5fd)
Descending sort:
![image](https://github.com/user-attachments/assets/c2180502-1a4a-4cf1-92da-1f95ede43125)

@samvera/hyku-code-reviewers
