### PR TITLE
Add missing translations

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -86,7 +86,9 @@ de:
             success: "%{group} aktualisiert"
         humanized_name:
           admin: Repository-Administratoren
+          group/admin: Administrator
           group/public: Unbefugte Benutzer
+          group/work_editor: Werkredakteur
           registered: Registrierte Benutzer
         label:
           actions: Aktionen

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -97,6 +97,8 @@ en:
           admin: Repository Administrators
           registered: Registered Users
           group/public: Unauthorized Users
+          group/admin: Admin
+          group/work_editor: Work Editor
         label:
           actions: Actions
           created_at: Date Created

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -86,7 +86,9 @@ es:
             success: "%{group} actualizado"
         humanized_name:
           admin: Administradores de repositorios
+          group/admin: Administración
           group/public: Usuarios no autorizados
+          group/work_editor: Editor de trabajo
           registered: Usuarios Registrados
         label:
           actions: Comportamiento

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -86,7 +86,9 @@ fr:
             success: "%{group} a mis à jour"
         humanized_name:
           admin: Administrateurs de référentiel
+          group/admin: Administrateur
           group/public: Utilisateurs non autorisés
+          group/work_editor: Rédacteur en chef
           registered: Utilisateurs enregistrés
         label:
           actions: actes

--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -696,6 +696,7 @@ de:
           highlighted: Hervorgehoben
           items: Artikel
           last_modified: Zuletzt geändert
+          profile_version: Profilversion
           title: Titel
           type: Art
           visibility: Sichtweite

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -697,6 +697,7 @@ es:
           highlighted: Resaltado
           items: Artículos
           last_modified: Última modificación
+          profile_version: Versión de perfil
           title: Título
           type: Tipo
           visibility: Visibilidad

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -695,6 +695,7 @@ fr:
           highlighted: Souligné
           items: Articles
           last_modified: Dernière modification
+          profile_version: Version du profil
           title: Titre
           type: Type
           visibility: Visibilité

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -697,6 +697,7 @@ it:
           highlighted: evidenziato
           items: Elementi
           last_modified: Ultima modifica
+          profile_version: Versione del profilo
           title: Titolo
           type: genere
           visibility: Visibilità

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -697,6 +697,7 @@ pt-BR:
           highlighted: Em destaque
           items: Itens
           last_modified: Última modificação
+          profile_version: Versão do perfil
           title: Título
           type: Tipo
           visibility: Visibilidade

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -697,6 +697,7 @@ zh:
           highlighted: 突出显示
           items: 物品
           last_modified: 最后修改
+          profile_version: 配置文件版本
           title: 标题
           type: 类型
           visibility: 能见度

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -86,7 +86,9 @@ it:
             success: "%{group} aggiornato"
         humanized_name:
           admin: Amministratori di repository
+          group/admin: Amministratore
           group/public: Utenti non autorizzati
+          group/work_editor: Redattore del lavoro
           registered: utente registrato
         label:
           actions: Azioni

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -86,7 +86,9 @@ pt-BR:
             success: "%{group} atualizado"
         humanized_name:
           admin: Administradores de repositório
+          group/admin: Administrador
           group/public: Usuários não autorizados
+          group/work_editor: Editor de Trabalho
           registered: Usuários registrados
         label:
           actions: Ações

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -86,7 +86,9 @@ zh:
             success: "%{group}更新"
         humanized_name:
           admin: 存储库管理员
+          group/admin: 行政
           group/public: 未授权用户
+          group/work_editor: 工作编辑
           registered: 注册用户
         label:
           actions: 操作


### PR DESCRIPTION
This commit will add the translation for
`hyku.admin.groups.humanized_name.group/admin` and `en.hyku.admin.groups.humanized_name.group/work_editor` and run the I18n task to translate them.

Fixes #2542