### PR TITLE
fix: correct range limit helper inclusion in SearchHistoryController

### DIFF
--- a/app/controllers/search_history_controller.rb
+++ b/app/controllers/search_history_controller.rb
@@ -3,5 +3,5 @@
 class SearchHistoryController < ApplicationController
   include Blacklight::SearchHistory
   helper BlacklightAdvancedSearch::RenderConstraintsOverride
-  helper RangeLimitHelper
+  helper BlacklightRangeLimit::ControllerOverride
 end


### PR DESCRIPTION
Changed helper Blacklight::RangeLimitHelper to include BlacklightRangeLimit::ControllerOverride since the proper module for range limit functionality is provided by the BlacklightRangeLimit engine's ControllerOverride module rather than through a helper method. This module provides the necessary controller-level range limit behavior while maintaining proper Rails engine namespace isolation.

When updating the PALS submodule to HYKU latest we got the following errors in the pipeline. Updating this resolved it. 

`uninitialized constant SearchHistoryController::RangeLimitHelper`