### PR TITLE
Fixes deposit a new work through collection

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,7 +141,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: 16664b8c660a91032761869b7cda6737c51aaa13
+  revision: 8d3fe92924898378247eb0a4ebfa617d48d8dd91
   branch: 5.0-flexible
   specs:
     hyrax (5.0.5)


### PR DESCRIPTION
### Fixes
Updates Hyrax to bring in fix https://github.com/samvera/hyrax/pull/7147
Resolves https://github.com/notch8/hykuup_knapsack/issues/434 for hyku.

### Summary

Fixes depositing a work into a collection from the collection show page error.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Display a collection from the dashboard list
* Click `Deposit new work through this collection`
* Select admin set appears on the modal popup, and work can be created normally.

### Type of change (for release notes)

notes-bugfix

### Detailed Description

Depositing a work into a collection from the collection show page has been broken because the admin sets for selection were not being loaded. This caused the javascript to return "undefined" when trying to find the admin set, and caused the Hyrax.query_service.find to fail trying to find the admin set.

<details>
<summary>Video</summary>

[recorded (17).webm](https://github.com/user-attachments/assets/801d6f59-c638-4248-a2c8-3908028bde9c)

</details>
@samvera/hyrax-code-reviewers

