### PR TITLE
🐛 Remove `Hide from catalog search` from metadata

### DIFF
--- a/config/metadata/collection_resource.yaml
+++ b/config/metadata/collection_resource.yaml
@@ -26,6 +26,7 @@ attributes:
     type: string
     multiple: false
     form:
+      display: false
       required: false
       primary: false
       multiple: false

--- a/config/metadata_profiles/m3_profile.yaml
+++ b/config/metadata_profiles/m3_profile.yaml
@@ -1802,6 +1802,7 @@ properties:
       - hide_from_catalog_search_bsi
       - hide_from_catalog_search_tesim
     form:
+      display: false
       primary: false
       required: false
       multiple: false


### PR DESCRIPTION
Remove the `Hide from catalog search` from create/edit form with metadata fields. Ensure it only appears as a checkbox on the collection edit branding tab for both flexible=true and flexible=false

Ref:
- https://github.com/notch8/adventist_knapsack/issues/892

@samvera/hyku-code-reviewers
