### PR TITLE
🐛 Fix re-split for PDFs

### DIFF
--- a/app/services/iiif_print/tenant_config.rb
+++ b/app/services/iiif_print/tenant_config.rb
@@ -107,10 +107,10 @@ module IiifPrint
 
       ##
       # @api public
-      def self.call(*args)
+      def self.call(path, **kwargs)
         return [] unless TenantConfig.use_iiif_print?
 
-        iiif_print_splitter.call(*args)
+        iiif_print_splitter.call(path, **kwargs)
       end
     end
 


### PR DESCRIPTION
This commit will add a fix for re-splitting PDFs, the problem was because of keyword arguments.

Ref:
- https://github.com/notch8/palni_palci_knapsack/issues/239
