### PR TITLE
Fix content blocks

### DIFF
--- a/app/views/hyrax/content_blocks/_form.html.erb
+++ b/app/views/hyrax/content_blocks/_form.html.erb
@@ -1,5 +1,6 @@
-<%# Copied from Hyrax v5.0.0rc2 to add home_text content block form - Adding themes %>
-<%# imported from hyrax 3.0.0.pre.rc1 %>
+<%# OVERRIDE Hyrax v5.0.0rc2 to add content blocks for:
+    - Home Page Text for theme
+    - Home "About" page content %>
 <%= render "shared/nav_safety_modal" %>
 <div class="card tabs">
   <ul class="nav nav-tabs" role="tablist">
@@ -14,7 +15,7 @@
       </a>
     </li>
     <li id="home-text-nav-item" class="nav-item">
-      <a href="#home_text" role="tab" data-toggle="tab" class="nav-safety-confirm">
+      <a href="#home_text" role="tab" data-toggle="tab" class="nav-link nav-safety-confirm">
         <%= t(:'hyrax.content_blocks.tabs.home_text') %>
       </a>
     </li>
@@ -24,22 +25,16 @@
       </a>
     </li>
     <li id="homepage-about-heading-nav-item" class="nav-item">
-      <a href="#homepage_about_section_heading" role="tab" data-toggle="tab" class="nav-safety-confirm">
+      <a href="#homepage_about_section_heading" role="tab" data-toggle="tab" class="nav-link nav-safety-confirm">
         <%= t(:'hyrax.content_blocks.tabs.homepage_about_section_heading') %>
       </a>
     </li>
     <li id="homepage-about-content-nav-item" class="nav-item">
-      <a href="#homepage_about_section_content" role="tab" data-toggle="tab" class="nav-safety-confirm">
-        <%= t(:'hyrax.content_blocks.tabs.homepage_about_section_content') %>
-      </a>
-    </li>
-    <li>
-      <a href="#homepage_about_section_heading" role="tab" data-toggle="tab" class="nav-safety-confirm"><%= t(:'hyrax.content_blocks.tabs.homepage_about_section_heading') %></a>
-    </li>
-    <li>
-      <a href="#homepage_about_section_content" role="tab" data-toggle="tab" class="nav-safety-confirm"><%= t(:'hyrax.content_blocks.tabs.homepage_about_section_content') %></a>
+      <a href="#homepage_about_section_content" role="tab" data-toggle="tab" class="nav-link nav-safety-confirm">
+        <%= t(:'hyrax.content_blocks.tabs.homepage_about_section_content') %></a>
     </li>
   </ul>
+
   <div class="tab-content">
     <div id="announcement_text" class="tab-pane show active">
       <div class="card labels">
@@ -59,6 +54,7 @@
         <% end %>
       </div>
     </div>
+
     <div id="marketing" class="tab-pane">
       <div class="card labels">
         <%= simple_form_for ContentBlock.for(:marketing), url: hyrax.content_block_path(ContentBlock.for(:marketing)), html: {class: 'nav-safety'} do |f| %>
@@ -77,7 +73,8 @@
         <% end %>
       </div>
     </div>
-    <%# Copied from Hyrax v2.9.0 to add home_text content block form - Adding themes %>
+
+    <%# OVERRIDE to add home text block %>
     <div id="home_text" class="tab-pane">
       <div class="card labels">
         <%= simple_form_for ContentBlock.for(:home_text), url: hyrax.content_block_path(ContentBlock.for(:home_text)), html: {class: 'nav-safety'} do |f| %>
@@ -114,6 +111,7 @@
         <% end %>
       </div>
     </div>
+    <%# OVERRIDE: add about section content blocks %>
     <div id="homepage_about_section_heading" class="tab-pane">
       <div class="card labels">
         <%= simple_form_for ContentBlock.for(:homepage_about_section_heading), url: hyrax.content_block_path(ContentBlock.for(:homepage_about_section_heading)), html: {class: 'nav-safety'} do |f| %>
