### PR TITLE
I240 featured collections columns

### DIFF
--- a/app/views/hyrax/homepage/_featured_collection_section.html.erb
+++ b/app/views/hyrax/homepage/_featured_collection_section.html.erb
@@ -1,8 +1,8 @@
 <div id="featured_collections">
   <% if @featured_collection_list.empty? %>
-    <p id='no-collections'><%= t('hyrax.homepage.featured_collections.no_collections') %></p>
+    <p id="no-collections"><%= t('hyrax.homepage.featured_collections.no_collections') %></p>
   <% elsif can? :update, FeaturedCollection %>
-    <%= form_for [main_app, @featured_collection_list] do |f| %>
+    <%= form_for [main_app, @featured_collection_list], html: { class: 'w-100' } do |f| %>
       <div class="dd" id="ff">
         <ol id="featured_works">
           <%= f.fields_for :featured_collections do |featured| %>
@@ -10,24 +10,34 @@
           <% end %>
         </ol>
       </div>
-      <%= f.submit("Save order", class: 'btn btn-secondary') %>
+      <%= f.submit('Save order', class: 'btn btn-secondary') %>
     <% end %>
   <% else %>
-    <div class="container-fluid">
-      <%= form_for [main_app, @featured_collection_list] do |f| %>
+    <% if home_page_theme == 'cultural_repository' || home_page_theme == 'institutional_repository' || home_page_theme == 'neutral_repository' %>
+      <%= form_for [main_app, @featured_collection_list], html: { class: 'w-100' } do |f| %>
         <div class="row">
           <%= f.fields_for :featured_collections do |featured| %>
             <%= render 'explore_collections', f: featured %>
           <% end %>
         </div>
       <% end %>
-    </div>
+    <% else %>
+      <table class="table table-striped collection-highlights">
+        <tbody>
+          <%= form_for [main_app, @featured_collection_list] do |f| %>
+            <%= f.fields_for :featured_collections do |featured| %>
+              <%= render 'explore_collections', f: featured %>
+            <% end %>
+          <% end %>
+        </tbody>
+      </table>
+    <% end %>
   <% end %>
 </div>
 <ul class="list-inline collection-highlights-list">
   <li>
     <%= link_to t('hyrax.homepage.admin_sets.link'),
-                main_app.search_catalog_path(f: { generic_type_sim: ["Collection"]}),
+                main_app.search_catalog_path(f: { generic_type_sim: ['Collection']}),
                 class: 'btn btn-secondary mt-1' %>
   </li>
 </ul>

--- a/app/views/themes/cultural_repository/hyrax/homepage/_featured_collection_section.html.erb
+++ b/app/views/themes/cultural_repository/hyrax/homepage/_featured_collection_section.html.erb
@@ -1,3 +1,5 @@
+<%# OVERRIDE Hyrax v5.0.4 for theming - cultural repository homepage featured collections uses a grid layout %>
+
 <div id="featured_collections">
   <% if @featured_collection_list.empty? %>
     <p id="no-collections"><%= t('hyrax.homepage.featured_collections.no_collections') %></p>
@@ -6,22 +8,22 @@
       <div class="dd" id="ff">
         <ol id="featured_works">
           <%= f.fields_for :featured_collections do |featured| %>
-            <%= render 'sortable_featured_collections', f: featured %>
+            <%= render 'hyrax/homepage/sortable_featured_collections', f: featured %>
           <% end %>
         </ol>
       </div>
       <%= f.submit('Save order', class: 'btn btn-secondary') %>
     <% end %>
   <% else %>
-    <table class="table table-striped collection-highlights">
-      <tbody>
+    <div class="container">
         <%= form_for [main_app, @featured_collection_list] do |f| %>
-          <%= f.fields_for :featured_collections do |featured| %>
-            <%= render 'explore_collections', f: featured %>
-          <% end %>
+          <div class="row">
+            <%= f.fields_for :featured_collections do |featured| %>
+              <%= render 'explore_collections', f: featured %>
+            <% end %>
+          </div>
         <% end %>
-      </tbody>
-    </table>
+    </div>
   <% end %>
 </div>
 <ul class="list-inline collection-highlights-list">

