### PR TITLE
Ensure there are UserStat records before running

### DIFF
--- a/app/jobs/user_stat_collection_job.rb
+++ b/app/jobs/user_stat_collection_job.rb
@@ -3,7 +3,8 @@ class UserStatCollectionJob < ApplicationJob
   queue_as :default
 
   def perform(*_args)
-    # Do something later
+    return unless UserStat.exists?
+
     importer = Hyrax::UserStatImporter.new(verbose: true, logging: true)
     importer.import
     UserStatCollectionJob.set(wait_until: Date.tomorrow.midnight).perform_later


### PR DESCRIPTION
Sidekiq is flooded with UserStatCollectionJob even when UserStats.any? => false. 

Let's not run the job is there are no user stats