### PR TITLE
🧹 Updates to search form overrides

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,7 +153,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: abd5955f325b966ebd21d0de8d96b61cf0421cf3
+  revision: b6dcb8af85ab346b475c05e6e68b93da7825d319
   branch: main
   specs:
     hyrax (5.0.1)
@@ -174,7 +174,6 @@ GIT
       dry-logic (~> 1.5)
       dry-monads (~> 1.6)
       dry-validation (~> 1.10)
-      faraday (= 2.9.1)
       flipflop (~> 2.3)
       flot-rails (~> 0.0.6)
       font-awesome-rails (~> 4.2)
@@ -193,7 +192,7 @@ GIT
       noid-rails (~> 3.0)
       oauth
       oauth2 (~> 1.2)
-      openseadragon
+      openseadragon (~> 0.9)
       posix-spawn
       qa (~> 5.5, >= 5.5.1)
       rails (~> 6.1)
@@ -211,7 +210,7 @@ GIT
       signet
       sprockets (= 3.7.2)
       tinymce-rails (~> 5.10)
-      valkyrie (~> 3.3)
+      valkyrie (~> 3.5)
       view_component (~> 2.74.1)
 
 GIT
@@ -1005,8 +1004,8 @@ GEM
       validate_email
       validate_url
       webfinger (~> 2.0)
-    openseadragon (0.6.0)
-      rails (> 3.2.0)
+    openseadragon (0.9.0)
+      rails (> 6.1.0)
     openssl (3.2.0)
     optimist (3.1.0)
     order_already (0.3.2)
@@ -1416,7 +1415,7 @@ GEM
     validate_url (1.0.15)
       activemodel (>= 3.0.0)
       public_suffix
-    valkyrie (3.3.0)
+    valkyrie (3.5.0)
       activemodel
       activesupport
       dry-struct

--- a/app/views/themes/cultural_repository/catalog/_search_form.html.erb
+++ b/app/views/themes/cultural_repository/catalog/_search_form.html.erb
@@ -1,4 +1,4 @@
-<% # OVERRIDE: Hyrax v5.0.0rc2 template to change the size of the column on line 8 from col-sm-3 to col-sm-4 %>
+<% # OVERRIDE: Hyrax v5.0.1 template to change the size of the column on line 8 from col-sm-3 to col-sm-4 %>
 
 <%= form_tag search_form_action, method: :get, class: "cultural-repository form-horizontal search-form", id: "search-form-header", role: "search" do %>
   <%= render Blacklight::HiddenSearchStateComponent.new(params: search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8)) %>

--- a/app/views/themes/cultural_repository/catalog/_search_form.html.erb
+++ b/app/views/themes/cultural_repository/catalog/_search_form.html.erb
@@ -1,4 +1,4 @@
-<% # OVERRIDE: Hyrax v5.0.0rc2 template to change the size of the column on line 8 from col-sm-3 to col-sm-4  %>
+<% # OVERRIDE: Hyrax v5.0.0rc2 template to change the size of the column on line 8 from col-sm-3 to col-sm-4 %>
 
 <%= form_tag search_form_action, method: :get, class: "cultural-repository form-horizontal search-form", id: "search-form-header", role: "search" do %>
   <%= render Blacklight::HiddenSearchStateComponent.new(params: search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8)) %>
@@ -26,20 +26,14 @@
             <span class="caret"></span>
           </button>
 
-          <ul class="dropdown-menu dropdown-menu-right">
-            <li class="dropdown-item">
-              <%= link_to t("hyrax.search.form.option.all.label_long", application_name: application_name), "#",
-                  data: { "search-option" => main_app.search_catalog_path, "search-label" => t("hyrax.search.form.option.all.label_short") } %>
-            </li>
-            <li class="dropdown-item">
-              <%= link_to t("hyrax.search.form.option.my_works.label_long"), "#",
-                  data: { "search-option" => hyrax.my_works_path, "search-label" => t("hyrax.search.form.option.my_works.label_short") } %>
-            </li>
-            <li class="dropdown-item">
-              <%= link_to t("hyrax.search.form.option.my_collections.label_long"), "#",
-                  data: { "search-option" => hyrax.my_collections_path, "search-label" => t("hyrax.search.form.option.my_collections.label_short") } %>
-            </li>
-          </ul>
+          <div class="dropdown-menu dropdown-menu-right">
+            <%= link_to t("hyrax.search.form.option.all.label_long", application_name: application_name), "#", class: "dropdown-item",
+                data: { "search-option" => main_app.search_catalog_path, "search-label" => t("hyrax.search.form.option.all.label_short") } %>
+            <%= link_to t("hyrax.search.form.option.my_works.label_long"), "#", class: "dropdown-item",
+                data: { "search-option" => hyrax.my_works_path, "search-label" => t("hyrax.search.form.option.my_works.label_short") } %>
+            <%= link_to t("hyrax.search.form.option.my_collections.label_long"), "#", class: "dropdown-item",
+                data: { "search-option" => hyrax.my_collections_path, "search-label" => t("hyrax.search.form.option.my_collections.label_short") } %>
+          </div>
         <% end %>
       </div><!-- /.input-group-btn -->
     </div><!-- /.input-group -->

