### PR TITLE
:bug: available works bug fix when flexible? is false

### DIFF
--- a/spec/services/hyrax/quick_classification_query_decorator_spec.rb
+++ b/spec/services/hyrax/quick_classification_query_decorator_spec.rb
@@ -3,23 +3,74 @@
 RSpec.describe Hyrax::QuickClassificationQuery, type: :decorator do
   subject { described_class.new(user) }
 
-  let(:site) { create(:site, available_works:) }
+  let(:site) { create(:site, available_works: available_works) }
   let(:user) { create(:user) }
   let(:available_works) { ['GenericWork', 'Image', 'SomeOtherWork'] }
 
   before do
+    allow(Site).to receive(:instance).and_return(site)
     allow(site).to receive(:available_works).and_return(available_works)
   end
 
   describe '#initialize' do
-    it 'uses Site.instance.available_works instead of Hyrax.config.registered_curation_concern_types' do
-      expect(subject.instance_variable_get(:@models)).to eq available_works
+    context 'when flexible metadata is disabled' do
+      before do
+        allow(Hyrax.config).to receive(:flexible?).and_return(false)
+      end
+
+      it 'uses Site.instance.available_works instead of Hyrax.config.registered_curation_concern_types' do
+        expect(subject.instance_variable_get(:@models)).to eq available_works
+      end
+    end
+
+    context 'when flexible metadata is enabled' do
+      let(:profile) { { 'classes' => { 'GenericWorkResource' => {}, 'ImageResource' => {} } } }
+
+      before do
+        allow(Hyrax.config).to receive(:flexible?).and_return(true)
+        allow(Hyrax::FlexibleSchema).to receive(:current_version).and_return(profile)
+        allow(Hyrax.config).to receive(:registered_curation_concern_types).and_return(['GenericWork', 'Image', 'Video'])
+      end
+
+      it 'filters available works based on both site settings and metadata profile' do
+        # Should include only works that are in both available_works and profile
+        expect(subject.instance_variable_get(:@models)).to eq(['GenericWork', 'Image'])
+      end
+
+      context 'when profile is nil' do
+        let(:profile) { nil }
+
+        it 'falls back to using Site.instance.available_works' do
+          expect(subject.instance_variable_get(:@models)).to eq available_works
+        end
+      end
     end
   end
 
   describe '#all?' do
-    it 'uses Site.instance.available_works instead of Hyrax.config.registered_curation_concern_types' do
-      expect(subject.all?).to eq true
+    context 'when flexible metadata is disabled' do
+      before do
+        allow(Hyrax.config).to receive(:flexible?).and_return(false)
+      end
+
+      it 'uses Site.instance.available_works instead of Hyrax.config.registered_curation_concern_types' do
+        expect(subject.all?).to eq true
+      end
+    end
+
+    context 'when flexible metadata is enabled with profile' do
+      let(:profile) { { 'classes' => { 'GenericWorkResource' => {}, 'ImageResource' => {} } } }
+
+      before do
+        allow(Hyrax.config).to receive(:flexible?).and_return(true)
+        allow(Hyrax::FlexibleSchema).to receive(:current_version).and_return(profile)
+        allow(Hyrax.config).to receive(:registered_curation_concern_types).and_return(['GenericWork', 'Image'])
+      end
+
+      it 'compares against filtered available works' do
+        filtered_query = described_class.new(user, models: ['GenericWork', 'Image'])
+        expect(filtered_query.all?).to eq true
+      end
     end
   end
 end


### PR DESCRIPTION

# Summary 

This decorator was introduced to validate the profile classes against the available work options. That implementation produced a bug because the concept of a profile doesn't exist with HYRAX_FLEXIBLE is false. 

We deployed to a non flexible environment which revealed this error: 

```
F, [2025-07-30T16:40:11.029555 #8] FATAL -- : [690307c24ff1c44e49798d9615ed68c8]   
[690307c24ff1c44e49798d9615ed68c8] ActionView::Template::Error (undefined method `profile' for nil:NilClass):
[690307c24ff1c44e49798d9615ed68c8]     3: <% if @presenter.display_share_button? && !Flipflop.read_only? %>
[690307c24ff1c44e49798d9615ed68c8]     4: <div class="home-share-work text-center">
[690307c24ff1c44e49798d9615ed68c8]     5:   <% if signed_in? %>
[690307c24ff1c44e49798d9615ed68c8]     6:     <% if @presenter.create_many_work_types? %>
[690307c24ff1c44e49798d9615ed68c8]     7:       <%= link_to '#',
[690307c24ff1c44e49798d9615ed68c8]     8:         class: "btn btn-primary btn-lg",
[690307c24ff1c44e49798d9615ed68c8]     9:         data: { behavior: 'select-work', toggle: 'modal', target: '#worktypes-to-create', 'create-type' => 'single' } do %>
[690307c24ff1c44e49798d9615ed68c8]   
[690307c24ff1c44e49798d9615ed68c8] app/services/hyrax/quick_classification_query_decorator.rb:30:in `filtered_available_works'
```

# Acceptance Criteria

- [ ] Users should be able to see available_work_types when HYRAX_FLEXIBLE is false.