### PR TITLE
i2509-fix-pdf-derivative-creation-ghostscript-error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,15 @@
 FROM ruby:3.2-bookworm AS hyku-base
 USER root
 
-RUN apt update && \
+RUN apt-get update && \
     curl -sL https://deb.nodesource.com/setup_20.x | bash - && \
-    apt install -y --no-install-recommends \
+    apt-get install -y --no-install-recommends \
     build-essential \
     curl \
     exiftool \
     ffmpeg \
     git \
+    ghostscript \
     imagemagick \
     less \
     libgsf-1-dev \


### PR DESCRIPTION
ref issue #2509 
Update from apt to apt-get and install ghostscript for pdf derivative creation