### PR TITLE
Update test action to remove node_modules for CI issue

### DIFF
--- a/.github/workflows/build-test-lint.yaml
+++ b/.github/workflows/build-test-lint.yaml
@@ -45,7 +45,7 @@ jobs:
 
   test:
     needs: build
-    uses: notch8/actions/.github/workflows/test.yaml@v0.0.23
+    uses: notch8/actions/.github/workflows/test.yaml@node-module-begon
     with:
       confdir: "/app/samvera/hyrax-webapp/solr/conf"
       rspec_cmd: "gem install semaphore_test_boosters && bundle && rspec_booster --job $CI_NODE_INDEX/$CI_NODE_TOTAL"


### PR DESCRIPTION
CI is periodically failing because the node_modules directory is running around. make sure it is removed before starting the containers,