--- a/app/views/themes/institutional_repository/hyrax/homepage/_featured_collection_section.html.erb
+++ b/app/views/themes/institutional_repository/hyrax/homepage/_featured_collection_section.html.erb
@@ -1,0 +1,35 @@
+<%# OVERRIDE Hyrax v5.0.4 for theming - institutional repository homepage featured collections uses a grid layout %>
+
+<div id="featured_collections">
+  <% if @featured_collection_list.empty? %>
+    <p id="no-collections"><%= t('hyrax.homepage.featured_collections.no_collections') %></p>
+  <% elsif can? :update, FeaturedCollection %>
+    <%= form_for [main_app, @featured_collection_list] do |f| %>
+      <div class="dd" id="ff">
+        <ol id="featured_works">
+          <%= f.fields_for :featured_collections do |featured| %>
+            <%= render 'hyrax/homepage/sortable_featured_collections', f: featured %>
+          <% end %>
+        </ol>
+      </div>
+      <%= f.submit('Save order', class: 'btn btn-secondary') %>
+    <% end %>
+  <% else %>
+    <div class="container">
+        <%= form_for [main_app, @featured_collection_list] do |f| %>
+          <div class="row">
+            <%= f.fields_for :featured_collections do |featured| %>
+              <%= render 'explore_collections', f: featured %>
+            <% end %>
+          </div>
+        <% end %>
+    </div>
+  <% end %>
+</div>
+<ul class="list-inline collection-highlights-list">
+  <li>
+    <%= link_to t('hyrax.homepage.admin_sets.link'),
+                main_app.search_catalog_path(f: { generic_type_sim: ['Collection']}),
+                class: 'btn btn-secondary mt-1' %>
+  </li>
+</ul>

--- a/app/views/themes/neutral_repository/hyrax/homepage/_featured_collection_section.html.erb
+++ b/app/views/themes/neutral_repository/hyrax/homepage/_featured_collection_section.html.erb
@@ -1,0 +1,35 @@
+<%# OVERRIDE Hyrax v5.0.4 for theming - neutral repository homepage featured collections uses a grid layout %>
+
+<div id="featured_collections">
+  <% if @featured_collection_list.empty? %>
+    <p id="no-collections"><%= t('hyrax.homepage.featured_collections.no_collections') %></p>
+  <% elsif can? :update, FeaturedCollection %>
+    <%= form_for [main_app, @featured_collection_list] do |f| %>
+      <div class="dd" id="ff">
+        <ol id="featured_works">
+          <%= f.fields_for :featured_collections do |featured| %>
+            <%= render 'hyrax/homepage/sortable_featured_collections', f: featured %>
+          <% end %>
+        </ol>
+      </div>
+      <%= f.submit('Save order', class: 'btn btn-secondary') %>
+    <% end %>
+  <% else %>
+    <div class="container">
+        <%= form_for [main_app, @featured_collection_list] do |f| %>
+          <div class="row">
+            <%= f.fields_for :featured_collections do |featured| %>
+              <%= render 'explore_collections', f: featured %>
+            <% end %>
+          </div>
+        <% end %>
+    </div>
+  <% end %>
+</div>
+<ul class="list-inline collection-highlights-list">
+  <li>
+    <%= link_to t('hyrax.homepage.admin_sets.link'),
+                main_app.search_catalog_path(f: { generic_type_sim: ['Collection']}),
+                class: 'btn btn-secondary mt-1' %>
+  </li>
+</ul>

--- a/spec/views/hyrax/homepage/_featured_collection_section.html.erb_spec.rb
+++ b/spec/views/hyrax/homepage/_featured_collection_section.html.erb_spec.rb
@@ -1,48 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.describe "hyrax/homepage/_featured_collection_section.html.erb", type: :view, singletenant: true do
-  # Define helper methods at the example group level
-  helper do
-    def home_page_theme
-      current_account.sites&.first&.home_theme || 'default_home'
-    end
-
-    def show_page_theme
-      current_account.sites&.first&.show_theme || 'default_show'
-    end
-
-    def search_results_theme
-      current_account.sites&.first&.search_theme || 'list_view'
-    end
-  end
-
   subject { rendered }
 
   let(:list) { FeaturedCollectionList.new }
