### PR TITLE
🧹 Remove title from index and update translations

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -174,8 +174,7 @@ class CatalogController < ApplicationController
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
-    config.add_show_field 'title_tesim'
-    config.add_show_field 'description_tesim'
+    config.add_show_field 'description_tesim', helper_method: :truncate_and_iconify_auto_link
     config.add_show_field 'keyword_tesim'
     config.add_show_field 'subject_tesim'
     config.add_show_field 'creator_tesim'
@@ -186,15 +185,15 @@ class CatalogController < ApplicationController
     config.add_show_field 'date_uploaded_tesim'
     config.add_show_field 'date_modified_tesim'
     config.add_show_field 'date_created_tesim'
-    config.add_show_field 'rights_statement_tesim'
-    config.add_show_field 'license_tesim'
+    config.add_show_field 'rights_statement_tesim', helper_method: :rights_statement_links
+    config.add_show_field 'license_tesim', helper_method: :license_links
     config.add_show_field 'resource_type_tesim', label: "Resource Type"
     config.add_show_field 'format_tesim'
     config.add_show_field 'identifier_tesim'
     config.add_show_field 'extent_tesim'
     config.add_show_field 'admin_note_tesim', label: "Administrative Notes"
     config.add_show_field "alternative_title_tesim", label: "Alternative title"
-    config.add_show_field "related_url_tesim"
+    config.add_show_field "related_url_tesim", helper_method: :truncate_and_iconify_auto_link
     config.add_show_field 'learning_resource_type_tesim'
     config.add_show_field 'education_level_tesim'
     config.add_show_field 'audience_tesim'

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -90,7 +90,6 @@ module ApplicationHelper
     # if we pass text containing no links, it just returns text.
     auto_link(html_escape(text)) do |value|
       "<span class='fa fa-external-link'></span>#{('&nbsp;' + value) if show_link}"
-    end
-    text.truncate(230, separator: ' ')
+    end.truncate(230, separator: ' ')
   end
 end

--- a/config/locales/blacklight.de.yml
+++ b/config/locales/blacklight.de.yml
@@ -15,21 +15,46 @@ de:
           publisher_sim: Herausgeber
           subject_sim: Fach
         index:
+          accessibility_feature_tesim: Zugänglichkeitsfunktion
+          accessibility_hazard_tesim: Zugänglichkeitsrisiko
+          accessibility_summary_tesim: Zusammenfassung zur Barrierefreiheit
+          additional_information_tesim: Weitere Informationen
+          admin_note_tesim: Administratorhinweis
+          alternative_title_tesim: Alternativer Titel
+          audience_tesim: Publikum
           based_near_label_tesim: Ort
+          chronology_note_tesim: Chronologie-Hinweis
+          contributing_library_tesim: Mitwirkende Bibliothek
           contributor_tesim: Mitwirkender
           creator_tesim: Schöpfer
           date_created_tesim: Datum erstellt
           date_modified_dtsi: Datum geändert
+          date_tesim: Datum
           date_uploaded_dtsi: Datum hochgeladen
           description_tesim: Beschreibung
+          discipline_tesim: Disziplin
+          education_level_tesim: Bildungsniveau
           extent_tesim: Umfang
           file_format_tesim: Datei Format
+          format_tesim: Format
           identifier_tesim: Identifikator
           keyword_tesim: Stichwort
           language_tesim: Sprache
+          learning_resource_type_tesim: Lernressourcentyp
+          library_catalog_identifier_tesim: Bibliothekskatalog-ID
+          license_tesim: Lizenz
+          newer_version_id_tesim: Neuere Versions-ID
+          oer_size_tesim: Oer Größe
+          previous_version_id_tesim: Vorherige Versions-ID
           publisher_tesim: Herausgeber
+          related_item_id_tesim: Zugehörige Artikel-ID
+          related_url_tesim: Verwandte URL
+          resource_type_tesim: Ressourcentyp
+          rights_holder_tesim: Rechteinhaber
+          rights_statement_tesim: Rechteerklärung
           rights_tesim: Rechte
           subject_tesim: Fach
+          table_of_contents_tesim: Inhaltsverzeichnis
         show:
           based_near_label_tesim: Ort
           contributor_tesim: Mitwirkender

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -14,21 +14,46 @@ en:
           publisher_sim: Publisher
           subject_sim: Subject
         index:
+          accessibility_feature_tesim: Accessibility Feature
+          accessibility_hazard_tesim: Accessibility Hazard
+          accessibility_summary_tesim: Accessibility Summary
+          additional_information_tesim: Additional Information
+          admin_note_tesim: Admin Note
+          alternative_title_tesim: Alternative Title
+          audience_tesim: Audience
           based_near_label_tesim: Location
+          chronology_note_tesim: Chronology Note
+          contributing_library_tesim: Contributing Library
           contributor_tesim: Contributor
           creator_tesim: Creator
           date_created_tesim: Date Created
           date_modified_dtsi: Date Modified
+          date_tesim: Date
           date_uploaded_dtsi: Date Uploaded
           description_tesim: Description
+          discipline_tesim: Discipline
+          education_level_tesim: Education Level
           extent_tesim: Extent
           file_format_tesim: File Format
+          format_tesim: Format
           identifier_tesim: Identifier
           keyword_tesim: Keyword
           language_tesim: Language
+          learning_resource_type_tesim: Learning Resource Type
+          library_catalog_identifier_tesim: Library Catalog Identifier
+          license_tesim: License
+          newer_version_id_tesim: Newer Version Id
+          oer_size_tesim: Oer Size
+          previous_version_id_tesim: Previous Version Id
           publisher_tesim: Publisher
+          related_item_id_tesim: Related Item Id
+          related_url_tesim: Related URL
+          resource_type_tesim: Resource Type
+          rights_holder_tesim: Rights Holder
+          rights_statement_tesim: Rights Statement
           rights_tesim: Rights
           subject_tesim: Subject
+          table_of_contents_tesim: Table Of Contents
         show:
           based_near_label_tesim: Location
           contributor_tesim: Contributor

--- a/config/locales/blacklight.es.yml
+++ b/config/locales/blacklight.es.yml
@@ -15,21 +15,46 @@ es:
           publisher_sim: Editor
           subject_sim: Tema
         index:
