### PR TITLE
Fix file permissions for branding and uploads directories

### DIFF
--- a/ops/demo-deploy.tmpl.yaml
+++ b/ops/demo-deploy.tmpl.yaml
@@ -206,9 +206,10 @@ worker:
     fsGroup: 101
     fsGroupChangePolicy: "OnRootMismatch"
 podSecurityContext:
-  runAsUser: 1001
-  runAsGroup: 101
-  fsGroup: 101
+  runAsUser: 50002
+  runAsGroup: 50002
+  fsGroup: 50002
+  fsGroupChangePolicy: "OnRootMismatch"
   fsGroupChangePolicy: "OnRootMismatch"
 
 embargoRelease:


### PR DESCRIPTION
Changes podSecurityContext to align with EFS filesystem permissions (50002). Previously files were being created with overly restrictive permissions (600) preventing web access to uploaded logos and branding images.

- Updates runAsUser, runAsGroup, and fsGroup to 50002 to match EFS POSIX user/group
- Sets fsGroupChangePolicy to OnRootMismatch for efficient permission handling
- Applied to both main pod and worker deployments

NOTE: I'm trying web change first before applying the same to worker