### PR TITLE
Removes _sim from facetable behavior

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,7 +163,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: c3a8e32c56e8e9b2011954bb0df742140cb09ea6
+  revision: 58534fba4e2232d917624044f710ffd505aef5c6
   branch: 5.0-flexible
   specs:
     hyrax (5.0.5)

--- a/config/metadata_profiles/m3_profile.yaml
+++ b/config/metadata_profiles/m3_profile.yaml
@@ -183,6 +183,7 @@ properties:
     indexing:
       - creator_sim
       - creator_tesim
+      - facetable
     form:
       required: true
       primary: true
@@ -423,6 +424,7 @@ properties:
     indexing:
       - contributor_tesim
       - contributor_sim
+      - facetable
     form:
       primary: false
     property_uri: http://purl.org/dc/elements/1.1/contributor
@@ -568,6 +570,7 @@ properties:
     indexing:
       - keyword_sim
       - keyword_tesim
+      - facetable
     form:
       primary: false
     property_uri: http://schema.org/keywords
@@ -629,6 +632,7 @@ properties:
     indexing:
       - language_sim
       - language_tesim
+      - facetable
     form:
       primary: false
     property_uri: http://purl.org/dc/elements/1.1/language
@@ -661,6 +665,7 @@ properties:
     indexing:
       - publisher_sim
       - publisher_tesim
+      - facetable
     form:
       primary: false
     property_uri: http://purl.org/dc/elements/1.1/publisher
@@ -746,6 +751,7 @@ properties:
     indexing:
       - resource_type_sim
       - resource_type_tesim
+      - facetable
     form:
       primary: false
     property_uri: http://purl.org/dc/terms/type
@@ -871,6 +877,7 @@ properties:
     indexing:
       - subject_sim
       - subject_tesim
+      - facetable
     form:
       primary: false
     property_uri: http://purl.org/dc/elements/1.1/subject

--- a/lib/flexible/m3_json_schema.json
+++ b/lib/flexible/m3_json_schema.json
@@ -272,9 +272,16 @@
             "type": "array",
             "items": {
               "type": "string",
-              "pattern": "^[a-z_]+_(tesi|tesim|teim|ssi|sim|ssm|bsi|isi|dts|dtsi|ti|si|ss|is|bs|dt|ssim)$"
+              "anyOf": [
+                {
+                  "pattern": "^[a-z_]+_(tesi|tesim|teim|ssi|sim|ssm|bsi|isi|dts|dtsi|ti|si|ss|is|bs|dt|ssim)$"
+                },
+                {
+                  "enum": ["facetable", "admin_only", "stored_searchable"]
+                }
+              ]
             },
-            "description": "Solr index key to map to."
+            "description": "Solr index key to map to, or behavioral flag (facetable, admin_only)."
           },
           "definition": {
             "type": "object",


### PR DESCRIPTION
1. Updates Hyrax: Users must say -facetable as an indexing value to determine facetable properties.
2. Updates JSON Schema to allow for behavioral terms
3. Adds -facetable value to the m3_profile per default Hyku/Hyrax faceted properties

  - ✅ Added facetable to:
    - creator (creator_sim)
    - contributor (contributor_sim)
    - keyword (keyword_sim)
    - language (language_sim)
    - publisher (publisher_sim)
    - resource_type (resource_type_sim)
    - subject (subject_sim)

Issue:
- notch8/hykuup_knapsack#456

# BEFORE



# AFTER


<img width="1299" height="541" alt="image" src="https://github.com/user-attachments/assets/4813a908-3b1f-44ee-a5c5-082bcdda205d" />
