### PR TITLE
[i557] - consolidate account settings (PR2)

### DIFF
--- a/app/models/concerns/account_settings.rb
+++ b/app/models/concerns/account_settings.rb
@@ -23,7 +23,6 @@ module AccountSettings
     setting :allow_downloads, type: 'boolean', default: true
     setting :allow_signup, type: 'boolean', default: true
     setting :analytics, type: 'boolean', default: false
-    setting :analytics_reporting, type: 'boolean', default: false
     setting :batch_email_notifications, type: 'boolean', default: false
     setting :bulkrax_field_mappings, type: 'json_editor', default: Hyku.default_bulkrax_field_mappings.to_json
     setting :bulkrax_validations, type: 'boolean', disabled: true
@@ -88,7 +87,7 @@ module AccountSettings
       # watch out because false is a valid value to return here
       define_method(name) do
         value = super()
-        if name == :analytics_reporting || name == :analytics
+        if name == :analytics
           return value.nil? ? args[:default] : set_type(value, (args[:type]).to_s)
         end
         value = value.nil? ? ENV.fetch("HYKU_#{name.upcase}", nil) : value
@@ -220,7 +219,7 @@ module AccountSettings
   end
 
   def configure_hyrax_analytics_settings(config)
-    if ActiveModel::Type::Boolean.new.cast(analytics_reporting) && analytics_credentials_present?
+    if ActiveModel::Type::Boolean.new.cast(analytics) && analytics_credentials_present?
       config.analytics = true
       config.analytics_reporting = true
     else
@@ -282,6 +281,8 @@ module AccountSettings
 
       # The config object lives on the GA4 provider, not the main Analytics module.
       # This was the root cause of the analytics methods not being loaded.
+      Hyrax.config.analytics = true
+      Hyrax.config.analytics_reporting = true
       Hyrax::Analytics::Ga4.config.analytics_id = google_analytics_id
       Hyrax::Analytics::Ga4.config.property_id = google_analytics_property_id
 

--- a/app/views/hyrax/dashboard/_user_activity.html.erb
+++ b/app/views/hyrax/dashboard/_user_activity.html.erb
@@ -4,7 +4,7 @@
     <%= t('.title') %>
   </div>
   <div class="card-body d-flex justify-content-center">
-  <% if current_account.analytics_reporting %>
+  <% if current_account.analytics %>
     <%
       # Set default date range if not provided
       @start_date ||= 30.days.ago.to_date

--- a/app/views/hyrax/dashboard/sidebar/_activity.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_activity.html.erb
@@ -67,7 +67,7 @@
   </li>
 <% end %>
 
-<% if current_ability.can_create_any_work? && Hyrax.config.analytics_reporting? %>
+<% if current_ability.can_create_any_work? && current_account.analytics_enabled? %>
   <li class="nav-item">
     <%= menu.collapsable_section t('hyrax.admin.sidebar.analytics'),
                                   icon_class: "fa fa-pie-chart",

--- a/db/migrate/20250828153422_remove_analytics_reporting_from_account_settings.rb
+++ b/db/migrate/20250828153422_remove_analytics_reporting_from_account_settings.rb
@@ -4,7 +4,7 @@ class RemoveAnalyticsReportingFromAccountSettings < ActiveRecord::Migration[6.1]
     Account.find_each do |account|
       if account.settings&.key?('analytics_reporting')
         # If analytics_reporting was enabled, ensure analytics is also enabled
-        if account.settings['analytics_reporting'] == '1' && account.settings['analytics'] != '1'
+        if ActiveModel::Type::Boolean.new.cast(account.settings['analytics_reporting']) && !ActiveModel::Type::Boolean.new.cast(account.settings['analytics'])
           account.settings['analytics'] = '1'
         end
         

