### PR TITLE
🐛 Rework home page featured collections layout

### DIFF
--- a/app/views/hyrax/homepage/_featured_collection_section.html.erb
+++ b/app/views/hyrax/homepage/_featured_collection_section.html.erb
@@ -1,8 +1,8 @@
 <div id="featured_collections">
   <% if @featured_collection_list.empty? %>
-    <p id='no-collections'><%= t('hyrax.homepage.featured_collections.no_collections') %></p>
+    <p id="no-collections"><%= t('hyrax.homepage.featured_collections.no_collections') %></p>
   <% elsif can? :update, FeaturedCollection %>
-    <%= form_for [main_app, @featured_collection_list] do |f| %>
+    <%= form_for [main_app, @featured_collection_list], html: { class: 'w-100' } do |f| %>
       <div class="dd" id="ff">
         <ol id="featured_works">
           <%= f.fields_for :featured_collections do |featured| %>
@@ -10,24 +10,34 @@
           <% end %>
         </ol>
       </div>
-      <%= f.submit("Save order", class: 'btn btn-secondary') %>
+      <%= f.submit('Save order', class: 'btn btn-secondary') %>
     <% end %>
   <% else %>
-    <div class="container-fluid">
-      <%= form_for [main_app, @featured_collection_list] do |f| %>
+    <% if home_page_theme == 'cultural_repository' || home_page_theme == 'institutional_repository' || home_page_theme == 'neutral_repository' %>
+      <%= form_for [main_app, @featured_collection_list], html: { class: 'w-100' } do |f| %>
         <div class="row">
           <%= f.fields_for :featured_collections do |featured| %>
             <%= render 'explore_collections', f: featured %>
           <% end %>
         </div>
       <% end %>
-    </div>
+    <% else %>
+      <table class="table table-striped collection-highlights">
+        <tbody>
+          <%= form_for [main_app, @featured_collection_list] do |f| %>
+            <%= f.fields_for :featured_collections do |featured| %>
+              <%= render 'explore_collections', f: featured %>
+            <% end %>
+          <% end %>
+        </tbody>
+      </table>
+    <% end %>
   <% end %>
 </div>
 <ul class="list-inline collection-highlights-list">
   <li>
     <%= link_to t('hyrax.homepage.admin_sets.link'),
-                main_app.search_catalog_path(f: { generic_type_sim: ["Collection"]}),
+                main_app.search_catalog_path(f: { generic_type_sim: ['Collection']}),
                 class: 'btn btn-secondary mt-1' %>
   </li>
 </ul>

--- a/spec/views/hyrax/homepage/_featured_collection_section.html.erb_spec.rb
+++ b/spec/views/hyrax/homepage/_featured_collection_section.html.erb_spec.rb
@@ -1,11 +1,48 @@
 # frozen_string_literal: true
 
 RSpec.describe "hyrax/homepage/_featured_collection_section.html.erb", type: :view, singletenant: true do
+  # Define helper methods at the example group level
+  helper do
+    def home_page_theme
+      current_account.sites&.first&.home_theme || 'default_home'
+    end
+
+    def show_page_theme
+      current_account.sites&.first&.show_theme || 'default_show'
+    end
+
+    def search_results_theme
+      current_account.sites&.first&.search_theme || 'list_view'
+    end
+  end
+
   subject { rendered }
 
   let(:list) { FeaturedCollectionList.new }
+  let(:doc) do
+    SolrDocument.new(id: '12345678',
+                     title_tesim: ['Doc title'],
+                     has_model_ssim: ['Collection'])
+  end
+  let(:ability) { double }
+  let(:presenter) { Hyku::WorkShowPresenter.new(doc, ability) }
+  let(:featured_collection) { FeaturedCollection.new }
+  let(:site) { Site.new(home_theme: 'cultural_repository') }
+  let(:account) { create(:account) }
 
-  before { assign(:featured_collection_list, list) }
+  before do
+    assign(:featured_collection_list, list)
+    allow(view).to receive(:render_thumbnail_tag).with(any_args).and_return('thumbnail')
+    allow(view).to receive(:markdown).with(any_args).and_return('Doc title')
+    allow(featured_collection).to receive(:presenter).and_return(presenter)
+    allow(presenter).to receive(:solr_document).and_return(doc)
+    allow(presenter).to receive(:title).and_return(['Doc title'])
+    allow(presenter).to receive(:to_s).and_return('Doc title')
+
+    # Add theme helper methods
+    allow(view).to receive(:current_account).and_return(account)
+    allow(account).to receive(:sites).and_return([site])
+  end
 
   context "without featured collections" do
     before { render }
