### PR TITLE
Update hyrax, fix institutional repository layout & based_near behavior

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: bead759d0cad95d9b35a5ecd1731f2e08be4d8c7
+  revision: 4f0ba25bc0149472f6dd1df2574bc3a3fe7709e8
   branch: main
   specs:
     hyrax (5.0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: ce352d3d10390f0032fa131010ab9d76759faddd
+  revision: bead759d0cad95d9b35a5ecd1731f2e08be4d8c7
   branch: main
   specs:
     hyrax (5.0.1)

--- a/app/assets/stylesheets/themes/institutional_repository.scss
+++ b/app/assets/stylesheets/themes/institutional_repository.scss
@@ -46,9 +46,6 @@
   // styles the top nav menu application name that is centered
   .institutional-repository-application-name {
     text-align: center;
-    position: absolute;
-    left: 50%;
-    transform: translateX(-50%);
 
     span {
       color: #fff;

--- a/app/forms/based_near_form_fields_behavior.rb
+++ b/app/forms/based_near_form_fields_behavior.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# A duplication of Hyrax's BasicMetadataFormFieldsBehavior which gets dynamically included via lib/hyrax/form_fields.rb
+# When :basic_metadata is not part of a resource's schema, and the resource includes basec_near, this module
+# must be explicitly included in the resources form.
+module BasedNearFormFieldsBehavior
+  # Provides compatibility with the behavior of the based_near (location) controlled vocabulary form field.
+  # The form expects a ControlledVocabularies::Location object as input and produces a hash like those
+  # used with accepts_nested_attributes_for.
+  def self.included(descendant)
+    descendant.property :based_near_attributes, virtual: true, populator: :based_near_populator, prepopulator: :based_near_prepopulator
+  end
+
+  private
+
+  def based_near_populator(fragment:, **_options)
+    adds = []
+    deletes = []
+    fragment.each do |_, h|
+      uri = RDF::URI.parse(h["id"]).to_s
+      if h["_destroy"] == "true"
+        deletes << uri
+      else
+        adds << uri
+      end
+    end
+    self.based_near = ((model.based_near + adds) - deletes).uniq
+  end
+
+  def based_near_prepopulator
+    self.based_near = based_near.map do |loc|
+      uri = RDF::URI.parse(loc)
+      if uri
+        Hyrax::ControlledVocabularies::Location.new(uri)
+      else
+        loc
+      end
+    end
+    based_near << Hyrax::ControlledVocabularies::Location.new if based_near.empty?
+  end
+end

--- a/app/forms/etd_resource_form.rb
+++ b/app/forms/etd_resource_form.rb
@@ -6,13 +6,17 @@
 # @see https://github.com/samvera/hyrax/wiki/Hyrax-Valkyrie-Usage-Guide#forms
 # @see https://github.com/samvera/valkyrie/wiki/ChangeSets-and-Dirty-Tracking
 class EtdResourceForm < Hyrax::Forms::ResourceForm(EtdResource)
-  # Commented out basic_metadata because these terms were added to etd_resource so we can customize it.
+  # Commented out basic_metadata because the terms were added to the resource's yaml
+  # so we can customize it
   # include Hyrax::FormFields(:basic_metadata)
   include Hyrax::FormFields(:bulkrax_metadata)
   include Hyrax::FormFields(:etd_resource)
   include Hyrax::FormFields(:with_pdf_viewer)
   include Hyrax::FormFields(:with_video_embed)
   include VideoEmbedBehavior::Validation
+  # this duplicates Hyrax::BasicMetadataFormFieldsBehavior behavior which previously
+  # came in dynamically via lib/hyrax/form_fields.rb
+  include BasedNearFormFieldsBehavior
   # Define custom form fields using the Valkyrie::ChangeSet interface
   #
   # property :my_custom_form_field

--- a/app/forms/oer_resource_form.rb
+++ b/app/forms/oer_resource_form.rb
@@ -6,13 +6,17 @@
 # @see https://github.com/samvera/hyrax/wiki/Hyrax-Valkyrie-Usage-Guide#forms
 # @see https://github.com/samvera/valkyrie/wiki/ChangeSets-and-Dirty-Tracking
 class OerResourceForm < Hyrax::Forms::ResourceForm(OerResource)
-  # Commented out basic_metadata because these terms were added to etd_resource so we can customize it.
+  # Commented out basic_metadata because the terms were added to the resource's yaml
+  # so we can customize it
   # include Hyrax::FormFields(:basic_metadata)
   include Hyrax::FormFields(:bulkrax_metadata)
   include Hyrax::FormFields(:oer_resource)
   include Hyrax::FormFields(:with_pdf_viewer)
   include Hyrax::FormFields(:with_video_embed)
   include VideoEmbedBehavior::Validation
+  # this duplicates Hyrax::BasicMetadataFormFieldsBehavior behavior which previously
+  # came in dynamically via lib/hyrax/form_fields.rb
+  include BasedNearFormFieldsBehavior
   # Define custom form fields using the Valkyrie::ChangeSet interface
   #
   # property :my_custom_form_field

--- a/app/views/themes/institutional_repository/_logo.html.erb
+++ b/app/views/themes/institutional_repository/_logo.html.erb
@@ -3,8 +3,4 @@
   <a id="logo" class="col-sm-5" href="<%= hyrax.root_path %>" data-no-turbolink="true">
     <%= image_tag logo_image, alt: block_for(name: 'logo_image_text') %>
   </a>
-<% else %>
-  <a id="logo" class="col-sm-5 navbar-brand" href="<%= hyrax.root_path %>" data-no-turbolink="true">
-    <span class="institution_name"><%= application_name %></span>
-  </a>
 <% end %>

--- a/config/metadata/oer_resource.yaml
+++ b/config/metadata/oer_resource.yaml
@@ -362,6 +362,8 @@ attributes:
   based_near:
     type: string
     multiple: true
+    form:
+      primary: false
     index_keys:
       - "based_near_sim"
       - "based_near_tesim"


### PR DESCRIPTION
# Summary
refs
- https://github.com/samvera/hyku/issues/2356

Fixes:
- header text position in institutional repository
- location faceting (a reindex will get works using `based_near` to appear in the facet if they are missing)
- based_near behavior fixes for ETD and OER resources types

Changes proposed in this pull request:
* update hyrax
* fix institutional repository layout
* ensure all resource types have based_near behavior that works

# Screenshots

<details>
<summary>Institutional Repository layout after changes</summary>

## With Logo
![Screenshot 2024-10-17 at 2 37 22 PM](https://github.com/user-attachments/assets/8f805a1c-25cf-4bf3-a38e-ee043d39da67)

## Without Logo
![Screenshot 2024-10-17 at 2 38 22 PM](https://github.com/user-attachments/assets/0d5094d3-7de1-4df3-855e-5d868a00dfaa)

</details>

<details>
<summary> Based near is now working</summary>

![Screenshot 2024-10-17 at 6 30 14 PM](https://github.com/user-attachments/assets/51e9cd79-a841-4318-b4d5-21122ed0833d)

</details>

@samvera/hyku-code-reviewers