-  let(:doc) do
-    SolrDocument.new(id: '12345678',
-                     title_tesim: ['Doc title'],
-                     has_model_ssim: ['Collection'])
-  end
-  let(:ability) { double }
-  let(:presenter) { Hyku::WorkShowPresenter.new(doc, ability) }
-  let(:featured_collection) { FeaturedCollection.new }
-  let(:site) { Site.new(home_theme: 'cultural_repository') }
-  let(:account) { create(:account) }
 
-  before do
-    assign(:featured_collection_list, list)
-    allow(view).to receive(:render_thumbnail_tag).with(any_args).and_return('thumbnail')
-    allow(view).to receive(:markdown).with(any_args).and_return('Doc title')
-    allow(featured_collection).to receive(:presenter).and_return(presenter)
-    allow(presenter).to receive(:solr_document).and_return(doc)
-    allow(presenter).to receive(:title).and_return(['Doc title'])
-    allow(presenter).to receive(:to_s).and_return('Doc title')
-
-    # Add theme helper methods
-    allow(view).to receive(:current_account).and_return(account)
-    allow(account).to receive(:sites).and_return([site])
-  end
+  before { assign(:featured_collection_list, list) }
 
   context "without featured collections" do
     before { render }
@@ -53,82 +16,27 @@ RSpec.describe "hyrax/homepage/_featured_collection_section.html.erb", type: :vi
   end
 
   context "with featured collections" do
+    let(:doc) do
+      SolrDocument.new(id: '12345678',
+                       title_tesim: ['Doc title'],
+                       has_model_ssim: ['Collection'])
+    end
+    let(:presenter) { Hyku::WorkShowPresenter.new(doc, nil) }
+    let(:featured_collection) { FeaturedCollection.new }
+
     before do
       allow(view).to receive(:can?).with(:update, FeaturedCollection).and_return(false)
-      allow(view).to receive(:can?).with(:destroy, FeaturedCollection).and_return(false)
+      allow(view).to receive(:render_thumbnail_tag).with(presenter, any_args).and_return('thumbnail')
       allow(list).to receive(:empty?).and_return(false)
       allow(list).to receive(:featured_collections).and_return([featured_collection])
-    end
-
-    context "in default theme" do
-      before do
-        allow(site).to receive(:home_theme).and_return('default_home')
-        render
-      end
-
-      it "renders collections in a table" do
-        is_expected.not_to have_content 'No collections have been featured'
-        is_expected.not_to have_selector('#no-collections')
-        is_expected.to have_selector('table.table.table-striped.collection-highlights')
-      end
-    end
-
-    context "in cultural repository theme" do
-      before do
-        allow(site).to receive(:home_theme).and_return('cultural_repository')
-        render
-      end
-
-      it "renders collections in a row layout" do
-        is_expected.not_to have_content 'No collections have been featured'
-        is_expected.not_to have_selector('#no-collections')
-        is_expected.not_to have_selector('table.table')
-        is_expected.to have_selector('div.row')
-      end
-    end
-
-    context "in institutional repository theme" do
-      before do
-        allow(site).to receive(:home_theme).and_return('institutional_repository')
-        render
-      end
-
-      it "renders collections in a row layout" do
-        is_expected.not_to have_content 'No collections have been featured'
-        is_expected.not_to have_selector('#no-collections')
-        is_expected.not_to have_selector('table.table')
-        is_expected.to have_selector('div.row')
-      end
-    end
-
-    context "in neutral repository theme" do
-      before do
-        allow(site).to receive(:home_theme).and_return('neutral_repository')
-        render
-      end
-
-      it "renders collections in a row layout" do
-        is_expected.not_to have_content 'No collections have been featured'
-        is_expected.not_to have_selector('#no-collections')
-        is_expected.not_to have_selector('table.table')
-        is_expected.to have_selector('div.row')
-      end
-    end
-  end
-
-  context "with featured collections and admin permissions" do
-    before do
-      allow(view).to receive(:can?).with(:update, FeaturedCollection).and_return(true)
-      allow(view).to receive(:can?).with(:destroy, FeaturedCollection).and_return(true)
-      allow(list).to receive(:empty?).and_return(false)
-      allow(list).to receive(:featured_collections).and_return([featured_collection])
+      allow(featured_collection).to receive(:presenter).and_return(presenter)
       render
     end
 
