### PR TITLE
:bug: rescue google permission denied error

### DIFF
--- a/app/models/concerns/account_settings.rb
+++ b/app/models/concerns/account_settings.rb
@@ -75,6 +75,8 @@ module AccountSettings
 
   # rubocop:disable Metrics/BlockLength
   class_methods do
+    # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/AbcSize
     def setting(name, args)
       known_type = ['array', 'boolean', 'hash', 'string', 'json_editor'].include?(args[:type])
       raise "Setting type #{args[:type]} is not supported. Can not laod." unless known_type
@@ -86,12 +88,17 @@ module AccountSettings
       # watch out because false is a valid value to return here
       define_method(name) do
         value = super()
+        if name == :analytics_reporting || name == :analytics
+          return value.nil? ? args[:default] : set_type(value, (args[:type]).to_s)
+        end
         value = value.nil? ? ENV.fetch("HYKU_#{name.upcase}", nil) : value
         value = value.nil? ? ENV.fetch("HYRAX_#{name.upcase}", nil) : value
         value = value.nil? ? ENV.fetch(name.upcase.to_s, nil) : value
         value = value.nil? ? args[:default] : value
         set_type(value, (args[:type]).to_s)
       end
+      # rubocop:enable Metrics/AbcSize
+      # rubocop:enable Metrics/MethodLength
     end
 
     # rubocop:disable Metrics/MethodLength

--- a/app/views/hyrax/dashboard/_user_activity.html.erb
+++ b/app/views/hyrax/dashboard/_user_activity.html.erb
@@ -1,0 +1,46 @@
+<%# OVERRIDE Hyraxv5.0.5 to handle analytics errors gracefully and respect tenant settings %>
+<div class="card">
+  <div class="card-header">
+    <%= t('.title') %>
+  </div>
+  <div class="card-body d-flex justify-content-center">
+  <% if current_account.analytics_reporting %>
+    <%
+      # Set default date range if not provided
+      @start_date ||= 30.days.ago.to_date
+      @end_date ||= Time.zone.today
+    %>
+    <% begin %>
+      <%= render 'hyrax/dashboard/user_activity_graph' %>
+
+      <!-- FIXME: This is like embedded a card in a card...seems odd -->
+      <div class="col-md-3">
+        <div class="card">
+          <div class="card-header">
+            <h2 class="card-title text-center"><%= t('.user_summary') %></h2>
+          </div>
+          <div class="card-body text-center">
+            <p><%= t('.registered_users') %>: <%= @presenter.user_count(@start_date.to_date, @end_date.to_date) %></p>
+            <p><%= t('.new_visitors') %>: <%= Hyrax::Analytics.new_visitors('range', "#{@start_date},#{@end_date}") %></p>
+            <p><%= t('.returning_visitors') %>: <%= Hyrax::Analytics.returning_visitors('range', "#{@start_date},#{@end_date}") %></p>
+            <p><%= t('.total_visitors') %>: <%= Hyrax::Analytics.total_visitors('range', "#{@start_date},#{@end_date}") %></p>
+          </div>
+        </div>
+      </div>
+    <% rescue Google::Cloud::PermissionDeniedError %>
+      <div class="alert alert-warning" role="alert">
+        <h4><i class="fa fa-exclamation-triangle"></i> Google Analytics Error</h4>
+        <p>There was a problem retrieving analytics data from Google. The service account does not have sufficient permissions for this property.</p>
+        <p>Please contact your administrator to resolve this issue. They will need to grant the service account 'Viewer' permissions on the Google Analytics property.</p>
+      </div>
+    <% rescue StandardError => e %>
+      <% Rails.logger.error("Dashboard analytics render error: #{e.class}: #{e.message}\n#{e.backtrace.first(5).join("\n")}") %>
+      <div class="alert alert-danger" role="alert">
+        <h4><i class="fa fa-exclamation-triangle"></i> Analytics Unavailable</h4>
+        <p>There was an unexpected problem retrieving analytics data.</p>
+        <p>Please contact your administrator to resolve this issue.</p>
+      </div>
+    <% end %>
+    <% end %>
+  </div>
+</div>


### PR DESCRIPTION
New tenants had analytics turned on by defaut when the global env variable was set. It should be set to false on a tenant level by default regardless if of the ENV var.

<details>

## BEFORE

Error present in demo.hykudemo.org reproduced locally:

<img width="678" height="347" alt="image" src="https://github.com/user-attachments/assets/2494fd2e-e7f3-45bf-a1eb-c79f01cf3889" />







## AFTER



<img width="1341" height="928" alt="image" src="https://github.com/user-attachments/assets/d84a8333-641a-440a-a962-cf9d361888dc" />

</details>

Additionally, when a tenant added configs that the site admin hasn't added as a service account to their Google Analytics, a Google::Cloud::PermissionDeniedError would break the site. This override will gracefully handle it by displaying an error on the dashboard.

# BEFORE

<img width="1028" height="715" alt="Screenshot 2025-07-18 at 1 45 19 PM" src="https://github.com/user-attachments/assets/f9b0dc95-b48e-488d-ae6a-8c4d6ab4a6f7" />



# AFTER

<img width="1921" height="873" alt="image" src="https://github.com/user-attachments/assets/5a3c3a06-0915-41c8-b58a-61331d0ee317" />

