### PR TITLE
Fix snippets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ gem 'hyrax-doi', github: 'samvera-labs/hyrax-doi', branch: 'rails_hyrax_upgrade'
 gem 'hyrax-iiif_av', github: 'samvera-labs/hyrax-iiif_av', branch: 'rails_hyrax_upgrade'
 gem 'i18n-debug', require: false, group: %i[development test]
 gem 'i18n-tasks', group: %i[development test]
-gem 'iiif_print', github: 'scientist-softserv/iiif_print', branch: 'main'
+gem 'iiif_print', github: 'scientist-softserv/iiif_print', branch: 'i769-snippets-rework'
 gem 'jbuilder', '~> 2.5'
 gem 'jquery-rails' # Use jquery as the JavaScript library
 gem 'openssl', '>= 3.2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ gem 'hyrax-doi', github: 'samvera-labs/hyrax-doi', branch: 'rails_hyrax_upgrade'
 gem 'hyrax-iiif_av', github: 'samvera-labs/hyrax-iiif_av', branch: 'rails_hyrax_upgrade'
 gem 'i18n-debug', require: false, group: %i[development test]
 gem 'i18n-tasks', group: %i[development test]
-gem 'iiif_print', github: 'scientist-softserv/iiif_print', branch: 'i769-snippets-rework'
+gem 'iiif_print', github: 'scientist-softserv/iiif_print', branch: 'main'
 gem 'jbuilder', '~> 2.5'
 gem 'jquery-rails' # Use jquery as the JavaScript library
 gem 'openssl', '>= 3.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,8 +194,8 @@ GIT
 
 GIT
   remote: https://github.com/scientist-softserv/iiif_print.git