+          accessibility_feature_tesim: Función de accesibilidad
+          accessibility_hazard_tesim: Riesgo de accesibilidad
+          accessibility_summary_tesim: Resumen de accesibilidad
+          additional_information_tesim: información adicional
+          admin_note_tesim: Nota de administración
+          alternative_title_tesim: Título alternativo
+          audience_tesim: Audiencia
           based_near_label_tesim: Ubicación
+          chronology_note_tesim: Nota cronológica
+          contributing_library_tesim: Biblioteca colaboradora
           contributor_tesim: Contribuidor
           creator_tesim: Creador
           date_created_tesim: Fecha de Creacion
           date_modified_dtsi: Fecha Modificada
+          date_tesim: Fecha
           date_uploaded_dtsi: Fecha de Subida
           description_tesim: Descripción
+          discipline_tesim: Disciplina
+          education_level_tesim: Nivel de educación
           extent_tesim: Grado
           file_format_tesim: Formato de Archivo
+          format_tesim: Formato
           identifier_tesim: Identificador
           keyword_tesim: Palabra clave
           language_tesim: Idioma
+          learning_resource_type_tesim: Tipo de recurso de aprendizaje
+          library_catalog_identifier_tesim: Identificador del catálogo de la biblioteca
+          license_tesim: Licencia
+          newer_version_id_tesim: Identificación de versión más nueva
+          oer_size_tesim: Tamaño Oer
+          previous_version_id_tesim: Id. de versión anterior
           publisher_tesim: Editor
+          related_item_id_tesim: Id. de artículo relacionado
+          related_url_tesim: URL relacionada
+          resource_type_tesim: Tipo de recurso
+          rights_holder_tesim: Titular de los derechos
+          rights_statement_tesim: Declaración de derechos
           rights_tesim: Derechos
           subject_tesim: Tema
+          table_of_contents_tesim: Tabla de contenido
         show:
           based_near_label_tesim: Ubicación
           contributor_tesim: Contribuidor

--- a/config/locales/blacklight.fr.yml
+++ b/config/locales/blacklight.fr.yml
@@ -15,21 +15,46 @@ fr:
           publisher_sim: Éditeur
           subject_sim: Assujettir
         index:
+          accessibility_feature_tesim: Fonctionnalité d'accessibilité
+          accessibility_hazard_tesim: Risque d'accessibilité
+          accessibility_summary_tesim: Résumé sur l'accessibilité
+          additional_information_tesim: Informations Complémentaires
+          admin_note_tesim: Note de l'administrateur
+          alternative_title_tesim: Titre alternatif
+          audience_tesim: Public
           based_near_label_tesim: Emplacement
+          chronology_note_tesim: Note sur la chronologie
+          contributing_library_tesim: Bibliothèque contributive
           contributor_tesim: Donateur
           creator_tesim: Créateur
           date_created_tesim: date créée
           date_modified_dtsi: Date modifiée
+          date_tesim: Date
           date_uploaded_dtsi: Date de téléchargement
           description_tesim: La description
+          discipline_tesim: Discipline
+          education_level_tesim: Niveau d'éducation
           extent_tesim: Ampleur
           file_format_tesim: Format de fichier
+          format_tesim: Format
           identifier_tesim: Identificateur
           keyword_tesim: Mot-clé
           language_tesim: La langue
+          learning_resource_type_tesim: Type de ressource d'apprentissage
+          library_catalog_identifier_tesim: Identifiant du catalogue de la bibliothèque
+          license_tesim: Licence
+          newer_version_id_tesim: ID de la nouvelle version
+          oer_size_tesim: Taille de l'Oer
+          previous_version_id_tesim: ID de la version précédente
           publisher_tesim: Éditeur
+          related_item_id_tesim: ID de l'élément associé
+          related_url_tesim: URL associée
+          resource_type_tesim: Type de ressource
+          rights_holder_tesim: Titulaire des droits
+          rights_statement_tesim: Déclaration des droits
           rights_tesim: Droits
           subject_tesim: Assujettir
+          table_of_contents_tesim: Table des matières
         show:
           based_near_label_tesim: Emplacement
           contributor_tesim: Donateur

--- a/config/locales/blacklight.it.yml
+++ b/config/locales/blacklight.it.yml
@@ -15,21 +15,46 @@ it:
           publisher_sim: Editore
           subject_sim: Soggetto
         index:
+          accessibility_feature_tesim: Funzione di accessibilità
+          accessibility_hazard_tesim: Pericolo di accessibilità
+          accessibility_summary_tesim: Riepilogo accessibilità
+          additional_information_tesim: Informazioni aggiuntive
+          admin_note_tesim: Nota dell'amministratore
+          alternative_title_tesim: Titolo alternativo
+          audience_tesim: Pubblico
           based_near_label_tesim: luogo
+          chronology_note_tesim: Nota cronologica
+          contributing_library_tesim: Biblioteca di contributo
           contributor_tesim: Collaboratore
           creator_tesim: Creatore
           date_created_tesim: data di creazione
           date_modified_dtsi: Data modificata
+          date_tesim: Data
           date_uploaded_dtsi: Data caricata
           description_tesim: Descrizione
+          discipline_tesim: Disciplina
+          education_level_tesim: Livello di istruzione
           extent_tesim: Estensione
           file_format_tesim: Formato del file
+          format_tesim: Formato
           identifier_tesim: Identifier
           keyword_tesim: Parola chiave
           language_tesim: Lingua
+          learning_resource_type_tesim: Tipo di risorsa di apprendimento
+          library_catalog_identifier_tesim: Identificatore del catalogo della biblioteca
+          license_tesim: Licenza
+          newer_version_id_tesim: ID versione più recente
+          oer_size_tesim: Dimensioni dell'oer
+          previous_version_id_tesim: ID versione precedente
           publisher_tesim: Editore
+          related_item_id_tesim: ID elemento correlato
+          related_url_tesim: URL correlato
+          resource_type_tesim: Tipo di risorsa
+          rights_holder_tesim: Titolare dei diritti
+          rights_statement_tesim: Dichiarazione sui diritti
           rights_tesim: Diritti
           subject_tesim: Soggetto
+          table_of_contents_tesim: Sommario
         show:
           based_near_label_tesim: luogo
           contributor_tesim: Collaboratore

