### PR TITLE
Fixes invalid method error in IR theme

### DIFF
--- a/app/controllers/hyrax/contact_form_controller_decorator.rb
+++ b/app/controllers/hyrax/contact_form_controller_decorator.rb
@@ -70,7 +70,7 @@ module Hyrax
     private
 
     def ir_counts
-      @ir_counts = get_facet_field_response('resource_type_sim', {}, "f.resource_type_sim.facet.limit" => "-1")
+      @ir_counts = search_service.facet_field_response('resource_type_sim', "f.resource_type_sim.facet.limit" => "-1")
     end
 
     # OVERRIDE: return collections for theming

--- a/app/controllers/hyrax/pages_controller_decorator.rb
+++ b/app/controllers/hyrax/pages_controller_decorator.rb
@@ -59,7 +59,7 @@ module Hyrax
 
     # OVERRIDE: Hyrax v5.0.1 to add facet counts for resource types for IR theme
     def ir_counts
-      @ir_counts = get_facet_field_response('resource_type_sim', {}, "f.resource_type_sim.facet.limit" => "-1")
+      @ir_counts = search_service.facet_field_response('resource_type_sim', "f.resource_type_sim.facet.limit" => "-1")
     end
   end
 end


### PR DESCRIPTION
Fixes 'invalid method error' by correcting the method name, number of arguments, and adding the appropriate object reference.


@samvera/hyku-code-reviewers
