### PR TITLE
bumps hyrax version for chunk upload fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,7 +141,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: 3fe634c2438e00de26ea2d1a22457825d21a23ad
+  revision: ec3ac86200a5b81dd4ef79405301a534d6d55e59
   branch: 5.0-flexible
   specs:
     hyrax (5.0.5)


### PR DESCRIPTION
- https://github.com/samvera/hyrax/commit/ec3ac86200a5b81dd4ef79405301a534d6d55e59

### BEFORE

Fully upload should be 72.92MB (which is the size of the file), but it only partially uploaded. When saved the file is invalid.

![image](https://github.com/user-attachments/assets/1bd37798-bc44-4e1d-a7e9-e652e0574795)



### AFTER

![image](https://github.com/user-attachments/assets/12addb73-5815-4330-975a-8592bdeb7bcd)

