### PR TITLE
⬆️ Update IIIF Print gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -766,7 +766,7 @@ GEM
       json
     iiif_manifest (1.3.1)
       activesupport (>= 4)
-    iiif_print (3.0.5)
+    iiif_print (3.0.6)
       blacklight_iiif_search (>= 1.0, < 3.0)
       derivative-rodeo (~> 0.5)
       hyrax (>= 2.5, < 6)


### PR DESCRIPTION
This commit will update IIIF Print for a patch fix for models that does not include IiifPrint.model_configuration.

Ref:
- https://github.com/notch8/iiif_print/commit/d703dab73fe556807c2d495d06b70d3b6f6c71e9
