### PR TITLE
🐛 Updates iiif_print version to return resource

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -772,7 +772,7 @@ GEM
       json
     iiif_manifest (1.3.1)
       activesupport (>= 4)
-    iiif_print (3.0.7)
+    iiif_print (3.0.8)
       blacklight_iiif_search (>= 1.0, < 3.0)
       derivative-rodeo (~> 0.5)
       hyrax (>= 2.5, < 6)


### PR DESCRIPTION
# Story

Update iiif_print version.

Regardless of the status of the parent, always return the FileSet resource instead of boolean true when no parent is found in ConditionallyDestroyChildrenFromSplit. This will ensure consistent return values across all code paths in the transaction step.

Ref:
- https://github.com/notch8/iiif_print/pull/395
- https://github.com/notch8/hykuup_knapsack/issues/477

@samvera/hyku-code-reviewers
