### PR TITLE
Additional fixes based on issues found in Adventist

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,7 +163,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: ec94f984da7e1c45cc685781a0982d5954b11265
+  revision: a726d9bc5b2ad6fcf40108bfa5c54feae7ba82cf
   branch: main_before_rails_72
   specs:
     hyrax (5.0.3)

--- a/app/assets/stylesheets/hyku.scss
+++ b/app/assets/stylesheets/hyku.scss
@@ -443,9 +443,9 @@ a.btn.btn-secondary.restore-default-color.with-color-hint {
   }
 }
 
-// make sure that URLs don't go outside the container on all work-show pages
+// make sure that URLs and titles don't go outside the container on all work-show pages
 .work-show ul.tabular li {
-  word-wrap: break-word;
+  overflow-wrap: anywhere;
 }
 
 // removes the extra whitespace extending past the sides of the page

--- a/app/assets/stylesheets/hyrax.scss
+++ b/app/assets/stylesheets/hyrax.scss
@@ -31,3 +31,21 @@
 #collection-edit-controls label.control-label {
   font-weight: bold !important;
 }
+
+// Overrides to prevent long titles from breaking out of their container
+// OVERRIDE: Hyrax for show page
+.work-title-wrapper .title-with-badges {
+  overflow-wrap: anywhere;
+  align-items: baseline;
+}
+
+// override Blacklight for catalog search
+.document-title-heading {
+  overflow-wrap: anywhere;
+}
+
+// Override Bootstrap for list results
+a {
+  overflow-wrap: anywhere;
+}
+

--- a/app/views/themes/cultural_show/hyrax/base/_work_title.html.erb
+++ b/app/views/themes/cultural_show/hyrax/base/_work_title.html.erb
@@ -1,11 +1,15 @@
-<% presenter.title.each_with_index do |title, index| %>
-  <div class="row">
-    <div class="col-12 text-show-title d-flex">
-      <% if index == 0 %>
-        <h2><%= markdown(title) %></h2><span class="ml-2 mt-2"><%= presenter.permission_badge %> <%= presenter.workflow.badge %></span>
-      <% else %>
-        <h2><%= markdown(title) %></h2>
-      <% end %>
-    </div>
+<div class="work-title-wrapper">
+  <div class="title-with-badges">
+    <% presenter.title.each_with_index do |title, index| %>
+      <div class="row">
+        <div class="col-12 text-show-title d-flex">
+          <% if index == 0 %>
+            <h2><%= markdown(title) %></h2><span class="ml-2 mt-2"><%= presenter.permission_badge %> <%= presenter.workflow.badge %></span>
+          <% else %>
+            <h2><%= markdown(title) %></h2>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
   </div>
-<% end %>
+</div>

--- a/app/views/themes/image_show/hyrax/base/_work_title.html.erb
+++ b/app/views/themes/image_show/hyrax/base/_work_title.html.erb
@@ -1,3 +1,9 @@
+<%# TODO: This theme is not defined in Hyku %>
+<!--  Pals has image_show.scss but is theme used anywhere?
+Activate classes for title wrapping if needed
+<div class="work-title-wrapper">
+<div class="title-with-badges">
+-->
 <% presenter.title.each_with_index do |title, index| %>
   <div class="row">
     <div class="col-sm-6">
@@ -16,3 +22,7 @@
     </div>
   </div>
 <% end %>
+<!--
+</div>
+</div>
+-->

