### PR TITLE
🧹 Remove Hyrax.config.analytics from the codebase

### DIFF
--- a/app/views/hyrax/base/_analytics_button.html.erb
+++ b/app/views/hyrax/base/_analytics_button.html.erb
@@ -1,5 +1,0 @@
-<% if Hyrax.config.analytics? %>
-  <% # turbolinks needs to be turned off or the page will use the cache and the %>
-  <% # analytics graph will not show unless the page is refreshed. %>
-  <%= link_to t('.analytics'), @presenter.stats_path, id: 'stats', class: 'btn btn-secondary btn-block center-block', data: { turbolinks: false } %>
-<% end %>

--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -18,7 +18,7 @@
             class: presenter.display_unfeature_link? ? 'btn btn-secondary' : 'btn btn-secondary collapse' %>
       <% end %>
     <% end %>
-    <% if Hyrax.config.analytics? %>
+    <% if Hyrax.config.analytics_reporting? %>
       <% # turbolinks needs to be turned off or the page will use the cache and the %>
       <% # analytics graph will not show unless the page is refreshed. %>
       <%= link_to t('.analytics'), presenter.stats_path, id: 'stats', class: 'btn btn-secondary', data: { turbolinks: false } %>

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -39,9 +39,6 @@
             <div class="col-sm-3 text-center">
               <%= render('download_pdf', presenter: @presenter, file_set_id: @presenter.file_set_presenters.first.id) if @presenter.show_pdf_download_button? %>
               <%= render 'citations', presenter: @presenter %>
-              <!-- OVERRIDE: analytics_button is disabled until future fix -->
-              <%#= render 'analytics_button', presenter: @presenter %>
-              <!-- OVERRIDE: remove social_media -->
             </div>
           <% end %>
           <div class="col-sm-9">

--- a/app/views/hyrax/dashboard/sidebar/_activity.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_activity.html.erb
@@ -67,7 +67,7 @@
   </li>
 <% end %>
 
-<% if current_ability.can_create_any_work? && Hyrax.config.analytics? %>
+<% if current_ability.can_create_any_work? && Hyrax.config.analytics_reporting? %>
   <li class="nav-item">
     <%= menu.collapsable_section t('hyrax.admin.sidebar.analytics'),
                                   icon_class: "fa fa-pie-chart",

--- a/app/views/hyrax/oers/show.html.erb
+++ b/app/views/hyrax/oers/show.html.erb
@@ -15,7 +15,7 @@
     <div class="card card-default">
       <div class="card-heading">
         <%= render 'work_title', presenter: @presenter %>
-        <%= render 'show_actions', presenter: @presenter %> 
+        <%= render 'show_actions', presenter: @presenter %>
       </div>
       <div class="card-body">
         <div class="row">
@@ -34,8 +34,6 @@
           <div class="col-sm-3 text-center">
             <%= render 'representative_media', presenter: @presenter, viewer: false unless @presenter.iiif_viewer? || @presenter.show_pdf_viewer? %>
             <%= render 'citations', presenter: @presenter %>
-            <!-- analytics_button is disabled until future fix -->
-            <%#= render 'analytics_button', presenter: @presenter %>
           </div>
           <% end %>
           <% if @presenter.viewer? %>

--- a/app/views/themes/cultural_show/hyrax/base/show.html.erb
+++ b/app/views/themes/cultural_show/hyrax/base/show.html.erb
@@ -41,8 +41,6 @@
             <div class="citations-container">
               <%= render 'citations', presenter: @presenter %>
             </div>
-            <!-- analytics_button is disabled until future fix -->
-            <%#= render 'analytics_button', presenter: @presenter %>
           </div>
           <div class="col-12 work-show-items">
             <%= render 'items', presenter: @presenter %>

--- a/app/views/themes/cultural_show/hyrax/oers/show.html.erb
+++ b/app/views/themes/cultural_show/hyrax/oers/show.html.erb
@@ -30,8 +30,6 @@
                 <br/>
                   <%= render('download_pdf', presenter: @presenter, file_set_id: @presenter.file_set_presenters.first.id) if @presenter.show_pdf_download_button? %>
                   <%= render 'citations', presenter: @presenter %>
-                  <!-- analytics_button is disabled until future fix -->
-                  <%#= render 'analytics_button', presenter: @presenter %>
                 <br/>
               </div>
             <% end %>
@@ -54,8 +52,6 @@
                   <br/>
                     <%= render('download_pdf', presenter: @presenter, file_set_id: @presenter.file_set_presenters.first.id) if @presenter.show_pdf_download_button? %>
                     <%= render 'citations', presenter: @presenter %>
-                    <!-- analytics_button is disabled until future fix -->
-                    <%#= render 'analytics_button', presenter: @presenter %>
                   <br/>
                 </div>
               <% end %>

--- a/app/views/themes/image_show/hyrax/base/show.html.erb
+++ b/app/views/themes/image_show/hyrax/base/show.html.erb
@@ -48,8 +48,6 @@
           <div class="col-sm-3 citations-social text-right">
             <%= render('download_pdf', presenter: @presenter, file_set_id: @presenter.file_set_presenters.first.id) if @presenter.show_pdf_download_button? %>
             <%= render 'citations', presenter: @presenter %>
-            <!-- analytics_button is disabled until future fix -->
-            <%#= render 'analytics_button', presenter: @presenter %>
           </div>
           <div class="col-sm-12">
             <%= render 'relationships', presenter: @presenter %>

--- a/app/views/themes/scholarly_show/hyrax/base/show.html.erb
+++ b/app/views/themes/scholarly_show/hyrax/base/show.html.erb
@@ -57,8 +57,6 @@
           <div class="col-sm-3 text-center">
             <%= render('download_pdf', presenter: @presenter, file_set_id: @presenter.file_set_presenters.first.id) if @presenter.show_pdf_download_button? %>
             <%= render 'citations', presenter: @presenter %>
-            <!-- analytics_button is disabled until future fix -->
-            <%#= render 'analytics_button', presenter: @presenter %>
           </div>
         </div>
         <div class="row">

--- a/app/views/themes/scholarly_show/hyrax/oers/show.html.erb
+++ b/app/views/themes/scholarly_show/hyrax/oers/show.html.erb
@@ -48,8 +48,6 @@
           <div class="col-sm-6">
             <%= render('download_pdf', presenter: @presenter, file_set_id: @presenter.file_set_presenters.first.id) if @presenter.show_pdf_download_button? %>
             <%= render 'citations', presenter: @presenter %>
-            <!-- analytics_button is disabled until future fix -->
-            <%#= render 'analytics_button', presenter: @presenter %>
           </div>
           <div class="col-sm-12">
             <%= render 'relationships', presenter: @presenter %>


### PR DESCRIPTION
We are now using Hyrax.config.analytics_reporting? instead.  The analytics_button partial is deprecated and all references removed.

Ref:
- https://github.com/notch8/palni_palci_knapsack/issues/177
