### PR TITLE
Fix sample seeds

### DIFF
--- a/app/services/sample/active_fedora_service.rb
+++ b/app/services/sample/active_fedora_service.rb
@@ -64,7 +64,7 @@ module Sample
       admin_set.save.tap do |result|
         if result
           ActiveRecord::Base.transaction do
-            permission_template = create_permission_template(result)
+            permission_template = create_permission_template(admin_set)
             workflow = create_workflows_for(permission_template: permission_template)
             create_default_access_for(permission_template: permission_template, workflow: workflow)
           end
@@ -204,6 +204,7 @@ module Sample
         description: [sample_data[:descriptions][index % sample_data[:descriptions].length]],
         creator: sample_data[:creators][index % sample_data[:creators].length],
         subject: sample_data[:subjects][index % sample_data[:subjects].length],
+        bulkrax_identifier: "Sample#{work_class}#{index}",
         visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC,
         admin_set: admin_set
       )

--- a/app/services/sample/active_fedora_service.rb
+++ b/app/services/sample/active_fedora_service.rb
@@ -59,7 +59,7 @@ module Sample
     def find_or_create_admin_set
       admin_set = AdminSet.where(id: AdminSet::DEFAULT_ID)&.first
       return admin_set if admin_set.present?
-      admin_set = AdminSet.new(id: AdminSet::DEFAULT_ID, title: Array.wrap(AdminSet::DEFAULT_TITLE))
+      admin_set = AdminSet.new(id: AdminSet::DEFAULT_ID, title: Array.wrap('Fedora Sample Admin Set'))
       admin_set.creator = [user.user_key] if user
       admin_set.save.tap do |result|
         if result

--- a/app/services/sample/valkyrie_service.rb
+++ b/app/services/sample/valkyrie_service.rb
@@ -230,6 +230,7 @@ module Sample
         creator: sample_data[:creators][index % sample_data[:creators].length],
         subject: sample_data[:subjects][index % sample_data[:subjects].length],
         visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC,
+        bulkrax_identifier: "SampleValk-#{work_class}#{index}",
         depositor: user.user_key,
         admin_set_id: admin_set.id
       }

--- a/lib/tasks/sample_seeds.rake
+++ b/lib/tasks/sample_seeds.rake
@@ -7,12 +7,12 @@ namespace :db do
       task :create, [:tenant, :type, :quantity] => :environment do |_t, args|
         if args[:tenant].blank?
           puts "ERROR: Tenant name is required!"
-          puts "Usage: bundle exec rake db:seed:sample:create[tenant_name,quantity,type]"
+          puts "Usage: bundle exec rake db:seed:sample:create[tenant_name,type,quantity]"
           puts "Examples:"
-          puts "  bundle exec rake db:seed:sample:create[myuniversity.edu,100,activefedora]"
-          puts "  bundle exec rake db:seed:sample:create[myuniversity.edu,50,valkyrie]"
-          puts "  bundle exec rake db:seed:sample:create[myuniversity.edu] (defaults: 50, activefedora)"
-          puts "Types: 'activefedora' (default) or 'valkyrie'"
+          puts "  bundle exec rake db:seed:sample:create[tenant_name,activefedora,100]"
+          puts "  bundle exec rake db:seed:sample:create[tenant_name,valkyrie,50]"
+          puts "  bundle exec rake db:seed:sample:create[tenant_name] (defaults: activefedora, 50)"
+          puts "Types: 'activefedora' of 'af' (default) or 'valkyrie' or 'val'"
           exit 1
         end
 


### PR DESCRIPTION
- Adds bulkrax identifier to sample seeds.
- Adjust title of admin set to clearly identify it as coming from the seeds. The ActiveFedora admin set is not able to be migrated or edited at the current time. The cause is unknown but does not affect using the remainder of the data.

Additional testing of the resulting data is recommended to enhance the sample seeding services.