### PR TITLE
Fixes db-wait.sh not found error on deploys?

### DIFF
--- a/ops/demo-deploy.tmpl.yaml
+++ b/ops/demo-deploy.tmpl.yaml
@@ -201,8 +201,16 @@ extraEnvVars: &envVars
     value: $SENTRY_ENVIRONMENT
   - name: VALKYRIE_TRANSITION
     value: "true"
+
 worker:
   replicaCount: 1
+  extraInitContainers:
+    - name: db-wait
+      image: "{{ .Values.worker.image.repository }}:{{ .Values.worker.image.tag | default .Chart.AppVersion }}"
+      command:
+        - sh
+        - -c
+        - /app/samvera/hyrax-webapp/bin/db-wait.sh "$REDIS_HOST:6379"
   extraVolumeMounts: *volMounts
   extraEnvVars: *envVars
   podSecurityContext:

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -196,6 +196,13 @@ extraEnvVars: &envVars
 
 worker:
   replicaCount: 1
+  extraInitContainers:
+    - name: db-wait
+      image: "{{ .Values.worker.image.repository }}:{{ .Values.worker.image.tag | default .Chart.AppVersion }}"
+      command:
+        - sh
+        - -c
+        - /app/samvera/hyrax-webapp/bin/db-wait.sh "$REDIS_HOST:6379"
   extraVolumeMounts: *volMounts
   extraEnvVars: *envVars
   podSecurityContext:


### PR DESCRIPTION
When deploying to demo and staging, the worker pod fails because it can't find db-wait.sh. The command is looking for it in the wrong place.

<img width="720" height="704" alt="image" src="https://github.com/user-attachments/assets/49f0f92a-5ee0-4d77-8ac8-a3062203309c" />

<img width="275" height="101" alt="image" src="https://github.com/user-attachments/assets/04356c60-a709-4e9e-b7fe-fae32c8ac3bd" />

