### PR TITLE
🧹 Align User Collection badge

### DIFF
--- a/app/views/catalog/_index_header_list_collection.html.erb
+++ b/app/views/catalog/_index_header_list_collection.html.erb
@@ -1,8 +1,8 @@
-<%# OVERRIDE Hyrax v5.0.0rc2 %>
+<%# OVERRIDE Hyrax v5.0.1 to use markdown and adjust h3 utility classes %>
 
-<div class="search-results-title-row col-12 d-flex flex-row align-items-center pb-2 mb-3">
+<div class="search-results-title-row col-12 d-flex flex-row align-items-center pb-2">
   <%# OVERRIDE begin %>
-  <h3 class="search-result-title mb-n2"><%= link_to markdown(document.title_or_label), generate_work_url(document, request) %></h3>
+  <h3 class="search-result-title"><%= link_to markdown(document.title_or_label), generate_work_url(document, request) %></h3>
   <%# OVERRIDE end %>
   <%= Hyrax::CollectionPresenter.new(document, current_ability).collection_type_badge %>
 </div>


### PR DESCRIPTION
Remove extra classes that throw the alignment of the badge off.

Before:
<img width="917" alt="image" src="https://github.com/user-attachments/assets/00ab06a5-72cf-42f2-ab1b-3495c1bd58b0" />


After:
<img width="920" alt="image" src="https://github.com/user-attachments/assets/4a71da6d-31c8-43a6-a221-bc69a065b9a4" />