-    it "renders sortable collections" do
-      is_expected.to have_selector('div.dd')
-      is_expected.to have_selector('div#ff')
-      is_expected.to have_selector('ol#featured_works')
+    it do
+      is_expected.not_to have_content 'No collections have been featured'
+      is_expected.not_to have_selector('#no-collections')
+      is_expected.to have_selector('form')
     end
   end
 end

--- a/spec/views/hyrax/homepage/_featured_collection_section.html.erb_spec.rb
+++ b/spec/views/hyrax/homepage/_featured_collection_section.html.erb_spec.rb
@@ -1,11 +1,48 @@
 # frozen_string_literal: true
 
 RSpec.describe "hyrax/homepage/_featured_collection_section.html.erb", type: :view, singletenant: true do
+  # Define helper methods at the example group level
+  helper do
+    def home_page_theme
+      current_account.sites&.first&.home_theme || 'default_home'
+    end
+
+    def show_page_theme
+      current_account.sites&.first&.show_theme || 'default_show'
+    end
+
+    def search_results_theme
+      current_account.sites&.first&.search_theme || 'list_view'
+    end
+  end
+
   subject { rendered }
 
   let(:list) { FeaturedCollectionList.new }
+  let(:doc) do
+    SolrDocument.new(id: '12345678',
+                     title_tesim: ['Doc title'],
+                     has_model_ssim: ['Collection'])
+  end
+  let(:ability) { double }
+  let(:presenter) { Hyku::WorkShowPresenter.new(doc, ability) }
+  let(:featured_collection) { FeaturedCollection.new }
+  let(:site) { Site.new(home_theme: 'cultural_repository') }
+  let(:account) { create(:account) }
 
-  before { assign(:featured_collection_list, list) }
+  before do
+    assign(:featured_collection_list, list)
+    allow(view).to receive(:render_thumbnail_tag).with(any_args).and_return('thumbnail')
+    allow(view).to receive(:markdown).with(any_args).and_return('Doc title')
+    allow(featured_collection).to receive(:presenter).and_return(presenter)
+    allow(presenter).to receive(:solr_document).and_return(doc)
+    allow(presenter).to receive(:title).and_return(['Doc title'])
+    allow(presenter).to receive(:to_s).and_return('Doc title')
+
+    # Add theme helper methods
+    allow(view).to receive(:current_account).and_return(account)
+    allow(account).to receive(:sites).and_return([site])
+  end
 
   context "without featured collections" do
     before { render }
@@ -16,27 +53,82 @@ RSpec.describe "hyrax/homepage/_featured_collection_section.html.erb", type: :vi
   end
 
   context "with featured collections" do
-    let(:doc) do
-      SolrDocument.new(id: '12345678',
-                       title_tesim: ['Doc title'],
-                       has_model_ssim: ['Collection'])
-    end
-    let(:presenter) { Hyku::WorkShowPresenter.new(doc, nil) }
-    let(:featured_collection) { FeaturedCollection.new }
-
     before do
       allow(view).to receive(:can?).with(:update, FeaturedCollection).and_return(false)
-      allow(view).to receive(:render_thumbnail_tag).with(presenter, any_args).and_return("thumbnail")
+      allow(view).to receive(:can?).with(:destroy, FeaturedCollection).and_return(false)
       allow(list).to receive(:empty?).and_return(false)
       allow(list).to receive(:featured_collections).and_return([featured_collection])
