### PR TITLE
:gift: adds batch email, depositor email, and user stat to Account Settings

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -183,9 +183,9 @@ class Account < ApplicationRecord
     ]
 
     # Add conditional checks based on a config or environment variable
-    jobs_to_schedule << BatchEmailNotificationJob if ENV['ENABLE_BATCH_EMAIL'] == 'true'
-    jobs_to_schedule << DepositorEmailNotificationJob if ENV['ENABLE_DEPOSITOR_EMAIL'] == 'true'
-    jobs_to_schedule << UserStatCollectionJob if ENV['ENABLE_USER_STAT'] == 'true'
+    jobs_to_schedule << BatchEmailNotificationJob if batch_email_notifications
+    jobs_to_schedule << DepositorEmailNotificationJob if depositor_email_notifications
+    jobs_to_schedule << UserStatCollectionJob if user_analytics
 
     jobs_to_schedule.each do |klass|
       klass.perform_later unless find_job(klass)

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -198,7 +198,7 @@ class Account < ApplicationRecord
   private
 
   def schedule_jobs_if_settings_changed
-    return unless self.class.column_names.include?('settings')
+    return unless settings
 
     relevant_settings = [
       'batch_email_notifications',
@@ -210,7 +210,10 @@ class Account < ApplicationRecord
     old_settings = saved_changes['settings'][0] || {}
     new_settings = saved_changes['settings'][1] || {}
 
-    return unless old_settings.slice(*relevant_settings) != new_settings.slice(*relevant_settings)
+    old_relevant_settings = old_settings.slice(*relevant_settings)
+    new_relevant_settings = new_settings.slice(*relevant_settings)
+
+    return unless old_relevant_settings != new_relevant_settings
     find_or_schedule_jobs
   end
 end

--- a/app/models/concerns/account_settings.rb
+++ b/app/models/concerns/account_settings.rb
@@ -23,11 +23,13 @@ module AccountSettings
     setting :allow_downloads, type: 'boolean', default: true
     setting :allow_signup, type: 'boolean', default: true
     setting :analytics_provider, type: 'string'
+    setting :batch_email_notifications, type: 'boolean', default: false
     setting :bulkrax_field_mappings, type: 'json_editor', default: Hyku.default_bulkrax_field_mappings.to_json
     setting :bulkrax_validations, type: 'boolean', disabled: true
     setting :cache_api, type: 'boolean', default: false
     setting :contact_email, type: 'string', default: 'change-me-in-settings@example.com'
     setting :contact_email_to, type: 'string', default: 'change-me-in-settings@example.com'
+    setting :depositor_email_notifications, type: 'boolean', default: false
     setting :doi_reader, type: 'boolean', default: false
     setting :doi_writer, type: 'boolean', default: false
     setting :file_acl, type: 'boolean', default: true, private: true
@@ -50,6 +52,7 @@ module AccountSettings
     setting :smtp_settings, type: 'hash', private: true, default: {}
     setting :solr_collection_options, type: 'hash', default: solr_collection_options
     setting :ssl_configured, type: 'boolean', default: true, private: true
+    setting :user_analytics, type: 'boolean', default: false
     setting :weekly_email_list, type: 'array', disabled: true
     setting :yearly_email_list, type: 'array', disabled: true
 

--- a/app/views/hyrax/dashboard/profiles/_edit_primary.html.erb
+++ b/app/views/hyrax/dashboard/profiles/_edit_primary.html.erb
@@ -56,12 +56,14 @@
   </div><!-- .form-group -->
 
   <!-- OVERRIDE: Add batch email frequency to edit -->
-  <div class="form-group row">
-    <%= f.label :batch_email_frequency, t("hyrax.user_profile.email_frequency.label").html_safe, class: 'col-4 col-form-label' %>
-    <div class="col-8">
-      <%= f.select :batch_email_frequency, controller.frequency_options, {}, { class: "form-control" } %>
-    </div>
-  </div><!-- .form-group -->
+  <% if current_account.batch_email_notifications %>
+    <div class="form-group row">
+      <%= f.label :batch_email_frequency, t("hyrax.user_profile.email_frequency.label").html_safe, class: 'col-4 col-form-label' %>
+      <div class="col-8">
+        <%= f.select :batch_email_frequency, controller.frequency_options, {}, { class: "form-control" } %>
+      </div>
+    </div><!-- .form-group -->
+  <% end %>
 
   <%= render 'trophy_edit', trophies: @trophies %>
 

--- a/app/views/hyrax/users/_user_info.html.erb
+++ b/app/views/hyrax/users/_user_info.html.erb
@@ -81,7 +81,9 @@
   <% end %>
 
   <!-- OVERRIDE Hyrax 5.0: Display batch email frequency -->
-  <dt><%= t("hyrax.user_profile.email_frequency.label").html_safe %></dt>
-  <% frequency = user.batch_email_frequency || 'not_set' %>
-  <dd><%= t("hyrax.user_profile.email_frequency.#{frequency}") %></dd>
+  <% if current_account.batch_email_notifications %>
+    <dt><%= t("hyrax.user_profile.email_frequency.label").html_safe %></dt>
+    <% frequency = user.batch_email_frequency || 'not_set' %>
+    <dd><%= t("hyrax.user_profile.email_frequency.#{frequency}") %></dd>
+  <% end %>
 </dl>

--- a/spec/features/accounts_spec.rb
+++ b/spec/features/accounts_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe 'Accounts administration', multitenant: true do
       allow(Apartment::Tenant).to receive(:switch).with(account.tenant) do |&block|
         block.call
       end
+      allow_any_instance_of(Account).to receive(:find_or_schedule_jobs)
     end
 
     around do |example|

--- a/spec/models/concerns/account_settings_spec.rb
+++ b/spec/models/concerns/account_settings_spec.rb
@@ -10,10 +10,12 @@ RSpec.describe AccountSettings do
         expect(account.public_settings(is_superadmin: true).keys.sort).to eq %i[allow_downloads
                                                                                 allow_signup
                                                                                 analytics_provider
+                                                                                batch_email_notifications
                                                                                 bulkrax_field_mappings
                                                                                 cache_api
                                                                                 contact_email
                                                                                 contact_email_to
+                                                                                depositor_email_notifications
                                                                                 doi_reader
                                                                                 doi_writer
                                                                                 email_domain
@@ -30,7 +32,8 @@ RSpec.describe AccountSettings do
                                                                                 s3_bucket
                                                                                 smtp_settings
                                                                                 solr_collection_options
-                                                                                ssl_configured]
+                                                                                ssl_configured
+                                                                                user_analytics]
       end
       # rubocop:enable RSpec/ExampleLength
     end

