### PR TITLE
Display superadmin settings when user has appropriate permissions

### DIFF
--- a/app/controllers/admin/accounts_controller.rb
+++ b/app/controllers/admin/accounts_controller.rb
@@ -29,7 +29,8 @@ module Admin
     private
 
     def account_params
-      params.require(:account).permit(:name, :cname, :title, *@account.public_settings.keys)
+      is_superadmin = current_ability.superadmin?
+      params.require(:account).permit(:name, :cname, :title, *@account.public_settings(is_superadmin: is_superadmin).keys)
     end
 
     def set_current_account

--- a/app/views/admin/accounts/edit.html.erb
+++ b/app/views/admin/accounts/edit.html.erb
@@ -1,7 +1,6 @@
 <% content_for :page_header do %>
   <h1><span class="fa fa-gears"></span> Editing Account</h1>
 <% end %>
-
 <div class="row">
   <div class="col-md-12">
     <div class="card account-form">
@@ -17,16 +16,14 @@
               </ul>
             </div>
           <% end %>
-
           <div class="form-group">
             <%= f.label :tenant %><br>
             <%= f.text_field :tenant, class: 'form-control', readonly: @account.persisted? %>
           </div>
-
-          <% current_account.public_settings.each do |key, value| %>
+          <% is_superadmin = current_ability.superadmin? %>
+          <% current_account.public_settings(is_superadmin: is_superadmin).each do |key, value| %>
             <%= render 'shared/settings', f: f, key: key, value: value %>
           <% end %>
-
           <div class="card-footer">
             <%= f.submit class: 'btn btn-secondary float-right' %>
           </div>


### PR DESCRIPTION
Issue:
- https://github.com/notch8/palni_palci_knapsack/issues/71

Previously, superadmin settings like oai_prefix, oai_sample_identifier, and s3_bucket were being filtered out because public_settings wasn't taking the user's permissions into account, if set. This adds a permission check and passes it to public_settings to dynamically show/hide superadmin settings based on user role.

## BEFORE

![image](https://github.com/user-attachments/assets/e9cda28f-b48c-4e6a-b537-56eed4c6bcaa)



## AFTER

![image](https://github.com/user-attachments/assets/2262b3cd-4404-4ea6-bd2f-d8f60f200fca)

# EXPECTATIONS

1. When looged in as super admin, extra settings should be availabile. 
2. The setting form should match production:

![image](https://github.com/user-attachments/assets/bc91f2a5-69b3-45cd-8fcd-18531311b0dd)


