### PR TITLE
Update IiifPrint Gem to v3.0.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ gem 'hyrax-doi', github: 'samvera-labs/hyrax-doi', branch: 'rails_hyrax_upgrade'
 gem 'hyrax-iiif_av', github: 'samvera-labs/hyrax-iiif_av', branch: 'rails_hyrax_upgrade'
 gem 'i18n-debug', require: false, group: %i[development test]
 gem 'i18n-tasks', group: %i[development test]
-gem 'iiif_print', github: 'notch8/iiif_print', branch: 'main'
+gem 'iiif_print', '~> 3.0'
 gem 'jbuilder', '~> 2.5'
 gem 'jquery-rails' # Use jquery as the JavaScript library
 gem 'openssl', '>= 3.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,18 +19,6 @@ GIT
       rack (>= 1.3.6)
 
 GIT
-  remote: https://github.com/notch8/iiif_print.git
-  revision: 55cbaaf8b01d9a2454211c0edbf82dcf137287e3
-  branch: main
-  specs:
-    iiif_print (3.0.1)
-      blacklight_iiif_search (>= 1.0, < 3.0)
-      derivative-rodeo (~> 0.5)
-      hyrax (>= 2.5, < 6)
-      nokogiri (>= 1.13.2)
-      rdf-vocab (~> 3.0)
-
-GIT
   remote: https://github.com/notch8/willow_sword.git
   revision: e4edebde9a29636d74c794efca423535db296880
   branch: main
@@ -770,6 +758,12 @@ GEM
       json
     iiif_manifest (1.3.1)
       activesupport (>= 4)
+    iiif_print (3.0.3)
+      blacklight_iiif_search (>= 1.0, < 3.0)
+      derivative-rodeo (~> 0.5)
+      hyrax (>= 2.5, < 6)
+      nokogiri (>= 1.13.2)
+      rdf-vocab (~> 3.0)
     iso-639 (0.3.6)
     iso8601 (0.9.1)
     jaro_winkler (1.5.6)
@@ -1530,7 +1524,7 @@ DEPENDENCIES
   hyrax-iiif_av!
   i18n-debug
   i18n-tasks
-  iiif_print!
+  iiif_print (~> 3.0)
   jbuilder (~> 2.5)
   jquery-rails
   json-canonicalization (= 0.3.1)


### PR DESCRIPTION
Brings in fixes for resplitting a PDF & deleting the child works along with the parent work.
Uses released gem version

Refs https://github.com/notch8/palni_palci_knapsack/issues/80