--- a/spec/services/create_account_spec.rb
+++ b/spec/services/create_account_spec.rb
@@ -146,13 +146,11 @@ RSpec.describe CreateAccount, clean: true do
       end
 
       it "only enqueues embargo and lease jobs" do
-        # These jobs should always run regardless of settings
         [EmbargoAutoExpiryJob, LeaseAutoExpiryJob].each do |klass|
           expect(account).to receive(:find_job).with(klass).and_return(false)
           expect(klass).to receive(:perform_later)
         end
 
-        # These jobs should not run when settings are disabled
         [
           BatchEmailNotificationJob,
           DepositorEmailNotificationJob,

--- a/spec/services/create_account_spec.rb
+++ b/spec/services/create_account_spec.rb
@@ -116,18 +116,54 @@ RSpec.describe CreateAccount, clean: true do
   end
 
   describe '#schedule_recurring_jobs' do
-    it "Enqueues Recurring jobs" do
-      [
-        EmbargoAutoExpiryJob,
-        LeaseAutoExpiryJob,
-        BatchEmailNotificationJob,
-        DepositorEmailNotificationJob,
-        UserStatCollectionJob
-      ].each do |klass|
-        expect(account).to receive(:find_job).with(klass).and_return(false)
-        expect(klass).to receive(:perform_later)
+    context 'when settings are enabled' do
+      before do
+        allow(account).to receive(:batch_email_notifications).and_return(true)
+        allow(account).to receive(:depositor_email_notifications).and_return(true)
+        allow(account).to receive(:user_analytics).and_return(true)
       end
-      subject.schedule_recurring_jobs
+
+      it "enqueues recurring jobs" do
+        [
+          EmbargoAutoExpiryJob,
+          LeaseAutoExpiryJob,
+          BatchEmailNotificationJob,
+          DepositorEmailNotificationJob,
+          UserStatCollectionJob
+        ].each do |klass|
+          expect(account).to receive(:find_job).with(klass).and_return(false)
+          expect(klass).to receive(:perform_later)
+        end
+        subject.schedule_recurring_jobs
+      end
+    end
+
+    context 'when settings are disabled' do
+      before do
+        allow(account).to receive(:batch_email_notifications).and_return(false)
+        allow(account).to receive(:depositor_email_notifications).and_return(false)
+        allow(account).to receive(:user_analytics).and_return(false)
+      end
+
+      it "only enqueues embargo and lease jobs" do
+        # These jobs should always run regardless of settings
+        [EmbargoAutoExpiryJob, LeaseAutoExpiryJob].each do |klass|
+          expect(account).to receive(:find_job).with(klass).and_return(false)
+          expect(klass).to receive(:perform_later)
+        end
+
+        # These jobs should not run when settings are disabled
+        [
+          BatchEmailNotificationJob,
+          DepositorEmailNotificationJob,
+          UserStatCollectionJob
+        ].each do |klass|
+          expect(account).not_to receive(:find_job).with(klass)
+          expect(klass).not_to receive(:perform_later)
+        end
+
+        subject.schedule_recurring_jobs
+      end
     end
   end
 end


### PR DESCRIPTION
Issue: 
- https://github.com/notch8/palni_palci_knapsack/issues/209

Feature flags are now visible in  ADMIN DASHBOARD > SETTINGS > ACCOUNT. When enabled, they will trigger the relevant background jobs.

![image](https://github.com/user-attachments/assets/391487e9-ad5c-4b83-9c51-297b95bd2343)

Additionally, if disabled a user will not see batch email frequency in their profiles. It also removed their ability to set it: 

### PROFILE SHOW PG

<details> 

#### WHEN DISABLED

![image](https://github.com/user-attachments/assets/95a92338-17ae-4164-b734-0de7df455ff8)

 
![image](https://github.com/user-attachments/assets/c7abe203-e99b-421b-ace4-ac45215ee805)

#### WHEN ENABLED

![image](https://github.com/user-attachments/assets/d3487827-4ea5-45a3-8449-6787c2081c23)

![image](https://github.com/user-attachments/assets/13a5dfcc-8a21-48a2-9b40-9c569032bdb4)


</details> 


### PROFILE EDIT PG

<details> 

#### WHEN DISABLED

![image](https://github.com/user-attachments/assets/24133b2a-fa93-431c-b53d-119973a46b65)

#### WHEN ENABLED

![image](https://github.com/user-attachments/assets/00ec7e79-59b3-40d6-9e2f-27a85b174af6)


</details> 

</details> 

## NOTES

## :gift: add dynamic toggling for job scheduling using environment variables

abf36be366b1c7b5468645d87255b9d178b48a30

- Updated `find_or_schedule_jobs` to dynamically include jobs based on environment variables.
- Introduced the following environment flags to control job scheduling:
  - `ENABLE_BATCH_EMAIL` for `BatchEmailNotificationJob`
  - `ENABLE_DEPOSITOR_EMAIL` for `DepositorEmailNotificationJob`
  - `ENABLE_USER_STAT` for `UserStatCollectionJob`
- This allows buggy jobs to be disabled temporarily without modifying the codebase.
- Default behavior ensures only non-buggy jobs are scheduled when flags are not set.

## ♻️ Refactor to remove ENV vars in favor of account settings pattern

52e90c5687e55f92f2ebad8010a579c0ff8268a6

- Adds batch_email_notifications, depositor_email_notifications, and user_analystics to account settings
- only displays batch email frequency if batch email notifications are enabled from account settings

## 🧹 Automatically schedule jobs when account settings change

06afd3e8b3980a98b0b4825cd4b2471b21f8dd94

When certain account settings (user_analytics, batch_email_notifications,
or depositor_email_notifications) are updated, the system will now
automatically schedule the corresponding background jobs. This eliminates
the need for a server restart to activate these features.

- Added after_save callback to detect settings changes
- Added logic to compare relevant settings before and after save
- Triggers find_or_schedule_jobs when settings change

This ensures features like user analytics start working immediately
after being enabled through the settings interface.

## ♻️ Refactor account settings change detection for better readability

50040bc16d1f7252429f81aa1a8b56cc6faa0dcf

Simplifies the #schedule_jobs_if_settings_changed method to be more
intuitive and easier to maintain:

- Replace database column check with direct settings check
- Add descriptive variable names and comments
- Break complex logic into clear, distinct steps
- Improve code organization with early returns

The functionality remains the same, but the code is now more
self-documenting and easier to understand.

## ✅ update schedule_recurring_jobs specs

30e144c936af57de9eab369b5534d86000a62bda

- Add test contexts for enabled and disabled account settings
- Verify that EmbargoAutoExpiryJob and LeaseAutoExpiryJob always run
- Verify that BatchEmailNotificationJob, DepositorEmailNotificationJob,
  and UserStatCollectionJob only run when their respective settings
  are enabled

## ✅ update account settings specs

20b1c9718a1e284a435ca0c91387767ee58c2bc8


## ✅ Update create_account_spec.rb

b2794c511863f9b9be0f3e33c495989a241660a5


## ✅ Mock find_or_schedule_jobs in account endpoints spec

fe02a778cf7385cfc2e254ce9233657f36e3cf04

The account endpoints spec was failing because it attempted to
schedule jobs before the tenant schema was created. By mocking
find_or_schedule_jobs in this specific test, we avoid the schema
error while preserving the actual job scheduling behavior in other
tests.
