### PR TITLE
Favor snake case for class-based locale lookups

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -47,8 +47,8 @@ module ApplicationHelper
 
   def locale_for(type:, term:, record_class:)
     term              = term.to_s
-    record_class      = record_class.to_s.downcase
-    work_or_collection = record_class == Hyrax.config.collection_model.downcase ? 'collection' : 'defaults'
+    record_class      = record_class.to_s.underscore
+    work_or_collection = record_class == Hyrax.config.collection_model.underscore ? 'collection' : 'defaults'
     locale             = t("hyrax.#{record_class}.#{type}.#{term}")
 
     if missing_translation(locale)


### PR DESCRIPTION
# Summary

Prior to this change, if you wanted to add record-specific locales for a class that has 1+ words in its name (e.g. `GenericWork`), you had to use the `downcase`d class name (e.g. `genericwork`). This PR aligns locale labels with the existing pattern in Hyku where lowercase class names are represented in snake case (e.g. `generic_work`). 

### Before

```yaml
hyrax:
  genericwork:
    my_label: Snake case best case
```

### After

```yaml
hyrax:
  generic_work:
    my_label: Snake case best case
```

@samvera/hyku-code-reviewers