--- a/config/locales/blacklight.pt-BR.yml
+++ b/config/locales/blacklight.pt-BR.yml
@@ -15,21 +15,46 @@ pt-BR:
           publisher_sim: Editor
           subject_sim: Sujeito
         index:
+          accessibility_feature_tesim: Recurso de acessibilidade
+          accessibility_hazard_tesim: Risco de acessibilidade
+          accessibility_summary_tesim: Resumo de acessibilidade
+          additional_information_tesim: Informações adicionais
+          admin_note_tesim: Nota do administrador
+          alternative_title_tesim: Título Alternativo
+          audience_tesim: Público
           based_near_label_tesim: Localização
+          chronology_note_tesim: Nota cronológica
+          contributing_library_tesim: Biblioteca Contribuinte
           contributor_tesim: Contribuinte
           creator_tesim: O Criador
           date_created_tesim: Data Criada
           date_modified_dtsi: Data modificada
+          date_tesim: Data
           date_uploaded_dtsi: Data carregada
           description_tesim: Descrição
+          discipline_tesim: Disciplina
+          education_level_tesim: Nível de educação
           extent_tesim: Extensão
           file_format_tesim: Formato de arquivo
+          format_tesim: Formatar
           identifier_tesim: Identificador
           keyword_tesim: Palavra-chave
           language_tesim: Língua
+          learning_resource_type_tesim: Tipo de recurso de aprendizagem
+          library_catalog_identifier_tesim: Identificador do catálogo da biblioteca
+          license_tesim: Licença
+          newer_version_id_tesim: Id da versão mais recente
+          oer_size_tesim: Tamanho Oer
+          previous_version_id_tesim: Id da versão anterior
           publisher_tesim: Editor
+          related_item_id_tesim: Id do item relacionado
+          related_url_tesim: URL relacionada
+          resource_type_tesim: Tipo de recurso
+          rights_holder_tesim: Titular dos direitos
+          rights_statement_tesim: Declaração de direitos
           rights_tesim: Direitos
           subject_tesim: Sujeito
+          table_of_contents_tesim: Índice
         show:
           based_near_label_tesim: Localização
           contributor_tesim: Contribuinte

--- a/config/locales/blacklight.zh.yml
+++ b/config/locales/blacklight.zh.yml
@@ -15,21 +15,46 @@ zh:
           publisher_sim: 出版者
           subject_sim: 学科
         index:
+          accessibility_feature_tesim: 辅助功能
+          accessibility_hazard_tesim: 可及性危险
+          accessibility_summary_tesim: 可访问性摘要
+          additional_information_tesim: 附加信息
+          admin_note_tesim: 管理员备注
+          alternative_title_tesim: 替代标题
+          audience_tesim: 观众
           based_near_label_tesim: 位置
+          chronology_note_tesim: 年表说明
+          contributing_library_tesim: 贡献库
           contributor_tesim: 贡献者
           creator_tesim: 创造者
           date_created_tesim: 创建日期
           date_modified_dtsi: 修改日期
+          date_tesim: 日期
           date_uploaded_dtsi: 日期上传
           description_tesim: 描述
+          discipline_tesim: 纪律
+          education_level_tesim: 教育程度
           extent_tesim: 范围
           file_format_tesim: 文件格式
+          format_tesim: 格式
           identifier_tesim: 识别码
           keyword_tesim: 关键词
           language_tesim: 语言
+          learning_resource_type_tesim: 学习资源类型
+          library_catalog_identifier_tesim: 图书馆目录标识符
+          license_tesim: 执照
+          newer_version_id_tesim: 较新版本 ID
+          oer_size_tesim: 尺寸
+          previous_version_id_tesim: 先前版本 ID
           publisher_tesim: 出版者
+          related_item_id_tesim: 相关商品编号
+          related_url_tesim: 相关网址
+          resource_type_tesim: 资源类型
+          rights_holder_tesim: 权利人
+          rights_statement_tesim: 权利声明
           rights_tesim: 权
           subject_tesim: 学科
+          table_of_contents_tesim: 目录
         show:
           based_near_label_tesim: 位置
           contributor_tesim: 贡献者

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -2,14 +2,28 @@
 de:
   activefedora:
     models:
+      etd: ETD
       generic_work: Arbeiten
       image: Bild
+      oer: OER
   activerecord:
     attributes:
       site:
         institution_name_full: Vollständiger Name der Institution
   application:
     tagline: Die Next-Generation Repository-Lösung
+  blacklight:
+    search:
+      fields:
+        facet:
+          contributing_library_sim: Mitwirkende Bibliothek
+          contributor_sim: Mitwirkender
+          human_readable_type_sim: Typ
+          member_of_collections_sim: Sammlungen
+          resource_type_sim: Ressourcentyp
+        show:
+          additional_information: Weitere Rechteinformationen
+    slideshow_info: Wählen Sie ein Bild aus, um die Diashow zu starten
   errors:
     messages:
       valid_embed_url: muss eine gültige YouTube- oder Vimeo-Einbettungs-URL sein.
@@ -174,6 +188,8 @@ de:
       appearances:
         show:
           forms:
+            active_tabs_background_color:
+              hint: Hover-Farbe für Homepage-Tabs.
             banner_image:
               hint: Um ein Bild als Masthead-Hintergrund zu verwenden, sollten Sie ein Bild (JPG, GIF oder PNG) verwenden, das mindestens 120 Pixel hoch und 1200 Pixel breit ist. Verwenden Sie für optimale Ergebnisse ein Bild mit einer Breite von mindestens 1800 Pixel.
             collection_banner_text_color:
@@ -206,6 +222,8 @@ de:
               hint: Gilt nur für die Schaltflächen „Startseite“, „Info“, „Kontakt“ und „Hilfe“ auf diesen spezifischen Seiten (bei 15 % Deckkraft).
             primary_button_hover_color:
               hint: Schaltflächen zum Teilen, Suchen und Sammeln von Interaktionen (Bearbeiten, Funktionen usw.). Der Rand dieser Schaltflächen wird ebenfalls diese Farbe haben.