--- a/app/views/themes/institutional_repository/catalog/_search_form.html.erb
+++ b/app/views/themes/institutional_repository/catalog/_search_form.html.erb
@@ -1,4 +1,4 @@
-<% # OVERRIDE: Hyrax v5.0.0rc2 template to change the size of the column on line 8 from col-sm-3 to col-sm-6 %>
+<% # OVERRIDE: Hyrax v5.0.1 template to change the size of the column on line 8 from col-sm-3 to col-sm-6 %>
 
 <%= form_tag search_form_action, method: :get, class: "institutional-repository form-horizontal search-form", id: "search-form-header", role: "search" do %>
   <%= render Blacklight::HiddenSearchStateComponent.new(params: search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8)) %>

--- a/app/views/themes/institutional_repository/catalog/_search_form.html.erb
+++ b/app/views/themes/institutional_repository/catalog/_search_form.html.erb
@@ -1,4 +1,4 @@
-<% # OVERRIDE: Hyrax v5.0.0rc2 template to change the size of the column on line 8 from col-sm-3 to col-sm-6  %>
+<% # OVERRIDE: Hyrax v5.0.0rc2 template to change the size of the column on line 8 from col-sm-3 to col-sm-6 %>
 
 <%= form_tag search_form_action, method: :get, class: "institutional-repository form-horizontal search-form", id: "search-form-header", role: "search" do %>
   <%= render Blacklight::HiddenSearchStateComponent.new(params: search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8)) %>
@@ -26,20 +26,14 @@
             <span class="caret"></span>
           </button>
 
-          <ul class="dropdown-menu dropdown-menu-right">
-            <li class="dropdown-item">
-              <%= link_to t("hyrax.search.form.option.all.label_long", application_name: application_name), "#",
-                  data: { "search-option" => main_app.search_catalog_path, "search-label" => t("hyrax.search.form.option.all.label_short") } %>
-            </li>
-            <li class="dropdown-item">
-              <%= link_to t("hyrax.search.form.option.my_works.label_long"), "#",
-                  data: { "search-option" => hyrax.my_works_path, "search-label" => t("hyrax.search.form.option.my_works.label_short") } %>
-            </li>
-            <li class="dropdown-item">
-              <%= link_to t("hyrax.search.form.option.my_collections.label_long"), "#",
-                  data: { "search-option" => hyrax.my_collections_path, "search-label" => t("hyrax.search.form.option.my_collections.label_short") } %>
-            </li>
-          </ul>
+          <div class="dropdown-menu dropdown-menu-right">
+            <%= link_to t("hyrax.search.form.option.all.label_long", application_name: application_name), "#", class: "dropdown-item",
+                data: { "search-option" => main_app.search_catalog_path, "search-label" => t("hyrax.search.form.option.all.label_short") } %>
+            <%= link_to t("hyrax.search.form.option.my_works.label_long"), "#", class: "dropdown-item",
+                data: { "search-option" => hyrax.my_works_path, "search-label" => t("hyrax.search.form.option.my_works.label_short") } %>
+            <%= link_to t("hyrax.search.form.option.my_collections.label_long"), "#", class: "dropdown-item",
+                data: { "search-option" => hyrax.my_collections_path, "search-label" => t("hyrax.search.form.option.my_collections.label_short") } %>
+          </div>
         <% end %>
       </div><!-- /.input-group-btn -->
     </div><!-- /.input-group -->


### PR DESCRIPTION
# Updated Search Form View File Overrides

Ref:
- https://github.com/notch8/palni_palci_knapsack/issues/156

This commit:
- updated the search form override view files for the Cultural and Institutional Repositories to align with existing code in Hyrax which fixed styling issues in the search form dropdown menus
- updated the Hyku dependencies to the latest versions of Hyrax gems

@samvera/hyku-code-reviewers