--- a/app/views/themes/scholarly_show/hyrax/base/_work_title.html.erb
+++ b/app/views/themes/scholarly_show/hyrax/base/_work_title.html.erb
@@ -1,16 +1,20 @@
-<% presenter.title.each_with_index do |title, index| %>
-  <div class="row">
-    <div class="col-md-6">
-      <% if index == 0 %>
-        <h2><%= markdown(title) %></h2><span class="ml-2 mt-2"><%= presenter.permission_badge %> <%= presenter.workflow.badge %></span>
-      <% else %>
-        <h2><%= markdown(title) %></h2>
-      <% end %>
-    </div>
-    <div class="col-md-6 text-md-right">
-      <% if index == 0 %>
-        <%= render "show_actions", presenter: presenter %>
-      <% end %>
-    </div>
+<div class="work-title-wrapper">
+  <div class="title-with-badges">
+    <% presenter.title.each_with_index do |title, index| %>
+      <div class="row">
+        <div class="col-md-6">
+          <% if index == 0 %>
+            <h2><%= markdown(title) %></h2><span class="ml-2 mt-2"><%= presenter.permission_badge %> <%= presenter.workflow.badge %></span>
+          <% else %>
+            <h2><%= markdown(title) %></h2>
+          <% end %>
+        </div>
+        <div class="col-md-6 text-md-right">
+          <% if index == 0 %>
+            <%= render "show_actions", presenter: presenter %>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
   </div>
-<% end %>
+</div>


### PR DESCRIPTION
# Summary

be318f0e **Brings in fix for BatchCreateJob**

The BatchCreateJob was overwriting attributes, causing a retry to fail due to missing attributes. 

6868880f **Handles long titles in views**

Due to the way IiifPrint creates child works,  there were some very long titles which were all one word. These long titles can distort views by stretching containers. Normally this wouldn't be a major issue, but early IiifPrint child works that weren't fully split correctly did not have the attribute to prevent them from appearing in public views.

These CSS and/or html changes wrap long titles to avoid distortions.

<details>
<summary>Home page</summary>

#### Default
![Screenshot 2025-02-08 at 3 13 30 PM](https://github.com/user-attachments/assets/15a4f2ff-af76-4568-95a9-bf77083fdee8)
![Screenshot 2025-02-08 at 3 13 36 PM](https://github.com/user-attachments/assets/fcb98e9e-1e77-4857-b906-8ba2f6fda584)

#### Cultural
![Screenshot 2025-02-08 at 3 41 56 PM](https://github.com/user-attachments/assets/5c00f5ba-e6e0-4fd9-b8b9-bc5af89b4b5e)

#### Institutional

![Screenshot 2025-02-08 at 4 06 30 PM](https://github.com/user-attachments/assets/63b99ad8-3f44-4701-9833-e588bc5d3191)

#### Neutral
![Screenshot 2025-02-08 at 4 15 52 PM](https://github.com/user-attachments/assets/b09b801e-0d8b-45f7-91ac-999ef4920afc)

</details>

<details>
<summary>Catalog page</summary>

#### List view
![Screenshot 2025-02-08 at 4 21 52 PM](https://github.com/user-attachments/assets/b61b5bbf-df95-4e78-b9ea-c7280fd4806f)

#### Gallery view
![Screenshot 2025-02-08 at 4 22 04 PM](https://github.com/user-attachments/assets/5a1d04ce-373e-4719-bfff-e8073f6700af)

</details>

<details>
<summary>Work show</summary>

#### Default
![Screenshot 2025-02-08 at 2 17 46 PM](https://github.com/user-attachments/assets/ba5d8184-5682-4f84-9b42-db09eaf066d1)

#### Cultural
![Screenshot 2025-02-08 at 4 23 43 PM](https://github.com/user-attachments/assets/c7136ba4-a90e-470c-b921-db19df2a0164)

#### Scholarly
![Screenshot 2025-02-08 at 5 46 42 PM](https://github.com/user-attachments/assets/3411bbb5-8b0a-418e-b4f9-a6d3c04019c9)

</details>

<details>
<summary>Collection show  - work list</summary>

#### List view
![Screenshot 2025-02-08 at 5 50 51 PM](https://github.com/user-attachments/assets/39acfd10-aeab-4e74-ac29-b67304b5af77)

#### Gallery view
![Screenshot 2025-02-08 at 5 51 05 PM](https://github.com/user-attachments/assets/80292780-05d7-47cb-829f-6b898c9a5305)

</details>

<details>
<summary>Dashboard works list</summary>

![Screenshot 2025-02-08 at 3 28 56 PM](https://github.com/user-attachments/assets/4392925b-3b60-4e25-a8f9-1c5f7efb41bc)

</details>
