### PR TITLE
🐛 Standardize carousel container dimensions

### DIFF
--- a/app/assets/stylesheets/themes/neutral_repository.scss
+++ b/app/assets/stylesheets/themes/neutral_repository.scss
@@ -115,23 +115,27 @@
 
   ////// Carousel & Featured Works //////
 
-
   .featured-works-section {
     border: 1px solid #ccc;
     padding: 1em;
   }
 
-  .carousel-opacity {
-    background-color: rgba(102, 102, 102, 0.5) !important;
+  // Custom height class for the carousel
+  .h-400 {
+    height: 400px;
   }
 
-  .carousel-inner > .item > img,
-  .carousel-inner > .item > a > img {
-    display: block;
-    height: 350px;
-    margin: auto;
-    max-width: 100%;
-    width: auto;
+  // Ensure smooth image transitions
+  .carousel-item {
+    img {
+      object-fit: contain;
+      object-position: center;
+      transition: transform .6s ease-in-out;
+    }
+  }
+
+  .carousel-opacity {
+    background-color: rgba(102, 102, 102, 0.5) !important;
   }
 
   div.carousel-caption {

--- a/app/views/themes/neutral_repository/_featured_carousel.html.erb
+++ b/app/views/themes/neutral_repository/_featured_carousel.html.erb
@@ -1,4 +1,4 @@
-<div id="featured-carousel" class="carousel slide" data-ride="carousel">
+<div id="featured-carousel" class="carousel slide h-400" data-ride="carousel">
   <!-- Indicators -->
   <ol class="carousel-indicators">
     <% @featured_work_list.featured_works.each.with_index(0) do |featured_work, order| %>
@@ -7,15 +7,15 @@
   </ol>
 
   <!-- Wrapper for slides -->
-  <div class="carousel-inner" role="listbox">
+  <div class="carousel-inner h-100" role="listbox">
     <% @featured_work_list.featured_works.each.with_index(0) do |featured_work, order| %>
       <% work = SolrDocument.find(featured_work.work_id) %>
-      <div class="carousel-item <%= order.zero? ? 'active' : '' %>">
+      <div class="carousel-item h-100 bg-light <%= order.zero? ? 'active' : '' %>">
         <%= link_to [main_app, work] do %>
-          <%= render_thumbnail_tag(work, {suppress_link: true}) %>
+          <%= render_thumbnail_tag(work, {suppress_link: true, class: 'w-100 h-100'}) %>
         <% end %>
         <div class="carousel-caption">
-          <h3 class="carousel-opacity p-10">
+          <h3 class="carousel-opacity p-2">
             <%= link_to [main_app, work] do %>
               <%= markdown(work.title.first) %>
             <% end %>


### PR DESCRIPTION
# Story: [i249] Standardize featured works carousel container dimensions in logged-out view of Neutral Theme

Ref:
- https://github.com/notch8/palni_palci_knapsack/issues/249

## Expected Behavior Before Changes

- Carousel container resized based on image dimensions causing page layout shifts
- Image transitions were jumpy

<details>
<summary>Video: Before changes</summary>

https://github.com/user-attachments/assets/b01089fb-3731-4e2e-9f31-d89a296b9da4

</details>

## Expected Behavior After Changes

- Set container height and standard image size
- Smooth transition during carousel changes

<details>
<summary>Video: After changes</summary>

https://github.com/user-attachments/assets/eab06c76-c27f-4483-86ab-811ecd3c8c56

</details>

## Notes

- adds a fixed height container (400px) to maintain consistent carousel size even when images have different dimensions
- adds object-fit and transition properties to prevent image stretching during slide transitions
- favors Bootstrap classes where possible
- improves image positioning and aspect ratio handling in carousel items

@samvera/hyku-code-reviewers
