### PR TITLE
Graceful error handling of ga4 errors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,7 +163,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: a4bcbe5988560102e8b5fcd8c574707c370f8f89
+  revision: 963235c8ef80595e4ee9b1515b38d403ea752b29
   branch: 5.0-flexible
   specs:
     hyrax (5.0.5)


### PR DESCRIPTION
# BEFORE

site crashed when credentials were invalid. These are errors that the user can fix (no dev needs to get involved).

<img width="1254" height="1093" alt="image" src="https://github.com/user-attachments/assets/4c32bc0a-64e0-407b-b01e-edd523081f9f" />

<img width="1343" height="578" alt="image" src="https://github.com/user-attachments/assets/6bc27b88-a753-4e97-aa79-9375d1e89562" />


# AFTER

Common user errors are caught and handled more gracefully. Setup Guide links to https://samvera.atlassian.net/wiki/spaces/hyku/pages/3185147970/Google+Analytics+4+GA4+Support:

<img width="2704" height="1462" alt="Screenshot 2025-09-09 at 18-31-32 Works Report" src="https://github.com/user-attachments/assets/d61e5749-81c5-47d2-948b-72bd1d85f90e" />

<img width="2704" height="1462" alt="Screenshot 2025-09-09 at 18-31-18 Works Report" src="https://github.com/user-attachments/assets/5792adff-f8a9-4703-bc12-2629d5739003" />



