### PR TITLE
🎁 Prevents removal of classes that have already-persisted records

### DIFF
--- a/app/services/hyrax/flexible_schema_validators/class_validator.rb
+++ b/app/services/hyrax/flexible_schema_validators/class_validator.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module FlexibleSchemaValidators
+    # Handles class-related validations for flexible metadata profiles
+    class ClassValidator
+      def initialize(profile, required_classes, errors)
+        @profile = profile
+        @required_classes = required_classes
+        @errors = errors
+      end
+
+      # Checks that any class referenced in the profile is a registered
+      # Hyrax curation concern type.
+      def validate_availability!
+        profile_classes = @profile['classes'].keys
+        properties = @profile['properties']
+        available_on_classes = properties.keys.flat_map do |key|
+          properties[key].fetch('available_on', nil)&.fetch('class', nil)
+        end.compact.uniq
+
+        combined_classes = profile_classes + available_on_classes
+        unique_classes = combined_classes.uniq
+        filtered_classes = unique_classes - @required_classes
+        classes = filtered_classes.map { |klass| klass.gsub(/(?<=.)Resource$/, '') }
+
+        invalid_classes = classes.filter_map do |klass|
+          klass unless Hyrax.config.registered_curation_concern_types.include?(klass)
+        end
+
+        return if invalid_classes.empty?
+
+        @errors << "Invalid classes: #{invalid_classes.join(', ')}."
+      end
+
+      # Validates that every class referenced under `available_on.class` is also
+      # defined in the profile's top-level `classes` section.
+      def validate_references!
+        properties = @profile['properties'] || {}
+
+        referenced_classes = properties.values.flat_map do |prop|
+          prop.dig('available_on', 'class')
+        end.compact.uniq
+
+        undefined_classes = referenced_classes - @profile['classes'].keys
+
+        return if undefined_classes.empty?
+
+        @errors << "Classes referenced in `available_on` but not defined in `classes`: #{undefined_classes.join(', ')}."
+      end
+
+      # Validates that classes with existing records in the repository are not removed from the profile.
+      def validate_existing_records!
+        classes_to_check = potential_existing_classes - @profile['classes'].keys
+        classes_with_records = []
+
+        classes_to_check.each do |class_name|
+          model_class = resolve_model_class(class_name)
+          next unless model_class
+
+          begin
+            count = Hyrax.query_service.count_all_of_model(model: model_class)
+            classes_with_records << class_name if count.positive?
+          rescue StandardError => e
+            Rails.logger.error "Error checking records for #{class_name}: #{e.message}"
+          end
+        end
+
+        return if classes_with_records.empty?
+
+        @errors << "Classes with existing records cannot be removed from the profile: #{classes_with_records.join(', ')}."
+      end
+
+      private
+
+      # Returns classes that could potentially have existing records
+      # @return [Array<String>] Class names in profile format
+      def potential_existing_classes
+        classes = @required_classes.dup
+
+        Hyrax.config.registered_curation_concern_types.each do |concern_type|
+          classes << "#{concern_type.capitalize}Resource"
+        end
+
+        classes.uniq
+      end
+
+      # Resolves a profile class name to its actual model class
+      # @param class_name [String] Class name in profile format (e.g., 'GenericWorkResource')
+      # @return [Class, nil] The resolved model class or nil if not found
+      def resolve_model_class(class_name)
+        return Hyrax.config.file_set_model.constantize if class_name == 'Hyrax::FileSet'
+        return Hyrax.config.admin_set_model.constantize if class_name == Hyrax.config.admin_set_model
+        return Hyrax.config.collection_model.constantize if class_name == Hyrax.config.collection_model
+
+        begin
+          class_name.constantize
+        rescue NameError
+          base_name = class_name.gsub(/Resource$/, '')
+          begin
+            base_name.constantize
+          rescue NameError
+            Rails.logger.warn "Could not resolve model class for: #{class_name}"
+            nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/hyrax/flexible_schema_validators/schema_validator.rb
+++ b/app/services/hyrax/flexible_schema_validators/schema_validator.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module FlexibleSchemaValidators
+    # Handles JSON schema validation for flexible metadata profiles
+    class SchemaValidator
+      def initialize(schemer, profile, errors)
+        @schemer = schemer
+        @profile = profile
+        @errors = errors
+      end
+
+      def validate!
+        @schemer.validate(@profile).to_a&.each do |error|
+          pointer = error['data_pointer']
+          type = error['type']
+
+          if pointer.end_with?('/available_on') && error['data'].nil? && type == 'object'
+            @errors << "Schema error at `#{pointer}`: `available_on` cannot be empty and must have a `class` or `context` sub-property."
+          elsif type == 'required'
+            missing_keys = error.dig('details', 'missing_keys')&.join("', '")
+            @errors << "Schema error at `#{pointer}`: Missing required properties: '#{missing_keys}'."
+          else
+            @errors << "Schema error at `#{pointer}`: Invalid value `#{error['data'].inspect}` for type `#{type}`."
+          end
+        end
+      end
+
+      private
+
+      attr_reader :schemer, :profile, :errors
+    end
+  end
+end

--- a/spec/services/hyrax/flexible_schema_validator_service_spec.rb
+++ b/spec/services/hyrax/flexible_schema_validator_service_spec.rb
@@ -122,5 +122,25 @@ RSpec.describe Hyrax::FlexibleSchemaValidatorService do
         )
       end
     end
+    context 'when the repository already contains records of a class the profile removes' do
+      before do
+        allow(Hyrax.query_service).to receive(:count_all_of_model).and_return(0)
+        allow(Hyrax.query_service).to receive(:count_all_of_model)
+          .with(model: ImageResource).and_return(1)
+
+        profile['classes'].delete('ImageResource')
+        profile['properties'].each_value do |prop_details|
+          prop_details.dig('available_on', 'class')&.delete('ImageResource')
+        end
+
+        service.validate!
+      end
+
+      it 'is invalid' do
+        expect(service.errors).to include(
+          'Classes with existing records cannot be removed from the profile: ImageResource.'
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
## Acceptance Criteria

- [ ] System prevents the removal of a work type from the flexible schema if there are already records of that type in the repository.

<img width="2704" height="1461" alt="Screenshot 2025-07-27 at 08-41-39 Metadata Profiles" src="https://github.com/user-attachments/assets/3b8061c6-77d9-4eb9-a77d-25f85a46267c" />

## Testing Instructions: 

Start with Hyku's default profile.
Create ImageResource works then try uploading the following profile

[no-image.yaml.zip](https://github.com/user-attachments/files/21454859/no-image.yaml.zip)
