### PR TITLE
🐛 refresh CodeMirror editor when CSS tab is shown

### DIFF
--- a/app/views/hyrax/admin/appearances/_custom_css_form.html.erb
+++ b/app/views/hyrax/admin/appearances/_custom_css_form.html.erb
@@ -10,6 +10,11 @@
         theme: 'base16-light',
         autoRefresh: true
       });
+
+      // refresh the editor when the tab is shown
+      jQuery('[href="#css"]').on('shown.bs.tab', function() {
+        editor.refresh();
+      });
     </script>
   </div>
   <div class="card-footer">


### PR DESCRIPTION
The CodeMirror editor was invisible until text was selected.  Added tab show event handler to properly refresh the editor when the CSS tab becomes visible.

![codemirror](https://github.com/user-attachments/assets/5c519e40-eb1a-414d-bc41-658b55bef927)
