### PR TITLE
🎁 Marks Notifications as Read on Dashboard

### DIFF
--- a/app/controllers/hyrax/notifications_controller_decorator.rb
+++ b/app/controllers/hyrax/notifications_controller_decorator.rb
@@ -30,3 +30,5 @@ module Hyrax
     end
   end
 end
+
+Hyrax::NotificationsController.prepend Hyrax::NotificationsControllerDecorator

--- a/app/controllers/hyrax/notifications_controller_decorator.rb
+++ b/app/controllers/hyrax/notifications_controller_decorator.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# OVERRIDE: Hyrax v5.0.4 to mark all unread messages as read when the user visits the notifications dashboard
+
+module Hyrax
+  module NotificationsControllerDecorator
+    def index
+      add_breadcrumb t(:'hyrax.controls.home'), root_path
+      add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
+      add_breadcrumb t(:'hyrax.admin.sidebar.notifications'), hyrax.notifications_path
+      @messages = user_mailbox.inbox
+
+      # OVERRIDE: Mark all unread messages as read when user visits the notifications dashboard
+      mark_messages_as_read
+
+      # Update the notifications now that there are zero unread
+      StreamNotificationsJob.perform_later(current_user)
+    end
+
+    private
+
+    def mark_messages_as_read
+      Mailboxer::Receipt.where(
+        receiver: current_user,
+        is_read: false,
+        deleted: false
+      ).find_each do |receipt|
+        receipt.update(is_read: true)
+      end
+    end
+  end
+end

--- a/spec/controllers/hyrax/notifications_controller_spec.rb
+++ b/spec/controllers/hyrax/notifications_controller_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::NotificationsController, type: :controller do
+  routes { Hyrax::Engine.routes }
+
+  let(:user) { create(:user) }
+
+  before do
+    sign_in user
+  end
+
+  describe "#index" do
+    let!(:conversation1) { create(:mailboxer_conversation) }
+    let!(:conversation2) { create(:mailboxer_conversation) }
+    let!(:message1) { create(:mailboxer_message, conversation: conversation1, sender: user) }
+    let!(:message2) { create(:mailboxer_message, conversation: conversation2, sender: user) }
+    let!(:receipt1) { create(:mailboxer_receipt, notification: message1, receiver: user, mailbox_type: 'inbox', is_read: false) }
+    let!(:receipt2) { create(:mailboxer_receipt, notification: message2, receiver: user, mailbox_type: 'inbox', is_read: false) }
+
+    it "shows notifications page" do
+      get :index
+      expect(response).to be_successful
+    end
+
+    it "assigns inbox messages" do
+      get :index
+      expect(assigns(:messages)).to match_array([conversation1, conversation2])
+    end
+
+    it "marks unread messages as read" do
+      expect do
+        get :index
+      end.to change {
+        Mailboxer::Receipt.where(receiver: user, is_read: false).count
+      }.from(2).to(0)
+    end
+
+    it "enqueues the StreamNotificationsJob" do
+      expect(StreamNotificationsJob).to receive(:perform_later).with(user)
+      get :index
+    end
+
+    it "sets breadcrumbs" do
+      expect(controller).to receive(:add_breadcrumb).exactly(3).times
+      get :index
+    end
+  end
+end


### PR DESCRIPTION
# Story: [i1019] Marks notifications as read when the user visits the notifications dashboard

Ref:
- https://github.com/notch8/palni-palci/issues/1019

## Expected Behavior Before Changes

- Notifications were only being marked as "read" if the user received a batch email with the notification
- If a user saw the email in the notification in the app dashboard the notification did not change status

## Expected Behavior After Changes

- When a user visits the notification dashboard, all existing notifications will be marked "read"
- Read notifications are not included in the batch email

## Screenshots / Video

<details>
<summary>Photo: a user's unread notification</summary>

<img width="613" alt="Screenshot 2025-02-21 at 2 56 44 PM" src="https://github.com/user-attachments/assets/c97bc150-667e-4205-b3e2-a39e9af9306b" />

</details>

<details>
<summary>Photo: after visiting the notification dashboard, there are no more unread notifications</summary>

<img width="618" alt="Screenshot 2025-02-21 at 2 58 02 PM" src="https://github.com/user-attachments/assets/ed2788ff-ac93-4474-b9db-c13258180f19" />

</details>

## Notes

- Adds a decorator for the NotificationsController to mark notifications as read when the user visits the notification dashboard
- Ensures that the user will not receive read notifications in the bulk email, only unread and undelivered notifications will be included
- Adds a spec for the NotificationsControllerDecorator

@samvera/hyku-code-reviewers
