### PR TITLE
Allow for theme color defaults

### DIFF
--- a/app/assets/javascripts/hyku/admin/appearance/colors.js
+++ b/app/assets/javascripts/hyku/admin/appearance/colors.js
@@ -18,4 +18,17 @@ $(document).on('turbolinks:load', function() {
       $(this).val($(this).data('default-value'));
     });
   });
+
+  $('.card-footer a.apply-theme-colors').click(function(e) {
+    e.preventDefault();
+
+    var themeColors = $(this).data('theme-colors');
+    
+    Object.keys(themeColors).forEach(function(colorName) {
+      var input = $("input[name='admin_appearance[" + colorName + "]']");
+      if (input.length) {
+        input.val(themeColors[colorName]);
+      }
+    });
+  });
 });

--- a/app/forms/hyku/forms/admin/appearance.rb
+++ b/app/forms/hyku/forms/admin/appearance.rb
@@ -157,6 +157,12 @@ module Hyku
           @site ||= Site.instance
         end
 
+        def custom_theme_colors
+          @home_theme_information ||= YAML.load_file(Hyku::Application.path_for('config/home_themes.yml'))
+          current_theme = site&.home_theme || 'default_home'
+          @home_theme_information.dig(current_theme, 'theme_custom_colors') || {}
+        end
+
         # The color for the collection banner text
         def collection_banner_text_color
           block_for('collection_banner_text_color')

--- a/app/views/hyrax/admin/appearances/_default_colors_form.html.erb
+++ b/app/views/hyrax/admin/appearances/_default_colors_form.html.erb
@@ -4,8 +4,15 @@
       <%= render 'color_input', f: f, color_name: color_name, hex: hex %>
     <% end %>
   </div>
+
+  <% theme_colors = @form.custom_theme_colors %>
+
   <div class="card-footer">
     <%= link_to 'Restore All Defaults', '#color', class: 'btn btn-secondary restore-all-default-colors' %>
+    <% if !theme_colors.empty? %>
+      <%= link_to 'Apply Theme Colors', '#color', class: 'btn btn-secondary apply-theme-colors', 
+        data: { theme_colors: theme_colors.to_json } %>
+    <% end %>
     <%= f.submit class: 'btn btn-primary float-right' %>
   </div>
 <% end %>

--- a/config/home_themes.yml
+++ b/config/home_themes.yml
@@ -2,6 +2,14 @@
 # and should follow the format
 # default:
 #   name: Default theme
+# An optional configuration for theme colors can be defined, which will add
+# a button to the appearance colors section of the admin dashboard, allowing
+# the user to easily set the custom colors. Only colors which are included
+# will be overwritten from the defaults.
+#   theme_custom_colors:
+#     collection_banner_text_color: '#000000'
+#     default_button_background_color: '#FFFFFF'
+#     default_button_border_color: '#5B5B5B'
 #
 default_home:
   banner_image: true


### PR DESCRIPTION
## Summary 
Creates a simple way to define and set default colors for themes in the admin UI. 

The colors to override are defined by attaching them in the `home_themes.yml`. The button to set the colors to the default for the theme will only be displayed if the theme defines custom colors.

<details>
<summary>Video</summary>

[recorded (1).webm](https://github.com/user-attachments/assets/9ea4bc9c-b683-4d7b-85fb-98d3a1f60452)

</details>
