### PR TITLE
⚙️ Change default work model for WillowSword

### DIFF
--- a/config/initializers/willow_sword.rb
+++ b/config/initializers/willow_sword.rb
@@ -6,7 +6,7 @@ Rails.application.config.after_initialize do
     config.work_models = Hyrax.config.registered_curation_concern_types
     config.collection_models = [Hyrax.config.collection_model]
     config.file_set_models = [Hyrax.config.file_set_model]
-    config.default_work_model = Hyrax.config.curation_concerns.first
+    config.default_work_model = GenericWorkResource
     config.authorize_request = true
     config.xml_mapping_read = 'Hyku'
   end


### PR DESCRIPTION
This commit will change the default work model for WillowSword to `GenericWorkResource` explicitly.