### PR TITLE
Update bulkrax and add user stat importer decorator

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,7 +153,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera/bulkrax.git
-  revision: a751f48d45478c67bff4e4cb07ca1b3d01d6131a
+  revision: 0e8de6174cd305bfdccdfbb8dd090c7c446f763d
   branch: main
   specs:
     bulkrax (9.0.2)

--- a/app/services/hyrax/user_stat_importer_decorator.rb
+++ b/app/services/hyrax/user_stat_importer_decorator.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# OVERRIDE Hyrax v5.0.1 to use Hyrax.query_service to find the fileset instead of FileSet.find
+#   Remove this if https://github.com/samvera/hyrax/pull/6992 gets merged and Hyrax is updated appropriately
+
+module Hyrax
+  module UserStatImporterDecorator
+    private
+
+    def process_files(stats, user, start_date)
+      file_ids_for_user(user).each do |file_id|
+        file = Hyrax.query_service.find_by(id: file_id)
+        view_stats = extract_stats_for(object: file, from: FileViewStat, start_date: start_date, user: user)
+        stats = tally_results(view_stats, :views, stats) if view_stats.present?
+        delay
+        dl_stats = extract_stats_for(object: file, from: FileDownloadStat, start_date: start_date, user: user)
+        stats = tally_results(dl_stats, :downloads, stats) if dl_stats.present?
+        delay
+      end
+    end
+  end
+end
+
+Hyrax::UserStatImporter.prepend(Hyrax::UserStatImporterDecorator)


### PR DESCRIPTION
## Update Bulkrax

8908166d017ee654b28caab0cddd550fa6107828

This commit will bring in view changes from Bulkrax for the importer
show page.

Ref:
- https://github.com/samvera/bulkrax/pull/1011

## Add `UserStatImporterDecorator`

27345d898f675475affc1f47cd14c97c7fd7b2b4

This commit will override the #process_files method to use the Hyrax
query service instead of the old ActiveFedora way of finding the
FileSet.

Ref:
- https://github.com/samvera/hyrax/pull/6992