### PR TITLE
Update Hyrax

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,7 +141,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: 137cd1eeb17bdcc720a6af73685020a55c30eb0e
+  revision: 2f180e50ae2850697e620e5ec80302df42e285ae
   branch: 5.0-flexible
   specs:
     hyrax (5.0.5)


### PR DESCRIPTION
- pulls in fix for chunk upload bug
- https://github.com/samvera/hyrax/commit/2f180e50ae2850697e620e5ec80302df42e285ae

### Fixes

- https://github.com/notch8/hykuup_knapsack/issues/388

### Summary

Chunks would get out of sync when multi processes were involved, which caused incomplete uploaded files if they were over 20MB.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* In an environment with multi processing, when creating a work attach a file that's larger than 20MB
* The file should fully upload

### BEFORE

Fully upload should be 72.92MB (which is the size of the file), but it only partially uploaded. When saved the file is invalid.

![image](https://github.com/user-attachments/assets/1bd37798-bc44-4e1d-a7e9-e652e0574795)



### AFTER

![image](https://github.com/user-attachments/assets/12addb73-5815-4330-975a-8592bdeb7bcd)


@samvera/hyrax-code-reviewers
