### PR TITLE
🎁 i892 exclude collections from catalog search

### DIFF
--- a/app/forms/collection_resource_form.rb
+++ b/app/forms/collection_resource_form.rb
@@ -7,4 +7,7 @@ class CollectionResourceForm < Hyrax::Forms::PcdmCollectionForm
   include Hyrax::FormFields(:bulkrax_metadata) unless Hyrax.config.flexible?
   include Hyrax::FormFields(:collection_resource) unless Hyrax.config.flexible?
   include CollectionAccessFiltering
+
+  # Add hide_from_catalog_search checkbox as a Reform property that will set the property as true or false
+  property :hide_from_catalog_search, type: Dry::Types['params.bool'], default: false
 end

--- a/app/views/hyrax/dashboard/collections/_form_discovery.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_discovery.html.erb
@@ -35,7 +35,14 @@
   <div class="form-check">
     <label class="form-check-label <%= disabled %>">
       <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE, disabled: disabled %>
-      <strong><%= t('hyrax.visibility.restricted.text') %></strong>- <%= t('hyrax.visibility.restricted.note_html') %>
+      <strong><%= t('hyrax.visibility.restricted.text') %></strong> - <%= t('hyrax.visibility.restricted.note_html') %>
+    </label>
+  </div>
+  <%# Hide from catalog search option %>
+  <div class="form-check mt-3">
+    <label class="form-check-label <%= disabled %>">
+      <%= f.check_box :hide_from_catalog_search, { disabled: disabled } %>
+      <strong>Hide from catalog search</strong> - When checked, this collection will not appear in catalog search results.
     </label>
   </div>
 </div>

--- a/app/views/hyrax/dashboard/collections/_form_discovery.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_discovery.html.erb
@@ -42,7 +42,7 @@
   <div class="form-check mt-3">
     <label class="form-check-label <%= disabled %>">
       <%= f.check_box :hide_from_catalog_search, { disabled: disabled } %>
-      <strong>Hide from catalog search</strong> - When checked, this collection will not appear in catalog search results.
+      <%= t('.hide_from_catalog_search_html') %>
     </label>
   </div>
 </div>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -571,6 +571,7 @@ en:
         form_discovery:
           para1: These settings determine who is able to discover and view this collection's landing page; they do not affect the visibility of items in the collection.
           para2: If you chose not to make this collection open access, you can still share the collection with specific users and groups using the Sharing tab.
+          hide_from_catalog_search_html: <strong>Hide from catalog search</strong> - When checked, this collection will not appear in catalog search results.
         form_relationships:
           add_other_collections_as_sub_collections_description: You can manage the sub-collections of this collection.
           buttons:

--- a/config/metadata/collection_resource.yaml
+++ b/config/metadata/collection_resource.yaml
@@ -21,4 +21,15 @@
 # Generated via
 #  `rails generate hyrax:collection_resource CollectionResource`
 
-attributes: {}
+attributes:
+  hide_from_catalog_search:
+    type: string
+    multiple: false
+    form:
+      required: false
+      primary: false
+      multiple: false
+    predicate: https://hykucommons.org/terms/hide_from_catalog_search
+    index_keys:
+    - hide_from_catalog_search_bsi
+    - hide_from_catalog_search_tesim

--- a/config/metadata_profiles/m3_profile.yaml
+++ b/config/metadata_profiles/m3_profile.yaml
@@ -1783,3 +1783,30 @@ properties:
     view:
       render_as: "faceted"
       html_dl: true
+  hide_from_catalog_search:
+    available_on:
+      class:
+        - CollectionResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#bool
+      sources:
+        - "null"
+    display_label:
+      default: Hide from Catalog Search
+    index_documentation: displayable, searchable
+    indexing:
+      - hide_from_catalog_search_bsi
+      - hide_from_catalog_search_tesim
+    form:
+      primary: false
+      required: false
+      multiple: false
+    property_uri: https://hykucommons.org/terms/hide_from_catalog_search
+    range: http://www.w3.org/2001/XMLSchema#bool
+    sample_values:
+      - true
+      - false

--- a/spec/forms/collection_resource_form_spec.rb
+++ b/spec/forms/collection_resource_form_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe CollectionResourceForm do
     context 'Valkyrie resource model' do
       # hide_from_catalog_search is an attribute in the collection_resource.yaml
       it 'is an attribute on the resource' do
