### PR TITLE
Set environment default for Hyku APP_NAME

### DIFF
--- a/.env
+++ b/.env
@@ -1,9 +1,9 @@
+APP_NAME=hyku
 CH12N_TOOL=fits_servlet
 CHROME_HOSTNAME=chrome
 COMPOSE_DOCKER_CLI_BUILD=1
 DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true
 DB_ADAPTER=postgresql
-DB_HOST=db
 DB_HOST=db
 DB_NAME=hyku
 DB_PASSWORD=DatabaseFTW
@@ -39,10 +39,10 @@ TB_RSPEC_OPTIONS="--format RspecJunitFormatter --out rspec.xml"
 VALKYRIE_ID_TYPE=string
 
 # Comment out these 5 for single tenancy / Uncomment for multi
-HYKU_ADMIN_HOST=admin-${APP_NAME}.localhost.direct
+HYKU_ADMIN_HOST="admin-${APP_NAME}.localhost.direct"
 HYKU_ADMIN_ONLY_TENANT_CREATION=false
 HYKU_BLOCK_VALKYRIE_REDIRECT=false
-HYKU_DEFAULT_HOST=%{tenant}-${APP_NAME}.localhost.direct
+HYKU_DEFAULT_HOST="%{tenant}-${APP_NAME}.localhost.direct"
 HYKU_ROOT_HOST=localhost.direct
 HYKU_MULTITENANT=true
 HYKU_USER_DEFAULT_PASSWORD=password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,10 +75,10 @@ services:
       - VIRTUAL_HOST=solr.hyku.test
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.solr-${APP_NAME:-hyku}.tls=true"
-      - "traefik.http.routers.solr-${APP_NAME:-hyku}.entrypoints=websecure"
-      - "traefik.http.routers.solr-${APP_NAME:-hyku}.rule=Host(`solr-${APP_NAME:-hyku}.localhost.direct`)"
-      - "traefik.http.services.solr-${APP_NAME:-hyku}.loadbalancer.server.port=8983"
+      - "traefik.http.routers.solr-${APP_NAME}.tls=true"
+      - "traefik.http.routers.solr-${APP_NAME}.entrypoints=websecure"
+      - "traefik.http.routers.solr-${APP_NAME}.rule=Host(`solr-${APP_NAME}.localhost.direct`)"
+      - "traefik.http.services.solr-${APP_NAME}.loadbalancer.server.port=8983"
     user: root
     command: bash -c "
       chown -R 8983:8983 /var/solr
@@ -104,10 +104,10 @@ services:
       - 8080
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.fits-${APP_NAME:-hyku}.tls=true"
-      - "traefik.http.routers.fits-${APP_NAME:-hyku}.entrypoints=websecure"
-      - "traefik.http.routers.fits-${APP_NAME:-hyku}.rule=Host(`fits-${APP_NAME:-hyku}.localhost.direct`)"
-      - "traefik.http.services.fits-${APP_NAME:-hyku}.loadbalancer.server.port=8080"
+      - "traefik.http.routers.fits-${APP_NAME}.tls=true"
+      - "traefik.http.routers.fits-${APP_NAME}.entrypoints=websecure"
+      - "traefik.http.routers.fits-${APP_NAME}.rule=Host(`fits-${APP_NAME}.localhost.direct`)"
+      - "traefik.http.services.fits-${APP_NAME}.loadbalancer.server.port=8080"
 
   fcrepo:
     image: ghcr.io/samvera/fcrepo4:4.7.5
@@ -123,10 +123,10 @@ services:
       - 8080
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.fcrepo-${APP_NAME:-hyku}.tls=true"
-      - "traefik.http.routers.fcrepo-${APP_NAME:-hyku}.entrypoints=websecure"
-      - "traefik.http.routers.fcrepo-${APP_NAME:-hyku}.rule=Host(`fcrepo-${APP_NAME:-hyku}.localhost.direct`)"
-      - "traefik.http.services.fcrepo-${APP_NAME:-hyku}.loadbalancer.server.port=8080"
+      - "traefik.http.routers.fcrepo-${APP_NAME}.tls=true"
+      - "traefik.http.routers.fcrepo-${APP_NAME}.entrypoints=websecure"
+      - "traefik.http.routers.fcrepo-${APP_NAME}.rule=Host(`fcrepo-${APP_NAME}.localhost.direct`)"
+      - "traefik.http.services.fcrepo-${APP_NAME}.loadbalancer.server.port=8080"
 
   db:
     image: postgres:11.1
