### PR TITLE
Update IIIF Print

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,7 @@ GIT
 
 GIT
   remote: https://github.com/notch8/iiif_print.git
-  revision: acef382ce710d6aad63e11cfa83b5803a9f30fa2
+  revision: 55cbaaf8b01d9a2454211c0edbf82dcf137287e3
   branch: main
   specs:
     iiif_print (3.0.1)


### PR DESCRIPTION
This commit will update IIIF Print gem's revision to include a fix for duplicate search results coming through the UV.

Ref:
- https://github.com/notch8/iiif_print/pull/379
- https://github.com/notch8/palni_palci_knapsack/issues/199
