### PR TITLE
Prevent field mappings set value from bleeding into other specs

### DIFF
--- a/.github/workflows/build-test-lint.yaml
+++ b/.github/workflows/build-test-lint.yaml
@@ -48,7 +48,7 @@ jobs:
     uses: scientist-softserv/actions/.github/workflows/test.yaml@v0.0.23
     with:
       confdir: "/app/samvera/hyrax-webapp/solr/conf"
-      rspec_cmd: "gem install semaphore_test_boosters && bundle && TB_RSPEC_OPTIONS='--seed=14318' rspec_booster --job $CI_NODE_INDEX/$CI_NODE_TOTAL"
+      rspec_cmd: "gem install semaphore_test_boosters && bundle && rspec_booster --job $CI_NODE_INDEX/$CI_NODE_TOTAL"
 
   reports:
     if: always()

--- a/.github/workflows/build-test-lint.yaml
+++ b/.github/workflows/build-test-lint.yaml
@@ -48,7 +48,7 @@ jobs:
     uses: scientist-softserv/actions/.github/workflows/test.yaml@v0.0.23
     with:
       confdir: "/app/samvera/hyrax-webapp/solr/conf"
-      rspec_cmd: "gem install semaphore_test_boosters && bundle && rspec_booster --job $CI_NODE_INDEX/$CI_NODE_TOTAL"
+      rspec_cmd: "gem install semaphore_test_boosters && bundle && TB_RSPEC_OPTIONS='--seed=14318' rspec_booster --job $CI_NODE_INDEX/$CI_NODE_TOTAL"
 
   reports:
     if: always()

--- a/spec/lib/bulkrax/bulkrax_decorator_spec.rb
+++ b/spec/lib/bulkrax/bulkrax_decorator_spec.rb
@@ -27,6 +27,12 @@ RSpec.describe PerTenantFieldMappings, type: :decorator do
         allow(Site.account).to receive(:bulkrax_field_mappings).and_return nil
       end
 
+      around do |example|
+        initialized_defaults = Hyku.default_bulkrax_field_mappings
+        example.run
+        Hyku.default_bulkrax_field_mappings = initialized_defaults
+      end
+
       it "returns Hyku's default field mappings" do
         Hyku.default_bulkrax_field_mappings = { this: 'is fine' }
 


### PR DESCRIPTION
Since `Hyku.default_bulkrax_field_mappings=` sets an instance variable, it can persist in scope for other specs, causing unexpected / flaky failures 