### PR TITLE
🐛 Use post method for nested collection queries

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,7 +163,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: 963235c8ef80595e4ee9b1515b38d403ea752b29
+  revision: c7c471e7dc33833c415a88fcb7438b93248de85a
   branch: 5.0-flexible
   specs:
     hyrax (5.0.5)


### PR DESCRIPTION
This commit updates the Hyrax gem to the latest version of `5.0-flexible` that includes a bug fix in the Nested Collection Controller. Since it is not based on catalog controller, so it does not inherit the POST behavior we added there. This causes the `parent_and_child_can_nest?` to do a GET request, which fails when too many ids are included in the request. In this fix, we add an explicit setting of `http_method` prior to doing this query.

Ref:
- https://github.com/notch8/adventist_knapsack/issues/1004

@samvera/hyku-code-reviewers
