### PR TITLE
🐛 Add title search field into all fields search

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -234,7 +234,7 @@ class CatalogController < ApplicationController
       all_names = config.show_fields.values.map(&:field).join(" ")
       title_name = 'title_tesim'
       field.solr_parameters = {
-        qf: "#{all_names} file_format_tesim all_text_tsimv all_text_tsimv",
+        qf: "#{all_names} #{title_name} file_format_tesim all_text_tsimv all_text_tsimv",
         pf: title_name.to_s
       }
     end


### PR DESCRIPTION
Not sure when this stopped working but we couldn't search for the title because `title_tesim` was not in the query fields and only in the phrase fields. Now we should be able to search for a title and get results back.

<img width="1478" alt="image" src="https://github.com/user-attachments/assets/a174edc4-851c-4307-bca5-430de2f0b953" />