-      allow(featured_collection).to receive(:presenter).and_return(presenter)
+    end
+
+    context "in default theme" do
+      before do
+        allow(site).to receive(:home_theme).and_return('default_home')
+        render
+      end
+
+      it "renders collections in a table" do
+        is_expected.not_to have_content 'No collections have been featured'
+        is_expected.not_to have_selector('#no-collections')
+        is_expected.to have_selector('table.table.table-striped.collection-highlights')
+      end
+    end
+
+    context "in cultural repository theme" do
+      before do
+        allow(site).to receive(:home_theme).and_return('cultural_repository')
+        render
+      end
+
+      it "renders collections in a row layout" do
+        is_expected.not_to have_content 'No collections have been featured'
+        is_expected.not_to have_selector('#no-collections')
+        is_expected.not_to have_selector('table.table')
+        is_expected.to have_selector('div.row')
+      end
+    end
+
+    context "in institutional repository theme" do
+      before do
+        allow(site).to receive(:home_theme).and_return('institutional_repository')
+        render
+      end
+
+      it "renders collections in a row layout" do
+        is_expected.not_to have_content 'No collections have been featured'
+        is_expected.not_to have_selector('#no-collections')
+        is_expected.not_to have_selector('table.table')
+        is_expected.to have_selector('div.row')
+      end
+    end
+
+    context "in neutral repository theme" do
+      before do
+        allow(site).to receive(:home_theme).and_return('neutral_repository')
+        render
+      end
+
+      it "renders collections in a row layout" do
+        is_expected.not_to have_content 'No collections have been featured'
+        is_expected.not_to have_selector('#no-collections')
+        is_expected.not_to have_selector('table.table')
+        is_expected.to have_selector('div.row')
+      end
+    end
+  end
+
+  context "with featured collections and admin permissions" do
+    before do
+      allow(view).to receive(:can?).with(:update, FeaturedCollection).and_return(true)
+      allow(view).to receive(:can?).with(:destroy, FeaturedCollection).and_return(true)
+      allow(list).to receive(:empty?).and_return(false)
+      allow(list).to receive(:featured_collections).and_return([featured_collection])
       render
     end
 
-    it do
-      is_expected.not_to have_content 'No collections have been featured'
-      is_expected.not_to have_selector('#no-collections')
-      is_expected.to have_selector('form')
+    it "renders sortable collections" do
+      is_expected.to have_selector('div.dd')
+      is_expected.to have_selector('div#ff')
+      is_expected.to have_selector('ol#featured_works')
     end
   end
 end

--- a/spec/views/themes/cultural_repository/_featured_collection_section.html.erb_spec.rb
+++ b/spec/views/themes/cultural_repository/_featured_collection_section.html.erb_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+RSpec.describe "themes/cultural_repository/hyrax/homepage/_featured_collection_section.html.erb", type: :view do
+  let(:list) { FeaturedCollectionList.new }
+  let(:presenter) do
+    Hyku::WorkShowPresenter.new(
+      SolrDocument.new(
+        id: '123',
+        title_tesim: ['Featured Collection'],
+        has_model_ssim: ['Collection']
+      ),
+      nil
+    )
+  end
+  let(:featured_collection) { FeaturedCollection.new }
+  let(:rendered_template) { render }
+
+  before do
+    assign(:featured_collection_list, list)
+    allow(view).to receive(:can?).with(:update, FeaturedCollection).and_return(false)
+    allow(view).to receive(:render_thumbnail_tag).with(presenter, any_args).and_return('thumbnail')
+    allow(view).to receive(:main_app).and_return(main_app)
+  end
+
+  context "when there are no featured collections" do
+    before { render }
+
+    it "displays the 'no collections' message" do
+      expect(rendered).to have_content(t('hyrax.homepage.featured_collections.no_collections'))
+    end
+
+    it "does not show the form" do
+      expect(rendered).not_to have_selector('form')
+    end
+  end
+
+  context "when user can update featured collections" do
+    before do
+      allow(view).to receive(:can?).with(:update, FeaturedCollection).and_return(true)
+      allow(view).to receive(:can?).with(:destroy, FeaturedCollection).and_return(true)
+      allow(list).to receive(:empty?).and_return(false)
+      allow(list).to receive(:featured_collections).and_return([featured_collection])
+      allow(featured_collection).to receive(:presenter).and_return(presenter)
+
+      allow(view).to receive(:render_thumbnail_tag).with(
+        presenter.solr_document,
+        { alt: "Featured Collection Thumbnail" },
+        { suppress_link: true }
+      ).and_return('thumbnail')
+
+      render
+    end
+
+    it "displays the form for reordering" do
+      expect(rendered).to have_selector('form')
+      expect(rendered).to have_selector('#ff')
+      expect(rendered).to have_selector('#featured_works')
+      expect(rendered).to have_selector('input[type="submit"][value="Save order"]')
+    end
+  end
+
+  context "when user cannot update featured collections" do
+    before do
+      allow(list).to receive(:empty?).and_return(false)
+      allow(list).to receive(:featured_collections).and_return([featured_collection])
+      allow(featured_collection).to receive(:presenter).and_return(presenter)
+      render
+    end
+
+    it "displays the collections in a grid" do
+      expect(rendered).to have_selector('.container')
+      expect(rendered).to have_selector('.row')
+    end
+
+    it "displays the link to browse all collections" do
+      expect(rendered).to have_selector('.collection-highlights-list')
+      expect(rendered).to have_link(t('hyrax.homepage.admin_sets.link'))
+    end
+  end
+end

