### PR TITLE
🐛 Fix visual bug with fonts selection label

### DIFF
--- a/app/views/hyrax/admin/appearances/_default_fonts_form.html.erb
+++ b/app/views/hyrax/admin/appearances/_default_fonts_form.html.erb
@@ -3,10 +3,10 @@
     <% df = @form.default_fonts %>
     <% font = f.object.body_font %>
 
-    <%= f.input :body_font, label: 'Select Body Font', required: false, input_html: { class: 'font-fields', data: { default_value: df['body_font'] } } %>
+    <%= f.input :body_font, label: 'Select Body Font', required: false, label_html: { class: 'text-left' }, input_html: { class: 'font-fields', data: { default_value: df['body_font'] } } %>
     <%= link_to 'Restore Default', '#font', class: 'btn btn-secondary restore-default-font', data: { default_target: 'body_font' } %>
 
-    <%= f.input :headline_font, label: 'Select Header Font', required: false, input_html: { class: 'font-fields', data: { default_value: df['headline_font'] } } %>
+    <%= f.input :headline_font, label: 'Select Header Font', required: false, label_html: { class: 'text-left' }, input_html: { class: 'font-fields', data: { default_value: df['headline_font'] } } %>
     <%= link_to 'Restore Default', '#font', class: 'btn btn-secondary restore-default-font', data: { default_target: 'headline_font' } %>
 
   </div>


### PR DESCRIPTION
This commit will align the label of the fonts selection label over the dropdown.

Ref:
- https://github.com/notch8/palni_palci_knapsack/issues/178

<img width="359" alt="image" src="https://github.com/user-attachments/assets/264a6a2b-8494-4fc3-8ecf-a2513dca9b9d" />
