### PR TITLE
Handles error gracefully when worktype isn't configured

### DIFF
--- a/app/factories/bulkrax/object_factory_interface_decorator.rb
+++ b/app/factories/bulkrax/object_factory_interface_decorator.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# TODO: remove when issue https://github.com/notch8/hykuup_knapsack/issues/387 has been addressed and updated into this repo
+
 module Bulkrax
   module ObjectFactoryInterfaceDecorator
     # Perform a work-type sanity check before the factory creates/updates the

--- a/app/factories/bulkrax/object_factory_interface_decorator.rb
+++ b/app/factories/bulkrax/object_factory_interface_decorator.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Bulkrax
+  module ObjectFactoryInterfaceDecorator
+    # Perform a work-type sanity check before the factory creates/updates the
+    # object.  Any failure is rescued by Bulkrax and recorded on the Entry.
+    def run(&block)
+      validate_work_type!(klass)
+      super(&block)
+    end
+
+    private
+
+    # Ensure the supplied work type is defined in the flexible-schema profile
+    # (when enabled) and allowed for the current tenant.
+    #
+    # @param work_type [Class] the Valkyrie/ActiveFedora work class
+    # @raise [StandardError] when the work type is invalid for the profile or tenant
+    def validate_work_type!(work_type)
+      full_name = work_type.to_s                   # e.g. "GenericWorkResource"
+      base_name = full_name.gsub(/Resource$/, '')  # e.g. "GenericWork"
+
+      # 1) Profile validation (only when Flexible Metadata is active)
+      if Hyrax.config.flexible?
+        profile = Hyrax::FlexibleSchema.current_version
+        if profile
+          profile_classes    = profile.dig('classes')&.keys || []
+          profile_work_types = profile_classes.map { |klass| klass.gsub(/Resource$/, '') }
+
+          unless profile_work_types.include?(base_name)
+            raise StandardError,
+                  "Work type '#{full_name}' is not defined in the current metadata profile. " \
+                  'Please add it to the profile.'
+          end
+        end
+      end
+
+      # 2) Tenant validation (must be listed in Site.available_works)
+      unless Site.instance.available_works.include?(full_name) ||
+             Site.instance.available_works.include?(base_name)
+        raise StandardError,
+              "Work type '#{full_name}' is not enabled for this tenant. " \
+              "Please enable it via the 'Available Work Types' setting of the Admin Dashboard."
+      end
+    end
+  end
+end
+
+::Bulkrax::ObjectFactoryInterface.prepend(Bulkrax::ObjectFactoryInterfaceDecorator)


### PR DESCRIPTION
# Summary

I thought about putting this in bulkrax directly, however I don't think it should know about the concept of flexible metadata in Hyrax. 

When a user includes a work type that is either not in their metadata profile, or it is but it's not enabled, Bulkrax will report a more helpful error than a NoMethodError. 

## Steps to reproduce: 

Upload a profile that doesn't have GenericWorkResource defined.
Import this zip with bulkrax's csv parser


[Archive(1).zip](https://github.com/user-attachments/files/21436270/Archive.1.zip)

# BEFORE: 



<img width="2082" height="556" alt="image" src="https://github.com/user-attachments/assets/c2c906c7-9e2e-4a84-8478-5424f9f27578" />



# AFTER: 

### when not defined in profile

<details>

<img width="2704" height="1461" alt="image" src="https://github.com/user-attachments/assets/272a4e38-ff27-4c09-8108-c034c05520f8" />

</details>

### when on the profile but not enabled in available_works

<details> 
<img width="631" height="268" alt="image" src="https://github.com/user-attachments/assets/7fb6eec3-ae42-4fdb-af94-fbf52f02a625" />

<img width="2704" height="1461" alt="image" src="https://github.com/user-attachments/assets/8da18733-2644-47e1-bfb5-36501518cc63" />

</details> 



