### PR TITLE
I189 institutional repository carousel

### DIFF
--- a/app/assets/javascripts/stat_slider.js
+++ b/app/assets/javascripts/stat_slider.js
@@ -1,20 +1,57 @@
-// jQuery Slider
-$(document).on('turbolinks:load', function() {
-  $('.institutional-repository-carousel .carousel-item').each(function(){
-    var itemToClone = $(this);
+// Handles the infinite scrolling of the resource icons in the resource_type_slider
 
-    for (var i = 1; i < 6; i++) {
-      itemToClone = itemToClone.next();
+let scrollPosition = 0;
 
-      // wrap around if at end of item collection
-      if (!itemToClone.length) {
-        itemToClone = $(this).siblings(':first');
-      }
+$(document).on('turbolinks:load', function initializeCarousel() {
+  const $resourceRow = $('.resource-row');
+  const $item = $resourceRow.children();
+  const resourceItemWidth = $('.resource-item').width() + 10; // 10px margin
 
-      // grab item, clone, add marker class, add to collection
-      itemToClone.children(':first-child').clone()
-        .addClass("cloneditem-"+(i))
-        .appendTo($(this));
-    }
+  // Clone first and last items for infinite scrolling
+  const $clonesBefore = $item.slice(-6).clone();
+  const $clonesAfter = $item.slice(0, 6).clone();
+
+  $resourceRow.prepend($clonesBefore).append($clonesAfter);
+
+  // Adjust the initial scroll position
+  scrollPosition = 6 * resourceItemWidth;
+  $resourceRow.css('transform', `translateX(-${scrollPosition}px)`);
+})
+
+function scrollResources(direction) {
+  const $resourceRow = $('.resource-row');
+  const totalItems = $resourceRow.children().length;
+  const resourceItemWidth = $('.resource-item').width() + 10; // 10px margin
+
+  if (direction === 'previous') {
+    scrollPosition -= resourceItemWidth;
+  } else if (direction === 'next') {
+    scrollPosition += resourceItemWidth;
+  }
+
+  $resourceRow.css({
+    transition: 'transform 0.3s ease',
+    transform: `translateX(-${scrollPosition}px)`
   });
-});
+
+  // Handle looping after the transition
+  $resourceRow.on('transitionend', function () {
+    if (scrollPosition < 6 * resourceItemWidth) {
+      // Reset to the original items at the end of the array
+      scrollPosition += (totalItems - 12) * resourceItemWidth;
+      $resourceRow.css({
+        transition: 'none',
+        transform: `translateX(-${scrollPosition}px)`
+      });
+    } else if (scrollPosition >= (totalItems - 6) * resourceItemWidth) {
+      // Reset to the original items at the beginning of the array
+      scrollPosition -= (totalItems - 12) * resourceItemWidth;
+      $resourceRow.css({
+        transition: 'none',
+        transform: `translateX(-${scrollPosition}px)`
+      });
+    }
+    // Remove the transitionend listener after execution
+    $resourceRow.off('transitionend');
+  });
+}

--- a/app/assets/stylesheets/themes/institutional_repository.scss
+++ b/app/assets/stylesheets/themes/institutional_repository.scss
@@ -164,31 +164,29 @@
     z-index: 5;
   }
 
-  //// Resources Carousel ////
+  ///// Resources Carousel /////
 
   .institutional-repository-carousel {
     .resource-container {
       display: flex;
       align-items: center;
       justify-content: space-between;
-      // overflow: hidden;
-      // width: 100%;
       position: relative;
     }
-    
+
     .resource-wrapper {
       overflow: hidden;
-      width: calc(6 * 160px); /* Requires the width of each item including margins */
+      width: calc(6 * 160px); /* Requires the width of each resource-item including margins */
     }
-    
+
     .resource-row {
       display: flex;
       transition: transform 0.3s ease;
-      width: max-content; /* Ensures the row expands with more icons */
+      width: max-content;
     }
-    
+
     .resource-item {
-      margin: 5px;
+      margin: 30px 5px 0 5px;
       width: 150px;
       text-align: center;
     }
@@ -198,7 +196,6 @@
     }
   }
 
-
   ////// All Collections //////
 
   // browse by collection page
@@ -207,3 +204,5 @@
     list-style-type: none;
   }
 }
+
+

