### PR TITLE
Fixes video embed viewer

### DIFF
--- a/config/metadata/with_video_embed.yaml
+++ b/config/metadata/with_video_embed.yaml
@@ -9,4 +9,4 @@ attributes:
       required: false
       multiple: false
     index_keys:
-      - "video_embed_tesi"
+      - "video_embed_tesim"


### PR DESCRIPTION
Viewer uses a different indexed term than the yaml specified. Changes video_embed_tesion to video_embed_tesim.

Fixes https://github.com/samvera/hyku/issues/2485

