### PR TITLE
Add custom query for IiifPrint

### DIFF
--- a/app/services/hyrax/custom_queries/find_by_model_and_property_value.rb
+++ b/app/services/hyrax/custom_queries/find_by_model_and_property_value.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+##
+# A custom query used by IiifPrint to find a resource by its model and title.
+# Ideally should be defined in IiifPrint, but currently gem custom queries are registered in
+# Hyku's initializer and not available in the gem itself, so we are defining it here.
+# There is not an equivalent custom query defined for wings, as IiifPrint did not need it.
+module Hyrax
+  module CustomQueries
+    ##
+    # @see https://github.com/samvera/valkyrie/wiki/Queries#custom-queries
+    class FindByModelAndPropertyValue
+      def self.queries
+        [:find_by_model_and_property_value]
+      end
+
+      def initialize(query_service:)
+        @query_service = query_service
+      end
+
+      attr_reader :query_service
+      delegate :resource_factory, to: :query_service
+      delegate :orm_class, to: :resource_factory
+
+      ##
+      # @param model [Class, #internal_resource]
+      # @param property [#to_s] the name of the property we're attempting to
+      #        query.
+      # @param value [#to_s] the property's value that we're trying to match.
+      #
+      # @return [NilClass] when no record was found
+      # @return [Valkyrie::Resource] when record was found (returns only first value)
+      def find_by_model_and_property_value(model:, property:, value:)
+        sql_query = sql_for_find_by_model_and_property_value
+        query_service.run_query(sql_query, model, property, value).first
+      end
+
+      private
+
+      def sql_for_find_by_model_and_property_value
+        # NOTE: This is querying the first element of the property, but we might
+        # want to check all of the elements.
+        <<-SQL
+          SELECT * FROM orm_resources
+          WHERE internal_resource = ? AND metadata -> ? ->> 0 = ?
+          LIMIT 1;
+        SQL
+      end
+    end
+  end
+end

--- a/config/initializers/wings.rb
+++ b/config/initializers/wings.rb
@@ -81,7 +81,8 @@ Rails.application.config.after_initialize do
     Hyrax::CustomQueries::FindModelsByAccess,
     Hyrax::CustomQueries::FindCountBy,
     Hyrax::CustomQueries::FindByDateRange,
-    Hyrax::CustomQueries::FindBySourceIdentifier
+    Hyrax::CustomQueries::FindBySourceIdentifier,
+    Hyrax::CustomQueries::FindByModelAndPropertyValue
   ].each do |handler|
     Hyrax.query_service.services[0].custom_queries.register_query_handler(handler)
   end


### PR DESCRIPTION
## Summary

This query had previously been defined in Bulkrax. Bulkrax needed a change to be able to find metadata without the model, but the original query is still needed in IiifPrint.

Ideally this should be defined in IiifPrint directly, but the current setup has the custom query for bulkrax being registered here. To avoid confusion, this query is being added to Hyku since it is registered in Hyku.

If we determine a better way to register custom queries in gems, this can be moved to IiifPrint.

refs: https://github.com/samvera/bulkrax/pull/1025
