### PR TITLE
Adds appearance color options

### DIFF
--- a/app/assets/stylesheets/hyku.scss
+++ b/app/assets/stylesheets/hyku.scss
@@ -595,8 +595,9 @@ span.constraint-value p, .facet-values p {
 }
 
 #file_download {
-  margin: 10px 0 10px 0;
-}
+  // margin: 10px 0 10px 0; // commented out because button does not align with row
+    word-wrap: break-word; // adding overflow-wrap elsewhere made this necessary
+  }
 
 // collection show page styles
 

--- a/app/forms/hyku/forms/admin/appearance.rb
+++ b/app/forms/hyku/forms/admin/appearance.rb
@@ -48,6 +48,8 @@ module Hyku
           'navbar_link_background_hover_color' => '#ffffff',
           'navbar_link_text_color' => '#eeeeee',
           'navbar_link_text_hover_color' => '#eeeeee',
+          'primary_button_background_color' => '#286090',
+          'primary_button_border_color' => '#245682',
           'primary_button_hover_color' => '#286090',
           'primary_button_text_color' => '#ffffff'
         }
@@ -94,6 +96,8 @@ module Hyku
               navbar_link_background_hover_color
               navbar_link_text_color
               navbar_link_text_hover_color
+              primary_button_background_color
+              primary_button_border_color
               primary_button_hover_color
               primary_button_text_color
             ]
@@ -266,7 +270,16 @@ module Hyku
         end
 
         # PRIMARY BUTTON COLORS
-        # The background hover color for "primary" buttons and basis for other primary button options
+        # The background color for "primary" buttons
+        def primary_button_background_color
+          block_for('primary_button_background_color')
+        end
+
+        # The border color for "primary" buttons
+        def primary_button_border_color
+          block_for('primary_button_border_color')
+        end
+
         def primary_button_hover_color
           block_for('primary_button_hover_color')
         end
@@ -274,11 +287,6 @@ module Hyku
         # The text color for "primary" buttons
         def primary_button_text_color
           block_for('primary_button_text_color')
-        end
-
-        # The border color for "primary" buttons
-        def primary_button_border_color
-          @primary_button_border ||= darken_color(primary_button_hover_color, 0.05)
         end
 
         # The mouse over color for the border of "primary" buttons
@@ -298,17 +306,17 @@ module Hyku
 
         # The mouse over color for "primary" buttons
         def primary_button_hover_background_color
-          darken_color(primary_button_hover_color, 0.1)
+          darken_color(primary_button_background_color, 0.1)
         end
 
         # The color for the background of active "primary" buttons
         def primary_button_active_background_color
-          darken_color(primary_button_hover_color, 0.1)
+          darken_color(primary_button_background_color, 0.1)
         end
 
         # The color for the background of focused "primary" buttons
         def primary_button_focus_background_color
-          darken_color(primary_button_hover_color, 0.1)
+          darken_color(primary_button_background_color, 0.1)
         end
 
         # The custom css module

--- a/app/views/shared/_appearance_styles.html.erb
+++ b/app/views/shared/_appearance_styles.html.erb
@@ -73,7 +73,7 @@ body.public-facing .nav-tabs > li.nav-item > a:focus {
 
 /* PRIMARY BUTTON STYLES */
 body.public-facing .btn-primary {
-  background-color: <%= appearance.primary_button_hover_color %> !important;
+  background-color: <%= appearance.primary_button_background_color %> !important;
   border-color: <%= appearance.primary_button_border_color %> !important;
   color: <%= appearance.primary_button_text_color %> !important;
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -225,10 +225,8 @@ en:
               hint: 'Applies to the Home, About, Contact and Help buttons on those specific pages only (at 15% opacity).'
             link_color:
               hint: 'Affects links on the home and work pages including: breadcrumbs, tabs, titles and terms of service.'
-            primary_button_hover_color:
-              hint: 'Share, search and collection interaction (edit, feature, etc.) buttons. The border of these buttons will also be this color.'
-            primary_button_text_color:
-              hint: 'Text color for share, search and collection interaction buttons'
+            primary_button_background_color:
+              hint: 'Background color for the share, search and collection interaction buttons.'
             default_button_background_color:
               hint: 'Work interaction (edit, feature, etc.) buttons; work views on collection page and search filter button.'
             facet_panel_background_color:

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1189,9 +1189,9 @@ en:
         creator: Creator
         collection_banner_text_color: Collection banner text color
         date_created: Date Created
-        default_button_background_color: Default button background color
-        default_button_border_color: Default button border color
-        default_button_text_color: Default button text color
+        default_button_background_color: Secondary button background color
+        default_button_border_color: Secondary button border color
+        default_button_text_color: Secondary button text color
         description: Description
         embargo_release_date: until
         facet_panel_background_color: Facet panel background color
@@ -1214,6 +1214,8 @@ en:
         navbar_link_text_hover_color: Navbar link text hover color
         primary_button_hover_color: Primary button hover color
         primary_button_text_color: Primary button text color
+        primary_button_background_color: Primary button background color
+        primary_button_border_color: Primary button border color
         publisher: Publisher
         related_url: Related URL
         rights_statement: Rights statement


### PR DESCRIPTION
## Summary

- Adds the ability to do more color customizations with the primary button.
- Removes some of the hint text that was redundant to reduce the size of the colors menu.
- Renames Default button to Secondary button on the colors menu for clarity.
- Adjusts CSS for the file button on items list so the text will stay within the box (previously for adventist it didn't due to larger fonts)
- The download button will now align with the rest of the row when logged out. 
<details>
<summary>Screenshots</summary>

## items list when logged out before
![Screenshot 2025-02-12 at 12 50 43 PM](https://github.com/user-attachments/assets/12864667-0c58-4089-baa8-b0a53e8f5daf)

## Items list when logged out after change
![Screenshot 2025-02-12 at 12 52 02 PM](https://github.com/user-attachments/assets/d92c9f6a-49b3-44bc-8aee-7439be45ac3a)

## New appearance colors menu
![screencapture-cat-hyku-test-admin-appearance-2025-02-12-12_35_28](https://github.com/user-attachments/assets/2df504d9-599b-42fd-b9c2-f8c88535fec8)

</details>
