### PR TITLE
Updates hyrax

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,7 +141,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: 16664b8c660a91032761869b7cda6737c51aaa13
+  revision: a3118683116df6d85a6d0657d87301525cbee91a
   branch: 5.0-flexible
   specs:
     hyrax (5.0.5)


### PR DESCRIPTION
pulls in 'make _citations partial more flexible'

ref:
- https://github.com/samvera/hyrax/commit/a3118683116df6d85a6d0657d87301525cbee91a


st-jude was failing because their description property must've been a string when this partial expects it to be an array. This broke the app and the user is blocked from fixing it. 

This should resolve the error: 

```
I, [2025-07-30T20:52:16.284285 #8]  INFO -- : [0f70a9542cb4f447dc753a5b6dfef58e] Completed 500 Internal Server Error in 1651ms (ActiveRecord: 233.2ms | Allocations: 635092)
D, [2025-07-30T20:52:16.287502 #8] DEBUG -- : [0f70a9542cb4f447dc753a5b6dfef58e]   Account Load (0.8ms)  SELECT "public"."accounts".* FROM "public"."accounts" WHERE "public"."accounts"."tenant" = $1 LIMIT $2  [["tenant", "public"], ["LIMIT", 1]]
F, [2025-07-30T20:52:16.288859 #8] FATAL -- : [0f70a9542cb4f447dc753a5b6dfef58e]   
[0f70a9542cb4f447dc753a5b6dfef58e] ActionView::Template::Error (undefined method `join' for "":String):
[0f70a9542cb4f447dc753a5b6dfef58e]      8:   <meta property="og:description" content="<%= @presenter.description.first.truncate(200) rescue @presenter.title.first %>" />
[0f70a9542cb4f447dc753a5b6dfef58e]      9:   <meta property="og:image" content="<%= @presenter.download_url %>" />
[0f70a9542cb4f447dc753a5b6dfef58e]     10:   <meta property="og:url" content="<%= polymorphic_url([main_app, @presenter]) %>" />
[0f70a9542cb4f447dc753a5b6dfef58e]     11:   <meta name="twitter:data1" content="<%= @presenter.keyword.join(', ') %>" />
[0f70a9542cb4f447dc753a5b6dfef58e]     12:   <meta name="twitter:label1" content="Keywords" />
[0f70a9542cb4f447dc753a5b6dfef58e]     13:   <meta name="twitter:data2" content="<%= @presenter.rights_statement.first %>" />
[0f70a9542cb4f447dc753a5b6dfef58e]     14:   <meta name="twitter:label2" content="Rights Statement" />
[0f70a9542cb4f447dc753a5b6dfef58e]   
[0f70a9542cb4f447dc753a5b6dfef58e] app/views/hyrax/base/show.html.erb:6
[0f70a9542cb4f447dc753a5b6dfef58e] (eval):2:in `process_action'
[0f70a9542cb4f447dc753a5b6dfef58e] (eval):3:in `block in process_action'
[0f70a9542cb4f447dc753a5b6dfef58e] app/controllers/concerns/hyku/works_controller_behavior.rb:99:in `inject_show_theme_views'
```
Passing specs in Hyrax: 

<img width="2704" height="5100" alt="image" src="https://github.com/user-attachments/assets/c486ac4b-287a-49ae-a4f9-e21a29b57c1f" />
