### PR TITLE
🧹 Switch from bootstrap class to css

### DIFF
--- a/app/assets/stylesheets/themes/cultural_show.scss
+++ b/app/assets/stylesheets/themes/cultural_show.scss
@@ -49,6 +49,11 @@
     }
   }
 
+  .citations-container {
+    display: flex;
+    justify-content: center;
+  }
+
   li.attribute,
   td.attribute {
     font-size: 18px;

--- a/app/views/themes/cultural_show/hyrax/base/show.html.erb
+++ b/app/views/themes/cultural_show/hyrax/base/show.html.erb
@@ -38,8 +38,8 @@
               <%= render 'relationships', presenter: @presenter %>
             </div>
             <%= render('download_pdf', presenter: @presenter, file_set_id: @presenter.file_set_presenters.first.id) if @presenter.show_pdf_download_button? %>
-            <div class="d-flex justify-content-center">
-            <%= render 'citations', presenter: @presenter %>
+            <div class="citations-container">
+              <%= render 'citations', presenter: @presenter %>
             </div>
             <!-- analytics_button is disabled until future fix -->
             <%#= render 'analytics_button', presenter: @presenter %>


### PR DESCRIPTION
This commit will change the cultural show page's citations div to use css instead of using bootstrap utility classes.  This way it will be easier for knapsack applications to override the style of that div.