### PR TITLE
🐛 Add account cname to thumbnail img src

### DIFF
--- a/app/helpers/blacklight/catalog_helper_behavior_decorator.rb
+++ b/app/helpers/blacklight/catalog_helper_behavior_decorator.rb
@@ -32,6 +32,13 @@ module Blacklight
       # rubocop:enable Style/GuardClause
     end
     # rubocop:enable Metrics/MethodLength
+
+    def thumbnail_url(document)
+      cname = document['account_cname_tesim']&.first
+      return super if cname.nil?
+
+      request.protocol + cname + super
+    end
   end
 end
 

--- a/app/views/themes/cultural_repository/hyrax/homepage/_recent_document.html.erb
+++ b/app/views/themes/cultural_repository/hyrax/homepage/_recent_document.html.erb
@@ -4,7 +4,7 @@
     <%= render_thumbnail_tag(recent_document, {suppress_link: true}, class: 'img-fluid center-block') %>
   <% end %>
   <div class="recent-doc-title">
-    <%= link_to [main_app, recent_document] do %>
+    <%= link_to generate_work_url(recent_document, request, params) do %>
       <h3><%= markdown(recent_document.to_s) %></h3>
     <% end %>
   </div>


### PR DESCRIPTION
This commit will add the account cname to the thumbnail img tag's src attribute.  In a search tenant we would only see /downloads/<id> which doesn't work because it needs to know which tenant the document came from.  Also fixed the cultural repository theme where the link was also not displaying the full URL in a search tenant.

Ref:
- https://github.com/notch8/hykuup_knapsack/issues/480

<img width="1102" height="929" alt="image" src="https://github.com/user-attachments/assets/fa6db48c-cde4-46f7-9d8d-d44c589015b0" />
