### PR TITLE
🐛 Add UV search params onto other gallery views

### DIFF
--- a/app/helpers/hyku/blacklight_helper_behavior.rb
+++ b/app/helpers/hyku/blacklight_helper_behavior.rb
@@ -44,7 +44,7 @@ module Hyku
       # pull solr_document from input if we don't already have a solr_document
       document = doc&.try(:solr_document) || doc
       Deprecation.silence(Blacklight::UrlHelperBehavior) do
-        link_to label, generate_work_url(document, request, universal_viewer_url_params(opts)), document_link_params(document, opts)
+        link_to label, generate_work_url(document, request, params), document_link_params(document, opts)
       end
     end
     # rubocop:enable Metrics/MethodLength
@@ -57,12 +57,6 @@ module Hyku
     # @private
     def document_link_params(_doc, opts)
       opts.except(:label, :counter, :q, :highlight)
-    end
-    private :document_link_params
-
-    # options needed to carry the search into the universalviewer
-    def universal_viewer_url_params(opts)
-      opts.slice(:q, :highlight)
     end
     private :document_link_params
   end


### PR DESCRIPTION
Issue: 
- https://github.com/notch8/palni_palci_knapsack/issues/199

This commit will remove a method that didn't seem to be working and instead use the #generate_work_url method instead.  This way it actually passes the UV search params.

### Gallery
<img width="871" alt="image" src="https://github.com/user-attachments/assets/a0578dd7-898d-46b8-ad9c-a90416a25f9e" />

### Masonry
<img width="838" alt="image" src="https://github.com/user-attachments/assets/fbe176ab-155e-45d5-9dc3-a765affbadf3" />

### Slideshow
<img width="749" alt="image" src="https://github.com/user-attachments/assets/832da373-da2d-4dba-9ac0-df830c392f73" />
