### PR TITLE
Hide PDF Resplit button

### DIFF
--- a/app/presenters/iiif_print/file_set_presenter_decorator.rb
+++ b/app/presenters/iiif_print/file_set_presenter_decorator.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# OVERRIDE IiifPrint v3 to hide the re-split button.
+#   Delete when splitting issue is resolved.
+#   see https://github.com/notch8/palni_palci_knapsack/issues/80#issuecomment-2632366138
+module IiifPrint
+  module FileSetPresenterDecorator
+    def show_split_button?
+      false
+    end
+  end
+end
+Hyrax::FileSetPresenter.prepend(IiifPrint::FileSetPresenterDecorator)


### PR DESCRIPTION
## Summary

Refs:
https://github.com/notch8/palni_palci_knapsack/issues/229 https://github.com/notch8/palni_palci_knapsack/issues/80

Adds a new decorator to override the IiifPrint FileSetPresenterDecorator and prevent the resplit PDF button from appearing.

This is a temporary fix until we can get the resplit button to work by resolving issue https://github.com/notch8/palni_palci_knapsack/issues/80

## Details

The PDF resplit button is added in IiifPrint, and appears (via Hyku::TenantConfig) if the Tenant is set to use PDf Splitting. By adding a copy of IiifPrint's FileSetPresenterDecorator, we override this button to never appear. 

![Screenshot 2025-02-04 at 2 13 03 PM](https://github.com/user-attachments/assets/0d10e749-dd08-4094-a735-40ad68cca4e9)

![Screenshot 2025-02-04 at 2 12 52 PM](https://github.com/user-attachments/assets/87650a92-8dd0-4969-addf-aae58d320e71)

