### PR TITLE
no-method-error-bulkrax-identifier-tesim

### DIFF
--- a/app/presenters/hyrax/generic_work_presenter.rb
+++ b/app/presenters/hyrax/generic_work_presenter.rb
@@ -5,5 +5,9 @@
 module Hyrax
   class GenericWorkPresenter < Hyku::WorkShowPresenter
     delegate :abstract, to: :solr_document
+
+    def bulkrax_identifier
+      Array(solr_document['bulkrax_identifier_tesim']).first
+    end
   end
 end

--- a/spec/presenters/hyrax/generic_work_presenter_spec.rb
+++ b/spec/presenters/hyrax/generic_work_presenter_spec.rb
@@ -5,6 +5,21 @@
 require 'rails_helper'
 
 RSpec.describe Hyrax::GenericWorkPresenter do
+  let(:solr_document) do
+    SolrDocument.new(
+      id: '123abc',
+      'bulkrax_identifier_tesim' => ['abc123']
+    )
+  end
+
+  let(:presenter) { described_class.new(solr_document, nil) }
+
+  describe '#bulkrax_identifier' do
+    it 'returns the bulkrax_identifier from solr_document' do
+      expect(presenter.bulkrax_identifier).to eq('abc123')
+    end
+  end
+
   it "exists" do
     expect(described_class).to be_a(Class)
   end


### PR DESCRIPTION
Fix `NoMethodError` for `bulkrax_identifier_tesim` on GenericWorks seen during Bulkrax::DeleteWorkJob

Add presenter method to safely access `bulkrax_identifier` from Solr

During Bulkrax jobs (e.g., `Bulkrax::DeleteWorkJob`), a `NoMethodError` was being raised due to dynamic attempts to call `bulkrax_identifier_tesim` on a `GenericWork`. This method does not exist on the model, as it is a Solr-only field.

To resolve this, we:
- Defined a `#bulkrax_identifier` method in `Hyrax::GenericWorkPresenter` that returns the first value from `solr_document['bulkrax_identifier_tesim']`
- Added a spec to ensure the presenter method behaves correctly

This prevents both UI and background job failures caused by incorrect assumptions about model method availability.

### Example stack trace:
```ruby
NoMethodError: undefined method `bulkrax_identifier_tesim' for #<GenericWork ...>
```

### Changes proposed in this pull request:
* Add `#bulkrax_identifier` to `GenericWorkPresenter`
* Return first item from Solr field `bulkrax_identifier_tesim`
* Add presenter spec to confirm expected output

Fixes: https://github.com/notch8/palni_palci_knapsack/issues/348