@@ -146,42 +144,6 @@
           <div class="card-footer d-flex justify-content-end">
             <%= f.button :submit, class: 'btn btn-primary text-white mr-2' %>
             <%= link_to t(:'hyrax.content_blocks.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-light' %>
-          </div>
-        <% end %>
-      </div>
-    </div>
-    <div id="homepage_about_section_heading" class="tab-pane">
-      <div class="card card-default labels">
-        <%= simple_form_for ContentBlock.for(:homepage_about_section_heading), url: hyrax.content_block_path(ContentBlock.for(:homepage_about_section_heading)), html: {class: 'nav-safety'} do |f| %>
-          <div class="card-body">
-            <div class="field form-group">
-                <%= f.label :homepage_about_section_heading %><br />
-                <%# the following line was changed from hyrax to give some context for what this context block does %>
-                <p class="content-block-instructions"><%= t(:'hyrax.content_blocks.instructions.homepage_about_section_heading_instructions') %></p>
-                <%= f.text_area :homepage_about_section_heading, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
-            </div>
-          </div>
-          <div class="card-footer">
-            <%= link_to t(:'hyrax.content_blocks.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-secondary pull-right' %>
-            <%= f.button :submit, class: 'btn btn-primary pull-right' %>
-          </div>
-        <% end %>
-      </div>
-    </div>
-    <div id="homepage_about_section_content" class="tab-pane">
-      <div class="card card-default labels">
-        <%= simple_form_for ContentBlock.for(:homepage_about_section_content), url: hyrax.content_block_path(ContentBlock.for(:homepage_about_section_content)), html: {class: 'nav-safety'} do |f| %>
-          <div class="card-body">
-            <div class="field form-group">
-                <%= f.label :homepage_about_section_content %><br />
-                <%# the following line was changed from hyrax to give some context for what this context block does %>
-                <p class="content-block-instructions"><%= t(:'hyrax.content_blocks.instructions.homepage_about_section_content_instructions') %></p>
-                <%= f.text_area :homepage_about_section_content, value: f.object.value, class: 'form-control tinymce', rows: 20, cols: 120 %>
-            </div>
-          </div>
-          <div class="card-footer">
-            <%= link_to t(:'hyrax.content_blocks.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-secondary pull-right' %>
-            <%= f.button :submit, class: 'btn btn-primary pull-right' %>
           </div>
         <% end %>
       </div>

--- a/app/views/hyrax/content_blocks/_form.html.erb
+++ b/app/views/hyrax/content_blocks/_form.html.erb
@@ -1,4 +1,4 @@
-<%# OVERRIDE Hyrax v5.0.0rc2 to add content blocks for:
+<%# OVERRIDE Hyrax v5.0.1 to add content blocks for:
     - Home Page Text for theme
     - Home "About" page content %>
 <%= render "shared/nav_safety_modal" %>

--- a/app/views/shared/_appearance_styles.html.erb
+++ b/app/views/shared/_appearance_styles.html.erb
@@ -31,7 +31,8 @@ body.public-facing footer.navbar {
 }
 body.public-facing footer.navbar .navbar-link { color: <%= appearance.footer_link_color %>; }
 body.public-facing footer.navbar .navbar-link:hover { color: <%= appearance.footer_link_hover_color %>; }
-body.public-facing footer.navbar .navbar-text {
+body.public-facing footer.navbar .navbar-text,
+body.public-facing .navbar-dark .navbar-nav .nav-link {
   color: <%= appearance.header_and_footer_text_color %> !important;
 }
 body.public-facing .navbar.navbar-expand-lg { border-color: <%= appearance.header_background_border_color %> !important; }
@@ -203,6 +204,9 @@ body.public-facing .card > .card-header,
 body.public-facing .card-header > .btn.w-100 {
   color: <%= appearance.facet_panel_text_color %>;
   background-color: <%= appearance.facet_panel_background_color %> !important;
+}
+body.public-facing .card {
+  border-color: <%= appearance.facet_panel_border_color  %> !important;
 }
 body.public-facing .card-body > .facet-limit-active {
   color: <%= appearance.facet_panel_text_color %> !important;

--- a/app/views/shared/_appearance_styles.html.erb
+++ b/app/views/shared/_appearance_styles.html.erb
@@ -31,8 +31,7 @@ body.public-facing footer.navbar {
 }
 body.public-facing footer.navbar .navbar-link { color: <%= appearance.footer_link_color %>; }
 body.public-facing footer.navbar .navbar-link:hover { color: <%= appearance.footer_link_hover_color %>; }
-body.public-facing footer.navbar .navbar-text,
-body.public-facing .navbar.navbar-expand-lg .navbar-nav a {
+body.public-facing footer.navbar .navbar-text {
   color: <%= appearance.header_and_footer_text_color %> !important;
 }
 body.public-facing .navbar.navbar-expand-lg { border-color: <%= appearance.header_background_border_color %> !important; }

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -507,11 +507,15 @@ en:
         featured_researcher: Featured Researcher
         home_text: Home Page Text
         marketing_text: Marketing Text
+        homepage_about_section_heading: About Section Heading
+        homepage_about_section_content: About Section Content
       instructions:
         announcement_instructions: Announcement Text displays on the homepage. It is for important or timely messages to be made prominently visible to all home page visitors. It would be appropriate to enter an announcement here, for example, to notify users about an upcoming planned maintenance outage of the system.
         featured_researcher_instructions: Featured Researcher is a space to enter information and on the home page reserved for highlighting repository users.
         home_text_instructions: Home Page Text refers to the custom messaging that is displayed on the home page either in the hero block or another section of the home page. This text appears when selecting a theme that either requires or allows home page text. We recommend no more than 3 sentences in this area.
         marketing_instructions: Banner Text refers to the text that is displayed over banner image on the homepage. We recommend no more than approximately 30 characters or spaces in this text area.
+        homepage_about_section_heading_instructions: This heading is not used by any of the default Hyku themes. It may be used for custom themes.
+        homepage_about_section_content_instructions: This content is not used by any of the default Hyku themes. It may be used for custom themes.
       updated: Content blocks updated.
     controls:
       about: About

--- a/spec/views/hyrax/content_blocks/edit.html.erb_spec.rb
+++ b/spec/views/hyrax/content_blocks/edit.html.erb_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "hyrax/content_blocks/edit", type: :view do
   end
 
   it "renders the instruction blocks" do
-    expect(rendered).to have_xpath('//p[@class="content-block-instructions" ]', count: 8)
+    expect(rendered).to have_xpath('//p[@class="content-block-instructions" ]', count: 6)
   end
 
   # TODO: These next 4 tests are tightly coupled with the implimentation,


### PR DESCRIPTION
Refs: 
https://github.com/samvera/hyku/pull/2417
https://github.com/notch8/palni_palci_knapsack/issues/172

Restore text color in dropdown menus: fix got lost during a merge conflict patch.
Restore facet border color but in the right location (removed https://github.com/samvera/hyku/pull/2420 due to double border)
Fixes appearance of content blocks form by removing duplicate tabs, adding appropriate classes, and adding translations.

<details>
<summary>Screenshots</summary>

### Dropdown menu text now matches link text color
![Screenshot 2025-01-21 at 3 54 29 PM](https://github.com/user-attachments/assets/cdf28e41-ecb0-4af2-af40-15f9eb130066)

### Facet border color once again based on a darker version of facet background color rather than bootstrap default
An exception is the cultural theme
![Screenshot 2025-01-22 at 1 59 05 PM](https://github.com/user-attachments/assets/afcaa862-8f3f-4c94-95b0-142aacccd95b)

### Fixes content blocks form
![Screenshot 2025-01-22 at 4 47 33 PM](https://github.com/user-attachments/assets/35a2582c-3af1-4709-9944-00f5aa471a97)

</details>
