### PR TITLE
I460 fedora admin edit issue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,7 +163,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: 6084778db325ec77dc2899b941a35522e7eef8bd
+  revision: c57dcb9652c2ff4097145a02c72e3c101b028909
   branch: 5.0-flexible
   specs:
     hyrax (5.0.5)


### PR DESCRIPTION
Update Hyrax to full in fix
  - Solves the issue of AdminSet -> Valkyrie Resource edit failure

Issue:

https://github.com/notch8/hykuup_knapsack/issues/460

## HYRAX_FLEXIBLE=false

<img width="2704" height="1460" alt="image" src="https://github.com/user-attachments/assets/f09329c0-30a5-4703-a321-e94e7c637ad9" />


## HYRAX_FLEXIBLE=true

<img width="2704" height="1460" alt="image" src="https://github.com/user-attachments/assets/eaa1b439-1749-4e1d-acf8-30ac67569c92" />

