### PR TITLE
🐛 A/V was not loading correctly

### DIFF
--- a/app/presenters/concerns/hyrax/iiif_av/displays_content_decorator.rb
+++ b/app/presenters/concerns/hyrax/iiif_av/displays_content_decorator.rb
@@ -47,7 +47,7 @@ module Hyrax
           streams.collect { |label, url| video_display_content(url, label) }
         else
           Hyku::Application.iiif_video_labels_and_mime_types.map do |label, mime_type|
-            url = Hyku::Application.iiif_video_url_builder.call(document: solr_document, label:, host: request.base_url)
+            url = Hyku::Application.iiif_av_url_builder.call(document: solr_document, label:, host: request.base_url, mime_type:)
             video_display_content(url, label, mime_type:)
           end
         end
@@ -78,7 +78,7 @@ module Hyrax
           streams.collect { |label, url| audio_display_content(url, label) }
         else
           Hyku::Application.iiif_audio_labels_and_mime_types.map do |label, mime_type|
-            url = Hyku::Application.iiif_audio_url_builder.call(document: solr_document, label:, host: request.base_url)
+            url = Hyku::Application.iiif_av_url_builder.call(document: solr_document, label:, host: request.base_url, mime_type:)
             audio_display_content(url, label, mime_type:)
           end
         end

--- a/config/application.rb
+++ b/config/application.rb
@@ -177,53 +177,39 @@ module Hyku
     # @!attribute iiif_video_labels_and_mime_types [r|w]
     #   @see Hyrax::IiifAv::DisplaysContentDecorator
     #   @return [Hash<String,String>] Hash of valid video labels and their mime types.
-    class_attribute :iiif_video_labels_and_mime_types, default: { "mp4" => "video/mpeg", "webm" => "audio/webm" }
+    class_attribute :iiif_video_labels_and_mime_types, default: { "mp4" => "video/mp4" }
 
     ##
-    # @!attribute iiif_video_url_builder [r|w]
+    # @!attribute iiif_av_url_builder [r|w]
     #   @param document [SolrDocument]
-    #   @param label [String]
+    #   @param label [String] the file extension
     #   @param host [String] (e.g. samvera.org)
+    #   @param mime_type [String] the MIME type of the audio/video file
     #   @return [String] the fully qualified URL.
     #   @see Hyrax::IiifAv::DisplaysContentDecorator
     #
     #   @example
-    #     # The below example will build a URL that will download directly from Hyrax as the
-    #     # video resource.  This is a hack to address the processing times of video derivatives;
-    #     # namely in certain setups/configurations of Hyku, video processing is laggy—as in days.
+    #     # The below example will build a URL that downloads directly from Hyrax as the
+    #     # audio/video resource using the standard downloads controller. This approach uses
+    #     # the file parameter to specify the desired format and includes the mime_type
+    #     # for proper content handling.
     #     #
-    #     # The draw back of using this method is that we're pointing to the original video file.
-    #     # This is acceptable if the original file has already been processed out of band (e.g.
-    #     # before uploading to Hyku/Hyrax).  When we're dealing with a raw video, this is likely
-    #     # not ideal for streaming.
-    #     Hyrax::IiifAv::DisplaysContent.iiif_video_url_builder = ->(document:, label:, host:) do
-    #       Hyrax::Engine.routes.url_helpers.download_url(document, host:, protocol: 'https')
+    #     # This method points to the original or processed audio/video file via Hyrax's
+    #     # download endpoint, which can handle format conversion and streaming as
+    #     # configured in the downloads controller.
+    #     Hyrax::IiifAv::DisplaysContent.iiif_audio_url_builder = ->(document:, label:, host:, mime_type:) do
+    #       Hyrax::Engine.routes.url_helpers.download_url(document.id, host:, file: label, mime_type:)
     #     end
-    class_attribute :iiif_video_url_builder,
-                    default: ->(document:, label:, host:) { Hyrax::IiifAv::Engine.routes.url_helpers.iiif_av_content_url(document.id, label:, host:) }
-
-    ##
-    # @!attribute iiif_audio_url_builder [r|w]
-    #   @param document [SolrDocument]
-    #   @param label [String]
-    #   @param host [String] (e.g. samvera.org)
-    #   @return [String] the fully qualified URL.
-    #   @see Hyrax::IiifAv::DisplaysContentDecorator
+    #     Hyrax::IiifAv::DisplaysContent.iiif_video_url_builder = ->(document:, label:, host:, mime_type:) do
+    #       Hyrax::Engine.routes.url_helpers.download_url(document.id, host:, file: label, mime_type:)
+    #     end
     #
-    #   @example
-    #     # The below example will build a URL that will download directly from Hyrax as the
-    #     # audio resource.  This is a hack to address the processing times of audio derivatives;
-    #     # namely in certain setups/configurations of Hyku, audio processing is laggy.
-    #     #
-    #     # The draw back of using this method is that we're pointing to the original audio file.
-    #     # This is acceptable if the original file has already been processed out of band (e.g.
-    #     # before uploading to Hyku/Hyrax).  When we're dealing with a raw audio, this may not
-    #     # be ideal for streaming.
-    #     Hyrax::IiifAv::DisplaysContent.iiif_audio_url_builder = ->(document:, label:, host:) do
-    #       Hyrax::Engine.routes.url_helpers.download_url(document, host:, protocol: 'https')
-    #     end
-    class_attribute :iiif_audio_url_builder,
-                    default: ->(document:, label:, host:) { Hyrax::IiifAv::Engine.routes.url_helpers.iiif_av_content_url(document.id, label:, host:) }
+    #   @see Hyrax::IiifAv::DisplaysContentDecorator#video_content
+    #   @see Hyrax::IiifAv::DisplaysContentDecorator#audio_content
+    class_attribute :iiif_av_url_builder,
+                    default: lambda { |document:, label:, host:, mime_type:|
+                      Hyrax::Engine.routes.url_helpers.download_url(document.id, host:, file: label, mime_type:)
+                    }
     # @!endgroup Class Attributes
 
     # Add this line to load the lib folder first because we need

--- a/spec/config/application_spec.rb
+++ b/spec/config/application_spec.rb
@@ -35,13 +35,8 @@ RSpec.describe Hyku::Application do
     it { is_expected.to be_a(Hash) }
   end
 
-  describe '.iiif_video_url_builder' do
-    subject { described_class.iiif_video_url_builder }
-    it { is_expected.to be_a(Proc) }
-  end
-
-  describe '.iiif_audio_url_builder' do
-    subject { described_class.iiif_audio_url_builder }
+  describe '.iiif_av_url_builder' do
+    subject { described_class.iiif_av_url_builder }
     it { is_expected.to be_a(Proc) }
   end
 


### PR DESCRIPTION
Hyrax changed the way derivatives are retrieved for audio and video resources which was not compatible with the way Hyku generates IIIF manifest urls.  This commit will simplify the code by using one av url generator instead of separate ones for audio and video and pass the mime_type in.

Ref
- https://github.com/notch8/hykuup_knapsack/issues/389
- https://github.com/samvera/hyrax/pull/6297

## Audio
<img width="1728" height="1037" alt="image" src="https://github.com/user-attachments/assets/5335ff3b-f7d1-486d-af0e-1b56e4776264" />


## Video
<img width="1728" height="1034" alt="image" src="https://github.com/user-attachments/assets/9e20a813-ca72-478f-8148-f99083902d2a" />
