### PR TITLE
🧹 Adjust show pages

### DIFF
--- a/app/assets/stylesheets/themes/cultural_show.scss
+++ b/app/assets/stylesheets/themes/cultural_show.scss
@@ -3,6 +3,10 @@
   dl.work-show dd {
     border-bottom: 1px solid #ddd;
 
+    &:last-child {
+      border-bottom: none; /* Removes border for the last dd element */
+    }
+
     .tabular {
       border-bottom: 0;
     }

--- a/app/views/themes/cultural_show/hyrax/base/_show_actions.html.erb
+++ b/app/views/themes/cultural_show/hyrax/base/_show_actions.html.erb
@@ -1,0 +1,54 @@
+<%# OVERRIDE Hyrax v5.0.1 Adjust permission checks for delete and add analytics button and add ENV to control turbolinks %>
+<div class="row show-actions button-row-top-two-column justify-content-start mt-1">
+  <div class="pr-3">
+    <% if Hyrax.config.analytics_reporting? %>
+      <% # turbolinks needs to be turned off or the page will use the cache and the %>
+      <% # analytics graph will not show unless the page is refreshed. %>
+      <%= link_to t('.analytics'), presenter.stats_path, id: 'stats', class: 'btn btn-secondary', data: { turbolinks: false } %>
+    <% end %>
+    <% if presenter.editor? && !workflow_restriction?(presenter) %>
+      <%= link_to t('.edit'), edit_polymorphic_path([main_app, presenter]), class: 'btn btn-secondary', data: { turbolinks: block_valkyrie_redirect? }  %>
+      <% if presenter.member_count > 1 %>
+          <%= link_to t("hyrax.file_manager.link_text"), polymorphic_path([main_app, :file_manager, presenter]), class: 'btn btn-secondary' %>
+      <% end %>
+      <% if presenter.valid_child_concerns.length > 0 %>
+        <div class="btn-group">
+          <button type="button" class="btn btn-secondary dropdown-toggle" type="button" id="dropdown-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <%= t('.attach_child') %>
+          </button>
+          <div class="dropdown-menu">
+            <% presenter.valid_child_concerns.each do |concern| %>
+              <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular.to_sym], parent_id: presenter.id), class: "dropdown-item" %>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+      <%# OVERRIDE to validate delete permission %>
+      <% if current_ability.can?(:delete, presenter.solr_document) %>
+        <%= link_to t('.delete'), [main_app, presenter], class: 'btn btn-danger', data: { confirm: t('.confirm_delete', work_type: presenter.human_readable_type) }, method: :delete %>
+      <% end %>
+      <% if !workflow_restriction?(presenter) %>
+        <% if presenter.show_deposit_for?(collections: @user_collections) %>
+          <input type="checkbox" aria-label="Batch Documents" style="display:none" name="batch_document_ids[]" id="batch_document_<%= presenter.id %>" value="<%= presenter.id %>" class="batch_document_selector" checked="checked" />
+          <%= button_tag t('hyrax.dashboard.my.action.add_to_collection'),
+                        class: 'btn btn-secondary submits-batches submits-batches-add',
+                        data: { toggle: "modal", target: "#collection-list-container" } %>
+        <% end %>
+        <% if presenter.work_featurable? %>
+          <%= link_to t('.feature'), hyrax.featured_work_path(presenter, format: :json),
+              data: { behavior: 'feature' },
+              class: presenter.display_feature_link? ? 'btn btn-secondary' : 'btn btn-secondary collapse' %>
+
+          <%= link_to t('.unfeature'), hyrax.featured_work_path(presenter, format: :json),
+              data: { behavior: 'unfeature' },
+              class: presenter.display_unfeature_link? ? 'btn btn-secondary' : 'btn btn-secondary collapse' %>
+        <% end %>
+      <% end %>
+    <% end %>
+  </div>
+</div>
+
+<!-- COinS hook for Zotero -->
+  <span class="Z3988" title="<%= export_as_openurl_ctx_kev(presenter) %>"></span>
+<!-- Render Modals -->
+  <%= render 'hyrax/dashboard/collections/form_for_select_collection', user_collections: @user_collections %>

--- a/app/views/themes/cultural_show/hyrax/base/_work_title.html.erb
+++ b/app/views/themes/cultural_show/hyrax/base/_work_title.html.erb
@@ -1,10 +1,8 @@
 <% presenter.title.each_with_index do |title, index| %>
   <div class="row">
