### PR TITLE
🐛 Collections facet in catalog search

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,7 +163,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: 6080766303065bf71ffe56280a5f828cc9de13cb
+  revision: 5516ee58f0b7210e3289e29b5d77f151ff268304
   branch: 5.0-flexible
   specs:
     hyrax (5.0.5)


### PR DESCRIPTION
Updates submodule to bring the following changes from Hyrax:

This commit adds `member_of_collections_ssim` to the SolrDocument ensuring collections with associated works are faceted in the catalog search results.

Prior to this change, collections were faceted for Active Fedora works but once the works were migrated or when new works are created the `member_of_collections_ssim` was not present in the Solr document.

Ref:
- https://github.com/notch8/adventist_knapsack/issues/952

@samvera/hyku-code-reviewers
