### PR TITLE
i240 home page layout on neutral and cultural theme

### DIFF
--- a/app/assets/stylesheets/themes/institutional_repository.scss
+++ b/app/assets/stylesheets/themes/institutional_repository.scss
@@ -135,7 +135,7 @@
   // home page stats not in carousel
   .ir-stats {
     display: flex;
-    justify-content: center;
+    overflow: auto;
   }
 
   .stats-color-block {

--- a/app/views/hyrax/homepage/_featured_collection_section.html.erb
+++ b/app/views/hyrax/homepage/_featured_collection_section.html.erb
@@ -1,4 +1,4 @@
-<div id="featured_collections" >
+<div id="featured_collections">
   <% if @featured_collection_list.empty? %>
     <p id='no-collections'><%= t('hyrax.homepage.featured_collections.no_collections') %></p>
   <% elsif can? :update, FeaturedCollection %>
@@ -13,21 +13,21 @@
       <%= f.submit("Save order", class: 'btn btn-secondary') %>
     <% end %>
   <% else %>
-    <table class="table table-striped collection-highlights">
-      <tbody>
-        <%= form_for [main_app, @featured_collection_list] do |f| %>
+    <div class="container-fluid">
+      <%= form_for [main_app, @featured_collection_list] do |f| %>
+        <div class="row">
           <%= f.fields_for :featured_collections do |featured| %>
             <%= render 'explore_collections', f: featured %>
           <% end %>
-        <% end %>
-      </tbody>
-    </table>
+        </div>
+      <% end %>
+    </div>
   <% end %>
 </div>
-  <ul class="list-inline collection-highlights-list">
-    <li>
-      <%= link_to t('hyrax.homepage.admin_sets.link'),
-                  main_app.search_catalog_path(f: { generic_type_sim: ["Collection"]}),
-                  class: 'btn btn-secondary mt-1' %>
-    </li>
-  </ul>
+<ul class="list-inline collection-highlights-list">
+  <li>
+    <%= link_to t('hyrax.homepage.admin_sets.link'),
+                main_app.search_catalog_path(f: { generic_type_sim: ["Collection"]}),
+                class: 'btn btn-secondary mt-1' %>
+  </li>
+</ul>

--- a/app/views/themes/institutional_repository/hyrax/homepage/_resource_type_stats.html.erb
+++ b/app/views/themes/institutional_repository/hyrax/homepage/_resource_type_stats.html.erb
@@ -1,7 +1,7 @@
 <div class="ir-stats">
   <% resource_types.each.with_index do |(k,v), i| %>
     <% next if v[0].zero? %>
-    <div class="col-12 col-sm-4 col-md-2">
+    <div class="col">
       <div class="text-center">
         <%= link_to "/catalog?f[resource_type_sim][]=#{k}", style: "color: inherit;" do %>
           <i class='<%= "#{v[1]}" %>' aria-hidden="true"></i>

--- a/app/views/themes/neutral_repository/hyrax/homepage/_explore_collections.html.erb
+++ b/app/views/themes/neutral_repository/hyrax/homepage/_explore_collections.html.erb
@@ -1,7 +1,7 @@
 <% # April's note: overriding Hyrax v5.0.0rc2 template for client theming %>
 
 <% featured_collection = f.object.presenter %>
-<div class="neutral-repository-collections pb-3 col-6 col-md-4">
+<div class="neutral-repository-collections col-6 col-md-4">
   <%= link_to [hyrax, featured_collection] do %>
     <%= render_thumbnail_tag(featured_collection, { class: "img-fluid", alt: "#{featured_collection.title.first} #{ t('hyrax.homepage.admin_sets.thumbnail')}" }, {suppress_link: true}) %>
   <% end %>

--- a/app/views/themes/neutral_repository/hyrax/homepage/_featured_works.html.erb
+++ b/app/views/themes/neutral_repository/hyrax/homepage/_featured_works.html.erb
@@ -4,7 +4,7 @@
 <% elsif can? :update, FeaturedWork %>
   <%= form_for [hyrax, @featured_work_list] do |f| %>
     <div class="dd" id="dd">
-      <ol id="featured_works" class="list-group">
+      <ol id="featured_works">
         <%= f.fields_for :featured_works do |featured| %>
           <%= render 'sortable_featured', f: featured %>
         <% end %>


### PR DESCRIPTION
# Story: [i240] Home Page Layout on Neutral and Cultural Theme

Ref:
- https://github.com/notch8/palni_palci_knapsack/issues/240

## Expected Behavior Before Changes

<details>
<summary>Photo: Logged in user on neutral theme - misaligned sorting button and featured work card</summary>

<img width="1083" alt="Screenshot 2025-02-04 at 11 05 46 AM" src="https://github.com/user-attachments/assets/9b1ed59f-8478-4cb1-a313-281c801f9c65" />

</details>

<details>
<summary>Photo: Logged out user on neutral + cultural themes - featured collections were in a column, not a row</summary>

<img width="1396" alt="Screenshot 2025-02-17 at 4 07 06 PM" src="https://github.com/user-attachments/assets/57a588aa-28fd-4557-98ba-08a155c5852f" />

</details>

## Expected Behavior After Changes

<details>
<summary>Photo: Logged in user on neutral theme - sorting button and featured work card are the same size</summary>

<img width="1491" alt="Screenshot 2025-02-18 at 12 07 38 PM" src="https://github.com/user-attachments/assets/8b849380-a1c9-4c64-9718-2799dc2e39a8" />

</details>

<details>
<summary>Photo: Logged out user on neutral + cultural themes - featured collections are a row and responsive</summary>

<img width="1534" alt="Screenshot 2025-02-18 at 12 04 48 PM" src="https://github.com/user-attachments/assets/8c71871c-d9ee-45c9-8e0b-0778acdd75d7" />

</details>

@samvera/hyku-code-reviewers
