### PR TITLE
use the prebuilt binaries for google protobuf again

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,8 +51,8 @@ gem 'fcrepo_wrapper', '~> 0.4', group: %i[development test]
 gem 'flutie'
 gem 'good_job', '~> 2.99'
 gem 'googleauth', '~> 1.9.0'
-gem 'google-protobuf', force_ruby_platform: true # required because google-protobuf is not compatible with Alpine linux
-gem 'grpc', force_ruby_platform: true # required because google-protobuf is not compatible with Alpine linux
+gem 'google-protobuf'
+gem 'grpc'
 gem 'hyrax', github: 'samvera/hyrax', branch: '5.0-flexible'
 gem 'hyrax-doi', github: 'samvera-labs/hyrax-doi', branch: 'rails_hyrax_upgrade'
 gem 'hyrax-iiif_av', github: 'samvera-labs/hyrax-iiif_av', branch: 'rails_hyrax_upgrade'


### PR DESCRIPTION
fixes a regression in the 6.2.0.rc1 code merges


@samvera/hyku-code-reviewers
