### PR TITLE
I29 m3 validator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,7 @@ gem 'i18n-tasks', group: %i[development test]
 gem 'iiif_print', '~> 3.0.5'
 gem 'jbuilder', '~> 2.5'
 gem 'jquery-rails' # Use jquery as the JavaScript library
+gem 'json_schemer' # Required for m3 schema validation
 gem 'openssl', '>= 3.2.0'
 # The maintainers yanked 0.3.2 version (see https://github.com/dryruby/json-canonicalization/issues/2)
 gem 'json-canonicalization', "0.3.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,7 +141,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: ec3ac86200a5b81dd4ef79405301a534d6d55e59
+  revision: 01a9d28003451fe9de2b7ccbf040a597aa95e475
   branch: 5.0-flexible
   specs:
     hyrax (5.0.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -685,6 +685,7 @@ GEM
       tilt
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
+    hana (1.3.7)
     hashdiff (1.0.1)
     hashie (5.0.0)
     highline (2.1.0)
@@ -803,6 +804,11 @@ GEM
     json-schema (5.1.1)
       addressable (~> 2.8)
       bigdecimal (~> 3.1)
+    json_schemer (2.4.0)
+      bigdecimal
+      hana (~> 1.3)
+      regexp_parser (~> 2.0)
+      simpleidn (~> 0.2)
     jsonlint (0.3.0)
       oj (~> 3)
       optimist (~> 3)
@@ -1339,6 +1345,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    simpleidn (0.2.3)
     slop (4.10.1)
     smart_properties (1.17.0)
     snaky_hash (2.0.3)
@@ -1553,6 +1560,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-rails
   json-canonicalization (= 0.3.1)
+  json_schemer
   launchy
   listen (>= 3.0.5, < 3.2)
   lograge

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,7 +141,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: 01a9d28003451fe9de2b7ccbf040a597aa95e475
+  revision: 77c02980aace8bfbbe5dcbb6104a3e37017a30e7
   branch: 5.0-flexible
   specs:
     hyrax (5.0.5)

--- a/app/models/hyrax/flexible_schema_decorator.rb
+++ b/app/models/hyrax/flexible_schema_decorator.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module FlexibleSchemaDecorator
+    private
+
+    def validate_profile_classes
+      validation_service = Hyrax::FlexibleSchemaValidatorService.new(profile:)
+      validation_service.validate!
+
+      validation_service.errors.each do |e|
+        errors.add(:profile, e.to_s)
+      end
+    end
+  end
+end
+
+Hyrax::FlexibleSchema.prepend(Hyrax::FlexibleSchemaDecorator)

--- a/app/services/hyrax/core_metadata_validator.rb
+++ b/app/services/hyrax/core_metadata_validator.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Hyrax
+  ##
+  # @api private
+  #
+  # Validates the core metadata properties of a flexible metadata profile.
+  class CoreMetadataValidator
+    ##
+    # @param profile [Hash] the flexible metadata profile
+    # @param errors [Array<String>] an array to append errors to
+    def initialize(profile:, errors:)
+      @profile = profile
+      @errors = errors
+    end
+
+    def validate!
+      core_metadata['attributes'].each do |property, config|
+        next unless validate_property_exists(property)
+
+        validate_property_multi_value(property, config)
+        validate_property_indexing(property, config)
+        validate_property_predicate(property, config)
+      end
+    end
+
+    private
+
+    attr_reader :profile, :errors
+
+    def core_metadata
+      @core_metadata ||= YAML.safe_load(File.open(Hyrax::Engine.root.join('config', 'metadata', 'core_metadata.yaml'))).with_indifferent_access
+    end
+
+    def validate_property_exists(property)
+      return true if profile['properties'][property].present?
+
+      errors << "Missing required property: #{property}."
+      false
+    end
+
+    def validate_property_multi_value(property, config)
+      return unless config.key?('multiple')
+      return if profile.dig('properties', property, 'multi_value') == config['multiple']
+
+      errors << "Property '#{property}' must have multi_value set to #{config['multiple']}."
+    end
+
+    def validate_property_indexing(property, config)
+      return unless config.key?('index_keys')
+
+      profile_indexing = profile.dig('properties', property, 'indexing') || []
+      missing_keys = config['index_keys'] - profile_indexing
+
+      return if missing_keys.empty?
+
+      errors << "Property '#{property}' is missing required indexing: #{missing_keys.join(', ')}."
+    end
+
+    def validate_property_predicate(property, config)
+      return unless config.key?('predicate')
+      return if profile.dig('properties', property, 'property_uri') == config['predicate']
+
+      errors << "Property '#{property}' must have property_uri set to #{config['predicate']}."
+    end
+  end
+end

--- a/app/services/hyrax/core_metadata_validator.rb
+++ b/app/services/hyrax/core_metadata_validator.rb
@@ -29,7 +29,7 @@ module Hyrax
     attr_reader :profile, :errors
 
     def core_metadata
-      @core_metadata ||= YAML.safe_load(File.open(Hyrax::Engine.root.join('config', 'metadata', 'core_metadata.yaml'))).with_indifferent_access
+      @core_metadata ||= YAML.safe_load(File.read(Hyrax::Engine.root.join('config', 'metadata', 'core_metadata.yaml'))).with_indifferent_access
     end
 
     def validate_property_exists(property)

--- a/app/services/hyrax/flexible_schema_validator_service.rb
+++ b/app/services/hyrax/flexible_schema_validator_service.rb
@@ -25,6 +25,7 @@ module Hyrax
       validate_classes
       validate_title_multi_value
       validate_schema
+      validate_label_prop
     end
 
     def default_schema
@@ -78,6 +79,19 @@ module Hyrax
       return if profile['properties']['title']['multi_value'] == true
 
       @errors << "Title must be multi value."
+    end
+
+    def validate_label_prop
+      label_prop = profile.dig('properties', 'label')
+      unless label_prop
+        @errors << "A `label` property is required."
+        return
+      end
+
+      available_on_classes = label_prop.dig('available_on', 'class')
+      return if available_on_classes&.include?('Hyrax::FileSet')
+
+      @errors << "Label must be available on Hyrax::FileSet."
     end
   end
 end

--- a/app/services/hyrax/flexible_schema_validator_service.rb
+++ b/app/services/hyrax/flexible_schema_validator_service.rb
@@ -69,7 +69,10 @@ module Hyrax
         properties[key].fetch('available_on', nil)&.fetch('class', nil)
       end.compact.uniq
 
-      classes = ((profile_classes + available_on_classes).uniq - required_classes).map { |klass| klass.gsub(/(?<=.)Resource$/, '') }
+      combined_classes = profile_classes + available_on_classes
+      unique_classes = combined_classes.uniq
+      filtered_classes = unique_classes - required_classes
+      classes = filtered_classes.map { |klass| klass.gsub(/(?<=.)Resource$/, '') }
 
       invalid_classes = classes.filter_map do |klass|
         klass unless Hyrax.config.registered_curation_concern_types.include?(klass)

--- a/app/services/hyrax/flexible_schema_validator_service.rb
+++ b/app/services/hyrax/flexible_schema_validator_service.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'json_schemer'
+
+module Hyrax
+  class FlexibleSchemaValidatorService
+    DEFAULT_SCHEMA = Rails.root.join('lib', 'flexible', 'm3_json_schema.json')
+    REQUIRED_CLASSES = [
+      Hyrax.config.admin_set_model,
+      Hyrax.config.collection_model,
+      Hyrax.config.file_set_model
+    ].map { |str| str.gsub(/^::/, '') }
+
+    attr_reader :profile, :schema, :schemer, :errors
+
+    def initialize(profile:, schema: default_schema)
+      @profile = profile
+      @schema = schema
+      @schemer = JSONSchemer.schema(schema)
+      @errors = []
+    end
+
+    def validate!
+      validate_required_classes
+      validate_classes
+      validate_title_multi_value
+      validate_schema
+    end
+
+    def default_schema
+      DEFAULT_SCHEMA
+    end
+
+    def required_classes
+      REQUIRED_CLASSES
+    end
+
+    private
+
+    def validate_schema
+      schemer.validate(profile).to_a&.each do |error|
+        @errors << <<~ERROR.strip
+          Data: #{error['data']}
+          Data pointer: #{error['data_pointer']}
+          Schema: #{error['schema']}
+          Schema pointer: #{error['schema_pointer']}
+          Type: #{error['type']}
+        ERROR
+      end
+    end
+
+    def validate_required_classes
+      missing_classes = required_classes - profile['classes'].keys
+      return if missing_classes.empty?
+
+      @errors << "Missing required classes: #{missing_classes.join(', ')}."
+    end
+
+    def validate_classes
+      profile_classes = profile['classes'].keys
+      properties = profile['properties']
+      available_on_classes = properties.keys.flat_map do |key|
+        properties[key].fetch('available_on', nil)&.fetch('class', nil)
+      end.compact.uniq
+
+      classes = ((profile_classes + available_on_classes).uniq - required_classes).map { |klass| klass.gsub(/(?<=.)Resource$/, '') }
+
+      invalid_classes = classes.filter_map do |klass|
+        klass unless Hyrax.config.registered_curation_concern_types.include?(klass)
+      end
+
+      return if invalid_classes.empty?
+
+      @errors << "Invalid classes: #{invalid_classes.join(', ')}."
+    end
+
+    def validate_title_multi_value
+      return if profile['properties']['title']['multi_value'] == true
+
+      @errors << "Title must be multi value."
+    end
+  end
+end

--- a/config/metadata_profiles/m3_profile.yaml
+++ b/config/metadata_profiles/m3_profile.yaml
@@ -19,28 +19,13 @@ classes:
     display_label: AdminSetResource
   CollectionResource:
     display_label: pcdmcollection
-  Hyrax::AdministrativeSet:
-    display_label: Administrative Set
   Hyrax::FileSet:
     display_label: FileSet
-  Hyrax::PcdmCollection:
-    display_label: PcdmCollection
 contexts:
   flexible_context:
     display_label: Flexible Metadata Example
   special_context:
     display_label: Special Context
-mappings:
-  blacklight:
-    name: Additional Blacklight Solr Mappings
-  metatags:
-    name: Metatags
-  mods_oai_pmh:
-    name: MODS OAI PMH
-  qualified_dc_pmh:
-    name: Qualified DC OAI PMH
-  simple_dc_pmh:
-    name: Simple DC OAI PMH
 properties:
   title:
     available_on:
@@ -52,8 +37,6 @@ properties:
         - ImageResource
         - OerResource
         - EtdResource
-    cardinality:
-      minimum: 1
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -65,7 +48,6 @@ properties:
         transcribe the title from the source itself.
     display_label:
       default: Title
-    index_documentation: displayable, searchable
     indexing:
       - title_sim
       - title_tesim
@@ -73,11 +55,6 @@ properties:
       required: true
       primary: true
       multi_value: true
-    mappings:
-      metatags: twitter:title, og:title
-      mods_oai_pmh: mods:titleInfo/mods:title
-      qualified_dc_pmh: dcterms:title
-      simple_dc_pmh: dc:title
     property_uri: http://purl.org/dc/terms/title
     range: http://www.w3.org/2001/XMLSchema#string
     requirement: required
@@ -98,9 +75,6 @@ properties:
         - ImageResource
         - OerResource
         - EtdResource
-    cardinality:
-      minimum: 0
-      maximum: 1
     multi_value: false
     display_label:
       default: Date Modified
@@ -128,9 +102,6 @@ properties:
         - ImageResource
         - OerResource
         - EtdResource
-    cardinality:
-      minimum: 0
-      maximum: 1
     multi_value: false
     display_label:
       default: Date Uploaded
@@ -148,9 +119,6 @@ properties:
         - ImageResource
         - OerResource
         - EtdResource
-    cardinality:
-      minimum: 0
-      maximum: 1
     multi_value: false
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -158,7 +126,6 @@ properties:
         - "null"
     display_label:
       default: Depositor
-    index_documentation: searchable
     indexing:
       - depositor_tesim
     property_uri: http://id.loc.gov/vocabulary/relators/dpt
@@ -175,8 +142,6 @@ properties:
         - ImageResource
         - OerResource
         - EtdResource
-    cardinality:
-      minimum: 1
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -184,7 +149,6 @@ properties:
         - "null"
     display_label:
       default: Creator
-    index_documentation: displayable, searchable
     indexing:
       - creator_sim
       - creator_tesim
@@ -207,8 +171,6 @@ properties:
         - ImageResource
         - OerResource
         - EtdResource
-    cardinality:
-      minimum: 0
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -216,7 +178,6 @@ properties:
         - "null"
     display_label:
       default: License
-    index_documentation: displayable, searchable
     indexing:
       - license_sim
       - license_tesim
@@ -238,8 +199,6 @@ properties:
         - ImageResource
         - OerResource
         - EtdResource
-    cardinality:
-      minimum: 0
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -247,7 +206,6 @@ properties:
         - "null"
     display_label:
       default: Abstract
-    index_documentation: displayable, searchable
     indexing:
       - abstract_sim
       - abstract_tesim
@@ -267,8 +225,6 @@ properties:
         - ImageResource
         - OerResource
         - EtdResource
-    cardinality:
-      minimum: 0
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -276,7 +232,6 @@ properties:
         - "null"
     display_label:
       default: Access Right
-    index_documentation: displayable, searchable
     indexing:
       - access_right_sim
       - access_right_tesim
@@ -297,8 +252,6 @@ properties:
         - ImageResource
         - OerResource
         - EtdResource
-    cardinality:
-      minimum: 0
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -306,7 +259,6 @@ properties:
         - "null"
     display_label:
       default: Alternative Title
-    index_documentation: displayable, searchable
     indexing:
       - alternative_title_sim
       - alternative_title_tesim
@@ -329,9 +281,6 @@ properties:
         - ImageResource
         - OerResource
         - EtdResource
-    cardinality:
-      minimum: 0
-      maximum: 1
     multi_value: false
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -354,8 +303,6 @@ properties:
         - ImageResource
         - OerResource
         - EtdResource
-    cardinality:
-      minimum: 0
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -363,7 +310,6 @@ properties:
         - "null"
     display_label:
       default: Location
-    index_documentation: displayable, searchable
     indexing:
       - based_near_sim
       - based_near_tesim
@@ -385,8 +331,6 @@ properties:
         - ImageResource
         - OerResource
         - EtdResource
-    cardinality:
-      minimum: 0
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -394,7 +338,6 @@ properties:
         - "null"
     display_label:
       default: Bibliographic Citation
-    index_documentation: displayable, searchable
     indexing:
       - bibliographic_citation_sim
       - bibliographic_citation_tesim
@@ -415,8 +358,6 @@ properties:
         - ImageResource
         - OerResource
         - EtdResource
-    cardinality:
-      minimum: 0
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -424,7 +365,6 @@ properties:
         - "null"
     display_label:
       default: Contributor
-    index_documentation: displayable, searchable
     indexing:
       - contributor_tesim
       - contributor_sim
@@ -446,8 +386,6 @@ properties:
         - ImageResource
         - OerResource
         - EtdResource
-    cardinality:
-      minimum: 0
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#dateTime
@@ -455,7 +393,6 @@ properties:
         - "null"
     display_label:
       default: Date Created
-    index_documentation: displayable, searchable
     indexing:
       - date_created_sim
       - date_created_tesim
@@ -478,8 +415,6 @@ properties:
         - ImageResource
         - OerResource
         - EtdResource
-    cardinality:
-      minimum: 0
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -487,7 +422,6 @@ properties:
         - "null"
     display_label:
       default: Description
-    index_documentation: displayable, searchable
     indexing:
       - description_sim
       - description_tesim
@@ -506,8 +440,6 @@ properties:
         - ImageResource
         - OerResource
         - EtdResource
-    cardinality:
-      minimum: 0
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -515,7 +447,6 @@ properties:
         - "null"
     display_label:
       default: Identifier
-    index_documentation: displayable, searchable
     indexing:
       - identifier_sim
       - identifier_tesim
@@ -537,9 +468,6 @@ properties:
         - ImageResource
         - OerResource
         - EtdResource
-    cardinality:
-      minimum: 0
-      maximum: 1
     multi_value: false
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -560,8 +488,6 @@ properties:
         - ImageResource
         - OerResource
         - EtdResource
-    cardinality:
-      minimum: 0
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -569,7 +495,6 @@ properties:
         - "null"
     display_label:
       default: Keyword
-    index_documentation: displayable, searchable
     indexing:
       - keyword_sim
       - keyword_tesim
@@ -592,9 +517,6 @@ properties:
         - ImageResource
         - OerResource
         - EtdResource
-    cardinality:
-      minimum: 0
-      maximum: 1
     multi_value: false
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -602,7 +524,6 @@ properties:
         - "null"
     display_label:
       default: Label
-    index_documentation: displayable, searchable
     indexing:
       - label_sim
       - label_tesim
@@ -621,8 +542,6 @@ properties:
         - ImageResource
         - OerResource
         - EtdResource
-    cardinality:
-      minimum: 0
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -630,7 +549,6 @@ properties:
         - "null"
     display_label:
       default: Language
-    index_documentation: displayable, searchable
     indexing:
       - language_sim
       - language_tesim
@@ -653,8 +571,6 @@ properties:
         - ImageResource
         - OerResource
         - EtdResource
-    cardinality:
-      minimum: 0
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -662,7 +578,6 @@ properties:
         - "null"
     display_label:
       default: Publisher
-    index_documentation: displayable, searchable
     indexing:
       - publisher_sim
       - publisher_tesim
@@ -684,8 +599,6 @@ properties:
         - ImageResource
         - OerResource
         - EtdResource
-    cardinality:
-      minimum: 0
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -693,7 +606,6 @@ properties:
         - "null"
     display_label:
       default: Related URL
-    index_documentation: displayable, searchable
     indexing:
       - related_url_sim
       - related_url_tesim
@@ -715,9 +627,6 @@ properties:
         - ImageResource
         - OerResource
         - EtdResource
-    cardinality:
-      minimum: 0
-      maximum: 1
     multi_value: false
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -738,8 +647,6 @@ properties:
         - ImageResource
         - OerResource
         - EtdResource
-    cardinality:
-      minimum: 0
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -747,7 +654,6 @@ properties:
         - "null"
     display_label:
       default: Resource Type
-    index_documentation: displayable, searchable
     indexing:
       - resource_type_sim
       - resource_type_tesim
@@ -770,8 +676,6 @@ properties:
         - ImageResource
         - OerResource
         - EtdResource
-    cardinality:
-      minimum: 0
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -779,7 +683,6 @@ properties:
         - "null"
     display_label:
       default: Rights Notes
-    index_documentation: displayable, searchable
     indexing:
       - rights_notes_sim
       - rights_notes_tesim
@@ -800,8 +703,6 @@ properties:
         - ImageResource
         - OerResource
         - EtdResource
-    cardinality:
-      minimum: 0
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -809,7 +710,6 @@ properties:
         - "null"
     display_label:
       default: Rights Statement
-    index_documentation: displayable, searchable
     indexing:
       - rights_statement_sim
       - rights_statement_tesim
@@ -832,8 +732,6 @@ properties:
         - ImageResource
         - OerResource
         - EtdResource
-    cardinality:
-      minimum: 0
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -841,7 +739,6 @@ properties:
         - "null"
     display_label:
       default: Source
-    index_documentation: displayable, searchable
     indexing:
       - source_sim
       - source_tesim
@@ -863,8 +760,6 @@ properties:
         - ImageResource
         - OerResource
         - EtdResource
-    cardinality:
-      minimum: 0
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -872,7 +767,6 @@ properties:
         - "null"
     display_label:
       default: Subject
-    index_documentation: displayable, searchable
     indexing:
       - subject_sim
       - subject_tesim
@@ -891,9 +785,6 @@ properties:
       class:
         - CollectionResource
         - EtdResource
-    cardinality:
-      minimum: 0
-      maximum: 1
     multi_value: false
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -914,9 +805,6 @@ properties:
     available_on:
       class:
         - CollectionResource
-    cardinality:
-      minimum: 0
-      maximum: 1
     multi_value: false
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -936,8 +824,6 @@ properties:
     available_on:
       class:
         - EtdResource
-    cardinality:
-      minimum: 0
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -945,7 +831,6 @@ properties:
         - "null"
     display_label:
       default: Format
-    index_documentation: searchable
     indexing:
       - "format_tesim"
     form:
@@ -961,8 +846,6 @@ properties:
     available_on:
       class:
         - ImageResource
-    cardinality:
-      minimum: 0
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -970,7 +853,6 @@ properties:
         - "null"
     display_label:
       default: Extent
-    index_documentation: searchable
     indexing:
       - "extent_tesim"
     form:
@@ -987,8 +869,6 @@ properties:
     available_on:
       class:
         - OerResource
-    cardinality:
-      minimum: 0
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -996,7 +876,6 @@ properties:
         - "null"
     display_label:
       default: Accessibility Feature
-    index_documentation: displayable, searchable
     indexing:
       - "accessibility_feature_tesim"
       - "accessibility_feature_sim"
@@ -1013,8 +892,6 @@ properties:
     available_on:
       class:
         - OerResource
-    cardinality:
-      minimum: 0
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -1022,7 +899,6 @@ properties:
         - "null"
     display_label:
       default: Accessibility Hazard
-    index_documentation: displayable, searchable
     indexing:
       - "accessibility_hazard_tesim"
       - "accessibility_hazard_sim"
@@ -1037,9 +913,6 @@ properties:
     available_on:
       class:
         - OerResource
-    cardinality:
-      minimum: 0
-      maximum: 1
     multi_value: false
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -1047,7 +920,6 @@ properties:
         - "null"
     display_label:
       default: Accessibility Summary
-    index_documentation: displayable, searchable
     indexing:
       - "accessibility_summary_tesim"
       - "accessibility_summary_sim"
@@ -1064,9 +936,6 @@ properties:
       class:
         - OerResource
         - EtdResource
-    cardinality:
-      minimum: 0
-      maximum: 1
     multi_value: false
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -1074,7 +943,6 @@ properties:
         - "null"
     display_label:
       default: Admin Note
-    index_documentation: searchable
     indexing:
       - "admin_note_tesim"
     form:
@@ -1092,8 +960,6 @@ properties:
       class:
         - OerResource
         - EtdResource
-    cardinality:
-      minimum: 0
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -1101,7 +967,6 @@ properties:
         - "null"
     display_label:
       default: Additional Information
-    index_documentation: searchable
     indexing:
       - "additional_information_tesim"
     form:
@@ -1116,8 +981,6 @@ properties:
     available_on:
       class:
         - OerResource
-    cardinality:
-      minimum: 0
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -1125,7 +988,6 @@ properties:
         - "null"
     display_label:
       default: Alternate Version ID
-    index_documentation: displayable, searchable
     indexing:
       - "alternate_version_id_tesim"
       - "alternate_version_id_sim"
@@ -1138,8 +1000,6 @@ properties:
     available_on:
       class:
         - OerResource
-    cardinality:
-      minimum: 1
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -1147,7 +1007,6 @@ properties:
         - "null"
     display_label:
       default: Audience
-    index_documentation: displayable, searchable
     indexing:
       - "audience_tesim"
       - "audience_sim"
@@ -1167,8 +1026,6 @@ properties:
       class:
         - OerResource
         - EtdResource
-    cardinality:
-      minimum: 0
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -1176,7 +1033,6 @@ properties:
         - "null"
     display_label:
       default: Date
-    index_documentation: displayable, searchable
     indexing:
       - "date_tesim"
       - "date_sim"
@@ -1189,8 +1045,6 @@ properties:
     available_on:
       class:
         - OerResource
-    cardinality:
-      minimum: 1
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -1198,7 +1052,6 @@ properties:
         - "null"
     display_label:
       default: Discipline
-    index_documentation: searchable
     indexing:
       - "discipline_tesim"
     form:
@@ -1216,8 +1069,6 @@ properties:
     available_on:
       class:
         - OerResource
-    cardinality:
-      minimum: 1
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -1225,7 +1076,6 @@ properties:
         - "null"
     display_label:
       default: Education Level
-    index_documentation: displayable, searchable
     indexing:
       - "education_level_tesim"
       - "education_level_sim"
@@ -1244,8 +1094,6 @@ properties:
     available_on:
       class:
         - OerResource
-    cardinality:
-      minimum: 1
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -1253,7 +1101,6 @@ properties:
         - "null"
     display_label:
       default: Learning Resource Type
-    index_documentation: displayable, searchable
     indexing:
       - "learning_resource_type_tesim"
       - "learning_resource_type_sim"
@@ -1272,8 +1119,6 @@ properties:
     available_on:
       class:
         - OerResource
-    cardinality:
-      minimum: 0
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -1281,7 +1126,6 @@ properties:
         - "null"
     display_label:
       default: Newer Version ID
-    index_documentation: displayable, searchable
     indexing:
       - "newer_version_id_tesim"
       - "newer_version_id_sim"
@@ -1294,8 +1138,6 @@ properties:
     available_on:
       class:
         - OerResource
-    cardinality:
-      minimum: 0
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -1303,7 +1145,6 @@ properties:
         - "null"
     display_label:
       default: OER Size
-    index_documentation: searchable
     indexing:
       - "oer_size_tesim"
     form:
@@ -1318,8 +1159,6 @@ properties:
     available_on:
       class:
         - OerResource
-    cardinality:
-      minimum: 0
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -1327,7 +1166,6 @@ properties:
         - "null"
     display_label:
       default: Previous Version ID
-    index_documentation: displayable, searchable
     indexing:
       - "previous_version_id_tesim"
       - "previous_version_id_sim"
@@ -1340,8 +1178,6 @@ properties:
     available_on:
       class:
         - OerResource
-    cardinality:
-      minimum: 0
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -1349,7 +1185,6 @@ properties:
         - "null"
     display_label:
       default: Related Item ID
-    index_documentation: displayable, searchable
     indexing:
       - "related_item_id_tesim"
       - "related_item_id_sim"
@@ -1362,8 +1197,6 @@ properties:
     available_on:
       class:
         - OerResource
-    cardinality:
-      minimum: 0
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -1371,7 +1204,6 @@ properties:
         - "null"
     display_label:
       default: Rights Holder
-    index_documentation: displayable, searchable
     indexing:
       - "rights_holder_tesim"
       - "rights_holder_sim"
@@ -1387,8 +1219,6 @@ properties:
     available_on:
       class:
         - OerResource
-    cardinality:
-      minimum: 0
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -1396,7 +1226,6 @@ properties:
         - "null"
     display_label:
       default: Table of Contents
-    index_documentation: searchable
     indexing:
       - "table_of_contents_tesim"
     form:
@@ -1413,8 +1242,6 @@ properties:
     available_on:
       class:
         - EtdResource
-    cardinality:
-      minimum: 0
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -1422,7 +1249,6 @@ properties:
         - "null"
     display_label:
       default: Advisor
-    index_documentation: searchable
     indexing:
       - "advisor_tesim"
     form:
@@ -1438,8 +1264,6 @@ properties:
     available_on:
       class:
         - EtdResource
-    cardinality:
-      minimum: 0
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -1447,7 +1271,6 @@ properties:
         - "null"
     display_label:
       default: Committee Member
-    index_documentation: searchable
     indexing:
       - "committee_member_tesim"
     form:
@@ -1463,8 +1286,6 @@ properties:
     available_on:
       class:
         - EtdResource
-    cardinality:
-      minimum: 1
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -1472,7 +1293,6 @@ properties:
         - "null"
     display_label:
       default: Degree Name
-    index_documentation: searchable
     indexing:
       - "degree_name_tesim"
     form:
@@ -1490,8 +1310,6 @@ properties:
     available_on:
       class:
         - EtdResource
-    cardinality:
-      minimum: 1
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -1499,7 +1317,6 @@ properties:
         - "null"
     display_label:
       default: Degree Level
-    index_documentation: searchable
     indexing:
       - "degree_level_tesim"
     form:
@@ -1517,8 +1334,6 @@ properties:
     available_on:
       class:
         - EtdResource
-    cardinality:
-      minimum: 1
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -1526,7 +1341,6 @@ properties:
         - "null"
     display_label:
       default: Degree Discipline
-    index_documentation: searchable
     indexing:
       - "degree_discipline_tesim"
     form:
@@ -1544,8 +1358,6 @@ properties:
     available_on:
       class:
         - EtdResource
-    cardinality:
-      minimum: 1
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -1553,7 +1365,6 @@ properties:
         - "null"
     display_label:
       default: Degree Grantor
-    index_documentation: searchable
     indexing:
       - "degree_grantor_tesim"
     form:
@@ -1577,9 +1388,6 @@ properties:
         - ImageResource
         - OerResource
         - EtdResource
-    cardinality:
-      minimum: 0
-      maximum: 1
     multi_value: false
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -1587,7 +1395,6 @@ properties:
         - "null"
     display_label:
       default: Bulkrax Identifier
-    index_documentation: displayable, searchable
     indexing:
       - "bulkrax_identifier_tesi"
       - "bulkrax_identifier_ssi"
@@ -1608,9 +1415,6 @@ properties:
         - ImageResource
         - OerResource
         - EtdResource
-    cardinality:
-      minimum: 0
-      maximum: 1
     multi_value: false
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#bool
@@ -1618,7 +1422,6 @@ properties:
         - "null"
     display_label:
       default: Show PDF Viewer
-    index_documentation: displayable, searchable
     indexing:
       - "show_pdf_viewer_bsi"
     form:
@@ -1638,9 +1441,6 @@ properties:
         - ImageResource
         - OerResource
         - EtdResource
-    cardinality:
-      minimum: 0
-      maximum: 1
     multi_value: false
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#bool
@@ -1648,7 +1448,6 @@ properties:
         - "null"
     display_label:
       default: Show PDF Download Button
-    index_documentation: displayable, searchable
     indexing:
       - "show_pdf_download_button_bsi"
     form:
@@ -1669,9 +1468,6 @@ properties:
         - ImageResource
         - OerResource
         - EtdResource
-    cardinality:
-      minimum: 0
-      maximum: 1
     multi_value: false
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -1679,7 +1475,6 @@ properties:
         - "null"
     display_label:
       default: Video Embed
-    index_documentation: searchable
     indexing:
       - "video_embed_tesi"
     form:
@@ -1700,9 +1495,6 @@ properties:
         - ImageResource
         - OerResource
         - EtdResource
-    cardinality:
-      minimum: 0
-      maximum: 1
     multi_value: false
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#bool
@@ -1710,7 +1502,6 @@ properties:
         - "null"
     display_label:
       default: Is Child
-    index_documentation: displayable, searchable
     indexing:
       - "is_child_bsi"
     form:
@@ -1730,9 +1521,6 @@ properties:
         - ImageResource
         - OerResource
         - EtdResource
-    cardinality:
-      minimum: 0
-      maximum: 1
     multi_value: false
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -1740,7 +1528,6 @@ properties:
         - "null"
     display_label:
       default: Split from PDF ID
-    index_documentation: searchable
     indexing:
       - "split_from_pdf_id_ssi"
     form:
@@ -1758,8 +1545,6 @@ properties:
         - ImageResource
       context:
         - special_context
-    cardinality:
-      minimum: 0
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
@@ -1767,7 +1552,6 @@ properties:
         - "null"
     display_label:
       default: Dimensions
-    index_documentation: displayable, searchable
     indexing:
       - dimensions_sim
       - dimensions_tesim

--- a/config/metadata_profiles/m3_profile.yaml
+++ b/config/metadata_profiles/m3_profile.yaml
@@ -128,6 +128,7 @@ properties:
       default: Depositor
     indexing:
       - depositor_tesim
+      - depositor_ssim
     property_uri: http://id.loc.gov/vocabulary/relators/dpt
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_03_03_164452) do
+ActiveRecord::Schema.define(version: 2024_12_05_212513) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -959,20 +959,6 @@ ActiveRecord::Schema.define(version: 2025_03_03_164452) do
     t.string "committer_login"
     t.datetime "created_at"
     t.datetime "updated_at"
