### PR TITLE
💄 Removes the multiple indicator from Solr suffix

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -12,11 +12,11 @@ class CatalogController < ApplicationController
   before_action :enforce_show_permissions, only: :show
 
   def self.created_field
-    'date_created_ssim'
+    'date_created_ssi'
   end
 
   def self.creator_field
-    'creator_ssim'
+    'creator_ssi'
   end
 
   def self.modified_field
@@ -24,7 +24,7 @@ class CatalogController < ApplicationController
   end
 
   def self.title_field
-    'title_ssim'
+    'title_ssi'
   end
 
   def self.uploaded_field

--- a/app/indexers/concerns/hyku_indexing.rb
+++ b/app/indexers/concerns/hyku_indexing.rb
@@ -23,9 +23,9 @@ module HykuIndexing
         solr_doc['member_ids_ssim'] = object.member_ids.map(&:id) if object.kind_of?(Valkyrie::Resource)
         solr_doc['all_text_tsimv'] = extract_full_text(object)
         # rubocop:enable Style/ClassCheck
-        solr_doc['title_ssim'] = SortTitle.new(object.title.first).alphabetical
+        solr_doc['title_ssi'] = SortTitle.new(object.title.first).alphabetical
         solr_doc['depositor_ssi'] = object.depositor
-        solr_doc['creator_ssim'] = object.creator&.first
+        solr_doc['creator_ssi'] = object.creator&.first
         if object.respond_to?(:date_created)
           solr_doc[CatalogController.created_field] =
             Array(object.date_created).first


### PR DESCRIPTION
This commit improves communication of intent by removing the multiple indicator from the hyku_indexing module.

Ref:
- https://github.com/scientist-softserv/adventist_knapsack/issues/185