+            primary_button_text_color:
+              hint: Textfarbe für die Interaktionsschaltflächen „Teilen“, „Suchen“ und „Sammeln“
             themes:
               confirm: Wenn Ihr Thema nicht richtig angewendet wird, stellen Sie sicher, dass es nicht von benutzerdefiniertem CSS überschrieben wird.
           hints:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,17 +28,6 @@ en:
           human_readable_type_sim: "Type"
           member_of_collections_sim: "Collections"
           resource_type_sim: "Resource Type"
-        index:
-          audience_tesim: "Audience"
-          date_tesim: "Date"
-          description_tesim: "Description"
-          depositor_tesim: "Owner"
-          discipline_tesim: "Discipline"
-          education_level_tesim: "Education level"
-          learning_resource_type_tesim: "Learning resource type"
-          license: "License"
-          resource_type_tesim: "Type"
-          rights_statement_tesim: "Rights statement"
         show:
           additional_information: "Additional rights information"
   devise:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2,14 +2,28 @@
 es:
   activefedora:
     models:
+      etd: Fecha de finalización estimada
       generic_work: Trabajar
       image: Imagen
+      oer: REA
   activerecord:
     attributes:
       site:
         institution_name_full: El nombre de la institución
   application:
     tagline: La solución de repositorio de próxima generación
+  blacklight:
+    search:
+      fields:
+        facet:
+          contributing_library_sim: Biblioteca colaboradora
+          contributor_sim: Contribuyente
+          human_readable_type_sim: Tipo
+          member_of_collections_sim: Colecciones
+          resource_type_sim: Tipo de recurso
+        show:
+          additional_information: Información adicional sobre derechos
+    slideshow_info: Seleccione una imagen para iniciar la presentación de diapositivas
   errors:
     messages:
       valid_embed_url: debe ser una URL de incrustación válida de YouTube o Vimeo.
@@ -175,6 +189,8 @@ es:
       appearances:
         show:
           forms:
+            active_tabs_background_color:
+              hint: Color al pasar el mouse sobre las pestañas de la página de inicio.
             banner_image:
               hint: Para usar una imagen como fondo de cabecera, debe usar una imagen (JPG, GIF o PNG) que tenga al menos 120 píxeles de alto y 1200 píxeles de ancho. Para obtener mejores resultados, use una imagen de al menos 1800 píxeles de ancho.
             collection_banner_text_color:
@@ -207,6 +223,8 @@ es:
               hint: Se aplica a los botones Inicio, Acerca de, Contacto y Ayuda solo en esas páginas específicas (al 15 % de opacidad).
             primary_button_hover_color:
               hint: Botones para compartir, buscar e interactuar con la colección (editar, presentar, etc.). El borde de estos botones también será de este color.
+            primary_button_text_color:
+              hint: Color del texto para los botones de interacción de compartir, buscar y recopilar
             themes:
               confirm: Si su tema no parece aplicarse correctamente, verifique que no esté siendo sobrescrito por CSS personalizado.
           hints:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -2,14 +2,28 @@
 fr:
   activefedora:
     models:
+      etd: ETD
       generic_work: Travail
       image: Image
+      oer: REL
   activerecord:
     attributes:
       site:
         institution_name_full: Nom complet de l'établissement
   application:
     tagline: La solution de dépôt de nouvelle génération
+  blacklight:
+    search:
+      fields:
+        facet:
+          contributing_library_sim: Bibliothèque contributive
+          contributor_sim: Donateur
+          human_readable_type_sim: Taper
+          member_of_collections_sim: Collections
+          resource_type_sim: Type de ressource
+        show:
+          additional_information: Informations complémentaires sur les droits
+    slideshow_info: Sélectionnez une image pour démarrer le diaporama
   errors:
     messages:
       valid_embed_url: doit être une URL d'incorporation valide de YouTube ou Vimeo.
@@ -175,6 +189,8 @@ fr:
       appearances:
         show:
           forms:
+            active_tabs_background_color:
+              hint: Couleur de survol pour les onglets de la page d'accueil.
             banner_image:
               hint: Pour utiliser une image comme arrière-plan d'une bannière Masthead, vous devez utiliser une image (JPG, GIF ou PNG) d'au moins 120 pixels de haut et 1 200 pixels de large. Pour de meilleurs résultats, utilisez une image d'au moins 1800 pixels de large.
             collection_banner_text_color:
@@ -207,6 +223,8 @@ fr:
               hint: S'applique aux boutons Accueil, À propos, Contact et Aide de ces pages spécifiques uniquement (à 15 % d'opacité).
             primary_button_hover_color:
               hint: Boutons de partage, de recherche et d'interaction de collecte (édition, fonctionnalité, etc.). La bordure de ces boutons sera également de cette couleur.
+            primary_button_text_color:
+              hint: Couleur du texte pour les boutons d'interaction de partage, de recherche et de collecte
             themes:
               confirm: Si votre thème ne semble pas s'appliquer correctement, vérifiez qu'il n'est pas écrasé par le CSS personnalisé.
           hints:

--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -6,8 +6,10 @@ de:
     active_consent_to_agreement: Ich habe die ... gelesen und stimme ihnen zu
     activefedora:
       models:
+        etd: ETD
         generic_work: Arbeit
         image: Bild
+        oer: OER
     admin:
       admin_sets:
         delete:
@@ -489,11 +491,15 @@ de:
         announcement_instructions: Ankündigungstext wird auf der Homepage angezeigt. Es ist wichtig, dass wichtige oder aktuelle Nachrichten für alle Besucher der Startseite sichtbar gemacht werden. Es wäre angebracht, hier eine Ankündigung einzugeben, um beispielsweise Benutzer über einen bevorstehenden geplanten Wartungsausfall des Systems zu informieren.
         featured_researcher_instructions: Featured Researcher ist ein Bereich zum Eingeben von Informationen und auf der Startseite, der zum Hervorheben von Repository-Benutzern reserviert ist.
         home_text_instructions: Der Text der Startseite bezieht sich auf die benutzerdefinierten Nachrichten, die auf der Startseite entweder im Heldenblock oder in einem anderen Abschnitt der Startseite angezeigt werden. Dieser Text wird angezeigt, wenn Sie ein Thema auswählen, für das Startseitentext erforderlich oder zulässig ist. Wir empfehlen nicht mehr als 3 Sätze in diesem Bereich.
