### PR TITLE
Add base multiarch push

### DIFF
--- a/.github/workflows/build-test-lint.yaml
+++ b/.github/workflows/build-test-lint.yaml
@@ -13,8 +13,9 @@ on:
         required: false
         description: "Pause the selected step to debug using tmate"
         type: choice
-        default: "build"
+        default: ""
         options:
+          - ""
           - build
           - test
           - lint

--- a/.github/workflows/build-test-lint.yaml
+++ b/.github/workflows/build-test-lint.yaml
@@ -13,9 +13,8 @@ on:
         required: false
         description: "Pause the selected step to debug using tmate"
         type: choice
-        default: ""
+        default: "build"
         options:
-          - ""
           - build
           - test
           - lint
@@ -109,7 +108,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Create multiarch manifests
         run: |
-          for component in solr web worker; do
+          for component in base solr web worker; do
             docker buildx imagetools create -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/$component:${{ env.TAG }} \
               ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/$component:${{ env.TAG }}-amd64 \
               ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/$component:${{ env.TAG }}-arm64

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,7 +138,7 @@ services:
   # Used exclusively for building and caching the base image to reduce build times
   base:
     <<: *app
-    image: ghcr.io/samvera/hyku/base:${BASE_TAG:-latest}
+    image: ghcr.io/samvera/hyku/base:${TAG:-latest}
     build:
       context: .
       target: hyku-base
@@ -154,7 +154,10 @@ services:
     # command: sleep infinity
     environment:
       - VIRTUAL_PORT=3000
-      - VIRTUAL_HOST=.hyku.test
+      - VIRTUAL_HOST=.localhost
+      - HYKU_ADMIN_HOST=localhost
+      - HYKU_DEFAULT_HOST=%{tenant}.localhost
+      - HYKU_ROOT_HOST=localhost
     depends_on:
       db:
         condition: service_started
@@ -176,10 +179,10 @@ services:
         condition: service_started
       initialize_app:
         condition: service_completed_successfully
-    # ports:
-    #   - 3000:3000
-    expose:
-      - 3000
+    ports:
+      - 3000:3000
+    # expose:
+    #   - 3000
 
   worker:
     <<: *app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,7 +138,7 @@ services:
   # Used exclusively for building and caching the base image to reduce build times
   base:
     <<: *app
-    image: ghcr.io/samvera/hyku/base:${TAG:-latest}
+    image: ghcr.io/samvera/hyku/base:${BASE_TAG:-latest}
     build:
       context: .
       target: hyku-base

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -154,10 +154,7 @@ services:
     # command: sleep infinity
     environment:
       - VIRTUAL_PORT=3000
-      - VIRTUAL_HOST=.localhost
-      - HYKU_ADMIN_HOST=localhost
-      - HYKU_DEFAULT_HOST=%{tenant}.localhost
-      - HYKU_ROOT_HOST=localhost
+      - VIRTUAL_HOST=.hyku.test
     depends_on:
       db:
         condition: service_started
@@ -179,10 +176,10 @@ services:
         condition: service_started
       initialize_app:
         condition: service_completed_successfully
-    ports:
-      - 3000:3000
-    # expose:
-    #   - 3000
+    # ports:
+    #   - 3000:3000
+    expose:
+      - 3000
 
   worker:
     <<: *app


### PR DESCRIPTION
Add base multiarch push
When updating the base image, we need to build and push a multi-architecture image tagged with its SHA digest.
This allows us to pin a specific version to the hyku-knap-base image in Knapsack during application development, ensuring consistency across environments.