-    <div class="col-12 text-show-title">
+    <div class="col-12 text-show-title d-flex">
       <% if index == 0 %>
-        <h2><%= markdown(title) %>
-          <small class="text-muted"><%= presenter.permission_badge %> <%= presenter.workflow.badge %></small>
-        </h2>
+        <h2><%= markdown(title) %></h2><span class="ml-2 mt-2"><%= presenter.permission_badge %> <%= presenter.workflow.badge %></span>
       <% else %>
         <h2><%= markdown(title) %></h2>
       <% end %>

--- a/app/views/themes/cultural_show/hyrax/base/show.html.erb
+++ b/app/views/themes/cultural_show/hyrax/base/show.html.erb
@@ -11,9 +11,6 @@
       <div class="card-body">
         <div class="row">
           <%= render 'workflow_actions_widget', presenter: @presenter %>
-          <div class="col-12">
-            <%= render "show_actions", presenter: @presenter %>
-          </div>
           <% if @presenter.video_embed_viewer? %>
             <%= render 'video_embed_viewer', presenter: @presenter %>
           <% elsif @presenter.iiif_viewer? %>
@@ -29,6 +26,9 @@
               <%= render 'representative_media', presenter: @presenter, viewer: false %>
             </div>
           <% end %>
+          <div class="col-12">
+            <%= render "show_actions", presenter: @presenter %>
+          </div>
           <div class="col-md-8">
             <%= render 'work_description', presenter: @presenter %>
             <%= render 'metadata', presenter: @presenter %>
@@ -38,7 +38,9 @@
               <%= render 'relationships', presenter: @presenter %>
             </div>
             <%= render('download_pdf', presenter: @presenter, file_set_id: @presenter.file_set_presenters.first.id) if @presenter.show_pdf_download_button? %>
+            <div class="d-flex justify-content-center">
             <%= render 'citations', presenter: @presenter %>
+            </div>
             <!-- analytics_button is disabled until future fix -->
             <%#= render 'analytics_button', presenter: @presenter %>
           </div>

--- a/app/views/themes/scholarly_show/hyrax/base/_show_actions.html.erb
+++ b/app/views/themes/scholarly_show/hyrax/base/_show_actions.html.erb
@@ -1,0 +1,54 @@
+<%# OVERRIDE Hyrax v5.0.1 Adjust permission checks for delete and add analytics button and add ENV to control turbolinks %>
+<div class="row show-actions button-row-top-two-column justify-content-end">
+  <div class="pr-3">
+    <% if Hyrax.config.analytics_reporting? %>
+      <% # turbolinks needs to be turned off or the page will use the cache and the %>
+      <% # analytics graph will not show unless the page is refreshed. %>
+      <%= link_to t('.analytics'), presenter.stats_path, id: 'stats', class: 'btn btn-secondary', data: { turbolinks: false } %>
+    <% end %>
+    <% if presenter.editor? && !workflow_restriction?(presenter) %>
+      <%= link_to t('.edit'), edit_polymorphic_path([main_app, presenter]), class: 'btn btn-secondary', data: { turbolinks: block_valkyrie_redirect? }  %>
+      <% if presenter.member_count > 1 %>
+          <%= link_to t("hyrax.file_manager.link_text"), polymorphic_path([main_app, :file_manager, presenter]), class: 'btn btn-secondary' %>
+      <% end %>
+      <% if presenter.valid_child_concerns.length > 0 %>
+        <div class="btn-group">
+          <button type="button" class="btn btn-secondary dropdown-toggle" type="button" id="dropdown-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <%= t('.attach_child') %>
+          </button>
+          <div class="dropdown-menu">
+            <% presenter.valid_child_concerns.each do |concern| %>
+              <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular.to_sym], parent_id: presenter.id), class: "dropdown-item" %>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+      <%# OVERRIDE to validate delete permission %>
+      <% if current_ability.can?(:delete, presenter.solr_document) %>
+        <%= link_to t('.delete'), [main_app, presenter], class: 'btn btn-danger', data: { confirm: t('.confirm_delete', work_type: presenter.human_readable_type) }, method: :delete %>
+      <% end %>
+      <% if !workflow_restriction?(presenter) %>
+        <% if presenter.show_deposit_for?(collections: @user_collections) %>
+          <input type="checkbox" aria-label="Batch Documents" style="display:none" name="batch_document_ids[]" id="batch_document_<%= presenter.id %>" value="<%= presenter.id %>" class="batch_document_selector" checked="checked" />
+          <%= button_tag t('hyrax.dashboard.my.action.add_to_collection'),
+                        class: 'btn btn-secondary submits-batches submits-batches-add',
+                        data: { toggle: "modal", target: "#collection-list-container" } %>
+        <% end %>
+        <% if presenter.work_featurable? %>
+          <%= link_to t('.feature'), hyrax.featured_work_path(presenter, format: :json),
+              data: { behavior: 'feature' },
+              class: presenter.display_feature_link? ? 'btn btn-secondary' : 'btn btn-secondary collapse' %>
+
+          <%= link_to t('.unfeature'), hyrax.featured_work_path(presenter, format: :json),
+              data: { behavior: 'unfeature' },
+              class: presenter.display_unfeature_link? ? 'btn btn-secondary' : 'btn btn-secondary collapse' %>
+        <% end %>
+      <% end %>
+    <% end %>
+  </div>
+</div>
+
+<!-- COinS hook for Zotero -->
+  <span class="Z3988" title="<%= export_as_openurl_ctx_kev(presenter) %>"></span>
+<!-- Render Modals -->
+  <%= render 'hyrax/dashboard/collections/form_for_select_collection', user_collections: @user_collections %>