+        homepage_about_section_content_instructions: Dieser Inhalt wird von keinem der Hyku-Standarddesigns verwendet. Er kann für benutzerdefinierte Designs verwendet werden.
+        homepage_about_section_heading_instructions: Diese Überschrift wird von keinem der Hyku-Standarddesigns verwendet. Sie kann für benutzerdefinierte Designs verwendet werden.
         marketing_instructions: Bannertext bezieht sich auf den Text, der über dem Bannerbild auf der Startseite angezeigt wird. Wir empfehlen nicht mehr als ungefähr 30 Zeichen oder Leerzeichen in diesem Textbereich.
       tabs:
         announcement_text: Ankündigungstext
         featured_researcher: Ausgewählter Forscher
         home_text: Startseite Text
+        homepage_about_section_content: Über den Abschnittsinhalt
+        homepage_about_section_heading: Über die Abschnittsüberschrift
         marketing_text: Marketing-Text
       updated: Inhaltsblöcke aktualisiert.
     controls:
@@ -937,6 +943,7 @@ de:
         agreement_page: Einzahlungsvereinbarung
         help_page: Hilfeseite
         terms_page: Nutzungsbedingungen
+      update: Änderungen speichern
       updated: Seiten aktualisiert.
     passive_consent_to_agreement: Durch das Speichern dieser Arbeit stimme ich dem zu
     product_name: Hyku
@@ -1172,6 +1179,7 @@ de:
       defaults:
         admin_set_id: Verwaltungsset
         based_near: Ort
+        collection_banner_text_color: Textfarbe für Sammlungsbanner
         contributor: Mitwirkender
         creator: Schöpfer
         date_created: Datum erstellt
@@ -1199,6 +1207,7 @@ de:
         navbar_link_text_color: Textfarbe für Navigationsleisten-Links
         navbar_link_text_hover_color: Hover-Farbe des Navigationsleisten-Linktextes
         primary_button_hover_color: Hover-Farbe der primären Schaltfläche
+        primary_button_text_color: Textfarbe der primären Schaltfläche
         publisher: Verleger
         related_url: Verwandte URL
         rights_statement: Rechteerklärung
@@ -1215,3 +1224,5 @@ de:
       defaults:
         find_child_work: Suche nach einer Arbeit…
         member_of_collection_ids: Sammlung auswählen…
+    required:
+      html: <span class="badge badge-info required-tag">erforderlich</span>

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -6,8 +6,10 @@ es:
     active_consent_to_agreement: he leído y estoy de acuerdo con
     activefedora:
       models:
+        etd: Fecha de finalización estimada
         generic_work: Trabajo
         image: Imagen
+        oer: REA
     admin:
       admin_sets:
         delete:
@@ -490,11 +492,15 @@ es:
         announcement_instructions: El texto del anuncio aparece en la página de inicio. Es para que los mensajes importantes u oportunos sean visibles de manera prominente para todos los visitantes de la página de inicio. Sería apropiado ingresar un anuncio aquí, por ejemplo, para notificar a los usuarios sobre una próxima interrupción de mantenimiento planificada del sistema.
         featured_researcher_instructions: Investigador destacado es un espacio para ingresar información y en la página de inicio reservada para resaltar usuarios del repositorio.
         home_text_instructions: El texto de la página de inicio se refiere a la mensajería personalizada que se muestra en la página de inicio, ya sea en el bloque de héroe o en otra sección de la página de inicio. Este texto aparece al seleccionar un tema que requiere o permite el texto de la página de inicio. Recomendamos no más de 3 frases en esta área.
+        homepage_about_section_content_instructions: Este contenido no lo utiliza ninguno de los temas predeterminados de Hyku. Puede utilizarse para temas personalizados.
+        homepage_about_section_heading_instructions: Este encabezado no lo utiliza ninguno de los temas predeterminados de Hyku. Puede utilizarse para temas personalizados.
         marketing_instructions: El texto del banner se refiere al texto que se muestra sobre la imagen del banner en la página de inicio. Recomendamos no más de aproximadamente 30 caracteres o espacios en esta área de texto.
       tabs:
         announcement_text: Texto de anuncio
         featured_researcher: Investigador destacado
         home_text: Texto de la página de inicio
+        homepage_about_section_content: Acerca del contenido de la sección
+        homepage_about_section_heading: Acerca del encabezado de sección
         marketing_text: Texto de marketing
       updated: Bloques de contenido actualizados.
     controls:
@@ -938,6 +944,7 @@ es:
         agreement_page: Acuerdo de depósito
         help_page: Página de ayuda
         terms_page: Términos de Uso
+      update: Guardar cambios
       updated: Páginas actualizadas.
     passive_consent_to_agreement: Al guardar este trabajo, acepto el
     product_name: Hyku
@@ -1173,6 +1180,7 @@ es:
       defaults:
         admin_set_id: Conjunto administrativo
         based_near: Ubicación
+        collection_banner_text_color: Color del texto del banner de colección
         contributor: Contribuyente
         creator: Creador
         date_created: fecha de creacion
@@ -1200,6 +1208,7 @@ es:
         navbar_link_text_color: Color del texto del enlace de la barra de navegación
         navbar_link_text_hover_color: Color de desplazamiento del texto del vínculo de la barra de navegación
         primary_button_hover_color: Color de desplazamiento del botón principal
+        primary_button_text_color: Color del texto del botón principal
         publisher: Editor
         related_url: URL relacionada
         rights_statement: Declaración de derechos
@@ -1216,3 +1225,5 @@ es:
       defaults:
         find_child_work: Busca trabajo ...
         member_of_collection_ids: Seleccione una colección ...
+    required:
+      html: <span class="badge badge-info required-tag">requerido</span>

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -6,8 +6,10 @@ fr:
     active_consent_to_agreement: j'ai lu et accepté les
     activefedora:
       models:
+        etd: ETD
         generic_work: Travail
         image: Image
+        oer: REL
     admin:
       admin_sets:
         delete:
