### PR TITLE
Update hyrax

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,7 +163,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: 3d81004c1859edf8327c794bd2d296dde3a54438
+  revision: 6080766303065bf71ffe56280a5f828cc9de13cb
   branch: 5.0-flexible
   specs:
     hyrax (5.0.5)


### PR DESCRIPTION
## Summary

Brings in batch edit fixes from 5.0-flexible

## Notes

This makes batch edit work (depending on the metadata profile, of course). Batch add will remain broken but is beyond a feature flipper flag, so it doesn't affect the user experience.