### PR TITLE
🐛 Moves HykuIndexing to CollectionResourceIndexer

### DIFF
--- a/app/indexers/collection_resource_indexer.rb
+++ b/app/indexers/collection_resource_indexer.rb
@@ -7,6 +7,7 @@ class CollectionResourceIndexer < Hyrax::Indexers::PcdmCollectionIndexer
   include Hyrax::Indexer(:bulkrax_metadata)
   include Hyrax::Indexer(:collection_resource)
   include Hyrax::IndexesThumbnails
+  include HykuIndexing
 
   def to_solr
     super.tap do |index_document|

--- a/app/models/collection_resource.rb
+++ b/app/models/collection_resource.rb
@@ -7,7 +7,6 @@ class CollectionResource < Hyrax::PcdmCollection
   include Hyrax::Schema(:bulkrax_metadata)
   include Hyrax::Schema(:collection_resource)
   include Hyrax::ArResource
-  include HykuIndexing
 
   Hyrax::ValkyrieLazyMigration.migrating(self, from: ::Collection)
 


### PR DESCRIPTION
Removes `HykuIndexing` mix in from the `CollectionResource` model and adds `HykuIndexing` mix in to `CollectionResourceIndexer` to fix a bug when sorting the catalog. 

Ref:
- https://github.com/scientist-softserv/adventist_knapsack/issues/185

@samvera/hyku-code-reviewers
