### PR TITLE
Fix incorrectly colored save button

### DIFF
--- a/app/views/hyrax/pages/_form.html.erb
+++ b/app/views/hyrax/pages/_form.html.erb
@@ -1,4 +1,4 @@
-<%# Copied from Hyrax v5.0.1 to correct button coloring since simpleform overrides hyku classes. %>
+<%# OVERRIDE from Hyrax v5.0.1 to correct button coloring since simpleform overrides hyku classes. %>
 <%= render "shared/nav_safety_modal" %>
 <div class="card tabs">
 
@@ -52,7 +52,7 @@
             </div>
           </div>
           <div class="card-footer d-flex justify-content-end">
-            <%= f.submit t(:'hyrax.pages.update'), class: 'btn btn-primary text-white mr-2' %>
+            <%= f.submit t(:'hyrax.pages.update'), class: 'btn btn-primary text-white mr-2' # OVERRIDE button to submit %>
             <%= link_to t(:'hyrax.pages.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-light' %>
           </div>
         <% end %>
@@ -68,7 +68,7 @@
             </div>
           </div>
           <div class="card-footer d-flex justify-content-end">
-            <%= f.submit t(:'hyrax.pages.update'), class: 'btn btn-primary text-white mr-2' %>
+            <%= f.submit t(:'hyrax.pages.update'), class: 'btn btn-primary text-white mr-2' # OVERRIDE button to submit %>
             <%= link_to t(:'hyrax.pages.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-light' %>
           </div>
         <% end %>
@@ -84,7 +84,7 @@
             </div>
           </div>
           <div class="card-footer d-flex justify-content-end">
-            <%= f.submit t(:'hyrax.pages.update'), class: 'btn btn-primary text-white mr-2' %>
+            <%= f.submit t(:'hyrax.pages.update'), class: 'btn btn-primary text-white mr-2' # OVERRIDE button to submit %>
             <%= link_to t(:'hyrax.pages.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-light' %>
           </div>
         <% end %>

--- a/app/views/hyrax/pages/_form.html.erb
+++ b/app/views/hyrax/pages/_form.html.erb
@@ -36,6 +36,7 @@
             </div>
           </div>
           <div class="card-footer d-flex justify-content-end">
+            <%# OVERRIDE change button to submit %>
             <%= f.submit t(:'hyrax.pages.update'), class: 'btn btn-primary text-white mr-2' %>
             <%= link_to t(:'hyrax.pages.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-light' %>
           </div>
@@ -52,7 +53,8 @@
             </div>
           </div>
           <div class="card-footer d-flex justify-content-end">
-            <%= f.submit t(:'hyrax.pages.update'), class: 'btn btn-primary text-white mr-2' # OVERRIDE button to submit %>
+            <%# OVERRIDE change button to submit %>
+            <%= f.submit t(:'hyrax.pages.update'), class: 'btn btn-primary text-white mr-2' %>
             <%= link_to t(:'hyrax.pages.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-light' %>
           </div>
         <% end %>
@@ -68,7 +70,8 @@
             </div>
           </div>
           <div class="card-footer d-flex justify-content-end">
-            <%= f.submit t(:'hyrax.pages.update'), class: 'btn btn-primary text-white mr-2' # OVERRIDE button to submit %>
+            <%# OVERRIDE change button to submit %>
+            <%= f.submit t(:'hyrax.pages.update'), class: 'btn btn-primary text-white mr-2' %>
             <%= link_to t(:'hyrax.pages.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-light' %>
           </div>
         <% end %>
@@ -84,7 +87,8 @@
             </div>
           </div>
           <div class="card-footer d-flex justify-content-end">
-            <%= f.submit t(:'hyrax.pages.update'), class: 'btn btn-primary text-white mr-2' # OVERRIDE button to submit %>
+            <%# OVERRIDE change button to submit %>
+            <%= f.submit t(:'hyrax.pages.update'), class: 'btn btn-primary text-white mr-2' %>
             <%= link_to t(:'hyrax.pages.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-light' %>
           </div>
         <% end %>

--- a/app/views/hyrax/pages/_form.html.erb
+++ b/app/views/hyrax/pages/_form.html.erb
@@ -1,0 +1,96 @@
+<%# Copied from Hyrax v5.0.1 to correct button coloring since simpleform overrides hyku classes. %>
+<%= render "shared/nav_safety_modal" %>
+<div class="card tabs">
+
+  <ul class="nav nav-tabs" role="tablist">
+    <li class="nav-item" role="presentation">
+      <a href="#about" role="tab" data-toggle="tab" class="nav-link active nav-safety-confirm">
+        <%= t(:'hyrax.pages.tabs.about_page') %>
+      </a>
+    </li>
+    <li class="nav-item" role="presentation">
+      <a href="#help" role="tab" data-toggle="tab" class="nav-link nav-safety-confirm">
+        <%= t(:'hyrax.pages.tabs.help_page') %>
+      </a>
+    </li>
+    <li class="nav-item" role="presentation">
+      <a href="#agreement" role="tab" data-toggle="tab" class="nav-link nav-safety-confirm">
+        <%= t(:'hyrax.pages.tabs.agreement_page') %>
+      </a>
+    </li>
+    <li class="nav-item" role="presentation">
+      <a href="#terms" role="tab" data-toggle="tab" class="nav-link nav-safety-confirm">
+        <%= t(:'hyrax.pages.tabs.terms_page') %>
+      </a>
+    </li>
+  </ul>
+
+  <div class="tab-content">
+    <div id="about" class="tab-pane show active">
+      <div class="card labels">
+        <%= simple_form_for ContentBlock.for(:about), url: hyrax.page_path(ContentBlock.for(:about)), html: { class: 'nav-safety' } do |f| %>
+          <div class="card-body">
+            <div class="field form-group">
+              <%= f.label :about %><br />
+              <%= f.text_area :about, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
+            </div>
+          </div>
+          <div class="card-footer d-flex justify-content-end">
+            <%= f.submit t(:'hyrax.pages.update'), class: 'btn btn-primary text-white mr-2' %>
+            <%= link_to t(:'hyrax.pages.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-light' %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+    <div id="help" class="tab-pane">
+      <div class="card labels">
+        <%= simple_form_for ContentBlock.for(:help), url: hyrax.page_path(ContentBlock.for(:help)), html: { class: 'nav-safety' } do |f| %>
+          <div class="card-body">
+            <div class="field form-group">
+              <%= f.label :help %><br />
+              <%= f.text_area :help, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
+            </div>
+          </div>
+          <div class="card-footer d-flex justify-content-end">
+            <%= f.submit t(:'hyrax.pages.update'), class: 'btn btn-primary text-white mr-2' %>
+            <%= link_to t(:'hyrax.pages.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-light' %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+    <div id="agreement" class="tab-pane">
+      <div class="card labels">
+        <%= simple_form_for ContentBlock.for(:agreement), url: hyrax.page_path(ContentBlock.for(:agreement)), html: { class: 'nav-safety' } do |f| %>
+          <div class="card-body">
+            <div class="field form-group">
+              <%= f.label :agreement %><br />
+              <%= f.text_area :agreement, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
+            </div>
+          </div>
+          <div class="card-footer d-flex justify-content-end">
+            <%= f.submit t(:'hyrax.pages.update'), class: 'btn btn-primary text-white mr-2' %>
+            <%= link_to t(:'hyrax.pages.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-light' %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+    <div id="terms" class="tab-pane">
+      <div class="card labels">
+        <%= simple_form_for ContentBlock.for(:terms), url: hyrax.page_path(ContentBlock.for(:terms)), html: { class: 'nav-safety' } do |f| %>
+          <div class="card-body">
+            <div class="field form-group">
+              <%= f.label :terms %><br />
+              <%= f.text_area :terms, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
+            </div>
+          </div>
+          <div class="card-footer d-flex justify-content-end">
+            <%= f.submit t(:'hyrax.pages.update'), class: 'btn btn-primary text-white mr-2' %>
+            <%= link_to t(:'hyrax.pages.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-light' %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+
+</div>
+<%= tinymce :content_block %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -942,6 +942,7 @@ en:
       change_tab_message: Are you sure you want to leave this tab?  Any unsaved data will be lost.
     pages:
       cancel: Cancel
+      update: Save changes
       tabs:
         about_page: About Page
         agreement_page: Deposit Agreement


### PR DESCRIPTION
Simpleform injects css classes into its button tags and those classes conflict with what is used in Hyku. The forms on the Pages page were using the button tag instead of the submit tag and causing the classes to be duplicated and conflict with each other. By using the submit tag it doesn't inject classes and only applies the classes specified in the tag.

Button color for "Save changes" button was white instead of blue like the rest of Hyku. This fixes that issue as well as issues in the future stemming from this "class injection".



@samvera/hyku-code-reviewers
