### PR TITLE
New account setting to override Bulkrax's default split pattern

### DIFF
--- a/app/models/concerns/account_settings.rb
+++ b/app/models/concerns/account_settings.rb
@@ -23,6 +23,7 @@ module AccountSettings
     setting :allow_downloads, type: 'boolean', default: true
     setting :allow_signup, type: 'boolean', default: true
     setting :analytics_provider, type: 'string'
+    setting :bulkrax_split_pattern, type: 'string', default: Bulkrax.multi_value_element_split_on.source
     setting :bulkrax_validations, type: 'boolean', disabled: true
     setting :cache_api, type: 'boolean', default: false
     setting :contact_email, type: 'string', default: 'change-me-in-settings@example.com'
@@ -58,7 +59,7 @@ module AccountSettings
     validates :contact_email, :oai_admin_email,
               format: { with: URI::MailTo::EMAIL_REGEXP },
               allow_blank: true
-    validate :validate_email_format, :validate_contact_emails
+    validate :validate_email_format, :validate_contact_emails, :validate_split_pattern_regex
     validates :google_analytics_id,
               format: { with: /((UA|YT|MO)-\d+-\d+|G-[A-Z0-9]{10})/i },
               allow_blank: true
@@ -152,6 +153,16 @@ module AccountSettings
       settings[key].each do |email|
         errors.add(:"#{key}") unless email.match?(URI::MailTo::EMAIL_REGEXP)
       end
+    end
+  end
+
+  def validate_split_pattern_regex
+    return if settings['bulkrax_split_pattern'].blank?
+
+    begin
+      Regexp.new(settings['bulkrax_split_pattern'])
+    rescue RegexpError => e
+      errors.add(:bulkrax_split_pattern, e.message)
     end
   end
 

--- a/app/parsers/bulkrax/application_parser_decorator.rb
+++ b/app/parsers/bulkrax/application_parser_decorator.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Bulkrax
+  module ApplicationParserDecorator
+    # OVERRIDE: [Bulkrax v8.3.0] Use the current Account's configured :bulkrax_split_pattern
+    # setting as the default split pattern when importing multi-valued fields
+    def multi_value_element_split_on
+      Regexp.new(Site.account&.settings&.dig('bulkrax_split_pattern')) || super
+    end
+  end
+end
+
+Bulkrax::ApplicationParser.singleton_class.send(:prepend, Bulkrax::ApplicationParserDecorator)

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -14,7 +14,6 @@ en:
         name: A single or hyphenated name used for technical aspects of the repository (e.g., "acme" or "acme-library").
         gtm_id: The ID of your Google Tag Manager account
         google_analytics_id: The ID of your Google Analytics account
-        contact_email_to: The email address that messages submitted via the contact page are sent to
         weekly_email_list: List of email addresses to email the weekly report. Leave a single space between each email
         monthly_email_list: List of email addresses to email the monthly report. Leave a single space between each email
         yearly_email_list: List of email addresses to email the yearly report. Leave a single space between each email
@@ -35,6 +34,7 @@ en:
         geonames_username: Register at http://www.geonames.org/manageaccount
         file_acl: Turn off if using a file system like samba or nfs that does not support setting access control lists
         ssl_configured: Set it true if using https
+        bulkrax_split_pattern: Default regular expression used by Bulkrax to split multiple values within the same column. <b>Omit surrounding slashes (e.g. [|;] not /[|;]/)</b>
       hyku_group:
         description: A brief summary of the role of the group
       user:


### PR DESCRIPTION
Ref:
- https://github.com/samvera/bulkrax/pull/984

# Summary

Add a new Account setting that will override Bulkrax's default multi-value split pattern. This effectively allows each tenant to have its own default split pattern

This change relies on this Bulkrax commit to work:
- https://github.com/samvera/bulkrax/pull/984/commits/9268bbb

![image](https://github.com/user-attachments/assets/ccdfdeae-0c2f-4776-8736-b8312ee2f377)

# Considerations

The default split pattern is only used when a field mapping specifies `split: true`:

```ruby
config.field_mappings['Bulkrax::CsvParser'] = {
  'contributor' => { from: %w[contributor], split: true },
```

If a field declares a specific split pattern, **it will be used for all tenants**:

```ruby
config.field_mappings['Bulkrax::CsvParser'] = {
  'contributor' => { from: %w[contributor], split: /\s*[|]\s*/ },
```

I think this is okay; in my experience, most installations use a single pattern for the vast majority of their fields. If I'm reading [Bulkrax's `#process_parse` method](https://github.com/samvera/bulkrax/blob/77528bf27940441206beae95fc6902168707115f/app/matchers/bulkrax/application_matcher.rb#L43) correctly, that could be used in conjunction with `split: false` to handle one-off fields with unique split patterns:

```ruby
config.field_mappings['Bulkrax::CsvParser'] = {
  'contributor' => { from: %w[contributor], split: false },

---

def parse_contributor(src)
  src.split(/custom pattern/)
end
```

That being said, if you can think of a better way to accomplish this, I'm open to suggestions 

@samvera/hyku-code-reviewers
