### PR TITLE
Remove contributor licence agreements from contributing docs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -11,17 +11,6 @@ experience for all its members, whether they are at a formal gathering, in
 a social setting, or taking part in activities online. Please see our
 [Code of Conduct](CODE_OF_CONDUCT.md) for more information.
 
-## Samvera Community Intellectual Property Licensing and Ownership
-
-All code contributors must have an Individual Contributor License Agreement
-(iCLA) on file with the Samvera Steering Group. If the contributor works for
-an institution, the institution must have a Corporate Contributor License
-Agreement (cCLA) on file.
-
-[Samvera Community Intellectual Property Licensing and Ownership](https://samvera.atlassian.net/wiki/spaces/samvera/pages/405211651)
-
-You should also add yourself to the `CONTRIBUTORS.md` file in the root of the project.
-
 ## Language
 
 The language we use matters.  Today, tomorrow, and for years to come

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,17 +11,6 @@ experience for all its members, whether they are at a formal gathering, in
 a social setting, or taking part in activities online. Please see our
 [Code of Conduct](CODE_OF_CONDUCT.md) for more information.
 
-## Samvera Community Intellectual Property Licensing and Ownership
-
-All code contributors must have an Individual Contributor License Agreement
-(iCLA) on file with the Samvera Steering Group. If the contributor works for
-an institution, the institution must have a Corporate Contributor License
-Agreement (cCLA) on file.
-
-[Samvera Community Intellectual Property Licensing and Ownership](https://samvera.atlassian.net/wiki/spaces/samvera/pages/405211651)
-
-You should also add yourself to the `CONTRIBUTORS.md` file in the root of the project.
-
 ## Language
 
 The language we use matters.  Today, tomorrow, and for years to come


### PR DESCRIPTION
These agreements are no longer required to contribute to this project.

Also, remove the requirement to add your name to CONTIBUTORS.md, since no such file exists in this repo.


Changes proposed in this pull request:
* Remove outdated CLA requirement from documentation about how to contribute to this project
* Remove the requirement that contributors write their name in a non-existent file (CONTRIBUTORS.md)

@samvera/hyku-code-reviewers
