### PR TITLE
I1019 batch email notifications

### DIFF
--- a/spec/factories/mailboxer_messages.rb
+++ b/spec/factories/mailboxer_messages.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
+  sequence :message_body do |n|
+    "Message body #{n}"
+  end
+
   factory :mailboxer_message, class: 'Mailboxer::Message' do
     type { 'Mailboxer::Message' }
-    body { 'Message body' }
+    body { generate(:message_body) }
     subject { 'Message subject' }
     association :sender, factory: :user
     association :conversation, factory: :mailboxer_conversation


### PR DESCRIPTION
# Story: [i1019] Reported errors in batch email notifications

Ref:
- https://github.com/notch8/palni-palci/issues/1019

## Expected Behavior Before Changes

- Inconsistency in the batch email notifications vs what is seen in-app
- Failing feature specs due to database deadlocks in JavaScript-enabled feature

## Expected Behavior After Changes

- Explicitly set batch emails to send all notifications that have the attributes `is_delivered: false` (has not been sent in a previous email) and `is_read: false` (has not been read in-app)
- Once an email is sent, the notifications are set to `is_delivered: true` and `is_read: true`
- Added additional specs to ensure batch email behavior is well defined
- All specs are passing

## Screenshots / Video

<details>
<summary>Image: Passing specs</summary>

<img width="546" alt="Screenshot 2025-02-17 at 1 35 39 PM" src="https://github.com/user-attachments/assets/10d6d319-e1a6-4d38-89d1-7e3752f8efa1" />

</details>

@samvera/hyku-code-reviewers
