### PR TITLE
:gift: Memoize the HYRAX_FLEXIBLE setting

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,7 +2,7 @@
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV['RAILS_ENV'] ||= 'test'
-ENV['HYRAX_FLEXIBLE'] = 'false'
+ENV['HYRAX_FLEXIBLE'] ||= 'false'
 # In test most, unset some variables that can cause trouble
 # before booting up Rails
 ENV['HYKU_ADMIN_HOST'] = 'test.host'


### PR DESCRIPTION
HYRAX_FLEXIBLE environment variable will only be
set to false if it isn't already defined.

This resolves the issue where the HYRAX_FLEXIBLE
environment variable was not being set to true in the knapsack test environment.

- Issue #434

FROM KNAPSACK'S PERSPECTIVE
# [BEFORE](https://github.com/notch8/hykuup_knapsack/actions/runs/16812344311)

<img width="248" height="164" alt="image" src="https://github.com/user-attachments/assets/d9485fd2-0d95-4851-af67-9c6340955f37" />

```
 Failed examples:

rspec ./spec/indexers/unca_work_indexer_spec.rb:12 # UncaWorkIndexer behaves like a Hyrax::Resource indexer #to_solr indexes base resource fields
```


# AFTER

```
  UncaWorkIndexer behaves like a Hyrax::Resource indexer #to_solr indexes base resource fields
    3.99 seconds ./hyrax-webapp/gems/hyrax/lib/hyrax/specs/shared_specs/indexers.rb:19

Finished in 4.39 seconds (files took 12 seconds to load)
1 example, 0 failures

Randomized with seed 25070
```