--- a/app/assets/stylesheets/themes/institutional_repository.scss
+++ b/app/assets/stylesheets/themes/institutional_repository.scss
@@ -1,6 +1,6 @@
 .institutional_repository {
 
-  ////// Basic Apperance Styles //////
+  ////// Basic Appearance Styles //////
 
   .mt-40 {
     margin-top: 40px;
@@ -164,31 +164,40 @@
     z-index: 5;
   }
 
+  //// Resources Carousel ////
+
   .institutional-repository-carousel {
-    .carousel-control {
-      background-image: none;
-      width: 4%;
-
-      .left {
-        margin-left: 0;
-      }
-
-      .right {
-        margin-right: 0;
-      }
-    }
-
-    .carousel-item.active {
+    .resource-container {
       display: flex;
-      padding-top: 1em;
-      padding-left: 10em;
-      padding-right: 10em;
+      align-items: center;
+      justify-content: space-between;
+      // overflow: hidden;
+      // width: 100%;
+      position: relative;
+    }
+    
+    .resource-wrapper {
+      overflow: hidden;
+      width: calc(6 * 160px); /* Requires the width of each item including margins */
+    }
+    
+    .resource-row {
+      display: flex;
+      transition: transform 0.3s ease;
+      width: max-content; /* Ensures the row expands with more icons */
+    }
+    
+    .resource-item {
+      margin: 5px;
+      width: 150px;
+      text-align: center;
+    }
+
+    .resource-item a {
+      text-decoration: none;
     }
   }
 
-  .carousel .item .col-xs-12 {
-    padding: 0;
-  }
 
   ////// All Collections //////
 
@@ -196,116 +205,5 @@
   ul.all-collection-list {
     font-size: 1.5em;
     list-style-type: none;
-  }
-
-  ////// Stats Carousel Media Queries //////
-
-  @media (max-width: 767px) {
-    .institutional-repository-carousel .cloneditem-1,
-    .institutional-repository-carousel .cloneditem-2,
-    .institutional-repository-carousel .cloneditem-3 {
-      display: none;
-    }
-  }
-
-  @media only screen and (max-width: 992px) {
-    .carousel .item .col-xs-12:nth-last-child(-n+2) {
-      display: none;
-    }
-  }
-
-  @media all and (min-width: 768px) {
-    .institutional-repository-carousel .carousel-inner > .active.left,
-    .institutional-repository-carousel .carousel-inner > .prev {
-      left: -50%;
-    }
-
-    .institutional-repository-carousel .carousel-inner > .active.right,
-    .institutional-repository-carousel .carousel-inner > .next {
-      left: 50%;
-    }
-
-    .institutional-repository-carousel .carousel-inner > .left,
-    .institutional-repository-carousel .carousel-inner > .prev.right,
-    .institutional-repository-carousel .carousel-inner > .active {
-      left: 0;
-    }
-
-    .institutional-repository-carousel .carousel-inner .cloneditem-1 {
-      display: block;
-    }
-  }
-
-  @media all and (min-width: 768px) and (transform-3d),
-  all and (min-width: 768px) and (-webkit-transform-3d) {
-    .institutional-repository-carousel .carousel-inner > .item.active.right,
-    .institutional-repository-carousel .carousel-inner > .item.next {
-      left: 0;
-      -webkit-transform: translate3d(50%, 0, 0);
-      transform: translate3d(50%, 0, 0);
-    }
-
-    .institutional-repository-carousel .carousel-inner > .item.active.left,
-    .institutional-repository-carousel .carousel-inner > .item.prev {
-      left: 0;
-      -webkit-transform: translate3d(-50%, 0, 0);
-      transform: translate3d(-50%, 0, 0);
-    }
-
-    .institutional-repository-carousel .carousel-inner > .item.left,
-    .institutional-repository-carousel .carousel-inner > .item.prev.right,
-    .institutional-repository-carousel .carousel-inner > .item.active {
-      left: 0;
-      -webkit-transform: translate3d(0, 0, 0);
-      transform: translate3d(0, 0, 0);
-    }
-  }
-
-  @media all and (min-width: 992px) {
-    .institutional-repository-carousel .carousel-inner > .active.left,
-    .institutional-repository-carousel .carousel-inner > .prev {
-      left: -16.6%;
-    }
-
-    .institutional-repository-carousel .carousel-inner > .active.right,
-    .institutional-repository-carousel .carousel-inner > .next {
-      left: 16.6%;
-    }
-
-    .institutional-repository-carousel .carousel-inner > .left,
-    .institutional-repository-carousel .carousel-inner > .prev.right,
-    .institutional-repository-carousel .carousel-inner > .active {
-      left: 0;
-    }
-
-    .institutional-repository-carousel .carousel-inner .cloneditem-2,
-    .institutional-repository-carousel .carousel-inner .cloneditem-3 {
-      display: block;
-    }
-  }
-
-  @media all and (min-width: 992px) and (transform-3d),
-  all and (min-width: 992px) and (-webkit-transform-3d) {
-    .institutional-repository-carousel .carousel-inner > .item.active.right,
-    .institutional-repository-carousel .carousel-inner > .item.next {
-      left: 0;
-      -webkit-transform: translate3d(16.6%, 0, 0);
-      transform: translate3d(16.6%, 0, 0);
-    }
-
-    .institutional-repository-carousel .carousel-inner > .item.active.left,
-    .institutional-repository-carousel .carousel-inner > .item.prev {
-      left: 0;
-      -webkit-transform: translate3d(-16.6%, 0, 0);
-      transform: translate3d(-16.6%, 0, 0);
-    }
-
-    .institutional-repository-carousel .carousel-inner > .item.left,
-    .institutional-repository-carousel .carousel-inner > .item.prev.right,
-    .institutional-repository-carousel .carousel-inner > .item.active {
-      left: 0;
-      -webkit-transform: translate3d(0, 0, 0);
-      transform: translate3d(0, 0, 0);
-    }
   }
 }

--- a/app/views/themes/institutional_repository/hyrax/homepage/_resource_type_slider.html.erb
+++ b/app/views/themes/institutional_repository/hyrax/homepage/_resource_type_slider.html.erb
@@ -5,7 +5,7 @@
 
 <div class="institutional-repository-carousel">
   <div class="resource-container">
-    <a role="button" onclick="scrollIcons('previous')">
+    <a role="button" onclick="scrollResources('previous')">
       <span class="carousel-control-prev-icon" aria-hidden="true"></span>
       <span class="sr-only">Previous</span>
     </a>
@@ -25,7 +25,7 @@
         <% end %>
       </div>
     </div>
-    <a role="button" onclick="scrollIcons('next')">
+    <a role="button" onclick="scrollResources('next')">
       <span class="carousel-control-next-icon" aria-hidden="true"></span>
       <span class="sr-only">Next</span>
     </a>

--- a/app/views/themes/institutional_repository/hyrax/homepage/_resource_type_slider.html.erb
+++ b/app/views/themes/institutional_repository/hyrax/homepage/_resource_type_slider.html.erb
@@ -3,27 +3,31 @@
   <meta name="turbolinks-cache-control" content="no-cache">
 <% end %>
 
-<div class="carousel slide institutional-repository-carousel" id="carousel-tilenav" data-ride="carousel" data-interval="false">
-  <div class="carousel-inner">
-    <% resource_types.each.with_index do |(k,v), i| %>
-      <% next if v[0].zero? %>
-      <div class="carousel-item <%= 'active' if i == 1 %>">
-        <div class="col-sm-3 col-md-2 text-center">
-          <%= link_to "/catalog?f[resource_type_sim][]=#{k}", style: "color: inherit;" do %>
-            <i class='<%= "#{v[1]}" %>' aria-hidden="true"></i>
-            <h5><%= k %></h5>
-            <p><%= v[0] %></p>
-          <% end %>
-        </div>
+<div class="institutional-repository-carousel">
+  <div class="resource-container">
+    <a role="button" onclick="scrollIcons('previous')">
+      <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+      <span class="sr-only">Previous</span>
+    </a>
+    <div class="resource-wrapper">
+      <div class="resource-row">
+        <% resource_types.each do |resource_type, value| %>
+          <% resource_count = value[0] %>
+          <% resource_icon = value[1] %>
+          <% next if resource_count.zero? %>
+          <div class="resource-item">
+            <%= link_to "/catalog?f[resource_type_sim][]=#{resource_type}", style: "color: inherit;" do %>
+              <i class='<%= "#{resource_icon}" %>' aria-hidden="true"></i>
+              <h6><%= resource_type %></h6>
+              <p><%= resource_count %></p>
+            <% end %>
+          </div>
+        <% end %>
       </div>
-    <% end %>
+    </div>
+    <a role="button" onclick="scrollIcons('next')">
+      <span class="carousel-control-next-icon" aria-hidden="true"></span>
+      <span class="sr-only">Next</span>
+    </a>
   </div>
-  <a class="carousel-control-prev" href="#carousel-tilenav" role="button" data-slide="prev">
-    <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-    <span class="sr-only">Previous</span>
-  </a>
-  <a class="carousel-control-next" href="#carousel-tilenav" role="button" data-slide="next">
-    <span class="carousel-control-next-icon" aria-hidden="true"></span>
-    <span class="sr-only">Next</span>
-  </a>
 </div>


### PR DESCRIPTION
# Story: [i189] Institutional Repository Carousel

Ref:
- https://github.com/notch8/palni_palci_knapsack/issues/189

## Expected Behavior Before Changes

The carousel on the homepage of the institutional repository was buggy. Icon duplications could be seen during transitions and the layout styling was not being applied during transitions.

<details>
<summary>Video: Reported issue</summary>

https://github.com/user-attachments/assets/316eb856-96a3-48c1-8bee-d7798b49c19d

</details>

## Expected Behavior After Changes

When there are six or more resources in the institutional repository, there is a slider showing six of the icons. A user can click on arrows to move the icons one place to the right or left. The icons are in a continuous loop.

<details>
<summary>Video: Corrected resource carousel</summary>

https://github.com/user-attachments/assets/8bff82b0-45c5-4e59-8e52-b00e6241746f

</details>

## Notes

Changes proposed in this pull request:
* This PR removes the Bootstrap carousel since out-of-box functionality does not allow for multiple items on the screen and the workarounds were causing errors
* This approach relies on jQuery to perform the icon transitions

@samvera/hyku-code-reviewers
