### PR TITLE
Fix tenant maintenance job

### DIFF
--- a/app/jobs/tenant_maintenance_job.rb
+++ b/app/jobs/tenant_maintenance_job.rb
@@ -6,7 +6,7 @@ class TenantMaintenanceJob < ApplicationJob
   non_tenant_job
 
   def perform
-    Account.each(&:find_or_schedule_jobs)
+    Account.find_each(&:find_or_schedule_jobs)
     TenantMaintenanceJob.set(wait_until: Date.tomorrow.midnight).perform_later
   end
 end


### PR DESCRIPTION
# Summary

Cannot call find on Account. Use find_each instead.

This fixes a failure that prevents the tenant jobs from being scheduled.