### PR TITLE
[i886] - update logic to fix collection thumbnail bug

### DIFF
--- a/app/services/hyrax/thumbnail_path_service_decorator.rb
+++ b/app/services/hyrax/thumbnail_path_service_decorator.rb
@@ -10,10 +10,14 @@ module Hyrax
       collection_thumbnail = CollectionBrandingInfo.where(collection_id: object.id.to_s, role: "thumbnail").first
       return collection_thumbnail.local_path.gsub(Hyrax.config.branding_path.to_s, '/branding') if collection_thumbnail
 
-      return default_image if object.try(:thumbnail_id).blank?
+      if object.try(:thumbnail_id).blank?
+        return default_collection_image if object.try(:collection?)
+        return default_image
+      end
 
       thumb = fetch_thumbnail(object)
       return default_collection_image unless thumb
+
       return call(thumb) unless thumb.file_set?
       if audio?(thumb)
         audio_image

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,7 +50,7 @@ Rails.application.configure do
   config.force_ssl = true
   config.ssl_options = {
     redirect: {
-      exclude: -> request { request.path == '/healthz' }
+      exclude: ->(request) { request.path == '/healthz' }
     }
   }
   # Use the lowest log level to ensure availability of diagnostic information

--- a/spec/services/hyrax/thumbnail_path_service_spec.rb
+++ b/spec/services/hyrax/thumbnail_path_service_spec.rb
@@ -18,4 +18,26 @@ RSpec.describe Hyrax::ThumbnailPathService, type: :decorator do
       end
     end
   end
+
+  describe '.default_collection_image' do
+    context 'when the site has a default collection image' do
+      let(:collection_image) { '/assets/site_default_collection_image.png' }
+      let(:site_instance_double) { instance_double(Site, default_collection_image: double('DefaultCollectionImage', url: collection_image)) }
+
+      before do
+        # Stub Site.instance to return our site_instance_double with the expected url
+        allow(Site).to receive(:instance).and_return(site_instance_double)
+      end
+
+      it 'returns the default collection image from the site' do
+        expect(described_class.default_collection_image).to eq(collection_image)
+      end
+    end
+
+    context 'when the site does not have a default collection image' do
+      it 'returns the Hyrax default collection image' do
+        expect(described_class.default_collection_image).to eq(ActionController::Base.helpers.image_path('default.png'))
+      end
+    end
+  end
 end


### PR DESCRIPTION
The default work thumbnail was displaying even though the default collection thumbnail was set.

Issue:
- https://github.com/scientist-softserv/adventist_knapsack/issues/886

# When No Collection Branding is Set

## When Default Collection Thumbnail is Set
- [ ] Collections should render the default thumbnail

![Screenshot 2024-11-13 at 13-49-38 Show Appearance __ Hyku](https://github.com/user-attachments/assets/e569edc4-4ae7-4117-bd2c-86259054aab1)

![Screenshot 2024-11-13 at 13-50-18 Collections](https://github.com/user-attachments/assets/58f5a5eb-e693-4afc-aa43-a02d21e47b71)


## When Default Collection Thumbnail is NOT set
- [ ] Collections should render Hyrax's default thumbnail

![Screenshot 2024-11-13 at 13-50-54 Show Appearance __ Hyku](https://github.com/user-attachments/assets/29a74933-c7f1-40b5-b20d-a46fe28bd1da)


![Screenshot 2024-11-13 at 13-51-05 Collections](https://github.com/user-attachments/assets/ce945c3b-41c8-4a4d-b22b-6e5fd79dddce)



# When Collection Branding is Set

## When Default Collection Thumbnail is Set
- [ ] Collections should render the Branding thumbnail

![Screenshot 2024-11-13 at 13-50-37 Edit User Collection es __ Hyku](https://github.com/user-attachments/assets/78569507-1f36-4c99-8879-fd391b4929f6)



![Screenshot 2024-11-13 at 15-40-53 Collections](https://github.com/user-attachments/assets/fe0b7100-0404-43b1-a074-d26fa4f3fea9)