-        resource.respond_to?(:hide_from_catalog_search)
+        expect(change_set.respond_to?(:hide_from_catalog_search)).to be true
       end
 
       it 'defaults as nil' do
@@ -35,8 +35,8 @@ RSpec.describe CollectionResourceForm do
 
     context 'change_set form' do
       it 'can get and set values' do
-        change_set.respond_to?(:hide_from_catalog_search)
-        change_set.respond_to?(:hide_from_catalog_search=)
+        expect(change_set.respond_to?(:hide_from_catalog_search)).to be true
+        expect(change_set.respond_to?(:hide_from_catalog_search=)).to be true
       end
 
       it 'can be set the value to true when the box is checked' do

--- a/spec/forms/collection_resource_form_spec.rb
+++ b/spec/forms/collection_resource_form_spec.rb
@@ -48,6 +48,26 @@ RSpec.describe CollectionResourceForm do
         change_set.hide_from_catalog_search = false
         expect(change_set.hide_from_catalog_search).to be false
       end
+
+      it 'converts string "1" to true (checkbox checked)' do
+        change_set.hide_from_catalog_search = "1"
+        expect(change_set.hide_from_catalog_search).to eq(true)
+      end
+
+      it 'converts string "0" to false (checkbox unchecked)' do
+        change_set.hide_from_catalog_search = "0"
+        expect(change_set.hide_from_catalog_search).to eq(false)
+      end
+
+      it 'converts string "true" to true (checkbox checked)' do
+        change_set.hide_from_catalog_search = "true"
+        expect(change_set.hide_from_catalog_search).to eq(true)
+      end
+
+      it 'converts string "false" to false (checkbox unchecked)' do
+        change_set.hide_from_catalog_search = "false"
+        expect(change_set.hide_from_catalog_search).to eq(false)
+      end
     end
   end
 end

--- a/spec/forms/collection_resource_form_spec.rb
+++ b/spec/forms/collection_resource_form_spec.rb
@@ -6,8 +6,48 @@ require 'rails_helper'
 require 'valkyrie/specs/shared_specs'
 
 RSpec.describe CollectionResourceForm do
-  let(:change_set) { described_class.new(resource:) }
+  # Valkyrie resource model
   let(:resource)   { CollectionResource.new }
+  # CollectionResourceForm class
+  let(:change_set) { described_class.new(resource:) }
 
   it_behaves_like 'a Valkyrie::ChangeSet'
+
+  describe 'hide_from_catalog_search' do
+    context 'Valkyrie resource model' do
+      # hide_from_catalog_search is an attribute in the collection_resource.yaml
+      it 'is an attribute on the resource' do
+        resource.respond_to?(:hide_from_catalog_search)
+      end
+
+      it 'defaults as nil' do
+        expect(resource.hide_from_catalog_search).to be nil
+      end
+
+      it 'can be set to a boolean value' do
+        resource.hide_from_catalog_search = true
+        expect(resource.hide_from_catalog_search).to be true
+
+        resource.hide_from_catalog_search = false
+        expect(resource.hide_from_catalog_search).to be false
+      end
+    end
+
+    context 'change_set form' do
+      it 'can get and set values' do
+        change_set.respond_to?(:hide_from_catalog_search)
+        change_set.respond_to?(:hide_from_catalog_search=)
+      end
+
+      it 'can be set the value to true when the box is checked' do
+        change_set.hide_from_catalog_search = true
+        expect(change_set.hide_from_catalog_search).to be true
+      end
+
+      it 'can be set the value to false when the box is unchecked' do
+        change_set.hide_from_catalog_search = false
+        expect(change_set.hide_from_catalog_search).to be false
+      end
+    end
+  end
 end

--- a/spec/indexers/collection_resource_indexer_spec.rb
+++ b/spec/indexers/collection_resource_indexer_spec.rb
@@ -10,4 +10,43 @@ RSpec.describe CollectionResourceIndexer do
   let(:resource)      { CollectionResource.new }
 
   it_behaves_like 'a Hyrax::Resource indexer'