-  end
-
-  create_table "work_authorizations", force: :cascade do |t|
-    t.string "work_title"
-    t.bigint "user_id"
-    t.datetime "expires_at"
-    t.string "work_pid", null: false
-    t.string "scope"
-    t.string "error"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["expires_at"], name: "index_work_authorizations_on_expires_at"
-    t.index ["user_id"], name: "index_work_authorizations_on_user_id"
-    t.index ["work_pid"], name: "index_work_authorizations_on_work_pid"
   end
 
   create_table "work_view_stats", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_12_05_212513) do
+ActiveRecord::Schema.define(version: 2025_03_03_164452) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -959,6 +959,20 @@ ActiveRecord::Schema.define(version: 2024_12_05_212513) do
     t.string "committer_login"
     t.datetime "created_at"
     t.datetime "updated_at"
+  end
+
+  create_table "work_authorizations", force: :cascade do |t|
+    t.string "work_title"
+    t.bigint "user_id"
+    t.datetime "expires_at"
+    t.string "work_pid", null: false
+    t.string "scope"
+    t.string "error"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["expires_at"], name: "index_work_authorizations_on_expires_at"
+    t.index ["user_id"], name: "index_work_authorizations_on_user_id"
+    t.index ["work_pid"], name: "index_work_authorizations_on_work_pid"
   end
 
   create_table "work_view_stats", id: :serial, force: :cascade do |t|