@@ -488,11 +490,15 @@ fr:
         announcement_instructions: Le texte de l'annonce s'affiche sur la page d'accueil. C'est pour que les messages importants ou opportuns soient rendus bien visibles par tous les visiteurs de la page d'accueil. Il serait approprié de saisir une annonce ici, par exemple, pour informer les utilisateurs d'une interruption de maintenance planifiée à venir du système.
         featured_researcher_instructions: Chercheur en vedette est un espace pour entrer des informations et sur la page d'accueil réservé pour mettre en évidence les utilisateurs du référentiel.
         home_text_instructions: Le texte de la page d'accueil fait référence à la messagerie personnalisée qui s'affiche sur la page d'accueil soit dans le bloc héros, soit dans une autre section de la page d'accueil. Ce texte apparaît lors de la sélection d'un thème qui requiert ou autorise le texte de la page d'accueil. Nous ne recommandons pas plus de 3 phrases dans ce domaine.
+        homepage_about_section_content_instructions: Ce contenu n'est utilisé par aucun des thèmes Hyku par défaut. Il peut être utilisé pour des thèmes personnalisés.
+        homepage_about_section_heading_instructions: Ce titre n'est utilisé par aucun des thèmes Hyku par défaut. Il peut être utilisé pour des thèmes personnalisés.
         marketing_instructions: Le texte de la bannière fait référence au texte qui s'affiche sur l'image de la bannière sur la page d'accueil. Nous ne recommandons pas plus d'environ 30 caractères ou espaces dans cette zone de texte.
       tabs:
         announcement_text: Texte de l'annonce
         featured_researcher: Chercheur en vedette
         home_text: Texte de la page d'accueil
+        homepage_about_section_content: À propos du contenu de la section
+        homepage_about_section_heading: À propos de l'en-tête de section
         marketing_text: Texte marketing
       updated: Blocs de contenu mis à jour.
     controls:
@@ -936,6 +942,7 @@ fr:
         agreement_page: Accord de dépôt
         help_page: Page d'aide
         terms_page: Conditions d'utilisation
+      update: Enregistrer les modifications
       updated: Pages mises à jour.
     passive_consent_to_agreement: En enregistrant ce travail, j'accepte les
     product_name: Hyku
@@ -1171,6 +1178,7 @@ fr:
       defaults:
         admin_set_id: Ensemble administratif
         based_near: Emplacement
+        collection_banner_text_color: Couleur du texte de la bannière de collection
         contributor: Donateur
         creator: Créateur
         date_created: date créée
@@ -1198,6 +1206,7 @@ fr:
         navbar_link_text_color: Couleur du texte du lien de la barre de navigation
         navbar_link_text_hover_color: Couleur de survol du texte du lien de la barre de navigation
         primary_button_hover_color: Couleur de survol du bouton principal
+        primary_button_text_color: Couleur du texte du bouton principal
         publisher: Éditeur
         related_url: URL associée
         rights_statement: Déclaration des droits
@@ -1214,3 +1223,5 @@ fr:
       defaults:
         find_child_work: Rechercher une œuvre…
         member_of_collection_ids: Sélectionnez une collection…
+    required:
+      html: <span class="badge badge-info required-tag">requis</span>

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -6,8 +6,10 @@ it:
     active_consent_to_agreement: Ho letto e accetto la
     activefedora:
       models:
+        etd: ETD
         generic_work: Lavoro
         image: Immagine
+        oer: Risorse educative aperte
     admin:
       admin_sets:
         delete:
@@ -490,11 +492,15 @@ it:
         announcement_instructions: Il testo dell'annuncio viene visualizzato sulla home page. È importante che messaggi importanti o tempestivi siano resi ben visibili a tutti i visitatori della home page. Sarebbe opportuno inserire qui un annuncio, ad esempio, per avvisare gli utenti di un'imminente interruzione programmata della manutenzione del sistema.
         featured_researcher_instructions: Il ricercatore in primo piano è uno spazio per inserire informazioni e nella home page riservato per evidenziare gli utenti del repository.
         home_text_instructions: Il testo della pagina iniziale si riferisce alla messaggistica personalizzata visualizzata nella pagina iniziale nel blocco eroe o in un'altra sezione della pagina iniziale. Questo testo viene visualizzato quando si seleziona un tema che richiede o consente il testo della home page. Raccomandiamo non più di 3 frasi in quest'area.
+        homepage_about_section_content_instructions: Questo contenuto non è utilizzato da nessuno dei temi Hyku predefiniti. Può essere utilizzato per temi personalizzati.
+        homepage_about_section_heading_instructions: Questa intestazione non è usata da nessuno dei temi Hyku predefiniti. Può essere usata per temi personalizzati.
         marketing_instructions: Il testo del banner si riferisce al testo visualizzato sull'immagine del banner nella home page. Si consiglia di non più di circa 30 caratteri o spazi in questa area di testo.
       tabs:
         announcement_text: Testo dell'annuncio
         featured_researcher: Ricercatore in primo piano
         home_text: Testo della home page
+        homepage_about_section_content: Informazioni sul contenuto della sezione
+        homepage_about_section_heading: Informazioni sull'intestazione della sezione
         marketing_text: Testo di marketing
       updated: Blocchi di contenuto aggiornati.
     controls:
@@ -938,6 +944,7 @@ it:
         agreement_page: Accordo di deposito
         help_page: Pagina di aiuto
         terms_page: Condizioni d'uso
+      update: Salvare le modifiche
       updated: Pagine aggiornate.
     passive_consent_to_agreement: Salvando questo lavoro accetto il
     product_name: Hyku
@@ -1173,6 +1180,7 @@ it:
       defaults:
         admin_set_id: Set amministrativo
         based_near: Posizione
+        collection_banner_text_color: Colore del testo del banner della raccolta
         contributor: Collaboratore
         creator: Creatore
         date_created: data di creazione
@@ -1200,6 +1208,7 @@ it:
         navbar_link_text_color: Colore del testo del collegamento alla barra di navigazione
         navbar_link_text_hover_color: Colore al passaggio del mouse del testo del collegamento della barra di navigazione
         primary_button_hover_color: Colore del pulsante principale al passaggio del mouse
+        primary_button_text_color: Colore del testo del pulsante primario
         publisher: Editore
         related_url: URL correlato
         rights_statement: Dichiarazione dei diritti
@@ -1216,3 +1225,5 @@ it:
       defaults:
         find_child_work: Cerca un'opera ...
         member_of_collection_ids: Seleziona una collezione ...
