### PR TITLE
Added slideshow start info back in from blacklight.

### DIFF
--- a/app/assets/stylesheets/hyku.scss
+++ b/app/assets/stylesheets/hyku.scss
@@ -716,3 +716,9 @@ tr[data-feature="use-iiif-print"] {
   flex-wrap: wrap;
   justify-content: space-between;
 }
+
+// slideshow heading
+.slideshow-info {
+  text-align: center;
+  margin-bottom: 15px;
+}

--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -135,6 +135,9 @@
     </div>
 
     <div class="hyc-blacklight hyc-bl-results">
+      <div class="slideshow-info">
+        <h4><%= t('blacklight.slideshow_info') %></h4>
+      </div>
       <%= render_document_index @member_docs %>
     </div>
 

--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -135,9 +135,11 @@
     </div>
 
     <div class="hyc-blacklight hyc-bl-results">
-      <div class="slideshow-info">
-        <h4><%= t('blacklight.slideshow_info') %></h4>
-      </div>
+      <% if document_index_view_type == :slideshow %>
+        <div class="slideshow-info">
+          <h4><%= t('blacklight.slideshow_info') %></h4>
+        </div>
+      <% end %>
       <%= render_document_index @member_docs %>
     </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,6 +19,7 @@ en:
       etd: "ETD"
       oer: "OER"
   blacklight:
+    slideshow_info: "Select an image to start the slideshow"
     search:
       fields:
         facet:


### PR DESCRIPTION
Blacklight has removed the info for how to start the slideshow. Not sure why it was removed [here](https://github.com/projectblacklight/blacklight-gallery/commit/498b463e0b4418411d303676c1877547044f43c8), without comment. It is probably better to have it in hyku so there is no worry about it being arbitrarily changed in the future. This change applies specifically to the public show page of collections.

@samvera/hyku-code-reviewers
