### PR TITLE
⚙️ Temporarily disable batch_upload feature

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,7 +141,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: 15617c8a9f1b4d4e2c1536851ac61ea525ade582
+  revision: b0475ea9de15afac61b4421acb45e108f31e9999
   branch: 5.0-flexible
   specs:
     hyrax (5.0.5)


### PR DESCRIPTION
Version bump:

This commit updates the version of Hyrax 5.0-flexible that prevents admin users from enabling batch_upload in settings.

This addresses the issue that batch uploads and Valkyrized works are incompatible. The current Batch Add uses a fake Active Fedora form with fixed terms that ignore the selected work type, causing Valkyrie validations to fail (especially on 6.2).

It was determined that fixing this issue is low-priority compared to general Bulkrax improvements. To ensure users are not enabling broken features, batch_upload is disabled until further decisions are made.

Ref:
- notch8/palni_palci_knapsack#479

<img width="1522" height="828" alt="Screenshot 2025-09-22 at 9 28 10 AM" src="https://github.com/user-attachments/assets/ccba9b87-85a3-4292-a191-76dbd64fced1" />

@samvera/hyku-code-reviewers
