### PR TITLE
Controlled vocab follow up

### DIFF
--- a/app/helpers/hyrax/form_helper_behavior.rb
+++ b/app/helpers/hyrax/form_helper_behavior.rb
@@ -87,6 +87,11 @@ module Hyrax
     def ensure_discogs_credentials
       return unless current_account.respond_to?(:discogs_user_token)
 
+      unless discogs_config_files_exist?
+        Rails.logger.warn('Discogs user token is present, but config/discogs-genres.yml and/or config/discogs-formats.yml are missing. Discogs integration is disabled.')
+        return
+      end
+
       # Clear token if current tenant doesn't have one configured
       if current_account.discogs_user_token.blank?
         Qa::Authorities::Discogs::GenericAuthority.discogs_user_token = nil
@@ -95,6 +100,11 @@ module Hyrax
 
       # Set token for current tenant
       Qa::Authorities::Discogs::GenericAuthority.discogs_user_token = current_account.discogs_user_token
+    end
+
+    def discogs_config_files_exist?
+      File.exist?(Rails.root.join('config', 'discogs-genres.yml')) &&
+        File.exist?(Rails.root.join('config', 'discogs-formats.yml'))
     end
   end
 end

--- a/app/models/concerns/account_settings.rb
+++ b/app/models/concerns/account_settings.rb
@@ -30,6 +30,7 @@ module AccountSettings
     setting :contact_email, type: 'string', default: 'change-me-in-settings@example.com'
     setting :contact_email_to, type: 'string', default: 'change-me-in-settings@example.com'
     setting :depositor_email_notifications, type: 'boolean', default: false
+    setting :discogs_user_token, type: 'string', private: true
     setting :doi_reader, type: 'boolean', default: false
     setting :doi_writer, type: 'boolean', default: false
     setting :file_acl, type: 'boolean', default: true, private: true
@@ -42,7 +43,6 @@ module AccountSettings
     setting :google_analytics_property_id, type: 'string', default: ''
     setting :google_scholarly_work_types, type: 'array', disabled: true
     setting :geonames_username, type: 'string', default: ''
-    setting :discogs_user_token, type: 'string', private: true
     setting :gtm_id, type: 'string'
     setting :hidden_index_fields, type: 'string', default: 'title'
     setting :locale_name, type: 'string', disabled: true


### PR DESCRIPTION
Prevents error when discogs set up isn't complete: 

## BEFORE

User would see the app crash when creating a new work

<img width="1080" height="420" alt="image" src="https://github.com/user-attachments/assets/e6fa20c1-f115-4860-96b8-c8b61f9c9bb9" />


## AFTER

App no longer crashes

<img width="1313" height="793" alt="image" src="https://github.com/user-attachments/assets/8cbabade-c7d3-43a2-b78a-ccd500ffb43b" />

