### PR TITLE
update-redis-in-deploys

### DIFF
--- a/ops/demo-deploy.tmpl.yaml
+++ b/ops/demo-deploy.tmpl.yaml
@@ -110,7 +110,7 @@ extraEnvVars: &envVars
   - name: PASSENGER_APP_ENV
     value: production
   - name: RAILS_CACHE_STORE_URL
-    value: redis://:staging@hyku-demo-redis-master:6379/0
+    value: redis://:$REDIS_PASSWORD@hyku-demo-redis-master:6379/0
   - name: RAILS_ENV
     value: production
   - name: RAILS_LOG_TO_STDOUT
@@ -122,7 +122,7 @@ extraEnvVars: &envVars
   - name: REDIS_HOST
     value: hyku-demo-redis-master
   - name: REDIS_URL
-    value: redis://:staging@hyku-demo-redis-master:6379/0
+    value: redis://:$REDIS_PASSWORD@hyku-demo-redis-master:6379/0
   - name: HYRAX_ACTIVE_JOB_QUEUE
     value: good_job
   - name: HYKU_BULKRAX_ENABLED
@@ -229,7 +229,7 @@ redis:
   enabled: true
   architecture: standalone
   auth:
-    password: staging
+    password: $REDIS_PASSWORD
 
 solr:
   enabled: false

--- a/ops/iiif-deploy.tmpl.yaml
+++ b/ops/iiif-deploy.tmpl.yaml
@@ -102,7 +102,7 @@ extraEnvVars: &envVars
   - name: PASSENGER_APP_ENV
     value: production
   - name: RAILS_CACHE_STORE_URL
-    value: redis://:staging@hyku-iiif-redis-master:6379/iiif
+    value: redis://:$REDIS_PASSWORD@hyku-iiif-redis-master:6379/0
   - name: RAILS_ENV
     value: production
   - name: RAILS_LOG_TO_STDOUT
@@ -114,7 +114,7 @@ extraEnvVars: &envVars
   - name: REDIS_HOST
     value: hyku-iiif-redis-master
   - name: REDIS_URL
-    value: redis://:staging@hyku-iiif-redis-master:6379/iiif
+    value: redis://:$REDIS_PASSWORD@hyku-iiif-redis-master:6379/0
   - name: HYRAX_ACTIVE_JOB_QUEUE
     value: good_job
   - name: HYKU_BULKRAX_ENABLED
@@ -203,9 +203,10 @@ fcrepo:
 postgresql:
   enabled: false
 redis:
-  cluster:
-    enabled: false
-  password: staging
+  enabled: true
+  architecture: standalone
+  auth:
+    password: $REDIS_PASSWORD
 solr:
   enabled: false
 

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -106,7 +106,7 @@ extraEnvVars: &envVars
   - name: PASSENGER_APP_ENV
     value: production
   - name: RAILS_CACHE_STORE_URL
-    value: redis://:mysecret@hyku-staging-redis-master:6379/0
+    value: redis://:$REDIS_PASSWORD@hyku-staging-redis-master:6379/0
   - name: RAILS_ENV
     value: production
   - name: RAILS_LOG_TO_STDOUT
@@ -118,7 +118,7 @@ extraEnvVars: &envVars
   - name: REDIS_HOST
     value: hyku-staging-redis-master
   - name: REDIS_URL
-    value: redis://:mysecret@hyku-staging-redis-master:6379/0
+    value: redis://:$REDIS_PASSWORD@hyku-staging-redis-master:6379/0
   - name: HYRAX_ACTIVE_JOB_QUEUE
     value: good_job
   - name: HYKU_BULKRAX_ENABLED
@@ -222,7 +222,7 @@ redis:
   enabled: true
   architecture: standalone
   auth:
-    password: staging
+    password: $REDIS_PASSWORD
 solr:
   enabled: false
 


### PR DESCRIPTION
Use Redis URL from secret env var

This PR updates the Redis configuration to use the Redis URL stored in a GitHub Actions secret, instead of hardcoding the password or including it in plaintext anywhere in the codebase.

This change resolves authentication issues caused by Redis rejecting invalid or missing credentials during application startup:

```
Redis::CommandError: WRONGPASS invalid username-password pair or user is disabled
```

By using the environment variable, we ensure secure and flexible deployment configuration, especially when working with environments that use Redis ACLs or password protection.

Changes proposed in this pull request:
* Use `ENV['REDIS_URL']` for Redis connection string
* Remove hardcoded Redis credentials, if any
* Support secure and configurable deployments

```ruby
# config/initializers/redis.rb or equivalent
Redis.current = Redis.new(url: ENV.fetch('REDIS_URL'))
```

> The `REDIS_URL` secret has already been added to GitHub

@samvera/hyku-code-reviewers
