### PR TITLE
[i461] - Rework fix for collection forms

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,7 +163,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: 64c9a030b3a42f260fd618731ba5f1a054333a2c
+  revision: 3d81004c1859edf8327c794bd2d296dde3a54438
   branch: 5.0-flexible
   specs:
     hyrax (5.0.5)


### PR DESCRIPTION
Active Fedora only => Valkryie forms would only render the title when other metadata is available to display.

This required rework because I forgot to apply the same implementation to the collections controller. Note: FileSets only rendered the title before this anyways so is less of an issue/concern - but I applied the code there as well for consistency's sake. 

Issue:
- https://github.com/notch8/hykuup_knapsack/issues/461#issuecomment-3214458421

# Collections

## BEFORE

<img width="1359" height="494" alt="image" src="https://github.com/user-attachments/assets/b7eb3ee7-1db4-447f-9e2d-b8a12388c3bc" />


## AFTER

<img width="2704" height="1460" alt="image" src="https://github.com/user-attachments/assets/7c8b3d99-c4f6-4ef6-ac47-8a07fa4802ee" />

# File Sets

## BEFORE

<img width="2704" height="1460" alt="image" src="https://github.com/user-attachments/assets/68a1182f-5e8e-4e08-adec-7413f01a369f" />


## AFTER

<img width="2704" height="1460" alt="image" src="https://github.com/user-attachments/assets/96d80c6e-9266-454b-89ea-211f68331aaf" />



# Works
ref: https://github.com/samvera/hyku/pull/2677
