### PR TITLE
rework user_analytics setting

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -185,8 +185,11 @@ class Account < ApplicationRecord
     ]
 
     jobs_to_schedule << BatchEmailNotificationJob if batch_email_notifications
-    jobs_to_schedule << DepositorEmailNotificationJob if depositor_email_notifications
-    jobs_to_schedule << UserStatCollectionJob if user_analytics
+    
+    if analytics_reporting && Hyrax.config.analytics_reporting?
+      jobs_to_schedule << DepositorEmailNotificationJob if depositor_email_notifications
+      jobs_to_schedule << UserStatCollectionJob
+    end
 
     jobs_to_schedule.each do |klass|
       klass.perform_later unless find_job(klass)
@@ -203,7 +206,7 @@ class Account < ApplicationRecord
     relevant_settings = [
       'batch_email_notifications',
       'depositor_email_notifications',
-      'user_analytics'
+      'analytics_reporting'
     ]
 
     return unless saved_changes['settings']

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -185,7 +185,7 @@ class Account < ApplicationRecord
     ]
 
     jobs_to_schedule << BatchEmailNotificationJob if batch_email_notifications
-    
+
     if analytics_reporting && Hyrax.config.analytics_reporting?
       jobs_to_schedule << DepositorEmailNotificationJob if depositor_email_notifications
       jobs_to_schedule << UserStatCollectionJob

--- a/app/models/concerns/account_settings.rb
+++ b/app/models/concerns/account_settings.rb
@@ -22,8 +22,8 @@ module AccountSettings
 
     setting :allow_downloads, type: 'boolean', default: true
     setting :allow_signup, type: 'boolean', default: true
-    setting :analytics, type: 'boolean', default: true
-    setting :analytics_reporting, type: 'boolean', default: true
+    setting :analytics, type: 'boolean', default: false
+    setting :analytics_reporting, type: 'boolean', default: false
     setting :batch_email_notifications, type: 'boolean', default: false
     setting :bulkrax_field_mappings, type: 'json_editor', default: Hyku.default_bulkrax_field_mappings.to_json
     setting :bulkrax_validations, type: 'boolean', disabled: true
@@ -54,7 +54,6 @@ module AccountSettings
     setting :smtp_settings, type: 'hash', private: true, default: {}
     setting :solr_collection_options, type: 'hash', default: solr_collection_options
     setting :ssl_configured, type: 'boolean', default: true, private: true
-    setting :user_analytics, type: 'boolean', default: false
     setting :weekly_email_list, type: 'array', disabled: true
     setting :yearly_email_list, type: 'array', disabled: true
 

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -22,6 +22,7 @@ en:
         allow_signup: Allow users to sign up to your repository
         analytics: Enable or disable Google Analytics 4 to track user interactions, including clicks.
         analytics_reporting: Enable or disable reporting from Google Analytics 4 to display analytics data in the dashboard. Requires developer support for setup.
+        depositor_email_notifications: Enable or disable email notifications to depositors a summary of statistics for their submissions. Analytics reporting must be enabled to use this feature.
         enable_oai_metadata: Enable or disable OAI link
         shared_login: Enable or disable shared login
         file_size_limit: This should be set to at least 536870912000

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -22,7 +22,7 @@ en:
         allow_signup: Allow users to sign up to your repository
         analytics: Enable or disable Google Analytics 4 to track user interactions, including clicks.
         analytics_reporting: Enable or disable reporting from Google Analytics 4 to display analytics data in the dashboard. Requires developer support for setup.
-        depositor_email_notifications: Enable or disable email notifications to depositors a summary of statistics for their submissions. Analytics reporting must be enabled to use this feature.
+        depositor_email_notifications: Enable or disable email notifications that send depositors a summary of statistics for their submissions. This feature requires analytics reporting to be enabled.
         enable_oai_metadata: Enable or disable OAI link
         shared_login: Enable or disable shared login
         file_size_limit: This should be set to at least 536870912000

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -598,7 +598,7 @@ RSpec.describe Account, type: :model do
     it 'schedules default jobs' do
       expect(EmbargoAutoExpiryJob).to receive(:perform_later)
       expect(LeaseAutoExpiryJob).to receive(:perform_later)
-      
+
       account.find_or_schedule_jobs
     end
 
@@ -608,7 +608,7 @@ RSpec.describe Account, type: :model do
 
       expect(EmbargoAutoExpiryJob).not_to receive(:perform_later)
       expect(LeaseAutoExpiryJob).not_to receive(:perform_later)
-      
+
       account.find_or_schedule_jobs
     end
 
@@ -659,14 +659,14 @@ RSpec.describe Account, type: :model do
     it 'switches back to original account' do
       expect(AccountElevator).to receive(:switch!).with(account)
       expect(AccountElevator).to receive(:switch!).with(site_account)
-      
+
       account.find_or_schedule_jobs
     end
 
     it 'resets when no original account exists' do
       allow(Site).to receive(:account).and_return(nil)
       expect(account).to receive(:reset!)
-      
+
       account.find_or_schedule_jobs
     end
   end

--- a/spec/models/concerns/account_settings_spec.rb
+++ b/spec/models/concerns/account_settings_spec.rb
@@ -34,8 +34,7 @@ RSpec.describe AccountSettings do
                                                                                 s3_bucket
                                                                                 smtp_settings
                                                                                 solr_collection_options
-                                                                                ssl_configured
-                                                                                user_analytics]
+                                                                                ssl_configured]
       end
       # rubocop:enable RSpec/ExampleLength
     end

--- a/spec/services/create_account_spec.rb
+++ b/spec/services/create_account_spec.rb
@@ -121,6 +121,7 @@ RSpec.describe CreateAccount, clean: true do
         allow(account).to receive(:batch_email_notifications).and_return(true)
         allow(account).to receive(:depositor_email_notifications).and_return(true)
         allow(account).to receive(:analytics_reporting).and_return(true)
+        allow(Hyrax.config).to receive(:analytics_reporting?).and_return(true)
       end
 
       it "enqueues recurring jobs" do

--- a/spec/services/create_account_spec.rb
+++ b/spec/services/create_account_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe CreateAccount, clean: true do
       before do
         allow(account).to receive(:batch_email_notifications).and_return(true)
         allow(account).to receive(:depositor_email_notifications).and_return(true)
-        allow(account).to receive(:user_analytics).and_return(true)
+        allow(account).to receive(:analytics_reporting).and_return(true)
       end
 
       it "enqueues recurring jobs" do
@@ -142,7 +142,7 @@ RSpec.describe CreateAccount, clean: true do
       before do
         allow(account).to receive(:batch_email_notifications).and_return(false)
         allow(account).to receive(:depositor_email_notifications).and_return(false)
-        allow(account).to receive(:user_analytics).and_return(false)
+        allow(account).to receive(:analytics_reporting).and_return(false)
       end
 
       it "only enqueues embargo and lease jobs" do


### PR DESCRIPTION
Issue: 
- https://github.com/notch8/palni_palci_knapsack/issues/267


- removes user_analytics and rely on analytics_reporting instead.
- adds conditional to determine if jobs should be enqueued based on settings
- adds help text describing the settings
- adds specs

TODO: Add error handling to hyrax job
https://github.com/samvera/hyrax/issues/7029
  