-  revision: 6e2d7e93f00974be479b815b90d16db9b7ee7f60
-  branch: i769-snippets-rework
+  revision: 7f35ea9e5b4aedc55f2a6abd1dc5181bf9ed75ff
+  branch: main
   specs:
     iiif_print (3.0.1)
       blacklight_iiif_search (>= 1.0, < 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,8 +194,8 @@ GIT
 
 GIT
   remote: https://github.com/scientist-softserv/iiif_print.git
-  revision: 02f68fc6d93b44b05d826b29645ef182534a51b5
-  branch: main
+  revision: 6e2d7e93f00974be479b815b90d16db9b7ee7f60
+  branch: i769-snippets-rework
   specs:
     iiif_print (3.0.1)
       blacklight_iiif_search (>= 1.0, < 3.0)

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -233,7 +233,7 @@ class CatalogController < ApplicationController
       all_names = config.show_fields.values.map(&:field).join(" ")
       title_name = 'title_tesim'
       field.solr_parameters = {
-        qf: "#{all_names} file_format_tesim all_text_timv",
+        qf: "#{all_names} file_format_tesim all_text_tsimv all_text_tsimv",
         pf: title_name.to_s
       }
     end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -41,7 +41,11 @@ class CatalogController < ApplicationController
 
     # IiifPrint index fields
     config.add_index_field 'all_text_timv'
-    config.add_index_field 'all_text_tsimv', label: "Item contents", highlight: true, helper_method: :render_ocr_snippets, if: :query_present?
+    config.add_index_field 'all_text_tsimv',
+      label: "Item contents",
+      highlight: true,
+      helper_method: :render_ocr_snippets,
+      values: ->(field_config, document, _context) { document.highlight_field(field_config.field).map(&:html_safe) if document.has_highlight_field? field_config.field }
 
     # configuration for Blacklight IIIF Content Search
     config.iiif_search = {
@@ -637,10 +641,6 @@ class CatalogController < ApplicationController
   # https://github.com/samvera/hyrax/blob/abeb5aff99d8ff6a7d32f6e8234538d7bef15fbd/.dassie/app/controllers/catalog_controller.rb#L304-L309
   def render_bookmarks_control?
     false
-  end
-
-  def query_present?
-    params[:q].present?
   end
 end
 # rubocop:enable Metrics/ClassLength, Metrics/BlockLength

--- a/app/helpers/hyku/blacklight_helper_behavior.rb
+++ b/app/helpers/hyku/blacklight_helper_behavior.rb
@@ -44,7 +44,7 @@ module Hyku
       # pull solr_document from input if we don't already have a solr_document
       document = doc&.try(:solr_document) || doc
       Deprecation.silence(Blacklight::UrlHelperBehavior) do
-        link_to label, generate_work_url(document, request), document_link_params(document, opts)
+        link_to label, generate_work_url(document, request, universal_viewer_url_params(opts)), document_link_params(document, opts)
       end
     end
     # rubocop:enable Metrics/MethodLength
@@ -56,7 +56,13 @@ module Hyku
     # method `session_tracking_params`so that instead of a path we have a URL
     # @private
     def document_link_params(_doc, opts)
-      opts.except(:label, :counter)
+      opts.except(:label, :counter, :q, :highlight)
+    end
+    private :document_link_params
+
+    # options needed to carry the search into the universalviewer
+    def universal_viewer_url_params(opts)
+      opts.slice(:q, :highlight)
     end
     private :document_link_params
   end

--- a/app/helpers/shared_search_helper.rb
+++ b/app/helpers/shared_search_helper.rb
@@ -19,7 +19,7 @@ module SharedSearchHelper
     url = get_url(id:, request: request_params, account_cname:, base_route_name:)
 
     # pass search query params to work show page
-    params[:q].present? ? "#{url}?q=#{params[:q]}" : url
+    (params[:q].present? && params[:highlight]) ? "#{url}?q=#{params[:q]}" : url
   end
 
   private

--- a/app/helpers/shared_search_helper.rb
+++ b/app/helpers/shared_search_helper.rb
@@ -1,29 +1,84 @@
 # frozen_string_literal: true
 
+# A helper module that generates work URLs based on models and request parameters.
 module SharedSearchHelper
-  def generate_work_url(model, request)
-    # handle the various types of info we receive:
+  # Generates a URL for the given model with optional query parameters.
+  #
+  # @param model [Object] the model object, typically a work or collection
+  # @param request [ActionDispatch::Request] the current HTTP request object
+  # @param params [Hash] additional query parameters (e.g., search queries)
+  # @return [String] the generated URL with or without query parameters
+  def generate_work_url(model, request, params = {})
+    id, base_route_name, account_cname = extract_model_info(model, request)
+    request_params = extract_request_params(request)
+    url = build_url(id, request_params, account_cname, base_route_name)
+
+    append_query_params(url, model, params)
+  end
+
+  private
+
+  # Extracts the model ID, route name, and account cname from the model and request.
+  #
+  # @param model [Object] the model object (e.g., Hyrax::IiifAv::IiifFileSetPresenter or others)
+  # @param request [ActionDispatch::Request] the current HTTP request object
+  # @return [Array<String>] a tuple containing the model's ID, route name, and account cname
+  def extract_model_info(model, request)
     if model.class == Hyrax::IiifAv::IiifFileSetPresenter
       base_route_name = model.model_name.plural
       id = model.id
       account_cname = request.server_name
     else
       model_hash = model.to_h.with_indifferent_access
-
       base_route_name = model_hash["has_model_ssim"].first.constantize.model_name.plural
       id = model_hash["id"]
       account_cname = Array.wrap(model_hash["account_cname_tesim"]).first
     end
-
-    request_params = %i[protocol host port].map { |method| ["request_#{method}".to_sym, request.send(method)] }.to_h
-    url = get_url(id:, request: request_params, account_cname:, base_route_name:)
-
-    # pass search query params to work show page
-    (params[:q].present? && params[:highlight]) ? "#{url}?q=#{params[:q]}" : url
+    [id, base_route_name, account_cname]
   end
 
-  private
+  # Extracts protocol, host, and port information from the request.
+  #
+  # @param request [ActionDispatch::Request] the current HTTP request object
+  # @return [Hash] a hash containing the protocol, host, and port extracted from the request
+  def extract_request_params(request)
+    %i[protocol host port].map { |method| ["request_#{method}".to_sym, request.send(method)] }.to_h
+  end
 
+  # Builds the base URL for the given model and request information.
+  #
+  # @param id [String] the model's ID
+  # @param request_params [Hash] the extracted request parameters (protocol, host, port)
+  # @param account_cname [String, nil] the account cname, if applicable
+  # @param base_route_name [String] the base route name (e.g., 'works', 'collections')
+  # @return [String] the constructed base URL
+  def build_url(id, request_params, account_cname, base_route_name)
+    get_url(id: id, request: request_params, account_cname: account_cname, base_route_name: base_route_name)
+  end
+
+  # Appends the appropriate query parameters to the base URL based on the model and params.
+  #
+  # @param url [String] the base URL
+  # @param model [Object] the model object (e.g., work or collection)
+  # @param params [Hash] the query parameters, which may include search queries
+  # @return [String] the URL with appended query parameters, if applicable
+  def append_query_params(url, model, params)
+    if params[:q].present? && model.any_highlighting_in_all_text_fields?
+      "#{url}?parent_query=#{params[:q]}&highlight=true"
+    elsif params[:q].present?
+      "#{url}?q=#{params[:q]}"
+    else
+      url
+    end
+  end
+
+  # Constructs a URL with the given parameters.
+  #
+  # @param id [String] the model's ID
+  # @param request [Hash] the request parameters (protocol, host, port)
+  # @param account_cname [String, nil] the account cname, if applicable
+  # @param base_route_name [String] the base route name (e.g., 'works', 'collections')
+  # @return [String] the constructed URL
   def get_url(id:, request:, account_cname:, base_route_name:)
     new_url = "#{request[:request_protocol]}#{account_cname || request[:request_host]}"
     new_url += ":#{request[:request_port]}" if Rails.env.development? || Rails.env.test?

--- a/app/helpers/shared_search_helper.rb
+++ b/app/helpers/shared_search_helper.rb
@@ -63,12 +63,11 @@ module SharedSearchHelper
   # @param params [Hash] the query parameters, which may include search queries
   # @return [String] the URL with appended query parameters, if applicable
   def append_query_params(url, model, params)
+    return url if params[:q].blank?
     if params[:q].present? && model.any_highlighting_in_all_text_fields?
       "#{url}?parent_query=#{params[:q]}&highlight=true"
-    elsif params[:q].present?
-      "#{url}?q=#{params[:q]}"
     else
-      url
+      "#{url}?q=#{params[:q]}"
     end
   end
 

--- a/app/presenters/blacklight/thumbnail_presenter_decorator.rb
+++ b/app/presenters/blacklight/thumbnail_presenter_decorator.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# OVERRIDE Blacklight 7.35 to pass the query parameters to the UV via the thumbnail URL
+module Blacklight
+  module ThumbnailPresenterDecorator
+    ##
+    # Render the thumbnail, if available, for a document and
+    # link it to the document record.
+    #
+    # @param [Hash] image_options to pass to the image tag
+    # @param [Hash] url_options to pass to #link_to_document
+    # @return [String]
+    def thumbnail_tag(image_options = {}, url_options = {})
+      value = thumbnail_value(image_options)
+      return value if value.nil? || url_options[:suppress_link]
+      view_context.link_to_document document, value, url_options
+    end
+  end
+end
+
+Blacklight::ThumbnailPresenter.prepend(Blacklight::ThumbnailPresenterDecorator)

--- a/app/views/catalog/_index_header_list_default.html.erb
+++ b/app/views/catalog/_index_header_list_default.html.erb
@@ -1,7 +1,7 @@
 <%# OVERRIDE Hyrax v5.0.1 to collection badge and markdown of links %>
 <div class="search-results-title-row col-12 d-flex flex-row align-items-center pb-2">
   <h4 class="search-result-title">
-    <%= link_to document.title_or_label, generate_work_url(document, request, params) %>
+    <%= link_to markdown(document.title_or_label), generate_work_url(document, request, params) %>
   </h4>
 
   <% if document.hydra_model == Hyrax.config.collection_class || document.hydra_model < Hyrax.config.collection_class %>

--- a/app/views/catalog/_index_header_list_default.html.erb
+++ b/app/views/catalog/_index_header_list_default.html.erb
@@ -1,13 +1,7 @@
 <%# OVERRIDE Hyrax v5.0.1 to collection badge and markdown of links %>
 <div class="search-results-title-row col-12 d-flex flex-row align-items-center pb-2">
   <h4 class="search-result-title">
-    <% if params['q'].present? && document.any_highlighting_in_all_text_fields? %>
-      <%= link_to document.title_or_label, [document, { parent_query: params['q'], highlight: 'true' }] %></h3>
-    <% elsif params['q'].present? %>
-      <%= link_to document.title_or_label, [document, { query: params['q'] }] %>
-    <% else %>
-      <%= link_to document.title_or_label, document %></h3>
-    <% end %>
+    <%= link_to document.title_or_label, generate_work_url(document, request, params) %>
   </h4>
 
   <% if document.hydra_model == Hyrax.config.collection_class || document.hydra_model < Hyrax.config.collection_class %>

--- a/app/views/catalog/_index_header_list_default.html.erb
+++ b/app/views/catalog/_index_header_list_default.html.erb
@@ -1,6 +1,15 @@
 <%# OVERRIDE Hyrax v5.0.1 to collection badge and markdown of links %>
 <div class="search-results-title-row col-12 d-flex flex-row align-items-center pb-2">
-  <h4 class="search-result-title"><%= link_to markdown(document.title_or_label), generate_work_url(document, request) %></h4>
+  <h4 class="search-result-title">
+    <% if params['q'].present? && document.any_highlighting_in_all_text_fields? %>
+      <%= link_to document.title_or_label, [document, { parent_query: params['q'], highlight: 'true' }] %></h3>
+    <% elsif params['q'].present? %>
+      <%= link_to document.title_or_label, [document, { query: params['q'] }] %>
+    <% else %>
+      <%= link_to document.title_or_label, document %></h3>
+    <% end %>
+  </h4>
+
   <% if document.hydra_model == Hyrax.config.collection_class || document.hydra_model < Hyrax.config.collection_class %>
     <%= Hyrax::CollectionPresenter.new(document, current_ability).collection_type_badge %>
   <% end %>

--- a/app/views/catalog/_index_list_default.html.erb
+++ b/app/views/catalog/_index_list_default.html.erb
@@ -1,12 +1,14 @@
 <%# OVERRIDE Hyrax 5.0.1 to enable markdown for index field values in search results %>
 <%# OVERRIDE Hyrax 5.0.1 to handle search only accounts %>
+<%# OVERRIDE Hyrax 5.0.1 display label only when a property has a value, to prevent blank metadata %>
 
 <div class="ol-md-9 col-lg-6">
   <div class="metadata">
     <dl>
       <% doc_presenter = index_presenter(document) %>
       <% index_fields(document).each do |field_name, field| -%>
-        <% if should_render_index_field? document, field %>
+      <% field_value = doc_presenter.field_value(field) %>
+        <% if should_render_index_field?(document, field) && field_value.present? %>
           <div class="row">
             <dt class="col-5 text-right" data-solr-field-name="<%= field_name %>"><%= render_index_field_label document, field: field_name %></dt>
             <dd class="col-7"><%= markdown(doc_presenter.field_value field) %></dd>

--- a/app/views/catalog/_thumbnail_list_default.html.erb
+++ b/app/views/catalog/_thumbnail_list_default.html.erb
@@ -1,0 +1,21 @@
+<!-- OVERRIDE Hyrax v5.0 to allow passign options to the thumbnail tag
+     to allow carrying along the query to the universal viewer -->
+<% model = document.hydra_model %>
+
+<% if params['q'].present? && document.any_highlighting_in_all_text_fields? %>
+  <% additional_options = params.slice('q').merge( { :highlight=>'true' } ) %>
+<% elsif params['q'].present? %>
+  <% additional_options  = params.slice('q') %>
+<% else %>
+  <% additional_options = {} %>
+<% end %>
+
+<div class="col-md-3">
+  <% if model == Hyrax::PcdmCollection || model < Hyrax::PcdmCollection %>
+    <%= document_presenter(document)&.thumbnail&.thumbnail_tag({}, suppress_link: true) %>
+  <% else %>
+    <div class="list-thumbnail">
+      <%= document_presenter(document)&.thumbnail&.thumbnail_tag({}, additional_options ) %>
+    </div>
+  <% end %>
+</div>

--- a/spec/helpers/shared_search_helper_spec.rb
+++ b/spec/helpers/shared_search_helper_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe SharedSearchHelper do
 
     let(:uuid) { SecureRandom.uuid }
     let(:request) { instance_double(ActionDispatch::Request, port: 3000, protocol: "https://", host: account.cname) }
-    let(:work_hash) { { id: uuid, 'has_model_ssim': ['GenericWork'], 'account_cname_tesim': account.cname } }
+    let(:work_hash) { SolrDocument.new(id: uuid, 'has_model_ssim': ['GenericWork'], 'account_cname_tesim': account.cname) }
 
     before do
       allow(helper).to receive(:current_account) { account }
@@ -30,7 +30,15 @@ RSpec.describe SharedSearchHelper do
         allow(params).to receive(:[]).with(:q).and_return('foo')
 
         url = "#{request.protocol}#{cname}/concern/generic_works/#{uuid}?q=foo"
-        expect(helper.generate_work_url(work_hash, request)).to eq(url)
+        expect(helper.generate_work_url(work_hash, request, params)).to eq(url)
+      end
+
+      it 'returns #generate_work_url with a query and highlight true for UV' do
+        allow(params).to receive(:[]).with(:q).and_return('cat')
+        allow(work_hash).to receive(:any_highlighting_in_all_text_fields?).and_return(true)
+
+        url = "#{request.protocol}#{cname}/concern/generic_works/#{uuid}?parent_query=cat&highlight=true"
+        expect(helper.generate_work_url(work_hash, request, params)).to eq(url)
       end
     end
 
@@ -46,7 +54,16 @@ RSpec.describe SharedSearchHelper do
         allow(params).to receive(:[]).with(:q).and_return('foo')
 
         url = "#{request.protocol}#{account.cname}:#{request.port}/concern/generic_works/#{uuid}?q=foo"
-        expect(helper.generate_work_url(work_hash, request)).to eq(url)
+        expect(helper.generate_work_url(work_hash, request, params)).to eq(url)
+        allow(work_hash).to receive(:any_highlighting_in_all_text_fields?).and_return(false)
+      end
+
+      it 'returns #generate_work_url with a query and highlight true for UV' do
+        allow(params).to receive(:[]).with(:q).and_return('cat')
+        allow(work_hash).to receive(:any_highlighting_in_all_text_fields?).and_return(true)
+
+        url = "#{request.protocol}#{account.cname}:#{request.port}/concern/generic_works/#{uuid}?parent_query=cat&highlight=true"
+        expect(helper.generate_work_url(work_hash, request, params)).to eq(url)
       end
     end
   end


### PR DESCRIPTION

Issue: 
- https://github.com/scientist-softserv/adventist_knapsack/issues/769


## TODO: 

- [x] uv search params should not search if no highlights exists ✅ 
- [x] #render_ocr_snippets should check for highlights and not snippets.blank? ✅ 
- [x] When there are no snippets the "keyword matches" label still appears. ✅  (M3) **[SHANA]**

<details> 

### when there's a match

<img width="1335" alt="image" src="https://github.com/user-attachments/assets/542d2496-ec85-4182-9d4f-d730f1144554">

### when there's no matches

<img width="1300" alt="image" src="https://github.com/user-attachments/assets/fdfb050b-13e7-446e-8f01-f2b9fd524761">

<img width="677" alt="image" src="https://github.com/user-attachments/assets/38553a57-efeb-41c1-a081-cd06d9d898f1">

</details> 


- [ ] When there is a match, it should highlight the first one. ❌ (prod issue - M3)
- [ ] When there is a match, it also finds more matches than it should. ❌ (prod issue - M3)
- [x] Thumbnail link does not perform a UV search ✅  (M1) **[LARITA]**
- [ ] Update Adventist knapsack and make any necessary additional changes (M1)