+    required:
+      html: <span class="badge badge-info required-tag">necessario</span>

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -6,8 +6,10 @@ pt-BR:
     active_consent_to_agreement: Eu li e concordo com o
     activefedora:
       models:
+        etd: ETD
         generic_work: Trabalhos
         image: Imagem
+        oer: REA
     admin:
       admin_sets:
         delete:
@@ -490,11 +492,15 @@ pt-BR:
         announcement_instructions: O texto do anúncio é exibido na página inicial. É para que mensagens importantes ou oportunas sejam visíveis a todos os visitantes da página inicial. Seria apropriado inserir um anúncio aqui, por exemplo, para notificar os usuários sobre uma futura interrupção planejada da manutenção do sistema.
         featured_researcher_instructions: Pesquisador em destaque é um espaço para inserir informações e na página inicial reservada para destacar os usuários do repositório.
         home_text_instructions: Texto da página inicial refere-se à mensagem personalizada que é exibida na página inicial no bloco principal ou em outra seção da página inicial. Este texto aparece ao selecionar um tema que requer ou permite o texto da página inicial. Recomendamos não mais do que 3 frases nesta área.
+        homepage_about_section_content_instructions: Este conteúdo não é usado por nenhum dos temas Hyku padrão. Ele pode ser usado para temas personalizados.
+        homepage_about_section_heading_instructions: Este título não é usado por nenhum dos temas Hyku padrão. Ele pode ser usado para temas personalizados.
         marketing_instructions: O texto do banner refere-se ao texto exibido sobre a imagem do banner na página inicial. Recomendamos não mais que aproximadamente 30 caracteres ou espaços nesta área de texto.
       tabs:
         announcement_text: Texto do anúncio
         featured_researcher: Pesquisador Destaque
         home_text: Texto da página inicial
+        homepage_about_section_content: Sobre o conteúdo da seção
+        homepage_about_section_heading: Sobre o título da seção
         marketing_text: Texto de Marketing
       updated: Blocos de conteúdo atualizados.
     controls:
@@ -938,6 +944,7 @@ pt-BR:
         agreement_page: Contrato de Depósito
         help_page: Página de ajuda
         terms_page: Termos de uso
+      update: Salvar alterações
       updated: Páginas atualizadas.
     passive_consent_to_agreement: Ao salvar este trabalho, concordo com o
     product_name: Hyku
@@ -1173,6 +1180,7 @@ pt-BR:
       defaults:
         admin_set_id: Conjunto administrativo
         based_near: Localização
+        collection_banner_text_color: Cor do texto do banner da coleção
         contributor: Contribuinte
         creator: O Criador
         date_created: Data Criada
@@ -1200,6 +1208,7 @@ pt-BR:
         navbar_link_text_color: Cor do texto do link da barra de navegação
         navbar_link_text_hover_color: Cor do foco do texto do link da barra de navegação
         primary_button_hover_color: Cor principal do foco do botão
+        primary_button_text_color: Cor do texto do botão primário
         publisher: Editor
         related_url: URL relacionado
         rights_statement: Declaração de direitos
@@ -1216,3 +1225,5 @@ pt-BR:
       defaults:
         find_child_work: Procure um trabalho…
         member_of_collection_ids: Selecione uma coleção…
+    required:
+      html: <span class="badge badge-info required-tag">obrigatório</span>

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -6,8 +6,10 @@ zh:
     active_consent_to_agreement: 我已经阅读并且同意
     activefedora:
       models:
+        etd: 紧急断电
         generic_work: 工作
         image: 图片
+        oer: 开放教育资源
     admin:
       admin_sets:
         delete:
@@ -490,11 +492,15 @@ zh:
         announcement_instructions: 公告文本显示在主页上。重要或及时的消息必须显眼地显示给所有主页访问者。在此处输入一个公告是适当的，例如，以通知用户即将进行的计划中的系统维护中断。
         featured_researcher_instructions: Featured Researcher是一个用于输入信息的空间，并且在主页上保留以突出显示存储库用户。
         home_text_instructions: 主页文本是指在主页上的英雄块或主页的其他部分中显示的自定义消息。选择需要或允许主页文本的主题时，将显示此文本。我们建议在此区域内不要超过3个句子。
+        homepage_about_section_content_instructions: 任何默认 Hyku 主题均未使用此内容。它可用于自定义主题。
+        homepage_about_section_heading_instructions: 任何默认 Hyku 主题均不使用此标题。它可用于自定义主题。
         marketing_instructions: 标语文本是指在首页上标语图像上方显示的文本。我们建议在此文本区域中不要超过30个字符或空格。
       tabs:
         announcement_text: 公告文字
         featured_researcher: 特色研究员
         home_text: 主页文字
+        homepage_about_section_content: 关于部分内容
+        homepage_about_section_heading: 关于章节标题
         marketing_text: 营销文字
       updated: 内容块已更新。
     controls:
@@ -938,6 +944,7 @@ zh:
         agreement_page: 存款协议
         help_page: 帮助页面
         terms_page: 使用条款
+      update: 保存更改
       updated: 页面已更新。
     passive_consent_to_agreement: 保存此作品，我同意
     product_name: 俳句
@@ -1173,6 +1180,7 @@ zh:
       defaults:
         admin_set_id: 行政套装
         based_near: 位置
+        collection_banner_text_color: 集合横幅文字颜色
         contributor: 撰稿人
         creator: 创作者
         date_created: 创建日期
@@ -1200,6 +1208,7 @@ zh:
         navbar_link_text_color: 导航栏链接文字颜色
         navbar_link_text_hover_color: 导航栏链接文本悬停颜色
         primary_button_hover_color: 主按钮悬停颜色
+        primary_button_text_color: 主要按钮文本颜色
         publisher: 发行人
         related_url: 相关网址
         rights_statement: 权利声明
@@ -1216,3 +1225,5 @@ zh:
       defaults:
         find_child_work: 正在搜寻作品…
         member_of_collection_ids: 选择一个收藏夹…
+    required:
+      html: <span class="badge badge-info required-tag">必需的</span>

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -2,14 +2,28 @@
 it:
   activefedora:
     models:
+      etd: ETD
       generic_work: Lavoro
       image: Immagine
