### PR TITLE
No hardlink

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -105,6 +105,8 @@ ONBUILD COPY --chown=1001:101 $APP_PATH /app/samvera/hyrax-webapp
 ONBUILD RUN bundle install --jobs "$(nproc)"
 
 FROM hyku-base AS hyku-web
+# ✅ Fix Git hardlink error in CI
+ENV BUNDLER_NO_HARDLINK=1
 RUN RAILS_ENV=production SECRET_KEY_BASE=`bin/rake secret` DB_ADAPTER=nulldb DB_URL='postgresql://fake' bundle exec rake assets:precompile && yarn install
 CMD ./bin/web
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -105,8 +105,6 @@ ONBUILD COPY --chown=1001:101 $APP_PATH /app/samvera/hyrax-webapp
 ONBUILD RUN bundle install --jobs "$(nproc)"
 
 FROM hyku-base AS hyku-web
-# ✅ Fix Git hardlink error in CI
-ENV BUNDLER_NO_HARDLINK=1
 RUN RAILS_ENV=production SECRET_KEY_BASE=`bin/rake secret` DB_ADAPTER=nulldb DB_URL='postgresql://fake' bundle exec rake assets:precompile && yarn install
 CMD ./bin/web
 

--- a/Gemfile
+++ b/Gemfile
@@ -124,7 +124,7 @@ gem 'valkyrie-shrine'
 gem 'web-console', '>= 3.3.0', group: %i[development] # <%= console %> in views
 gem 'webdrivers', '~> 4.7.0', group: %i[test]
 gem 'webmock', group: %i[test]
-gem 'willow_sword', github: 'notch8/willow_sword', branch: 'main'
+gem 'willow_sword', github: 'notch8/willow_sword', ref: '05cdbdebc83239647becd6fa4b4f81237c183055'
 
 # Enabling the following gem breaks sidekiq. To Enable: assets.debug must be set to true in config/development.rb
 # gem "xray-rails", git: "https://github.com/brentd/xray-rails.git", branch: "bugs/ruby-3.0.0", group: %i[development]


### PR DESCRIPTION
Not sure why exactly but hyku up knapsack failed to build because of a hardlink error with willow_sword. When I pinned the submodule's version to match its Gemfile.lock version, the error got resolved. 


ref: 
- https://github.com/notch8/hykuup_knapsack/actions/runs/16763094750/job/47462704204#step:12:1338
- https://github.com/notch8/hykuup_knapsack/pull/451