### PR TITLE
Add member methods on AdminSetResource

### DIFF
--- a/app/models/admin_set_resource.rb
+++ b/app/models/admin_set_resource.rb
@@ -6,4 +6,12 @@ class AdminSetResource < Hyrax::AdministrativeSet
   Hyrax::ValkyrieLazyMigration.migrating(self, from: ::AdminSet)
 
   include WithPermissionTemplateShim
+
+  def member_of
+    Hyrax.query_service.find_inverse_references_by(resource: self, property: :admin_set_id)
+  end
+
+  def member_collection_ids
+    member_of.map(&:id)
+  end
 end

--- a/spec/models/admin_set_resource_spec.rb
+++ b/spec/models/admin_set_resource_spec.rb
@@ -3,7 +3,8 @@
 require 'spec_helper'
 
 RSpec.describe AdminSetResource do
-  subject(:admin_set) { described_class.new }
+  subject(:admin_set) { FactoryBot.valkyrie_create(:hyku_admin_set) }
+  let!(:resource) { FactoryBot.valkyrie_create(:generic_work_resource, admin_set_id: admin_set.id) }
 
   it_behaves_like 'a Hyrax::AdministrativeSet'
 
@@ -18,5 +19,17 @@ RSpec.describe AdminSetResource do
   context 'class configuration' do
     subject { described_class }
     its(:to_rdf_representation) { is_expected.to eq('AdminSet') }
+  end
+
+  describe '#member_of' do
+    it 'returns the resources in the admin set' do
+      expect(subject.member_of).to eq [resource]
+    end
+  end
+
+  describe '#member_collection_ids' do
+    it 'returns the collection ids of the resources in the admin set' do
+      expect(subject.member_collection_ids).to eq [resource.id]
+    end
   end
 end


### PR DESCRIPTION
This commit will introduce two instance methods on the AdminSetResource:
- #member_of
- #member_collection_ids

These methods will make it possible for users to query for resources are on the given AdminSetResource.  This is particularly useful for the WillowSword gem.

Ref:
- https://github.com/notch8/palni-palci/issues/1071