--- a/spec/views/themes/institutional_repository/_featured_collection_section.html.erb_spec.rb
+++ b/spec/views/themes/institutional_repository/_featured_collection_section.html.erb_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+RSpec.describe "themes/institutional_repository/hyrax/homepage/_featured_collection_section.html.erb", type: :view do
+  let(:list) { FeaturedCollectionList.new }
+  let(:presenter) do
+    Hyku::WorkShowPresenter.new(
+      SolrDocument.new(
+        id: '123',
+        title_tesim: ['Featured Collection'],
+        has_model_ssim: ['Collection']
+      ),
+      nil
+    )
+  end
+  let(:featured_collection) { FeaturedCollection.new }
+  let(:rendered_template) { render }
+
+  before do
+    assign(:featured_collection_list, list)
+    allow(view).to receive(:can?).with(:update, FeaturedCollection).and_return(false)
+    allow(view).to receive(:render_thumbnail_tag).with(presenter, any_args).and_return('thumbnail')
+    allow(view).to receive(:main_app).and_return(main_app)
+  end
+
+  context "when there are no featured collections" do
+    before { render }
+
+    it "displays the 'no collections' message" do
+      expect(rendered).to have_content(t('hyrax.homepage.featured_collections.no_collections'))
+    end
+
+    it "does not show the form" do
+      expect(rendered).not_to have_selector('form')
+    end
+  end
+
+  context "when user can update featured collections" do
+    before do
+      allow(view).to receive(:can?).with(:update, FeaturedCollection).and_return(true)
+      allow(view).to receive(:can?).with(:destroy, FeaturedCollection).and_return(true)
+      allow(list).to receive(:empty?).and_return(false)
+      allow(list).to receive(:featured_collections).and_return([featured_collection])
+      allow(featured_collection).to receive(:presenter).and_return(presenter)
+
+      allow(view).to receive(:render_thumbnail_tag).with(
+        presenter.solr_document,
+        { alt: "Featured Collection Thumbnail" },
+        { suppress_link: true }
+      ).and_return('thumbnail')
+
+      render
+    end
+
+    it "displays the form for reordering" do
+      expect(rendered).to have_selector('form')
+      expect(rendered).to have_selector('#ff')
+      expect(rendered).to have_selector('#featured_works')
+      expect(rendered).to have_selector('input[type="submit"][value="Save order"]')
+    end
+  end
+
+  context "when user cannot update featured collections" do
+    before do
+      allow(list).to receive(:empty?).and_return(false)
+      allow(list).to receive(:featured_collections).and_return([featured_collection])
+      allow(featured_collection).to receive(:presenter).and_return(presenter)
+      render
+    end
+
+    it "displays the collections in a grid" do
+      expect(rendered).to have_selector('.container')
+      expect(rendered).to have_selector('.row')
+    end
+
+    it "displays the link to browse all collections" do
+      expect(rendered).to have_selector('.collection-highlights-list')
+      expect(rendered).to have_link(t('hyrax.homepage.admin_sets.link'))
+    end
+  end
+end