@@ -150,10 +150,10 @@ services:
       - VIRTUAL_HOST=admin.hyku.test
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.adminer-${APP_NAME:-hyku}.tls=true"
-      - "traefik.http.routers.adminer-${APP_NAME:-hyku}.entrypoints=websecure"
-      - "traefik.http.routers.adminer-${APP_NAME:-hyku}.rule=Host(`adminer-${APP_NAME:-hyku}.localhost.direct`)"
-      - "traefik.http.services.adminer-${APP_NAME:-hyku}.loadbalancer.server.port=8080"
+      - "traefik.http.routers.adminer-${APP_NAME}.tls=true"
+      - "traefik.http.routers.adminer-${APP_NAME}.entrypoints=websecure"
+      - "traefik.http.routers.adminer-${APP_NAME}.rule=Host(`adminer-${APP_NAME}.localhost.direct`)"
+      - "traefik.http.services.adminer-${APP_NAME}.loadbalancer.server.port=8080"
 
   web:
     <<: *app
@@ -164,11 +164,11 @@ services:
       - VIRTUAL_HOST=.hyku.test
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.web-${APP_NAME:-hyku}.tls=true"
-      - "traefik.http.routers.web-${APP_NAME:-hyku}.entrypoints=websecure"
-      - "traefik.http.routers.web-${APP_NAME:-hyku}.priority=10"
-      - "traefik.http.routers.web-${APP_NAME:-hyku}.rule=HostRegexp(`.+-${APP_NAME:-hyku}.localhost.direct`)"
-      - "traefik.http.services.web-${APP_NAME:-hyku}.loadbalancer.server.port=3000"
+      - "traefik.http.routers.web-${APP_NAME}.tls=true"
+      - "traefik.http.routers.web-${APP_NAME}.entrypoints=websecure"
+      - "traefik.http.routers.web-${APP_NAME}.priority=10"
+      - "traefik.http.routers.web-${APP_NAME}.rule=HostRegexp(`.+-${APP_NAME}.localhost.direct`)"
+      - "traefik.http.services.web-${APP_NAME}.loadbalancer.server.port=3000"
     depends_on:
       db:
         condition: service_started
@@ -284,7 +284,7 @@ services:
       - VIRTUAL_HOST=chrome.hyku.test
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.chrome-${APP_NAME:-hyku}.tls=true"
-      - "traefik.http.routers.chrome-${APP_NAME:-hyku}.entrypoints=websecure"
-      - "traefik.http.routers.chrome-${APP_NAME:-hyku}.rule=Host(`chrome-${APP_NAME:-hyku}.localhost.direct`)"
-      - "traefik.http.services.chrome-${APP_NAME:-hyku}.loadbalancer.server.port=7900"
+      - "traefik.http.routers.chrome-${APP_NAME}.tls=true"
+      - "traefik.http.routers.chrome-${APP_NAME}.entrypoints=websecure"
+      - "traefik.http.routers.chrome-${APP_NAME}.rule=Host(`chrome-${APP_NAME}.localhost.direct`)"
+      - "traefik.http.services.chrome-${APP_NAME}.loadbalancer.server.port=7900"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,6 +7,7 @@ Hyku is primarily configured using environment variables. The default configurat
 
 | Name | Description | Default | Development or Test Only |
 | ------------- | ------------- | ------------- | ------------- |
+| APP_NAME | uniquely identify the endpoint for tenant administration - e.g. `https://admin-hyku.example.org` (production) or `https://admin-hyku.localhost.direct` (development) | hyku | no |
 | CHROME_HOSTNAME | specifies the chromium host for feature specs | chrome | yes |
 | DB_ADAPTER | which Rails database adapter, mapped in to config/database.yml. Common values are postgresql, mysql2, jdbc, nulldb | postgresql | no |
 | DB_HOST | host name for the database | db | no |


### PR DESCRIPTION
Changes proposed in this pull request:
* Set the APP_NAME default in the .env file
* Remove redundant defaults in docker-compose.yml

Additional fixes:
* Add quotes to interpolated values in .env file
* Remove redundant DB_HOST key in .env file

**ISSUE**
When APP_NAME is not set in the environment (either directly before launching the application, or via .env file), internal variables such as `$HYKU_ADMIN_HOST` are set to invalid values, causing admin routing to break.

I.E. when APP_NAME is not set, HYKU_ADMIN_HOST is set to `admin-.localhost.direct`, which results in an illegal hostname (because hostnames can not start or end with dashes).

**FIX**
Set the APP_NAME default in the .env file, which is loaded by `docker compose` and interpolated into `docker-compose.yml`. This ensures the samv value is used in both docker configuration and inside the Rails application.

@samvera/hyku-code-reviewers