--- a/db/migrate/20250828153422_remove_analytics_reporting_from_account_settings.rb
+++ b/db/migrate/20250828153422_remove_analytics_reporting_from_account_settings.rb
@@ -1,0 +1,23 @@
+class RemoveAnalyticsReportingFromAccountSettings < ActiveRecord::Migration[6.1]
+  def up
+    # Remove analytics_reporting from all existing accounts and ensure analytics is set
+    Account.find_each do |account|
+      if account.settings&.key?('analytics_reporting')
+        # If analytics_reporting was enabled, ensure analytics is also enabled
+        if account.settings['analytics_reporting'] == '1' && account.settings['analytics'] != '1'
+          account.settings['analytics'] = '1'
+        end
+        
+        # Remove the old analytics_reporting setting
+        account.settings.delete('analytics_reporting')
+        account.save!
+      end
+    end
+  end
+
+  def down
+    # This migration cannot be safely reversed as it removes data
+    # If needed, you would need to recreate the analytics_reporting setting
+    # based on the current analytics setting
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_12_05_212513) do
+ActiveRecord::Schema.define(version: 2025_08_28_153422) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -152,7 +152,6 @@ Hyku supports Google Analytics 4 for tracking user interactions and generating a
 ```bash
 # Enable GA4 globally across all tenants
 HYRAX_ANALYTICS=true
-HYRAX_ANALYTICS_REPORTING=true
 HYRAX_ANALYTICS_PROVIDER=ga4
 
 # Global Service Account JSON (REQUIRED - obtained from step 1)
@@ -170,7 +169,6 @@ Create or update your `.env` file in the project root:
 
 ```bash
 echo 'HYRAX_ANALYTICS=true' >> .env
-echo 'HYRAX_ANALYTICS_REPORTING=true' >> .env
 echo 'HYRAX_ANALYTICS_PROVIDER=ga4' >> .env
 echo 'GOOGLE_ACCOUNT_JSON={"type":"service_account","project_id":"YOUR_PROJECT",...}' >> .env
 ```
@@ -182,7 +180,6 @@ services:
   web:
     environment:
       - HYRAX_ANALYTICS=true
-      - HYRAX_ANALYTICS_REPORTING=true
       - HYRAX_ANALYTICS_PROVIDER=ga4
       - GOOGLE_ACCOUNT_JSON={"type":"service_account","project_id":"YOUR_PROJECT",...}
 ```
@@ -222,7 +219,9 @@ Once access is granted, each tenant configures their specific GA4 property in **
 
 - **Google Analytics ID**: Measurement ID (`G-XXXXXXXXXX`)
 - **Google Analytics Property ID**: Numeric Property ID (`NUMERIC_PROPERTY_ID`)
-- Enable **Analytics** and **Analytics Reporting** checkboxes
+- Enable **Google Analytics** checkbox
+
+> **💡 Simplified Setup**: The single "Google Analytics" checkbox now controls both user interaction tracking and dashboard reporting. When enabled, it automatically activates both features when proper credentials are configured.
 
 **Important:** Each tenant needs their own dedicated GA4 property for data isolation. The global service account must have Viewer access to each tenant's GA4 property for the integration to work.
 
@@ -255,7 +254,7 @@ Once access is granted, each tenant configures their specific GA4 property in **
 
 - **Check Service Account Access**: Verify the administrator's service account has been added to the tenant's GA4 property with Viewer access
 - **Verify Property ID**: Ensure the Property ID is numeric (not the Measurement ID)
-- **Check Tenant Settings**: Confirm Analytics and Analytics Reporting are enabled in Admin → Settings
+- **Check Tenant Settings**: Confirm Google Analytics is enabled in Admin → Settings
 - **Wait for Propagation**: If access was just granted, wait up to 24 hours for Google Analytics to fully activate the permissions
 
 ### 📊 Analytics Features

--- a/ops/demo-deploy.tmpl.yaml
+++ b/ops/demo-deploy.tmpl.yaml
@@ -84,8 +84,6 @@ extraEnvVars: &envVars
   # Google Analytics 4 (GA4) Configuration
   - name: HYRAX_ANALYTICS
     value: $HYRAX_ANALYTICS