--- a/spec/views/themes/neutral_repository/_featured_collection_section.html.erb_spec.rb
+++ b/spec/views/themes/neutral_repository/_featured_collection_section.html.erb_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+RSpec.describe "themes/neutral_repository/hyrax/homepage/_featured_collection_section.html.erb", type: :view do
+  let(:list) { FeaturedCollectionList.new }
+  let(:presenter) do
+    Hyku::WorkShowPresenter.new(
+      SolrDocument.new(
+        id: '123',
+        title_tesim: ['Featured Collection'],
+        has_model_ssim: ['Collection']
+      ),
+      nil
+    )
+  end
+  let(:featured_collection) { FeaturedCollection.new }
+  let(:rendered_template) { render }
+
+  before do
+    assign(:featured_collection_list, list)
+    allow(view).to receive(:can?).with(:update, FeaturedCollection).and_return(false)
+    allow(view).to receive(:render_thumbnail_tag).with(presenter, any_args).and_return('thumbnail')
+    allow(view).to receive(:main_app).and_return(main_app)
+  end
+
+  context "when there are no featured collections" do
+    before { render }
+
+    it "displays the 'no collections' message" do
+      expect(rendered).to have_content(t('hyrax.homepage.featured_collections.no_collections'))
+    end
+
+    it "does not show the form" do
+      expect(rendered).not_to have_selector('form')
+    end
+  end
+
+  context "when user can update featured collections" do
+    before do
+      allow(view).to receive(:can?).with(:update, FeaturedCollection).and_return(true)
+      allow(view).to receive(:can?).with(:destroy, FeaturedCollection).and_return(true)
+      allow(list).to receive(:empty?).and_return(false)
+      allow(list).to receive(:featured_collections).and_return([featured_collection])
+      allow(featured_collection).to receive(:presenter).and_return(presenter)
+
+      allow(view).to receive(:render_thumbnail_tag).with(
+        presenter.solr_document,
+        { alt: "Featured Collection Thumbnail" },
+        { suppress_link: true }
+      ).and_return('thumbnail')
+
+      render
+    end
+
+    it "displays the form for reordering" do
+      expect(rendered).to have_selector('form')
+      expect(rendered).to have_selector('#ff')
+      expect(rendered).to have_selector('#featured_works')
+      expect(rendered).to have_selector('input[type="submit"][value="Save order"]')
+    end
+  end
+
+  context "when user cannot update featured collections" do
+    before do
+      allow(list).to receive(:empty?).and_return(false)
+      allow(list).to receive(:featured_collections).and_return([featured_collection])
+      allow(featured_collection).to receive(:presenter).and_return(presenter)
+      render
+    end
+
+    it "displays the collections in a grid" do
+      expect(rendered).to have_selector('.container')
+      expect(rendered).to have_selector('.row')
+    end
+
+    it "displays the link to browse all collections" do
+      expect(rendered).to have_selector('.collection-highlights-list')
+      expect(rendered).to have_link(t('hyrax.homepage.admin_sets.link'))
+    end
+  end
+end


### PR DESCRIPTION
# Story: [i240] Featured Collections 

Ref:
- https://github.com/notch8/palni_palci_knapsack/issues/240

## Expected Behavior Before Changes

The default theme's featured collection section on the logged out home page uses a table layout where all the other themes should use a grid layout but were rendering in a column.

## Expected Behavior After Changes

All featured collection section on the logged out home page should follow the theme's desired structure.

## Screenshots / Video

<details>
<summary>Photo: Default theme featured collection section on the logged out home page</summary>

![image](https://github.com/user-attachments/assets/2c3750da-b000-4b0a-a8a5-197eab733ee2)

</details>

<details>
<summary>Photo: Cultural theme featured collection section on the logged out home page</summary>

![image](https://github.com/user-attachments/assets/bfe6ff3a-0ed5-4b91-8c1c-90d3de4465d2)

</details>

<details>
<summary>Photo: Institutional theme featured collection section on the logged out home page</summary>

![image](https://github.com/user-attachments/assets/0ace39a2-56ea-4a94-b982-e806c5febed8)

</details>

<details>
<summary>Photo: Neutral theme featured collection section on the logged out home page</summary>

![image](https://github.com/user-attachments/assets/a14c7d7d-c4af-4bb0-adfa-0551688f5317)

</details>

@samvera/hyku-code-reviewers
