### PR TITLE
Fix universal viewer duplicates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ gem 'hyrax-doi', github: 'samvera-labs/hyrax-doi', branch: 'rails_hyrax_upgrade'
 gem 'hyrax-iiif_av', github: 'samvera-labs/hyrax-iiif_av', branch: 'rails_hyrax_upgrade'
 gem 'i18n-debug', require: false, group: %i[development test]
 gem 'i18n-tasks', group: %i[development test]
-gem 'iiif_print'
+gem 'iiif_print', github: 'scientist-softserv/iiif_print', branch: 'main'
 gem 'jbuilder', '~> 2.5'
 gem 'jquery-rails' # Use jquery as the JavaScript library
 gem 'openssl', '>= 3.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,6 +193,18 @@ GIT
       rack (>= 1.3.6)
 
 GIT
+  remote: https://github.com/scientist-softserv/iiif_print.git
+  revision: 02f68fc6d93b44b05d826b29645ef182534a51b5
+  branch: main
+  specs:
+    iiif_print (3.0.1)
+      blacklight_iiif_search (>= 1.0, < 3.0)
+      derivative-rodeo (~> 0.5)
+      hyrax (>= 2.5, < 6)
+      nokogiri (>= 1.13.2)
+      rdf-vocab (~> 3.0)
+
+GIT
   remote: https://github.com/scientist-softserv/willow_sword.git
   revision: 904313fcb669837b363d7095db8e6b7a818d0e21
   branch: main
@@ -330,10 +342,11 @@ GEM
     blacklight_advanced_search (7.0.0)
       blacklight (~> 7.0)
       parslet
-    blacklight_iiif_search (2.0.0)
+    blacklight_iiif_search (2.1.0)
       blacklight (~> 7.0)
+      ffi (~> 1.16.3)
       iiif-presentation
-      rails (>= 5.1, < 7)
+      rails (>= 6, < 7.3)
     blacklight_oai_provider (7.0.2)
       blacklight (~> 7.0)
       oai (~> 1.2)
@@ -752,12 +765,6 @@ GEM
       json
     iiif_manifest (1.3.1)
       activesupport (>= 4)
-    iiif_print (3.0.1)
-      blacklight_iiif_search (>= 1.0, < 3.0)
-      derivative-rodeo (~> 0.5)
-      hyrax (>= 2.5, < 6)
-      nokogiri (>= 1.13.2)
-      rdf-vocab (~> 3.0)
     iso-639 (0.3.6)
     iso8601 (0.9.1)
     jaro_winkler (1.5.6)
@@ -1516,7 +1523,7 @@ DEPENDENCIES
   hyrax-iiif_av!
   i18n-debug
   i18n-tasks
-  iiif_print
+  iiif_print!
   jbuilder (~> 2.5)
   jquery-rails
   json-canonicalization (= 0.3.1)

--- a/app/indexers/concerns/hyku_indexing.rb
+++ b/app/indexers/concerns/hyku_indexing.rb
@@ -11,7 +11,7 @@ module HykuIndexing
       super(*args, **kwargs, &block).tap do |solr_doc|
         # rubocop:disable Style/ClassCheck
 
-        # Active Fedora refers to objce
+        # Active Fedora refers to object
         # Specs refer to object as @object
         # Valkyrie refers to resource
         object ||= @object || resource
@@ -20,7 +20,7 @@ module HykuIndexing
         solr_doc['bulkrax_identifier_tesim'] = object.bulkrax_identifier if object.respond_to?(:bulkrax_identifier)
         solr_doc['account_institution_name_ssim'] = Site.instance.institution_label
         solr_doc['valkyrie_bsi'] = object.kind_of?(Valkyrie::Resource)
-        solr_doc['member_ids_ssim'] = object.member_ids.map(&:id) if object.kind_of?(Valkyrie::Resource)
+        solr_doc['member_ids_ssim'] = object.member_ids.map(&:to_s)
         solr_doc['all_text_tsimv'] = extract_full_text(object)
         # rubocop:enable Style/ClassCheck
         solr_doc['title_ssi'] = SortTitle.new(object.title.first).alphabetical

--- a/app/presenters/hyrax/iiif_manifest_presenter_decorator.rb
+++ b/app/presenters/hyrax/iiif_manifest_presenter_decorator.rb
@@ -25,6 +25,18 @@ module Hyrax
     end
 
     ##
+    # OVERRIDE to find child work's filesets for IiifPrint
+    # @return [Array<#to_s>]
+    def member_ids
+      m = model.is_a?(::SolrDocument) ? model.hydra_model : model.class
+      m < Hyrax::Resource ? Array.wrap(file_ids) : Hyrax::SolrDocument::OrderedMembers.decorate(model).ordered_member_ids
+    end
+
+    def file_ids
+      model["descendent_member_ids_ssim"] || model.member_ids
+    end
+
+    ##
     # @return [String] the URL where the manifest can be found
     def manifest_url
       return '' if id.blank?


### PR DESCRIPTION
Refs https://github.com/scientist-softserv/adventist_knapsack/issues/817

Updates IiifPrint to bring in fixes re: items list duplication.
Uses new index field to get full list of file set ids, since member_ids_ssim index override has been removed.