@@ -16,27 +53,82 @@ RSpec.describe "hyrax/homepage/_featured_collection_section.html.erb", type: :vi
   end
 
   context "with featured collections" do
-    let(:doc) do
-      SolrDocument.new(id: '12345678',
-                       title_tesim: ['Doc title'],
-                       has_model_ssim: ['Collection'])
-    end
-    let(:presenter) { Hyku::WorkShowPresenter.new(doc, nil) }
-    let(:featured_collection) { FeaturedCollection.new }
-
     before do
       allow(view).to receive(:can?).with(:update, FeaturedCollection).and_return(false)
-      allow(view).to receive(:render_thumbnail_tag).with(presenter, any_args).and_return("thumbnail")
+      allow(view).to receive(:can?).with(:destroy, FeaturedCollection).and_return(false)
       allow(list).to receive(:empty?).and_return(false)
       allow(list).to receive(:featured_collections).and_return([featured_collection])
-      allow(featured_collection).to receive(:presenter).and_return(presenter)
+    end
+
+    context "in default theme" do
+      before do
+        allow(site).to receive(:home_theme).and_return('default_home')
+        render
+      end
+
+      it "renders collections in a table" do
+        is_expected.not_to have_content 'No collections have been featured'
+        is_expected.not_to have_selector('#no-collections')
+        is_expected.to have_selector('table.table.table-striped.collection-highlights')
+      end
+    end
+
+    context "in cultural repository theme" do
+      before do
+        allow(site).to receive(:home_theme).and_return('cultural_repository')
+        render
+      end
+
+      it "renders collections in a row layout" do
+        is_expected.not_to have_content 'No collections have been featured'
+        is_expected.not_to have_selector('#no-collections')
+        is_expected.not_to have_selector('table.table')
+        is_expected.to have_selector('div.row')
+      end
+    end
+
+    context "in institutional repository theme" do
+      before do
+        allow(site).to receive(:home_theme).and_return('institutional_repository')
+        render
+      end
+
+      it "renders collections in a row layout" do
+        is_expected.not_to have_content 'No collections have been featured'
+        is_expected.not_to have_selector('#no-collections')
+        is_expected.not_to have_selector('table.table')
+        is_expected.to have_selector('div.row')
+      end
+    end
+
+    context "in neutral repository theme" do
+      before do
+        allow(site).to receive(:home_theme).and_return('neutral_repository')
+        render
+      end
+
+      it "renders collections in a row layout" do
+        is_expected.not_to have_content 'No collections have been featured'
+        is_expected.not_to have_selector('#no-collections')
+        is_expected.not_to have_selector('table.table')
+        is_expected.to have_selector('div.row')
+      end
+    end
+  end
+
+  context "with featured collections and admin permissions" do
+    before do
+      allow(view).to receive(:can?).with(:update, FeaturedCollection).and_return(true)
+      allow(view).to receive(:can?).with(:destroy, FeaturedCollection).and_return(true)
+      allow(list).to receive(:empty?).and_return(false)
+      allow(list).to receive(:featured_collections).and_return([featured_collection])
       render
     end
 
-    it do
-      is_expected.not_to have_content 'No collections have been featured'
-      is_expected.not_to have_selector('#no-collections')
-      is_expected.to have_selector('form')
+    it "renders sortable collections" do
+      is_expected.to have_selector('div.dd')
+      is_expected.to have_selector('div#ff')
+      is_expected.to have_selector('ol#featured_works')
     end
   end
 end


### PR DESCRIPTION
# Story: [i240] Featured Collections Home Page Layout

Ref:
- https://github.com/notch8/palni_palci_knapsack/issues/240

## Expected Behavior Before Changes

Previous changes to the Featured Collections section on the home page layout of the Neutral Theme for logged out users created layout issues in the Featured Collections section on the home page layout of the Default Theme

## Expected Behavior After Changes

A conditional statement will allow theme with Featured Collections in a grid to have different styling applied than the themes with a table layout

## Screenshots / Video

<details>
<summary>Photo: theme with a grid layout</summary>

<img width="1174" alt="Screenshot 2025-02-19 at 6 15 11 PM" src="https://github.com/user-attachments/assets/31bb7c58-6226-4666-8d7d-be32225f65cd" />

</details>

<details>
<summary>Photo: theme with a table layout</summary>

![image](https://github.com/user-attachments/assets/f9538e84-b5c3-45b6-96e2-e0b023cccfad)

</details>

@samvera/hyku-code-reviewers
