### PR TITLE
⚙️ Update tessdata download location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,8 +67,8 @@ RUN wget https://github.com/ImageMagick/ImageMagick/archive/refs/tags/7.1.0-57.t
 
 # Install "best" training data for Tesseract
 RUN echo "📚 Installing Tesseract Best (training data)!" && \
-    mkdir -p /usr/share/tessdata/ && \
-    cd /usr/share/tessdata/ && \
+    mkdir -p /usr/share/tesseract-ocr/5/tessdata/ && \
+    cd /usr/share/tesseract-ocr/5/tessdata/ && \
     wget https://github.com/tesseract-ocr/tessdata_best/blob/main/eng.traineddata?raw=true -O eng_best.traineddata
 
 RUN useradd -m -u 1001 -U -s /bin/bash --home-dir /app app && \


### PR DESCRIPTION
Whenever running tesseract with IIIF Print we were getting the error: `Error opening data file /usr/share/tesseract-ocr/5/tessdata/eng_best.traineddata`

This indicated that it was looking for the traineddata file in the wrong spot.  This commit will update the build to put it in the expected location.

Ref:
- https://github.com/notch8/hykuup_knapsack/issues/332