--- a/lib/flexible/m3_json_schema.json
+++ b/lib/flexible/m3_json_schema.json
@@ -270,14 +270,11 @@
           },
           "indexing": {
             "type": "array",
-            "description": "a list of Solr dynamic field names following the pattern property_name + suffix",
             "items": {
               "type": "string",
-              "pattern": "^[a-z_]+_(tesi|tesim|teim|ssi|sim|ssm|bsi|isi|dts|dtsi|ti|si|ss|is|bs|dt)$"
+              "pattern": "^[a-z_]+_(tesi|tesim|teim|ssi|sim|ssm|bsi|isi|dts|dtsi|ti|si|ss|is|bs|dt|ssim)$"
             },
-            "examples": [
-              ["creator_tesim", "title_sim", "date_created_dtsi"]
-            ]
+            "description": "Solr index key to map to."
           },
           "definition": {
             "type": "object",

--- a/lib/flexible/m3_json_schema.json
+++ b/lib/flexible/m3_json_schema.json
@@ -1,0 +1,482 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://example.com/m3_json_schema.json",
+  "type": "object",
+  "title": "The M3 JSON Schema",
+  "comment": "profile, classes and properties are required; contexts and mappings are not",
+  "required": [
+    "m3_version",
+    "profile",
+    "classes",
+    "properties"
+  ],
+  "properties": {
+
+    "m3_version": {
+      "$id": "#/properties/m3_version",
+      "type": "string",
+      "title": "Schema Version",
+      "readOnly": true,
+      "default": "1.0.beta2",
+      "description": "Version number for the M3 specification. Change this to make a new release. Instances will be validated to check they have this version in place.",
+      "pattern": "1.0.beta2"
+    },
+
+    "profile": {
+      "$id": "#/properties/profile",
+      "type": "object",
+      "title": "Profile Information",
+      "description": "Administrative information about the profile or model defined in the file.",
+      "additionalProperties": false,
+      "required": [
+        "responsibility",
+        "date_modified"
+      ],
+      "properties": {
+        "date_modified": {
+          "$id": "#/properties/profile/date_modified",
+          "title": "Date Modified",
+          "description": "the date the profile was last altered",
+          "type": "string",
+          "format": "date",
+          "comment": "In YAML, dates must be wrapped in quotes to be validated by json schema",
+          "examples": [
+            "2019-07-03"
+          ]
+        },
+        "responsibility": {
+          "$id": "#/properties/profile/responsibility",
+          "title": "Responsiblity",
+          "description": "uri for the organization or individual responsible for maintaining the profile",
+          "type": "string",
+          "format": "uri",
+          "examples": [
+            "https://wiki.duraspace.org/display/samvera/Samvera+Metadata+Interest+Group"
+          ]
+        },
+        "responsibility_statement": {
+          "$id": "#/properties/profile/responsibility_statement",
+          "title": "Reponsibility Statement",
+          "description": "statement of the organization or individual responsible for maintaining the profile",
+          "type": "string",
+          "examples": [
+            "Samvera Metadata Interest Group"
+          ]
+        },
+        "type": {
+          "$id": "#/properties/profile/type",
+          "title": "Type",
+          "description": "type of thing does the profile describe",
+          "type": "string",
+          "examples": [
+            "metadata models"
+          ]
+        },
+        "version": {
+          "$id": "#/properties/profile/version",
+          "title": "Version",
+          "description": "version of the profile",
+          "type": "number",
+          "readOnly": true,
+          "default": 0.0,
+          "examples": [
+            0.8
+          ]
+        }
+      }
+    },
+    "classes": {
+      "$id": "#/properties/classes",
+      "type": "object",
+      "title": "Class Definitions",
+      "description": "Definition of the classes used in the profile. Classes should be provided with a generic local name for the class, in CamelCase.",
+      "comment": "Class names are pattern matched.",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["display_label"],
+        "properties": {
+          "display_label": {
+            "type": "string",
+            "description": "Human-readable label for the class.",
+            "comment": "For classes, display label is a string.",
+            "examples": [
+              "Generic Work"
+            ]
+          },
+          "schema_url": {
+            "type": "string",
+            "format": "uri",
+            "description": "URI for the class, from a local or shared ontology."
+          },
+          "contexts": {
+            "type": "array",
+            "description": "A list of contexts in which this class may be used. Empty is taken to indicate all contexts.",
+            "comment": "Contexts must match a context defined in the contexts block.",
+            "items": {
+              "type": "string"
+            },
+            "examples": [
+              ["chem"]
+            ]
+          }
+        }
+      },
+      "propertyNames": {
+        "pattern": "[A-Z]+[A-Z]?[a-z]*$"
+      },
+      "examples": [
+        {
+          "GenericWork": {
+            "display_label": "Generic Work"
+          }
+        },
+        {
+          "Collection": {
+            "display_label": "Collection"
+          }
+        },
+        {
+          "Agent": {
+            "display_label": "Agent",
+            "schema_uri": "http://id.loc.gov/ontologies/bibframe/Agent"
+          }
+        }
+      ]
+    },
+    "contexts": {
+      "$id": "#/properties/contexts",
+      "type": "object",
+      "title": "Context Definitions",
+      "description": "Definition of the contexts used in the profile. Contexts should be provided with a stable generic local name for the context. Names must be lower case alpha characters separated with underscores.",
+      "comment": "Context names are pattern matched.",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["display_label"],
+        "properties": {
+          "display_label": {
+            "type": "string",
+            "description": "Human-readable label for the context.",
+            "comment": "For contexts, display label is a string.",
+            "examples": [
+              "Department of Chemistry"
+            ]
+          }
+        }
+      },
+      "propertyNames": {
+        "pattern": "^[a-z_]*$"
+      },
+      "examples": [
+        {
+          "chem": {
+            "display_label": "Department of Chemistry"
+          }
+        }
+      ]
+    },
+    "properties": {
+      "$id": "#/properties/properties",
+      "type": "object",
+      "title": "Property Definitions",
+      "description": "Definition of the properties used in the model. Properties should be provided with a stable generic local name for the property. Names must be lower case alpha characters separated with underscores.",
+      "comment": "Property names pattern matched.",
+      "propertyNames": {
+        "pattern": "^[a-z_]*$"
+      },
+      "additionalProperties": {
+        "type": "object",
+        "required": ["display_label", "available_on", "range"],
+        "properties": {
+
+          "display_label": {
+            "type": "object",
+            "description": "Human-readable label for the property.  Class or context specific display_labels provided as a list using the class and value.",
+            "properties": {
+              "default": {
+                "type": "string",
+                "description": "Default value."
+              }
+            },
+            "additionalProperties": {
+              "type": "string"
+            },
+            "examples": [
+              {
+                "default": "Default display label.",
+                "MyCustomWorkType": "Context dependent display label.",
+                "project_x": "Project specific display label"
+              }
+            ]
+          },
+          "available_on": {
+            "type": "object",
+            "description": "The classes (objects and/or work types) or contexts this property is available on (defined in 'classes' or 'contexts' section.)",
+            "properties": {
+              "class": {
+                "comment": "Listed values must match a class defined in the classes block.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "context": {
+                "comment": "Listed values must match a context defined in the contexts block.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "examples": [
+              {
+                "class": [
+                  "Collection",
+                  "MyCustomWorkType"
+                ],
+                "context": [
+                  "chem"
+                ]
+              }
+            ]
+          },
+          "cardinality": {
+            "type": "object",
+            "description": "System cardinality and obligation.",
+            "properties": {
+              "minimum": {
+                "type": "integer",
+                "description": "Minimum number of values the property must have.  If there is no value provided, the assumed default minimum is 0. A minimum of 1 means the property is required.",
+                "default": 0,
+                "examples": [
+                  1
+                ]
+              },
+              "maximum": {
+                "type": "integer",
+                "description": "Maximum number of values the property may have.  If there is no value provided, the assumed default maximum is unlimited.",
+                "examples": [
+                  5
+                ]
+              }
+            },
+            "examples": [
+              {
+                "cardinality": {
+                  "minimum": 0,
+                  "maximum": 100
+                }
+              }
+            ]
+          },
+          "indexing": {
+            "type": "array",
+            "description": "a list of Solr dynamic field names following the pattern property_name + suffix",
+            "items": {
+              "type": "string",
+              "pattern": "^[a-z_]+_(tesi|tesim|teim|ssi|sim|ssm|bsi|isi|dts|dtsi|ti|si|ss|is|bs|dt)$"
+            },
+            "examples": [
+              ["creator_tesim", "title_sim", "date_created_dtsi"]
+            ]
+          },
+          "definition": {
+            "type": "object",
+            "description": "The definition for the metadata property being described.",
+            "properties": {
+              "default": {
+                "type": "string",
+                "description": "Default value."
+              }
+            },
+            "additionalProperties": {
+              "type": "string"
+            },
+            "examples": [
+              {
+                "default": "Default display label.",
+                "MyCustomWorkType": "Context dependent display label."
+              }
+            ]
+          },
+          "usage_guidelines": {
+            "type": "object",
+            "description": "Description of how the defined property should be used (helper text, hints, deposit text, etc.)",
+            "properties": {
+              "default": {
+                "type": "string",
+                "description": "Default value."
+              }
+            },
+            "additionalProperties": {
+              "type": "string"
+            },
+            "examples": [
+              {
+                "default": "Default display label.",
+                "MyCustomWorkType": "Context dependent display label."
+              }
+            ]
+          },
+          "requirement": {
+            "type": "string",
+            "description": "Whether the property is required, optional, recommended, etc. from a best practices standpoint. Please use cardinality - minimum to programmatically set a property to be required.",
+            "examples": [
+              "recommended, if applicable"
+            ]
+          },
+          "controlled_value": {
+            "type": "object",
+            "description": "",
+            "properties": {
+              "format": {
+                "type": "string",
+                "description": "Controlled vocabulary constraint on the property's value.",
+                "examples": []
+              },
+              "sources": {
+                "type": "array",
+                "description": "Link to a controlled vocabulary source list or file path to a config file listing accepted values.",
+                "items": {
+                  "type": "string"
+                },
+                "examples": []
+              }
+            },
+            "examples": [
+              {
+                "controlled_value": {
+                  "format": "http://www.w3.org/2001/XMLSchema#anyURI",
+                  "sources": [
+                    "/qa/terms/local/roles/"
+                  ]
+                }
+              }
+            ]
+          },
+          "sample_value": {
+            "type": "array",
+            "description": "Example value(s) for the property.",
+            "items": {
+              "type": "string"
+            },
+            "examples": [
+              [
+                "Smith, John",
+                "Library of Congress"
+              ]
+            ]
+          },
+          "property_uri": {
+            "type": "string",
+            "format": "uri",
+            "description": "URI for the property, from a local or shared ontology.",
+            "examples": [
+              "http://purl.org/dc/elements/1.1/creator"
+            ]
+          },
+          "range": {
+            "type": "string",
+            "format": "uri",
+            "description": "Class constraint on the property's value.  If there is no value provided, the assumed default range is http://www.w3.org/2000/01/rdf-schema#Literal",
+            "default": "http://www.w3.org/2000/01/rdf-schema#Literal",
+            "examples": [
+              "http://www.w3.org/2000/01/rdf-schema#Literal"
+            ]
+          },
+          "data_type": {
+            "type": "string",
+            "format": "uri",
+            "description": "Type constraint on the property's value. If there is no value provided, the assumed default data_type is http://www.w3.org/2001/XMLSchema#string. If multiple data types are possible, general best practice is to use the most specific type that applies to all values.  If multiple types are listed, the lowest common denominator will be used for validation.",
+            "default": "http://www.w3.org/2001/XMLSchema#string",
+            "examples": [
+              "http://www.w3.org/2001/XMLSchema#string"
+            ]
+          },
+          "syntax": {
+            "type": "string",
+            "description": "Type constraint on the property's value. If there is no value provided, the assumed default data_type is http://www.w3.org/2001/XMLSchema#string. If multiple data types are possible, general best practice is to use the most specific type that applies to all values.  If multiple types are listed, the lowest common denominator will be used for validation.",
+            "examples": [
+              "edtf"
+            ]
+          },
+          "index_documentation": {
+            "type": "string",
+            "description": "Free text documentation field about whether a property should be faceted, searchable, displayable, treated as text, etc.",
+            "examples": [
+              "searchable, displayable, creator facet"
+            ]
+          },
+          "validations": {
+            "type": "object",
+            "description": "Regular Expression pattern each value must match to be valid.",
+            "properties": {
+              "match_regex": {
+                "type": "string",
+                "description": "Regular Expression pattern each value must match to be valid.",
+                "examples": [
+                  "^[a-z_]*$"
+                ]
+              }
+            },
+            "examples": [
+              {
+                "validations": {
+                  "match_regex": "^[a-z_]*$"
+                }
+              }
+            ]
+          },
+          "mapping": {
+            "type": "object",
+            "description": "A pair value defining the target property for a mapping (defined in 'mapping definitions' section.)",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "pattern": "^[a-z_]*$"
+            },
+            "examples": [
+              {
+                "dpla": "http://purl.org/dc/elements/1.1/creator"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "mappings": {
+      "$id": "#/properties/mappings",
+      "type": "object",
+      "title": "Mapping Definitions",
+      "description": "Definition of the mappings to different services or target schemas referenced in the profile.",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "propertyNames": {
+        "pattern": "^[a-z_]*$"
+      },
+      "examples": [
+        {
+          "dpla": {
+            "name": "Digital Public Library of America"
+          }
+        },
+        {
+          "datacite": {
+            "name": "DataCite"
+          }
+        },
+        {
+          "dc": {
+            "name": "Dublin Core"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/spec/fixtures/files/m3_profile.yaml
+++ b/spec/fixtures/files/m3_profile.yaml
@@ -127,6 +127,7 @@ properties:
       default: Depositor
     indexing:
       - "depositor_tesim"
+      - "depositor_ssim"
     property_uri: http://id.loc.gov/vocabulary/relators/dpt
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:

--- a/spec/fixtures/files/m3_profile.yaml
+++ b/spec/fixtures/files/m3_profile.yaml
@@ -1,0 +1,150 @@
+---
+m3_version: 1.0.beta2
+profile:
+  date_modified: '2024-06-01'
+  responsibility: https://samvera.org
+  responsibility_statement: Hyrax Initial Profile
+  type: Initial Profile
+  version: 1
+classes:
+  AdminSetResource:
+    display_label: Admin Set
+  CollectionResource:
+    display_label: Collection
+  Hyrax::FileSet:
+    display_label: File Set
+  GenericWorkResource:
+    display_label: Generic Work
+  ImageResource:
+    display_label: Image
+  EtdResource:
+    display_label: ETD
+  OerResource:
+    display_label: OER
+contexts:
+  flexible_context:
+    display_label: Flexible Metadata Example
+mappings:
+  blacklight:
+    name: Additional Blacklight Solr Mappings
+  metatags:
+    name: Metatags
+  mods_oai_pmh:
+    name: MODS OAI PMH
+  qualified_dc_pmh:
+    name: Qualified DC OAI PMH
+  simple_dc_pmh:
+    name: Simple DC OAI PMH
+properties:
+  title:
+    available_on:
+      class:
+      - AdminSetResource
+      - CollectionResource
+      - Hyrax::FileSet
+      - GenericWorkResource
+      - ImageResource
+      - EtdResource
+      - OerResource
+    multi_value: true
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+      - 'null'
+    definition:
+      default: Enter a standardized title for display. If only one
+        title is needed, transcribe the title from the source
+        itself.
+    display_label:
+      default: Title
+    indexing:
+    - 'title_sim'
+    - 'title_tesim'
+    form:
+      required: true
+      primary: true
+      multi_value: true
+    mappings:
+      metatags: twitter:title, og:title
+      mods_oai_pmh: mods:titleInfo/mods:title
+      qualified_dc_pmh: dcterms:title
+      simple_dc_pmh: dc:title
+    property_uri: http://purl.org/dc/terms/title
+    range: http://www.w3.org/2001/XMLSchema#string
+    requirement: required
+    sample_values:
+    - Pencil drawn portrait study of woman
+  date_modified:
+    available_on:
+      class:
+      - AdminSetResource
+      - CollectionResource
+      - Hyrax::FileSet
+      - GenericWorkResource
+      - ImageResource
+      - EtdResource
+      - OerResource
+    multi_value: false
+    display_label:
+      default: Date Modified
+    property_uri: http://purl.org/dc/terms/modified
+    range: http://www.w3.org/2001/XMLSchema#dateTime
+    sample_values:
+    - "2024-06-06 21:06:51 +0000"
+  date_uploaded:
+    available_on:
+      class:
+      - AdminSetResource
+      - CollectionResource
+      - Hyrax::FileSet
+      - GenericWorkResource
+      - ImageResource
+      - EtdResource
+      - OerResource
+    multi_value: false
+    display_label:
+      default: Date Uploaded
+    property_uri: http://purl.org/dc/terms/dateSubmitted
+    range: http://www.w3.org/2001/XMLSchema#dateTime
+    sample_values:
+    - "2024-06-06 21:06:51 +0000"
+  depositor:
+    available_on:
+      class:
+      - AdminSetResource
+      - CollectionResource
+      - Hyrax::FileSet
+      - GenericWorkResource
+      - ImageResource
+      - EtdResource
+      - OerResource
+    multi_value: false
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+      - 'null'
+    display_label:
+      default: Depositor
+    indexing:
+    - 'depositor_tesim'
+    property_uri: http://id.loc.gov/vocabulary/relators/dpt
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+    - Julie Allinson
+  creator:
+    available_on:
+      class:
+      - Hyrax::FileSet
+    multi_value: true
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+      - 'null'
+    display_label:
+      default: Creator
+    indexing:
+    - 'creator_tesim'
+    property_uri: http://purl.org/dc/elements/1.1/creator
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+    - Julie Allinson

--- a/spec/fixtures/files/m3_profile.yaml
+++ b/spec/fixtures/files/m3_profile.yaml
@@ -1,7 +1,7 @@
 ---
 m3_version: 1.0.beta2
 profile:
-  date_modified: '2024-06-01'
+  date_modified: "2024-06-01"
   responsibility: https://samvera.org
   responsibility_statement: Hyrax Initial Profile
   type: Initial Profile
@@ -39,18 +39,18 @@ properties:
   title:
     available_on:
       class:
-      - AdminSetResource
-      - CollectionResource
-      - Hyrax::FileSet
-      - GenericWorkResource
-      - ImageResource
-      - EtdResource
-      - OerResource
+        - AdminSetResource
+        - CollectionResource
+        - Hyrax::FileSet
+        - GenericWorkResource
+        - ImageResource
+        - EtdResource
+        - OerResource
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
-      - 'null'
+        - "null"
     definition:
       default: Enter a standardized title for display. If only one
         title is needed, transcribe the title from the source
@@ -58,8 +58,8 @@ properties:
     display_label:
       default: Title
     indexing:
-    - 'title_sim'
-    - 'title_tesim'
+      - "title_sim"
+      - "title_tesim"
     form:
       required: true
       primary: true
@@ -73,78 +73,103 @@ properties:
     range: http://www.w3.org/2001/XMLSchema#string
     requirement: required
     sample_values:
-    - Pencil drawn portrait study of woman
+      - Pencil drawn portrait study of woman
   date_modified:
     available_on:
       class:
-      - AdminSetResource
-      - CollectionResource
-      - Hyrax::FileSet
-      - GenericWorkResource
-      - ImageResource
-      - EtdResource
-      - OerResource
+        - AdminSetResource
+        - CollectionResource
+        - Hyrax::FileSet
+        - GenericWorkResource
+        - ImageResource
+        - EtdResource
+        - OerResource
     multi_value: false
     display_label:
       default: Date Modified
     property_uri: http://purl.org/dc/terms/modified
     range: http://www.w3.org/2001/XMLSchema#dateTime
     sample_values:
-    - "2024-06-06 21:06:51 +0000"
+      - "2024-06-06 21:06:51 +0000"
   date_uploaded:
     available_on:
       class:
-      - AdminSetResource
-      - CollectionResource
-      - Hyrax::FileSet
-      - GenericWorkResource
-      - ImageResource
-      - EtdResource
-      - OerResource
+        - AdminSetResource
+        - CollectionResource
+        - Hyrax::FileSet
+        - GenericWorkResource
+        - ImageResource
+        - EtdResource
+        - OerResource
     multi_value: false
     display_label:
       default: Date Uploaded
     property_uri: http://purl.org/dc/terms/dateSubmitted
     range: http://www.w3.org/2001/XMLSchema#dateTime
     sample_values:
-    - "2024-06-06 21:06:51 +0000"
+      - "2024-06-06 21:06:51 +0000"
   depositor:
     available_on:
       class:
-      - AdminSetResource
-      - CollectionResource
-      - Hyrax::FileSet
-      - GenericWorkResource
-      - ImageResource
-      - EtdResource
-      - OerResource
+        - AdminSetResource
+        - CollectionResource
+        - Hyrax::FileSet
+        - GenericWorkResource
+        - ImageResource
+        - EtdResource
+        - OerResource
     multi_value: false
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
-      - 'null'
+        - "null"
     display_label:
       default: Depositor
     indexing:
-    - 'depositor_tesim'
+      - "depositor_tesim"
     property_uri: http://id.loc.gov/vocabulary/relators/dpt
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
-    - Julie Allinson
+      - Julie Allinson
   creator:
     available_on:
       class:
-      - Hyrax::FileSet
+        - Hyrax::FileSet
     multi_value: true
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
-      - 'null'
+        - "null"
     display_label:
       default: Creator
     indexing:
-    - 'creator_tesim'
+      - "creator_tesim"
     property_uri: http://purl.org/dc/elements/1.1/creator
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
-    - Julie Allinson
+      - Julie Allinson
+  label:
+    available_on:
+      class:
+        - Hyrax::FileSet
+        - CollectionResource
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    multi_value: false
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Label
+    indexing:
+      - label_sim
+      - label_tesim
+    form:
+      primary: false
+    property_uri: info:fedora/fedora-system:def/model#downloadFilename
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - file_label.txt

--- a/spec/services/hyrax/core_metadata_validator_spec.rb
+++ b/spec/services/hyrax/core_metadata_validator_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::CoreMetadataValidator do
+  subject(:service) { described_class.new(profile: profile, errors: errors) }
+  let(:profile) { YAML.safe_load_file(yaml) }
+  let(:yaml) { Rails.root.join('spec', 'fixtures', 'files', 'm3_profile.yaml').to_s }
+  let(:errors) { [] }
+
+  describe '#validate!' do
+    before { service.validate! }
+
+    context 'with a valid schema' do
+      it 'does not have any errors' do
+        expect(errors).to be_empty
+      end
+    end
+
+    context 'when core metadata properties are misconfigured' do
+      context 'when a required property is missing' do
+        before do
+          profile['properties'].delete('depositor')
+          service.validate!
+        end
+
+        it 'is invalid' do
+          expect(errors).to include('Missing required property: depositor.')
+        end
+      end
+
+      context 'when multi_value is incorrect' do
+        before do
+          profile['properties']['title']['multi_value'] = false
+          service.validate!
+        end
+
+        it 'is invalid' do
+          expect(errors).to include("Property 'title' must have multi_value set to true.")
+        end
+      end
+
+      context 'when indexing is missing keys' do
+        before do
+          profile['properties']['depositor']['indexing'] = ['depositor_tesim']
+          service.validate!
+        end
+
+        it 'is invalid' do
+          expect(errors).to include("Property 'depositor' is missing required indexing: depositor_ssim.")
+        end
+      end
+
+      context 'when predicate (property_uri) is incorrect' do
+        before do
+          profile['properties']['title']['property_uri'] = 'http://example.com/wrong-predicate'
+          service.validate!
+        end
+
+        it 'is invalid' do
+          expect(errors).to include("Property 'title' must have property_uri set to http://purl.org/dc/terms/title.")
+        end
+      end
+    end
+  end
+end

--- a/spec/services/hyrax/flexible_schema_validator_service_spec.rb
+++ b/spec/services/hyrax/flexible_schema_validator_service_spec.rb
@@ -78,6 +78,41 @@ RSpec.describe Hyrax::FlexibleSchemaValidatorService do
           expect(service.errors.last).to include('Data pointer: /properties/creator')
         end
       end
+
+      context 'when the label property is misconfigured' do
+        context 'when it is missing' do
+          before do
+            profile['properties'].delete('label')
+            service.validate!
+          end
+
+          it 'is invalid' do
+            expect(service.errors.first).to eq 'A `label` property is required.'
+          end
+        end
+
+        context 'when it is not available on Hyrax::FileSet' do
+          before do
+            profile['properties']['label']['available_on']['class'] = ['GenericWorkResource']
+            service.validate!
+          end
+
+          it 'is invalid' do
+            expect(service.errors.first).to eq 'Label must be available on Hyrax::FileSet.'
+          end
+        end
+
+        context 'when it is available on Hyrax::FileSet and other classes' do
+          before do
+            profile['properties']['label']['available_on']['class'] = ['Hyrax::FileSet', 'GenericWorkResource']
+            service.validate!
+          end
+
+          it 'is valid' do
+            expect(service.errors).to be_empty
+          end
+        end
+      end
     end
   end
 end

--- a/spec/services/hyrax/flexible_schema_validator_service_spec.rb
+++ b/spec/services/hyrax/flexible_schema_validator_service_spec.rb
@@ -102,52 +102,6 @@ RSpec.describe Hyrax::FlexibleSchemaValidatorService do
           end
         end
       end
-
-      context 'when core metadata properties are misconfigured' do
-        context 'when a required property is missing' do
-          before do
-            profile['properties'].delete('depositor')
-            service.validate!
-          end
-
-          it 'is invalid' do
-            expect(service.errors).to include('Missing required property: depositor.')
-          end
-        end
-
-        context 'when multi_value is incorrect' do
-          before do
-            profile['properties']['title']['multi_value'] = false
-            service.validate!
-          end
-
-          it 'is invalid' do
-            expect(service.errors).to include("Property 'title' must have multi_value set to true.")
-          end
-        end
-
-        context 'when indexing is missing keys' do
-          before do
-            profile['properties']['depositor']['indexing'] = ['depositor_tesim']
-            service.validate!
-          end
-
-          it 'is invalid' do
-            expect(service.errors).to include("Property 'depositor' is missing required indexing: depositor_ssim.")
-          end
-        end
-
-        context 'when predicate (property_uri) is incorrect' do
-          before do
-            profile['properties']['title']['property_uri'] = 'http://example.com/wrong-predicate'
-            service.validate!
-          end
-
-          it 'is invalid' do
-            expect(service.errors).to include("Property 'title' must have property_uri set to http://purl.org/dc/terms/title.")
-          end
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
# Summary

Previously, invalid profiles could break the app because it would allow the user to save bad profiles. Users were unable to resolve the issues themselves. 

This validator is required for the hyku v6.2.0 release. 

## Ticket Number
- https://github.com/notch8/amigos/issues/29

# Screenshots / Video

<img width="676" height="254" alt="image" src="https://github.com/user-attachments/assets/85e74037-33dd-4b09-9530-67fa3ce77446" />


# Expected Behavior 

Validation Rules include: 
- [x] - validate schema (houndstooth validator)
- [x] - required properties exist
  - [x] available_on/class
  - [x] range
  - [x] display_label/default 
- [ ] - check for existences of local vocab if one is being referred (will do after controlled vocab pr gets merged) 
  - [ ] https://github.com/samvera/hyku/pull/2608
  - [ ] https://github.com/notch8/hykuup_knapsack/issues/421
- [x] - check that the backend supports all the models listed in available_on.classes
- [x] - title cardinality - if no maximum caused issues
- [x] label for FileSet class to allow filesets to work
- [x] core metadata (from Hyrax) is required
- [x] prevent profile from saving (thus crashing the app) when bad data exists


# NOTES

We considered turning houndstooth into a gem, however we decided to hold off for now. There's a ticket to revisit this topic at a later date: 
- https://github.com/notch8/hykuup_knapsack/issues/409
- samvera community convo is happening [here](https://samvera.slack.com/archives/C0X9STKSP/p1752619285458939)