### PR TITLE
Fix advanced search

### DIFF
--- a/lib/blacklight_advanced_search/advanced_query_parser_decorator.rb
+++ b/lib/blacklight_advanced_search/advanced_query_parser_decorator.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+if Gem::Version.new(BlacklightAdvancedSearch::VERSION) < Gem::Version.new('8.0.0')
+  module BlacklightAdvancedSearch
+    module QueryParserDecorator
+      # OVERRIDE: BlacklightAdvancedSearch v7.0.0
+      #
+      # Ensure @params has indifferent access. This resolves a bug where field-specific
+      # queries (e.g. { title: "foo" }) weren't working because:
+      # 1. @params was a Hash
+      # 2. @params[:search_field] was being invoked while the expected value was in @params['search_field']
+      # 3. The advanced search logic was short-circuited in #keyword_queries because @params[:search_field] was nil
+      #
+      # Reading the code in BlacklightAdvancedSearch, it's clear that @params is intended to have indifferent
+      # access. Strangely, advanced search worked as expected in development mode; @params was a
+      # ActiveSupport::HashWithIndifferentAccess in development mode as opposed to a Hash in production mode.
+      #
+      # @see BlacklightAdvancedSearch::QueryParser#keyword_queries
+      #
+      # TODO: Remove this override after upgrading to BlacklightAdvancedSearch v8.x.x;
+      # it appears that @search_state will be used instead of @params.
+      def initialize(params, config)
+        super
+        @params = @params.with_indifferent_access
+      end
+    end
+  end
+
+  BlacklightAdvancedSearch::QueryParser.prepend(BlacklightAdvancedSearch::QueryParserDecorator)
+end


### PR DESCRIPTION
Ref:
- https://github.com/notch8/hykuup_knapsack/issues/299

Override BlacklightAdvancedSearch v7.0.0 to ensure `@params` has indifferent access. This resolves a bug where field-specific queries (e.g. { title: "foo" }) weren't working because:

1. `@params` was a Hash
2. `@params[:search_field]` was being invoked while the expected value was in `@params['search_field']`
3. The advanced search logic was short-circuited in #keyword_queries because `@params[:search_field]` was nil

Reading the code in BlacklightAdvancedSearch, it's clear that `@params` is intended to have indifferent access. Strangely, advanced search worked as expected in development mode; `@params` was a ActiveSupport::HashWithIndifferentAccess in development mode as opposed to a Hash in production mode.

See [BlacklightAdvancedSearch::QueryParser#keyword_queries](https://github.com/projectblacklight/blacklight_advanced_search/blob/d9d985acb6b87c896b8725cfc13933a85a12afcb/lib/blacklight_advanced_search/advanced_query_parser.rb#L38)

> [!NOTE]
> This override should be removed after upgrading to `BlacklightAdvancedSearch` v8.x.x; it appears that `@search_state` will be used instead of `@params`.