### PR TITLE
Snippet fixes for catalog search into viewer

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -95,7 +95,7 @@ class CatalogController < ApplicationController
       "hl.simple.post": "</span>",
       "hl.snippets": 30,
       "hl.fragsize": 100,
-      "hl.maxAnalyzedChars": 5100000
+      "hl.maxAnalyzedChars": 5_100_000
     }
 
     # Specify which field to use in the tag cloud on the homepage.

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -82,6 +82,7 @@ class CatalogController < ApplicationController
     config.http_method = :post
 
     ## Default parameters to send to solr for all search-like requests. See also SolrHelper#solr_search_params
+    #  Max fragsize is needed to not cut off full text search at default 51,000 characters
     config.default_solr_params = {
       qt: "search",
       rows: 10,
@@ -93,7 +94,8 @@ class CatalogController < ApplicationController
       "hl.simple.pre": "<span class='highlight'>",
       "hl.simple.post": "</span>",
       "hl.snippets": 30,
-      "hl.fragsize": 100
+      "hl.fragsize": 100,
+      "hl.maxAnalyzedChars": 5100000
     }
 
     # Specify which field to use in the tag cloud on the homepage.

--- a/app/helpers/shared_search_helper.rb
+++ b/app/helpers/shared_search_helper.rb
@@ -63,11 +63,10 @@ module SharedSearchHelper
   # @param params [Hash] the query parameters, which may include search queries
   # @return [String] the URL with appended query parameters, if applicable
   def append_query_params(url, model, params)
-    return url if params[:q].blank?
     if params[:q].present? && model.any_highlighting_in_all_text_fields?
       "#{url}?parent_query=#{params[:q]}&highlight=true"
     else
-      "#{url}?q=#{params[:q]}"
+      url
     end
   end
 

--- a/app/views/catalog/_index_list_default.html.erb
+++ b/app/views/catalog/_index_list_default.html.erb
@@ -11,7 +11,7 @@
         <% if should_render_index_field?(document, field) && field_value.present? %>
           <div class="row">
             <dt class="col-5 text-right" data-solr-field-name="<%= field_name %>"><%= render_index_field_label document, field: field_name %></dt>
-            <dd class="col-7"><%= markdown(doc_presenter.field_value field) %></dd>
+            <dd class="col-7"><%= markdown(field_value) %></dd>
           </div>
         <% end %>
       <% end %>

--- a/spec/helpers/shared_search_helper_spec.rb
+++ b/spec/helpers/shared_search_helper_spec.rb
@@ -28,8 +28,9 @@ RSpec.describe SharedSearchHelper do
 
       it 'returns #generate_work_url with a query' do
         allow(params).to receive(:[]).with(:q).and_return('foo')
+        allow(work_hash).to receive(:any_highlighting_in_all_text_fields?).and_return(false)
 
-        url = "#{request.protocol}#{cname}/concern/generic_works/#{uuid}?q=foo"
+        url = "#{request.protocol}#{cname}/concern/generic_works/#{uuid}"
         expect(helper.generate_work_url(work_hash, request, params)).to eq(url)
       end
 
@@ -50,12 +51,12 @@ RSpec.describe SharedSearchHelper do
         expect(helper.generate_work_url(work_hash, request)).to eq(url)
       end
 
-      it 'returns #generate_work_url with a query' do
+      it 'returns #generate_work_url if given a query but no highlighting' do
         allow(params).to receive(:[]).with(:q).and_return('foo')
-
-        url = "#{request.protocol}#{account.cname}:#{request.port}/concern/generic_works/#{uuid}?q=foo"
-        expect(helper.generate_work_url(work_hash, request, params)).to eq(url)
         allow(work_hash).to receive(:any_highlighting_in_all_text_fields?).and_return(false)
+
+        url = "#{request.protocol}#{account.cname}:#{request.port}/concern/generic_works/#{uuid}"
+        expect(helper.generate_work_url(work_hash, request, params)).to eq(url)
       end
 
       it 'returns #generate_work_url with a query and highlight true for UV' do


### PR DESCRIPTION
Summary:

Fix generated work url.
Adjust char limit to accomplish full text search.
Modify view to only load field_value once.
Adjust specs for url change.

refs https://github.com/scientist-softserv/adventist_knapsack/issues/769

<details>
<summary>Screenshots</summary>

### Snippets are found and highlighted in catalog search
![Screenshot 2024-10-30 at 4 51 25 PM](https://github.com/user-attachments/assets/654d85de-2091-40fc-bc07-38a9c2f093d1)

### Metadata searches are found in catalog search and do not show snippets
![Screenshot 2024-10-30 at 4 51 38 PM](https://github.com/user-attachments/assets/9d912bf1-ab22-4bd5-889f-5a71690ec399)

### Catalog search carries into universal viewer
![Screenshot 2024-10-30 at 4 52 39 PM](https://github.com/user-attachments/assets/9f94a2d7-b641-4152-8fa2-0368603739ee)

</details>

### Remaining known issues

- [ ] There seems to be come caching of a search which can carry along into the viewer occasionally
- [ ] https://github.com/scientist-softserv/adventist_knapsack/issues/863 The annotations counts and markings on the viewer are incorrect... counts are doubled, and an extra annotation also exists with no location.
- [ ] When a query carries into the viewer, it doesn't open the page where the first hit is located. This is likely due to one of the extra annotations that has no location (so it's positioned at the beginning of the document)