--- a/app/views/themes/scholarly_show/hyrax/base/_work_title.html.erb
+++ b/app/views/themes/scholarly_show/hyrax/base/_work_title.html.erb
@@ -2,9 +2,7 @@
   <div class="row">
     <div class="col-md-6">
       <% if index == 0 %>
-        <h2><%= markdown(title) %>
-          <small class="text-muted"><%= presenter.permission_badge %> <%= presenter.workflow.badge %></small>
-        </h2>
+        <h2><%= markdown(title) %></h2><span class="ml-2 mt-2"><%= presenter.permission_badge %> <%= presenter.workflow.badge %></span>
       <% else %>
         <h2><%= markdown(title) %></h2>
       <% end %>

--- a/app/views/themes/scholarly_show/hyrax/base/show.html.erb
+++ b/app/views/themes/scholarly_show/hyrax/base/show.html.erb
@@ -54,7 +54,7 @@
           <div class="col-sm-9 image-show-metadata">
             <%= render 'metadata', presenter: @presenter %>
           </div>
-          <div class="col-sm-3">
+          <div class="col-sm-3 text-center">
             <%= render('download_pdf', presenter: @presenter, file_set_id: @presenter.file_set_presenters.first.id) if @presenter.show_pdf_download_button? %>
             <%= render 'citations', presenter: @presenter %>
             <!-- analytics_button is disabled until future fix -->
@@ -62,7 +62,7 @@
           </div>
         </div>
         <div class="row">
-          <div class="col-sm-8">
+          <div class="col-12 work-show-items">
             <%= render 'relationships', presenter: @presenter %>
             <% if @presenter.class == Hyrax::OerPresenter %>
               <%= render 'hyrax/oers/related_items', presenter: @presenter %>

--- a/spec/services/create_account_spec.rb
+++ b/spec/services/create_account_spec.rb
@@ -6,6 +6,11 @@ RSpec.describe CreateAccount, clean: true do
   let(:account) { FactoryBot.build(:sign_up_account) }
   let(:stubbed_admin_set) { double(AdminSetResource, id: "admin_set/id") }
 
+  after do
+    # Ensure we reset to the default tenant after each test
+    Apartment::Tenant.switch!(Apartment.default_tenant)
+  end
+
   describe '#create_tenant' do
     it 'creates a new apartment tenant' do
       expect(Apartment::Tenant).to receive(:create).with(account.tenant)


### PR DESCRIPTION
This commit will adjust the show pages of various themes and make them look better.

Default show:
![image](https://github.com/user-attachments/assets/a17a0b1d-9dc1-412f-9fdb-67147e75644c)

Cultural show:
![image](https://github.com/user-attachments/assets/c0c0be4b-eb79-452f-a28d-5dd007b7f595)

Scholarly show:
![image](https://github.com/user-attachments/assets/bbc8c360-a359-4aac-9ca0-09693bfefe05)
