### PR TITLE
🐛 Make analytics go away if it is not checked

### DIFF
--- a/app/models/concerns/account_settings.rb
+++ b/app/models/concerns/account_settings.rb
@@ -212,7 +212,7 @@ module AccountSettings
   end
 
   def configure_hyrax_analytics_settings(config)
-    if analytics_credentials_present?
+    if ActiveModel::Type::Boolean.new.cast(analytics_reporting) && analytics_credentials_present?
       config.analytics = true
       config.analytics_reporting = true
     else


### PR DESCRIPTION
This commit will add a conditional check to see if the analytics reporting checkbox in the settings is checked or not.
![anayltics-reporting](https://github.com/user-attachments/assets/d495bb8c-320e-43a2-9139-33c4bd1d80dd)
