### PR TITLE
Small fixes for views & branding

### DIFF
--- a/app/controllers/hyrax/dashboard/collections_controller_decorator.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller_decorator.rb
@@ -28,10 +28,12 @@ module Hyrax
         result = transactions['change_set.update_collection']
                  .with_step_args(
                           'collection_resource.save_collection_banner' => { update_banner_file_ids: params["banner_files"],
-                                                                            alttext: params["banner_text"]&.first },
+                                                                            alttext: params["banner_text"]&.first,
+                                                                            banner_unchanged_indicator: params["banner_unchanged"] },
                           'collection_resource.save_collection_logo' => { update_logo_file_ids: params["logo_files"],
                                                                           alttext_values: params["alttext"],
-                                                                          linkurl_values: params["linkurl"] },
+                                                                          linkurl_values: params["linkurl"],
+                                                                          logo_unchanged_indicator: false },
                           'collection_resource.save_collection_thumbnail' => { update_thumbnail_file_ids: params["thumbnail_files"],
                                                                                thumbnail_unchanged_indicator: params["thumbnail_unchanged"],
                                                                                alttext_values: params["thumbnail_text"] }

--- a/app/presenters/hyrax/presenter_renderer_decorator.rb
+++ b/app/presenters/hyrax/presenter_renderer_decorator.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# OVERRIDE Hyrax 5 to display based near label instead of URI
+# @TODO Move this behavior into Hyrax in a flexible manner
+module Hyrax
+  module PresenterRendererDecorator
+    def value(field_name, locals = {})
+      field_name == :based_near ? super(:based_near_label, locals) : super(field_name, locals)
+    end
+  end
+end
+
+Hyrax::PresenterRenderer.prepend(Hyrax::PresenterRendererDecorator)

--- a/app/views/hyrax/oers/_attribute_rows.html.erb
+++ b/app/views/hyrax/oers/_attribute_rows.html.erb
@@ -12,6 +12,7 @@
 <%= presenter.attribute_to_html(:date_created, html_dl: true) %>
 <%= presenter.attribute_to_html(:table_of_contents, html_dl: true) %> 
 <%= presenter.attribute_to_html(:subject, render_as: :faceted, html_dl: true) %>
+<%= presenter.attribute_to_html(:based_near_label, html_dl: true) %>
 <%= presenter.attribute_to_html(:rights_statement, render_as: :rights_statement, html_dl: true) %>
 <%= presenter.attribute_to_html(:license, render_as: :license, html_dl: true) %>
 <%= presenter.attribute_to_html(:rights_holder, render_as: :linked, html_dl: true) %>

--- a/app/views/themes/cultural_show/hyrax/oers/_related_item.html.erb
+++ b/app/views/themes/cultural_show/hyrax/oers/_related_item.html.erb
@@ -1,0 +1,4 @@
+<tr>
+  <td><strong><%= "#{relationship.titlecase}" %>: </strong></td>
+  <td class="attribute"><%= link_to(member.link_name, contextual_path(member, @presenter)) %></td>
+</tr>

