### PR TITLE
🐛 Change `link_to_search` to `link_to_facet`

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -141,23 +141,23 @@ class CatalogController < ApplicationController
     #   The ordering of the field names is the order of the display
     config.add_index_field 'title_tesim', label: "Title", itemprop: 'name', if: false
     config.add_index_field 'description_tesim', itemprop: 'description', helper_method: :iconify_auto_link
-    config.add_index_field 'keyword_tesim', itemprop: 'keywords', link_to_search: 'keyword_sim'
-    config.add_index_field 'subject_tesim', itemprop: 'about', link_to_search: 'subject_sim'
-    config.add_index_field 'creator_tesim', itemprop: 'creator', link_to_search: 'creator_sim'
+    config.add_index_field 'keyword_tesim', itemprop: 'keywords', link_to_facet: 'keyword_sim'
+    config.add_index_field 'subject_tesim', itemprop: 'about', link_to_facet: 'subject_sim'
+    config.add_index_field 'creator_tesim', itemprop: 'creator', link_to_facet: 'creator_sim'
     config.add_index_field 'date_tesim', itemprop: 'date'
-    config.add_index_field 'contributor_tesim', itemprop: 'contributor', link_to_search: 'contributor_sim'
+    config.add_index_field 'contributor_tesim', itemprop: 'contributor', link_to_facet: 'contributor_sim'
     config.add_index_field 'proxy_depositor_ssim', label: "Depositor", helper_method: :link_to_profile
     config.add_index_field 'depositor_tesim', label: "Owner", helper_method: :link_to_profile
-    config.add_index_field 'publisher_tesim', itemprop: 'publisher', link_to_search: 'publisher_sim'
-    config.add_index_field 'based_near_label_tesim', itemprop: 'contentLocation', link_to_search: 'based_near_label_sim'
-    config.add_index_field 'language_tesim', itemprop: 'inLanguage', link_to_search: 'language_sim'
+    config.add_index_field 'publisher_tesim', itemprop: 'publisher', link_to_facet: 'publisher_sim'
+    config.add_index_field 'based_near_label_tesim', itemprop: 'contentLocation', link_to_facet: 'based_near_label_sim'
+    config.add_index_field 'language_tesim', itemprop: 'inLanguage', link_to_facet: 'language_sim'
     config.add_index_field 'date_uploaded_dtsi', itemprop: 'datePublished', helper_method: :human_readable_date
     config.add_index_field 'date_modified_dtsi', itemprop: 'dateModified', helper_method: :human_readable_date
     config.add_index_field 'date_created_tesim', itemprop: 'dateCreated'
     config.add_index_field 'rights_statement_tesim', helper_method: :rights_statement_links
     config.add_index_field 'license_tesim', helper_method: :license_links
-    config.add_index_field 'resource_type_tesim', label: "Resource Type", link_to_search: 'resource_type_sim'
-    config.add_index_field 'file_format_tesim', link_to_search: 'file_format_sim'
+    config.add_index_field 'resource_type_tesim', label: "Resource Type", link_to_facet: 'resource_type_sim'
+    config.add_index_field 'file_format_tesim', link_to_facet: 'file_format_sim'
     config.add_index_field 'identifier_tesim', helper_method: :index_field_link, field_name: 'identifier'
     config.add_index_field 'embargo_release_date_dtsi', label: "Embargo release date", helper_method: :human_readable_date
     config.add_index_field 'lease_expiration_date_dtsi', label: "Lease expiration date", helper_method: :human_readable_date


### PR DESCRIPTION
This commit will update the `CatalogController` to use the Blacklight 7 option `link_to_facet`.

Ref:
- https://github.com/projectblacklight/blacklight/wiki/Blacklight-configuration#linking-a-value-to-a-facet-search

## Before
<img width="951" alt="image" src="https://github.com/user-attachments/assets/83d33dd4-e564-4c23-9e07-e05e9d90b68a">

## After
<img width="854" alt="image" src="https://github.com/user-attachments/assets/e212a2f2-2e8c-4594-a941-1116323b6482">
