### PR TITLE
🧹 Clean up featured collection UI

### DIFF
--- a/app/assets/stylesheets/hyku.scss
+++ b/app/assets/stylesheets/hyku.scss
@@ -519,6 +519,15 @@ body.public-facing {
   border: 1px solid #ccc;
 }
 
+.new_featured_collection_list {
+  width: 100%;
+}
+
+// align featured collections with featured works
+#featured_collections {
+  margin-top: -5px;
+}
+
 .mb-30 {
   margin-bottom: 30px;
 }
@@ -714,6 +723,10 @@ tr[data-feature="use-iiif-print"] {
   display: flex;
   flex-wrap: wrap;
   justify-content: left;
+
+  h3 {
+    font-size: inherit;
+  }
 }
 
 // slideshow heading

--- a/app/assets/stylesheets/themes/institutional_repository.scss
+++ b/app/assets/stylesheets/themes/institutional_repository.scss
@@ -105,7 +105,6 @@
     padding-bottom: 0 !important;
   }
 
-  .collections-container,
   .recently-uploaded {
     a {
       img {

--- a/app/views/hyrax/homepage/_explore_collections.html.erb
+++ b/app/views/hyrax/homepage/_explore_collections.html.erb
@@ -12,11 +12,11 @@
           ) %>
         <% end %>
       </div>
-      <div>
+      <h3>
         <%= link_to [hyrax, featured_collection] do %>
           <%= markdown(featured_collection.title.first) %>
         <% end %>
-      </div>
+      </h3>
     </div>
   </td>
 </tr>

--- a/app/views/hyrax/homepage/_featured_collection_fields.html.erb
+++ b/app/views/hyrax/homepage/_featured_collection_fields.html.erb
@@ -1,17 +1,10 @@
-<div class="featured-item-title d-flex">
-  <div class="sr-only">
-    <%= t('hyrax.homepage.featured_collections.document.title_label') %>
-  </div>
-  <div class='homepage-work-thumbnail'>
-    <%= link_to [hyrax, featured] do %>
-      <%= render_thumbnail_tag(featured.solr_document, {suppress_link: true}) %>
-    <% end %>
-  </div>
-  <div>
-    <h5>
+<div>
+  <div class="featured-item-title">
+    <span class="sr-only"><%= t('hyrax.homepage.featured_collections.document.title_label') %></span>
+    <h3>
       <%= link_to [hyrax, featured] do %>
-        <%= markdown(featured.title.first) %>
+        <%= render_thumbnail_tag(featured.solr_document, {alt: "#{featured.title.first.to_s} #{ t('hyrax.homepage.admin_sets.thumbnail')}" }, {suppress_link: true})%><%= markdown(featured.title.first) %>
       <% end %>
-    </h5>
+    </h3>
   </div>
 </div>

--- a/app/views/hyrax/homepage/_sortable_featured_collections.html.erb
+++ b/app/views/hyrax/homepage/_sortable_featured_collections.html.erb
@@ -1,13 +1,11 @@
 <% presenter = f.object.presenter %>
 <li class="dd-item dd3-item featured-item" data-id="<%= presenter.id %>">
-  <div class="dd-handle dd3-handle">
-    <%= t 'hyrax.homepage.featured_works.drag' %>
-  </div>
+  <div class="dd-handle dd3-handle"><%= t 'hyrax.homepage.featured_works.drag' %></div>
   <div class="dd3-content card">
     <%= f.hidden_field :id %>
     <%= f.hidden_field :order, data: { property: "order" } %>
-    <div class="card-body row">
-      <div class="col-md-12">
+    <div class="main row">
+      <div class="col-sm-12">
         <% if can? :destroy, FeaturedCollection %>
           <h3 class="float-right">
             <%= link_to main_app.featured_collection_path(presenter, format: :json),

--- a/app/views/shared/_appearance_styles.html.erb
+++ b/app/views/shared/_appearance_styles.html.erb
@@ -8,17 +8,17 @@
   @import url(//<%= appearance.font_import_headline_url %>);
 <% end %>
 
-body.public-facing { font-family: <%= appearance.font_body_family %>; }
+body.public-facing { font-family: <%= appearance.font_body_family %> !important; }
 body.public-facing h1,
 body.public-facing h2,
 body.public-facing h3,
 body.public-facing h4,
 body.public-facing h5,
-body.public-facing h6 { font-family: <%= appearance.font_headline_family %>; }
+body.public-facing h6 { font-family: <%= appearance.font_headline_family %> !important; }
 
 /* LINK COLORS */
 body.public-facing a,
-body.public-facing .dropdown-menu a { 
+body.public-facing .dropdown-menu a {
   color: <%= appearance.link_color %>;
 }
 body.public-facing a:hover,


### PR DESCRIPTION
This commit will add a few more html tags to the featured collections, both from the admin end and public facing end, to make it look more like the featured works.  This will fix custom font issues where the titles of the collections were not getting the correct font that was set.

### Admin view:
![image](https://github.com/user-attachments/assets/c315e866-8753-4f62-8a73-7a077d23b9f8)

### Public view:
![image](https://github.com/user-attachments/assets/ca5f9b9d-5e6b-4aaa-9183-e284c4165a9b)

Ref:
- https://github.com/notch8/palni_palci_knapsack/issues/178