+      oer: Risorse educative aperte
   activerecord:
     attributes:
       site:
         institution_name_full: Nome dell'istituto completo
   application:
     tagline: La soluzione di repository di nuova generazione
+  blacklight:
+    search:
+      fields:
+        facet:
+          contributing_library_sim: Biblioteca di contributo
+          contributor_sim: Collaboratore
+          human_readable_type_sim: Tipo
+          member_of_collections_sim: Collezioni
+          resource_type_sim: Tipo di risorsa
+        show:
+          additional_information: Informazioni aggiuntive sui diritti
+    slideshow_info: Seleziona un'immagine per avviare la presentazione
   errors:
     messages:
       valid_embed_url: deve essere un URL di incorporamento valido di YouTube o Vimeo.
@@ -175,6 +189,8 @@ it:
       appearances:
         show:
           forms:
+            active_tabs_background_color:
+              hint: Colore al passaggio del mouse sulle schede della home page.
             banner_image:
               hint: Per utilizzare un'immagine come sfondo di masthead, è necessario utilizzare un'immagine (JPG, GIF o PNG) alta almeno 120 pixel e larga 1200 pixel. Per risultati ottimali, utilizzare un'immagine larga almeno 1800 pixel.
             collection_banner_text_color:
@@ -207,6 +223,8 @@ it:
               hint: Si applica ai pulsanti Home, Informazioni, Contatti e Guida solo su quelle pagine specifiche (con un'opacità del 15%).
             primary_button_hover_color:
               hint: Pulsanti di interazione di condivisione, ricerca e raccolta (modifica, funzionalità, ecc.). Anche il bordo di questi pulsanti sarà di questo colore.
+            primary_button_text_color:
+              hint: Colore del testo per i pulsanti di interazione di condivisione, ricerca e raccolta
             themes:
               confirm: Se il tuo tema non sembra essere applicato correttamente, verifica che non venga sovrascritto dal CSS personalizzato.
           hints:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -2,14 +2,28 @@
 pt-BR:
   activefedora:
     models:
+      etd: ETD
       generic_work: Trabalhar
       image: Imagem
+      oer: REA
   activerecord:
     attributes:
       site:
         institution_name_full: Nome completo da instituição
   application:
     tagline: A solução de repos
+  blacklight:
+    search:
+      fields:
+        facet:
+          contributing_library_sim: Biblioteca Contribuinte
+          contributor_sim: Contribuinte
+          human_readable_type_sim: Tipo
+          member_of_collections_sim: Coleções
+          resource_type_sim: Tipo de recurso
+        show:
+          additional_information: Informações adicionais sobre direitos
+    slideshow_info: Selecione uma imagem para iniciar a apresentação de slides
   errors:
     messages:
       valid_embed_url: deve ser uma URL de incorporação válida do YouTube ou Vimeo.
@@ -175,6 +189,8 @@ pt-BR:
       appearances:
         show:
           forms:
+            active_tabs_background_color:
+              hint: Cor de foco para abas da página inicial.
             banner_image:
               hint: Para usar uma imagem como plano de fundo do cabeçalho, você deve usar uma imagem (JPG, GIF ou PNG) com pelo menos 120 pixels de altura e 1200 pixels de largura. Para obter melhores resultados, use uma imagem com pelo menos 1800 pixels de largura.
             collection_banner_text_color:
@@ -207,6 +223,8 @@ pt-BR:
               hint: Aplica-se apenas aos botões Início, Sobre, Contato e Ajuda nessas páginas específicas (com 15% de opacidade).
             primary_button_hover_color:
               hint: Botões de compartilhamento, pesquisa e interação de coleção (editar, recurso, etc.). A borda desses botões também será dessa cor.
+            primary_button_text_color:
+              hint: Cor do texto para botões de interação de compartilhamento, pesquisa e coleção
             themes:
               confirm: Se o seu tema não parece estar sendo aplicado corretamente, verifique se ele não está sendo substituído pelo CSS personalizado.
           hints:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -2,14 +2,28 @@
 zh:
   activefedora:
     models:
+      etd: 紧急断电
       generic_work: 工作
       image: 图像
+      oer: 开放教育资源
   activerecord:
     attributes:
       site:
         institution_name_full: 完整的机构名称
   application:
     tagline: 下一代存储库解决方案
+  blacklight:
+    search:
+      fields:
+        facet:
+          contributing_library_sim: 贡献库
+          contributor_sim: 撰稿人
+          human_readable_type_sim: 类型
+          member_of_collections_sim: 收藏
+          resource_type_sim: 资源类型
+        show:
+          additional_information: 附加权利信息
+    slideshow_info: 选择一张图片开始幻灯片放映
   errors:
     messages:
       valid_embed_url: 必须是有效的YouTube或Vimeo嵌入URL。
@@ -175,6 +189,8 @@ zh:
       appearances:
         show:
           forms:
+            active_tabs_background_color:
+              hint: 主页标签的悬停颜色。
             banner_image:
               hint: 要将图像用作标头广告背景，您应该使用至少120像素高和1200像素宽的图像（JPG，GIF或PNG）。为了获得最佳效果，请使用至少1800像素宽的图像。
             collection_banner_text_color:
@@ -207,6 +223,8 @@ zh:
               hint: 仅适用于这些特定页面上的“主页”、“关于”、“联系方式”和“帮助”按钮（不透明度为 15%）。
             primary_button_hover_color:
               hint: 共享、搜索和收藏交互（编辑、功能等）按钮。这些按钮的边框也将是这种颜色。
+            primary_button_text_color:
+              hint: 分享、搜索和收藏交互按钮的文字颜色
             themes:
               confirm: 如果您的主题似乎没有正确应用，请确认该主题未被Custom CSS覆盖。
           hints:


### PR DESCRIPTION
This commit will remove the title property from the index show page because it already shows up in a different partial so it's redundant. Also, there were a few missing translations so those have been updated. It seemed that the translations were in two different spots so I consolidated them so it's easier to manage.  I've updated the other languages as well using the i18n Google translate task.

Before:
<img width="401" alt="image" src="https://github.com/user-attachments/assets/2b0cbadb-288c-4c59-b869-c76c81f83b74" />

After:
<img width="411" alt="image" src="https://github.com/user-attachments/assets/d0c55ccc-a310-4ef3-9600-01bb7d020cbd" />
