### PR TITLE
Pitt account settings follow up

### DIFF
--- a/app/models/concerns/account_settings.rb
+++ b/app/models/concerns/account_settings.rb
@@ -23,13 +23,13 @@ module AccountSettings
     setting :allow_downloads, type: 'boolean', default: true
     setting :allow_signup, type: 'boolean', default: true
     setting :analytics_provider, type: 'string'
-    setting :batch_email_notifications, type: 'boolean', default: false
+    setting :batch_email_notifications, type: 'boolean', default: false, disabled: true
     setting :bulkrax_field_mappings, type: 'json_editor', default: Hyku.default_bulkrax_field_mappings.to_json
     setting :bulkrax_validations, type: 'boolean', disabled: true
     setting :cache_api, type: 'boolean', default: false
     setting :contact_email, type: 'string', default: 'change-me-in-settings@example.com'
     setting :contact_email_to, type: 'string', default: 'change-me-in-settings@example.com'
-    setting :depositor_email_notifications, type: 'boolean', default: false
+    setting :depositor_email_notifications, type: 'boolean', default: false, disabled: true
     setting :doi_reader, type: 'boolean', default: false
     setting :doi_writer, type: 'boolean', default: false
     setting :file_acl, type: 'boolean', default: true, private: true
@@ -52,7 +52,7 @@ module AccountSettings
     setting :smtp_settings, type: 'hash', private: true, default: {}
     setting :solr_collection_options, type: 'hash', default: solr_collection_options
     setting :ssl_configured, type: 'boolean', default: true, private: true
-    setting :user_analytics, type: 'boolean', default: false
+    setting :user_analytics, type: 'boolean', default: false, disabled: true
     setting :weekly_email_list, type: 'array', disabled: true
     setting :yearly_email_list, type: 'array', disabled: true
 

--- a/spec/models/concerns/account_settings_spec.rb
+++ b/spec/models/concerns/account_settings_spec.rb
@@ -10,12 +10,10 @@ RSpec.describe AccountSettings do
         expect(account.public_settings(is_superadmin: true).keys.sort).to eq %i[allow_downloads
                                                                                 allow_signup
                                                                                 analytics_provider
-                                                                                batch_email_notifications
                                                                                 bulkrax_field_mappings
                                                                                 cache_api
                                                                                 contact_email
                                                                                 contact_email_to
-                                                                                depositor_email_notifications
                                                                                 doi_reader
                                                                                 doi_writer
                                                                                 email_domain
@@ -32,8 +30,7 @@ RSpec.describe AccountSettings do
                                                                                 s3_bucket
                                                                                 smtp_settings
                                                                                 solr_collection_options
-                                                                                ssl_configured
-                                                                                user_analytics]
+                                                                                ssl_configured]
       end
       # rubocop:enable RSpec/ExampleLength
     end


### PR DESCRIPTION
Disable Pitt feature that sends user stats and emails, until these feature bugs get fixed: 

:batch_email_notifications
:depositor_email_notifications
:user_analytics

The settings are no longer visible on the account form: 

![image](https://github.com/user-attachments/assets/f116406d-0d5d-43e9-8ee8-dc5f0963c2c6)
