### PR TITLE
I429 profile defines available work types

### DIFF
--- a/app/controllers/admin/work_types_controller.rb
+++ b/app/controllers/admin/work_types_controller.rb
@@ -10,15 +10,22 @@ module Admin
 
     def edit
       site
+      setup_profile_work_types if Hyrax.config.flexible?
     end
 
     def update
-      site.available_works = params[:available_works]
+      # Filter out work types not in profile when flexible metadata is enabled
+      available_works = params[:available_works] || []
+      available_works = filter_by_profile(available_works) if Hyrax.config.flexible?
+
+      site.available_works = available_works
       if site.save
         flash[:notice] = "Work types have been successfully updated"
       else
         flash[:error] = "Work types were not updated"
       end
+
+      setup_profile_work_types if Hyrax.config.flexible?
       render action: "edit"
     end
 
@@ -26,6 +33,29 @@ module Admin
 
     def site
       @site ||= Site.first
+    end
+
+    def setup_profile_work_types
+      return unless Hyrax.config.flexible?
+
+      profile = Hyrax::FlexibleSchema.current_version
+      return unless profile
+
+      profile_classes = profile['classes']&.keys || []
+      @profile_work_types = profile_classes.map { |klass| klass.gsub(/Resource$/, '') } & Hyrax.config.registered_curation_concern_types
+    end
+
+    def filter_by_profile(available_works)
+      return available_works unless Hyrax.config.flexible?
+
+      profile = Hyrax::FlexibleSchema.current_version
+      return available_works unless profile
+
+      profile_classes = profile['classes']&.keys || []
+      profile_work_types = profile_classes.map { |klass| klass.gsub(/Resource$/, '') } & Hyrax.config.registered_curation_concern_types
+
+      # Only allow work types that are in the profile
+      available_works & profile_work_types
     end
   end
 end

--- a/app/services/hyrax/flexible_schema_validator_service.rb
+++ b/app/services/hyrax/flexible_schema_validator_service.rb
@@ -37,7 +37,6 @@ module Hyrax
       validate_available_on_classes_defined
       validate_schema
       validate_label_prop
-      validate_enabled_work_types
       CoreMetadataValidator.new(profile: profile, errors: @errors).validate!
     end
 
@@ -56,25 +55,6 @@ module Hyrax
     end
 
     private
-
-    # Validates that the profile's work types correspond to the site's
-    # enabled work types, adding human-readable error messages for any
-    # discrepancies.
-    #
-    # @return [void]
-    def validate_enabled_work_types
-      enabled_work_types = Site.instance.available_works
-      all_work_types = Hyrax.config.registered_curation_concern_types
-      profile_work_types = profile['classes'].keys.map { |klass| klass.gsub(/Resource$/, '') } & all_work_types
-
-      missing_from_profile = enabled_work_types - profile_work_types
-      @errors << "Enabled work types not in profile: #{missing_from_profile.join(', ')}." if missing_from_profile.any?
-
-      not_enabled_in_site = profile_work_types - enabled_work_types
-      return if not_enabled_in_site.empty?
-
-      @errors << "Profile includes work types that are not enabled: #{not_enabled_in_site.join(', ')}."
-    end
 
     # Runs JSON schema validation and translates resulting errors into
     # user-friendly messages appended to {#errors}.

--- a/app/views/admin/work_types/edit.html.erb
+++ b/app/views/admin/work_types/edit.html.erb
@@ -2,14 +2,47 @@
   <h1><span class="fa fa-address-book"></span> <%= t('hyku.admin.work_types') %></h1>
 <% end %>
 
+<% 
+  # Check if there are any work types that will be disabled (not in profile)
+  has_disabled_work_types = false
+  if Hyrax.config.flexible? && @profile_work_types
+    has_disabled_work_types = Hyrax.config.registered_curation_concern_types.any? do |type|
+      !@profile_work_types.include?(type)
+    end
+  end
+%>
+
+<% if has_disabled_work_types %>
+  <div class="alert alert-info" role="alert">
+    <strong>Note:</strong> Work types grayed out below are not included in the current metadata profile. 
+    To enable them, please add them to your metadata profile first.
+  </div>
+<% end %>
+
 <div class="card">
   <div class="card-body">
     <%= simple_form_for @site, url: '/admin/work_types' do |f| %>
       <% Hyrax.config.registered_curation_concern_types.each do |type| %>