--- a/app/views/themes/cultural_show/hyrax/oers/show.html.erb
+++ b/app/views/themes/cultural_show/hyrax/oers/show.html.erb
@@ -1,0 +1,74 @@
+<% content_for(:extra_body_classes, 'works-show text-show-theme-partial ') %>
+<% provide :page_title, @presenter.page_title %>
+<%= render 'shared/citations' %>
+<%= render './shared/additional_citations' %>
+<div class="row">
+  <div itemscope itemtype="http://schema.org/CreativeWork" class="col-xs-12">
+    <div class="card">
+      <div class="card-header">
+        <%= render 'work_title', presenter: @presenter %>
+      </div>
+      <div class="card-body">
+        <div class="row">
+          <%= render 'workflow_actions_widget', presenter: @presenter %>
+          <% if @presenter.iiif_viewer? %>
+            <div class="col-sm-12">
+              <%= render 'representative_media', presenter: @presenter, viewer: true %>
+            </div>
+          <% elsif Flipflop.default_pdf_viewer? && @presenter.show_pdf_viewer? && @presenter.file_set_presenters.any?(&:pdf?) %>
+            <div class="col-sm-12">
+              <%= render 'pdf_js', file_set_presenter: pdf_file_set_presenter(@presenter) %>
+            </div>
+          <% end %>
+          <div class="col-sm-12">
+            <%= render "show_actions", presenter: @presenter %>
+          </div>
+          <div class="centered-media <%= !@presenter.iiif_viewer? ? 'col-sm-6 text-center' : '' %>">
+            <%= render 'representative_media', presenter: @presenter, viewer: false unless @presenter.iiif_viewer? || @presenter.show_pdf_viewer? %>
+            <% if !@presenter.iiif_viewer? %>
+              <div>
+                <br/>
+                  <%= render('download_pdf', presenter: @presenter, file_set_id: @presenter.file_set_presenters.first.id) if @presenter.show_pdf_download_button? %>
+                  <%= render 'citations', presenter: @presenter %>
+                  <!-- analytics_button is disabled until future fix -->
+                  <%#= render 'analytics_button', presenter: @presenter %>
+                <br/>
+              </div>
+            <% end %>
+          </div>
+          <div class="<%= @presenter.iiif_viewer? ? 'col-sm-8' : 'col-sm-6' %>">
+            <%= render 'work_description', presenter: @presenter %>
+            <%= render 'metadata', presenter: @presenter %>
+          </div>
+          <div class="<%= @presenter.iiif_viewer? ? 'col-sm-4' : 'col-sm-12' %>  relationships-container">
+            <div class='relationships-box'>
+              <%= render 'relationships', presenter: @presenter %>
+              </div>
+              <% if @presenter.class == Hyrax::OerPresenter %>
+                <div class='relationships-box'>
+                  <%= render 'related_items', presenter: @presenter %>
+                </div>
+              <% end %>
+              <% if @presenter.iiif_viewer? %>
+                <div>
+                  <br/>
+                    <%= render('download_pdf', presenter: @presenter, file_set_id: @presenter.file_set_presenters.first.id) if @presenter.show_pdf_download_button? %>
+                    <%= render 'citations', presenter: @presenter %>
+                    <!-- analytics_button is disabled until future fix -->
+                    <%#= render 'analytics_button', presenter: @presenter %>
+                  <br/>
+                </div>
+              <% end %>
+            </div>
+          </div>
+          <div class="col-sm-12">
+            <%= render 'items', presenter: @presenter %>
+            <%# TODO: we may consider adding these partials in the future %>
+            <%# = render 'sharing_with', presenter: @presenter %>
+            <%# = render 'user_activity', presenter: @presenter %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/themes/neutral_repository/hyrax/homepage/_recent_document.html.erb
+++ b/app/views/themes/neutral_repository/hyrax/homepage/_recent_document.html.erb
@@ -1,3 +1,4 @@
+<%# OVERRIDE Hyrax v5.0.0rc2 template for client theming and shared search %>
 <h3 class="sr-only"><%= t('hyrax.homepage.recently_uploaded.document.title_label') %></h3>
 <div class="recently-uploaded pb-3 col-6 col-md-6">
   <%= link_to(generate_work_url(recent_document, request)) do %>

--- a/config/authorities/discipline.yml
+++ b/config/authorities/discipline.yml
@@ -127,3 +127,5 @@ terms:
     term: Engineering - Industrial
   - id: Law
     term: Law
+  - id: Other
+    term: Other

--- a/spec/services/hyrax/discipline_service_spec.rb
+++ b/spec/services/hyrax/discipline_service_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Hyrax::DisciplineService do
 
     it "has a select list" do
       expect(subject.first).to eq ["Languages - Spanish", "Languages - Spanish"]
-      expect(subject.size).to eq 64
+      expect(subject.size).to eq 65
     end
   end
 


### PR DESCRIPTION
Incorporates several small fixes:
- Moves several partials for the OER work type that was contributed back from pals and weren't included previously
- Collection metadata now shows text for based_near location instead of URI
- Fix collection branding (banner & logo)

Ref https://github.com/scientist-softserv/palni_palci_knapsack/pull/165
