### PR TITLE
add architecture: standalone to staging

### DIFF
--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -219,9 +219,10 @@ fcrepo:
 postgresql:
   enabled: false
 redis:
-  cluster:
-    enabled: false
-  password: staging
+  enabled: true
+  architecture: standalone
+  auth:
+    password: staging
 solr:
   enabled: false
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ed1e8347-3e9c-4199-99ac-4249cd92f953)

hyku-staging-redis-replicas spins up with 3 - it shouldn't spin up at all according to April. 