### PR TITLE
[i777] - collection metadata clean up

### DIFF
--- a/app/assets/stylesheets/hyrax.scss
+++ b/app/assets/stylesheets/hyrax.scss
@@ -25,3 +25,8 @@
     background: #ffff00;
   font-weight: 700;
 }
+
+// to make collection form labels bold
+#collection-edit-controls label.control-label {
+  font-weight: bold !important;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -48,11 +48,11 @@ module ApplicationHelper
   def locale_for(type:, term:, record_class:)
     term              = term.to_s
     record_class      = record_class.to_s.downcase
-    work_or_collection = record_class == 'collection' ? 'collection' : 'defaults'
+    work_or_collection = record_class == Hyrax.config.collection_model.downcase ? 'collection' : 'defaults'
     locale             = t("hyrax.#{record_class}.#{type}.#{term}")
 
     if missing_translation(locale)
-      (t("simple_form.#{type}.#{work_or_collection}.#{term}") || term.titleize) .html_safe
+      (t("simple_form.#{type}.#{work_or_collection}.#{term}")).try(:html_safe)
     else
       locale.html_safe
     end

--- a/spec/features/create_etd_spec.rb
+++ b/spec/features/create_etd_spec.rb
@@ -62,20 +62,17 @@ RSpec.describe 'Create a Etd', type: :feature, js: true, clean: true, cohort: 'b
       fill_in('Keyword', with: 'testing')
       select('In Copyright', from: 'Rights')
       fill_in('Date', with: '01/27/2021')
-      fill_in('Degree Name', with: 'Bachelor of Science')
-      fill_in('Degree Level', with: 'Undergraduate')
-      fill_in('Degree Discipline', with: 'Computer Science')
-      fill_in('Degree Grantor', with: 'University of Technology')
-      fill_in('Level', with: 'High')
-      fill_in('Discipline', with: 'Com Sci')
-      fill_in('Grantor', with: 'PALNI/PALCI')
+      fill_in('Degree name', with: 'Bachelor of Science')
+      fill_in('Degree level', with: 'Undergraduate')
+      fill_in('Degree discipline', with: 'Computer Science')
+      fill_in('Degree grantor', with: 'University of Technology')
       select('Article', from: 'Resource type')
 
       page.choose('etd_visibility_open')
       expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
       find('#agreement').click
 
-      click_on('Save')
+      click_button('with_files_submit')
       expect(page).to have_content('My Test Work')
       expect(page).to have_content("Your files are being processed by Hyku in the background.")
     end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe ApplicationHelper do
+RSpec.describe ApplicationHelper, type: :helper do
   describe "#markdown" do
     let(:header) { '# header' }
     let(:bold) { '*bold*' }
@@ -13,8 +13,9 @@ RSpec.describe ApplicationHelper do
 
   describe '#local_for' do
     context 'when term is missing' do
-      subject { helper.locale_for(type: 'labels', record_class: "account", term: :very_much_missing) }
-      it { is_expected.to be_a(String) }
+      it 'returns nil' do
+        expect(helper.locale_for(type: 'labels', record_class: "account", term: :very_much_missing)).to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
- updates styling to make labels bold in the collection form
- updates locale helper method to account for collection resources
  - Before, if there wasn't a matching term in the locale it would look like the labels were repeated. 



Issue:
- https://github.com/scientist-softserv/adventist_knapsack/issues/777

### BEFORE

![image](https://github.com/user-attachments/assets/8708ae4d-7b5a-4d12-a5d3-3d36413dcf97)



### AFTER
![image](https://github.com/user-attachments/assets/7811516c-e264-4663-a046-1993c1e849ed)




