### PR TITLE
⚙️ Update Bulkrax + run migration

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera/bulkrax.git
-  revision: b511db6968a12023d74b6e2788947bfe70d5405d
+  revision: b4328d73e595f9de3daa8666066f25e7d4f44573
   branch: main
   specs:
     bulkrax (8.1.0)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_08_20_200440) do
+ActiveRecord::Schema.define(version: 2024_09_16_182823) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -151,6 +151,8 @@ ActiveRecord::Schema.define(version: 2024_08_20_200440) do
     t.datetime "last_error_at"
     t.datetime "last_succeeded_at"
     t.string "status_message", default: "Pending"
+    t.datetime "last_imported_at"
+    t.datetime "next_import_at"
     t.index ["user_id"], name: "index_bulkrax_importers_on_user_id"
   end
 
@@ -161,6 +163,7 @@ ActiveRecord::Schema.define(version: 2024_08_20_200440) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "order", default: 0
+    t.string "status_message", default: "Pending"
     t.index ["child_id"], name: "index_bulkrax_pending_relationships_on_child_id"
     t.index ["importer_run_id"], name: "index_bulkrax_pending_relationships_on_importer_run_id"
     t.index ["parent_id"], name: "index_bulkrax_pending_relationships_on_parent_id"


### PR DESCRIPTION
Updates bulkrax gem and runs migration to add last_imported_at and next_import_at columns. This fixes the bulkrax index sorting errors.

Issue: 
- https://github.com/scientist-softserv/adventist_knapsack/issues/758