-  - name: HYRAX_ANALYTICS_REPORTING
-    value: $HYRAX_ANALYTICS_REPORTING
   - name: HYRAX_ANALYTICS_PROVIDER
     value: "ga4"
   - name: GOOGLE_ACCOUNT_JSON

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -84,8 +84,6 @@ extraEnvVars: &envVars
   # Google Analytics 4 (GA4) Configuration
   - name: HYRAX_ANALYTICS
     value: $HYRAX_ANALYTICS
-  - name: HYRAX_ANALYTICS_REPORTING
-    value: $HYRAX_ANALYTICS_REPORTING
   - name: HYRAX_ANALYTICS_PROVIDER
     value: "ga4"
   - name: GOOGLE_ACCOUNT_JSON

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -635,7 +635,7 @@ RSpec.describe Account, type: :model do
 
     context 'with analytics enabled' do
       before do
-        account.settings['analytics_reporting'] = true
+        account.settings['analytics'] = true
         allow(Hyrax.config).to receive(:analytics_reporting?).and_return(true)
       end
 

--- a/spec/models/concerns/account_settings_spec.rb
+++ b/spec/models/concerns/account_settings_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe AccountSettings do
         expect(account.public_settings(is_superadmin: true).keys.sort).to eq %i[allow_downloads
                                                                                 allow_signup
                                                                                 analytics
-                                                                                analytics_reporting
                                                                                 batch_email_notifications
                                                                                 bulkrax_field_mappings
                                                                                 cache_api

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -11,7 +11,6 @@ ENV['HYKU_ADMIN_ONLY_TENANT_CREATION'] = nil
 ENV['HYKU_DEFAULT_HOST'] = nil
 ENV['HYKU_MULTITENANT'] = 'true'
 ENV['VALKYRIE_TRANSITION'] = 'true'
-ENV['HYRAX_ANALYTICS_REPORTING'] = 'false'
 
 require 'simplecov'
 SimpleCov.start('rails')

--- a/spec/services/create_account_spec.rb
+++ b/spec/services/create_account_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe CreateAccount, clean: true do
       before do
         allow(account).to receive(:batch_email_notifications).and_return(true)
         allow(account).to receive(:depositor_email_notifications).and_return(true)
-        allow(account).to receive(:analytics_reporting).and_return(true)
+        allow(account).to receive(:analytics).and_return(true)
         allow(Hyrax.config).to receive(:analytics_reporting?).and_return(true)
       end
 
@@ -143,7 +143,7 @@ RSpec.describe CreateAccount, clean: true do
       before do
         allow(account).to receive(:batch_email_notifications).and_return(false)
         allow(account).to receive(:depositor_email_notifications).and_return(false)
-        allow(account).to receive(:analytics_reporting).and_return(false)
+        allow(account).to receive(:analytics).and_return(false)
       end
 
       it "only enqueues embargo and lease jobs" do


### PR DESCRIPTION


This PR allows users to only have to click 1 analytics checkbox to enable all related features. It also fixes a bug where analytics will only display if the tenant has enabled it. 

<details> 

disabled analytics

<img width="852" height="517" alt="image" src="https://github.com/user-attachments/assets/020b3e65-ebf8-4d57-8e09-7d45b3d9460f" />

</details> 

# BEFORE 

<img width="1044" height="161" alt="image" src="https://github.com/user-attachments/assets/25e0ba9b-99bf-46dd-8c44-07f74b0f14b4" />


# AFTER

<img width="603" height="80" alt="image" src="https://github.com/user-attachments/assets/b2fc2b01-2699-4164-9c90-72390f8c1529" />



### When all values are present (google analytic id and measurement id, the sidebar displays analytics) 

<img width="1878" height="948" alt="image" src="https://github.com/user-attachments/assets/68b51d9d-5eae-4f40-b795-632a0e84bf82" />
