### PR TITLE
Update Hyrax for ActiveFedora edit render fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,7 +163,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: c57dcb9652c2ff4097145a02c72e3c101b028909
+  revision: 64c9a030b3a42f260fd618731ba5f1a054333a2c
   branch: 5.0-flexible
   specs:
     hyrax (5.0.5)


### PR DESCRIPTION

https://github.com/samvera/hyrax/pull/7165

Persists Wings-backed works via transaction on the edit action. This triggers a just-in-time migration to a native Valkyrie resource, ensuring the edit form renders all metadata correctly when `HYRAX_FLEXIBLE=true`.

Resolves Issue:
- https://github.com/notch8/hykuup_knapsack/issues/461

## BEFORE

<img width="2704" height="1620" alt="Screenshot 2025-08-19 at 14-02-56 Image 4 Video Documentation of Art Installation __ Image 91cc9bbc-3c23-4474-b2a0-52912a1a318d __ Hyku" src="https://github.com/user-attachments/assets/7a3f5b20-7ec7-4ffd-88a1-9997a767c076" />



## AFTER

<img width="2704" height="1460" alt="Screenshot 2025-08-19 at 14-05-15 Image 4 Video Documentation of Art Installation __ Image 91cc9bbc-3c23-4474-b2a0-52912a1a318d __ Hyku" src="https://github.com/user-attachments/assets/f2aac157-b623-4fa3-99b8-7324b7d295b7" />
