### PR TITLE
Update hyrax to use 5.0-stable branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,7 @@ gem 'good_job', '~> 2.99'
 gem 'googleauth', '~> 1.9.0'
 gem 'google-protobuf'
 gem 'grpc'
-gem 'hyrax', github: 'samvera/hyrax', branch: 'main_before_rails_72'
+gem 'hyrax', github: 'samvera/hyrax', branch: '5.0-stable'
 gem 'hyrax-doi', github: 'samvera-labs/hyrax-doi', branch: 'rails_hyrax_upgrade'
 gem 'hyrax-iiif_av', github: 'samvera-labs/hyrax-iiif_av', branch: 'rails_hyrax_upgrade'
 gem 'i18n-debug', require: false, group: %i[development test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,7 +141,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera/bulkrax.git
-  revision: fe825f98347c38c45cecb567c06cb0ee6c9a2ebd
+  revision: 9f5ae25760eae1cb32d9e9af39d2888ea6ea034f
   branch: main
   specs:
     bulkrax (9.1.0)
@@ -163,10 +163,10 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: 52d3d5bd21115d03fe4d1676bca5871669ba7593
-  branch: main_before_rails_72
+  revision: c79c97d1e0261ba9ed8230b3d464cf8a143de8f4
+  branch: 5.0-stable
   specs:
-    hyrax (5.0.4)
+    hyrax (5.0.5)
       active-fedora (~> 14.0)
       almond-rails (~> 0.1)
       awesome_nested_set (~> 3.1)
@@ -766,7 +766,7 @@ GEM
       json
     iiif_manifest (1.3.1)
       activesupport (>= 4)
-    iiif_print (3.0.7)
+    iiif_print (3.0.8)
       blacklight_iiif_search (>= 1.0, < 3.0)
       derivative-rodeo (~> 0.5)
       hyrax (>= 2.5, < 6)


### PR DESCRIPTION
## Summary

Updates iiif_print and bulkrax to most recent, and Hyrax to 5.0-stable.

Refs 
- https://github.com/notch8/palni_palci_knapsack/issues/385
- https://github.com/notch8/palni_palci_knapsack/issues/386
- https://github.com/notch8/palni_palci_knapsack/issues/284

## Details

Hyku 6.1 series now uses Hyrax 5.0-stable branch. This brings in several new bug fixes, including making the batch add and edit processes functional for use with lazy migration. 