-        <div class="form-check">
+        <% 
+          is_in_profile = !Hyrax.config.flexible? || @profile_work_types&.include?(type)
+          is_checked = @site.available_works&.include?(type)
+          is_disabled = Hyrax.config.flexible? && !is_in_profile
+        %>
+        <div class="form-check <%= 'text-muted' if is_disabled %>">
           <label class="form-check-label" for="input-<%= type %>">
-            <input class="form-check-input" type="checkbox" value="<%= type %>" id="input-<%= type %>" name="available_works[]" <%= 'checked' if @site.available_works&.include?(type) %>>
+            <input 
+              class="form-check-input" 
+              type="checkbox" 
+              value="<%= type %>" 
+              id="input-<%= type %>" 
+              name="available_works[]" 
+              <%= 'checked' if is_checked %>
+              <%= 'disabled' if is_disabled %>
+            >
             <span><%= type %></span>
+            <% if is_disabled %>
+              <small class="text-muted d-block">Not included in metadata profile</small>
+            <% end %>
           </label>
         </div>
       <% end %>

--- a/spec/services/hyrax/flexible_schema_validator_service_spec.rb
+++ b/spec/services/hyrax/flexible_schema_validator_service_spec.rb
@@ -109,34 +109,6 @@ RSpec.describe Hyrax::FlexibleSchemaValidatorService do
       end
     end
 
-    context 'when an enabled work type is not in the profile' do
-      let(:site) { Site.create(available_works: ['GenericWork', 'OerResource']) }
-
-      before do
-        allow(Site).to receive(:instance).and_return(site)
-
-        profile['classes'].delete('OerResource')
-        service.validate!
-      end
-
-      it 'is invalid' do
-        expect(service.errors).to include('Enabled work types not in profile: OerResource.')
-      end
-    end
-
-    context 'when a work type in the profile is not enabled' do
-      let(:site) { Site.create(available_works: ['GenericWork']) }
-
-      before do
-        allow(Site).to receive(:instance).and_return(site)
-        service.validate!
-      end
-
-      it 'is invalid' do
-        expect(service.errors).to include('Profile includes work types that are not enabled: Image, Etd, Oer.')
-      end
-    end
-
     context 'when a property references a class not defined in the classes section' do
       before do
         # Remove a valid class definition but leave references in `available_on`


### PR DESCRIPTION
Issue: 
- https://github.com/notch8/hykuup_knapsack/issues/429

<img width="1009" height="164" alt="image" src="https://github.com/user-attachments/assets/9123ae64-b7f7-4fa9-9a18-5ca7780c1203" />

This will prevent users from being able to create works from work types that haven't been defined in their metadata profiles, when Hyrax.config.flexible? is true

Previously, users could upload a profile without defining the class then enable that work type in "available work types". If the user then tried to create a work error (because it wasn't defined in the profile). 

<img width="1351" height="634" alt="image" src="https://github.com/user-attachments/assets/c293ca10-f11e-4dde-972a-2e198ce0a647" />



## Import a metadata without GenericWorkResource defined: 

[m3_profile.yaml.zip](https://github.com/user-attachments/files/21418324/m3_profile.yaml.zip)


### When HYRAX_FLEXIBLE = false


<img width="2704" height="1461" alt="Screenshot 2025-07-24 at 11-42-19 Edit Work Type __ Hyku" src="https://github.com/user-attachments/assets/e914d40d-955d-4ede-a740-4ba8673c4005" />


## WHEN HYRAX_FLEXIBLE = true

<img width="2704" height="1461" alt="Screenshot 2025-07-24 at 11-06-24 Edit Work Type __ Hyku" src="https://github.com/user-attachments/assets/5d18c0b9-4246-403f-8fc7-f20c1f35ad91" />



<img width="2704" height="1461" alt="Screenshot 2025-07-24 at 11-09-48 Works" src="https://github.com/user-attachments/assets/716e6cb4-0b45-4bcf-996a-3b6870fcf80f" />