+
+  describe 'hide_from_catalog_search indexing' do
+    let(:indexer) { described_class.new(resource: resource) }
+    let(:document) { indexer.to_solr }
+
+    context 'when hide_from_catalog_search is true' do
+      before { resource.hide_from_catalog_search = true }
+
+      it 'indexes hide_from_catalog_search_bsi as true' do
+        expect(document['hide_from_catalog_search_bsi']).to be true
+      end
+
+      it 'indexes hide_from_catalog_search_tesim as true' do
+        expect(document['hide_from_catalog_search_tesim']).to eq true
+      end
+    end
+
+    context 'when hide_from_catalog_search is false' do
+      before { resource.hide_from_catalog_search = false }
+
+      it 'indexes hide_from_catalog_search_bsi as false' do
+        expect(document['hide_from_catalog_search_bsi']).to be false
+      end
+
+      it 'indexes hide_from_catalog_search_tesim as false' do
+        expect(document['hide_from_catalog_search_tesim']).to eq false
+      end
+    end
+
+    context 'when hide_from_catalog_search is not set' do
+      it 'indexes hide_from_catalog_search_bsi as nil (default)' do
+        expect(document['hide_from_catalog_search_bsi']).to be nil
+      end
+
+      it 'indexes hide_from_catalog_search_tesim as nil (default)' do
+        expect(document['hide_from_catalog_search_tesim']).to eq nil
+      end
+    end
+  end
 end

--- a/spec/models/collection_resource_spec.rb
+++ b/spec/models/collection_resource_spec.rb
@@ -19,4 +19,25 @@ RSpec.describe CollectionResource do
     subject { described_class }
     its(:to_rdf_representation) { is_expected.to eq('Collection') }
   end
+
+  describe 'hide_from_catalog_search attribute' do
+    it 'can get and set values' do
+      expect(collection).to respond_to(:hide_from_catalog_search)
+      expect(collection).to respond_to(:hide_from_catalog_search=)
+    end
+
+    it 'defaults to nil' do
+      expect(collection.hide_from_catalog_search).to be nil
+    end
+
+    it 'can be set to true' do
+      collection.hide_from_catalog_search = true
+      expect(collection.hide_from_catalog_search).to be true
+    end
+
+    it 'can be set to false' do
+      collection.hide_from_catalog_search = false
+      expect(collection.hide_from_catalog_search).to be false
+    end
+  end
 end

--- a/spec/search_builders/adv_search_builder_spec.rb
+++ b/spec/search_builders/adv_search_builder_spec.rb
@@ -58,9 +58,34 @@ RSpec.describe AdvSearchBuilder do
         highlight_search_params
         show_parents_only
         include_allinson_flex_fields
+        filter_hidden_collections
       ]
     end
 
     it { is_expected.to eq(expected_default_processor_chain) }
+  end
+
+  describe '#filter_hidden_collections' do
+    let(:solr_params) { {} }
+
+    before { builder.filter_hidden_collections(solr_params) }
+
+    it 'adds filter query to exclude hidden collections' do
+      expect(solr_params[:fq]).to include('-(hide_from_catalog_search_bsi:true)')
+    end
+
+    it 'preserves existing fq parameters' do
+      existing_fq = ['existing_filter:value']
+      solr_params[:fq] = existing_fq
+      builder.filter_hidden_collections(solr_params)
+
+      expect(solr_params[:fq]).to include('existing_filter:value')
+      expect(solr_params[:fq]).to include('-(hide_from_catalog_search_bsi:true)')
+    end
+
+    it 'initializes fq array if not present' do
+      expect(solr_params[:fq]).to be_an(Array)
+      expect(solr_params[:fq]).to include('-(hide_from_catalog_search_bsi:true)')
+    end
   end
 end


### PR DESCRIPTION
## Summary

This adds the ability to exclude a collection from the catalog search results. A checkbox to `Hide from catalog search` is added to the `Discovery` tab of the collection edit form. Checking the box will set the `hide_from_catalog_search` attribute on the CollectionResource to true which will filter it from the search results.

The `hide_from_catalog_search` attribute will be required in the flexible metadata profile if flexible is enabled.

Ref:
- https://github.com/notch8/adventist_knapsack/issues/892

<img width="1594" height="660" alt="Screenshot 2025-08-28 at 3 28 23 PM" src="https://github.com/user-attachments/assets/70007197-2449-4000-a551-a721fa96ca4e" />

@samvera/hyku-code-reviewers
