### PR TITLE
🎁 Full text search to include .txt files

### DIFF
--- a/spec/fixtures/files/text_file.txt
+++ b/spec/fixtures/files/text_file.txt
@@ -1,0 +1,1 @@
+Hello world!

--- a/spec/indexers/txt_indexer_spec.rb
+++ b/spec/indexers/txt_indexer_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.describe 'txt indexer' do
+  let(:work) { valkyrie_create(:generic_work_resource) }
+  let(:file_set) { valkyrie_create(:hyrax_file_set, :with_files, ios: [File.open(File.join(fixture_path, 'files', 'text_file.txt'))]) }
+
+  before do
+    fm = file_set.original_file
+    fm.mime_type = 'text/plain' # since it doesn't go through characterization in a spec we have to set it manually
+    Hyrax.persister.save(resource: fm)
+    work.member_ids << file_set.id
+    work.save
+  end
+
+  it 'indexes txt files onto the work' do
+    indexer = "#{work.class}Indexer".constantize
+    expect(indexer.included_modules).to include(HykuIndexing)
+    expect(work.to_solr['all_text_tsimv']).to eq('Hello world!')
+  end
+end


### PR DESCRIPTION
This commit enables user to upload a txt file and perform a full text search from the catalog search. This is used to enable full text search for pdfs or other files that don't have OCR.

Ref:
- https://github.com/notch8/adventist_knapsack/issues/936

Text search for a PDF + txt file:
<img width="1691" height="651" alt="Screenshot 2025-09-08 at 9 59 34 AM" src="https://github.com/user-attachments/assets/956a6f43-6f7b-4321-95ce-4545af226e78" />


@samvera/hyku-code-reviewers
