### PR TITLE
Only throttle `/catalog` requests

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -10,6 +10,7 @@ unless throttle_off
     req.ip if req.path.starts_with?('/catalog')
   end
 
+  FileUtils.mkdir_p(Rails.root.join('log', 'rack_attack'))
   throttle_logger = ActiveSupport::Logger.new(
     Rails.root.join('log', 'rack_attack', 'throttled_requests.log'),
     'daily'

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,6 +1,33 @@
 # frozen_string_literal: true
-# No more that 500 requersts per minitue per ip
-limit = ENV.fetch('HYKU_ATTACK_RATE_LIMIT', 500).to_i
+
+# No more that 20 requests per minute per ip
+limit = ENV.fetch('HYKU_ATTACK_RATE_LIMIT', 20).to_i
 period = ENV.fetch('HYKU_ATTACK_RATE_PERIOD', 60).to_i
 throttle_off = ActiveModel::Type::Boolean.new.cast(ENV.fetch('HYKU_ATTACK_RATE_THROTTLE_OFF', Rails.env.development? || Rails.env.test?))
-Rack::Attack.throttle("requests by ip", limit: limit, period: period, &:ip) unless throttle_off
+
+unless throttle_off
+  Rack::Attack.throttle('throttle catalog requests by ip', limit: limit, period: period) do |req|
+    req.ip if req.path.starts_with?('/catalog')
+  end
+
+  throttle_logger = ActiveSupport::Logger.new(
+    Rails.root.join('log', 'rack_attack', 'throttled_requests.log'),
+    'daily'
+  )
+  throttle_logger.formatter = proc do |_severity, datetime, _progname, msg|
+    "#{datetime.iso8601} #{msg}\n"
+  end
+
+  ActiveSupport::Notifications.subscribe('throttle.rack_attack') do |_name, _start, _finish, _request_id, payload|
+    req = payload[:request]
+
+    throttle_logger.info(
+      "#{req.ip} " \
+      "#{req.env['rack.attack.match_type']} " \
+      "#{req.env['rack.attack.match_data'][:count]}/#{req.env['rack.attack.match_data'][:limit]} " \
+      "#{req.env['rack.attack.match_data'][:period]}s " \
+      "#{req.request_method} " \
+      "#{req.fullpath}"
+    )
+  end
+end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -7,7 +7,7 @@ throttle_off = ActiveModel::Type::Boolean.new.cast(ENV.fetch('HYKU_ATTACK_RATE_T
 
 unless throttle_off
   Rack::Attack.throttle('throttle catalog requests by ip', limit: limit, period: period) do |req|
-    if req.path.starts_with?('/catalog')
+    if req.path.starts_with?('/catalog') # rubocop:disable Style/IfUnlessModifier
       req.get_header('HTTP_X_ORIGINAL_FORWARDED_FOR') || req.ip
     end
   end

--- a/ops/demo-deploy.tmpl.yaml
+++ b/ops/demo-deploy.tmpl.yaml
@@ -12,8 +12,6 @@ derivativesVolume:
 uploadsVolume:
   storageClass: aws-efs
   size: 200Gi
-logs:
-  storageClass: efs-sc
 
 # imagePullSecrets:
 #  - name: github
@@ -37,7 +35,7 @@ extraVolumeMounts: &volMounts
   - name: uploads
     mountPath: /app/samvera/hyrax-webapp/storage/files
     subPath: storage-files
-  - name: logs
+  - name: uploads
     mountPath: /app/samvera/hyrax-webapp/log/rack_attack
     subPath: rack-attack
 

--- a/ops/demo-deploy.tmpl.yaml
+++ b/ops/demo-deploy.tmpl.yaml
@@ -35,6 +35,9 @@ extraVolumeMounts: &volMounts
   - name: uploads
     mountPath: /app/samvera/hyrax-webapp/storage/files
     subPath: storage-files
+  - name: logs
+    mountPath: /app/samvera/hyrax-webapp/log/rack_attack
+    subPath: rack-attack
 
 ingress:
   enabled: true

--- a/ops/demo-deploy.tmpl.yaml
+++ b/ops/demo-deploy.tmpl.yaml
@@ -12,6 +12,8 @@ derivativesVolume:
 uploadsVolume:
   storageClass: aws-efs
   size: 200Gi
+logs:
+  storageClass: efs-sc
 
 # imagePullSecrets:
 #  - name: github

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -12,8 +12,6 @@ derivativesVolume:
 uploadsVolume:
   storageClass: aws-efs
   size: 200Gi
-logs:
-  storageClass: efs-sc
 
 # imagePullSecrets:
 #  - name: github
@@ -37,7 +35,7 @@ extraVolumeMounts: &volMounts
   - name: uploads
     mountPath: /app/samvera/hyrax-webapp/storage/files
     subPath: storage-files
-  - name: logs
+  - name: uploads
     mountPath: /app/samvera/hyrax-webapp/log/rack_attack
     subPath: rack-attack
 

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -35,6 +35,9 @@ extraVolumeMounts: &volMounts
   - name: uploads
     mountPath: /app/samvera/hyrax-webapp/storage/files
     subPath: storage-files
+  - name: logs
+    mountPath: /app/samvera/hyrax-webapp/log/rack_attack
+    subPath: rack-attack
 
 ingress:
   enabled: true

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -12,6 +12,8 @@ derivativesVolume:
 uploadsVolume:
   storageClass: aws-efs
   size: 200Gi
+logs:
+  storageClass: efs-sc
 
 # imagePullSecrets:
 #  - name: github


### PR DESCRIPTION
The throttle limit previously had to be increased to 500 by default because each thumbnail a page loads counts as a request. Bots primarily scrape `/catalog` pages, so we're narrowing our focus to specifically throttle those requests more aggressively

@samvera/hyku-code-reviewers
