### PR TITLE
Set default preferred_locale to 'en' for users

### DIFF
--- a/db/migrate/20250923223123_set_default_preferred_locale_for_users.rb
+++ b/db/migrate/20250923223123_set_default_preferred_locale_for_users.rb
@@ -1,0 +1,11 @@
+class SetDefaultPreferredLocaleForUsers < ActiveRecord::Migration[6.1]
+  def up
+    execute "UPDATE users SET preferred_locale = 'en' WHERE preferred_locale IS NULL OR preferred_locale = ''"
+    
+    change_column_default :users, :preferred_locale, 'en'
+  end
+
+  def down
+    change_column_default :users, :preferred_locale, nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_07_01_163138) do
+ActiveRecord::Schema.define(version: 2025_09_23_223123) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -951,7 +951,7 @@ ActiveRecord::Schema.define(version: 2025_07_01_163138) do
     t.integer "invitation_limit"
     t.integer "invited_by_id"
     t.string "invited_by_type"
-    t.string "preferred_locale"
+    t.string "preferred_locale", default: "en"
     t.string "provider"
     t.string "uid"
     t.string "batch_email_frequency", default: "never"


### PR DESCRIPTION
# Summary

Set default preferred_locale to 'en' for users to prevent application crashes when users have blank locale values. This may be a band aid fix for a deeper issue. 

## Ticket Number

https://github.com/notch8/hykuup_knapsack/issues/524

# Screenshots / Video

## BEFORE

<img width="720" height="186" alt="image" src="https://github.com/user-attachments/assets/a4de8800-b882-4f46-9a2d-86f472d3cbdc" />


## AFTER

<img width="1348" height="801" alt="image" src="https://github.com/user-attachments/assets/eedbfb17-eded-4d12-8e82-fcd5f6b3aa44" />

# Expected Behavior 

- New users should automatically have `preferred_locale` set to 'en'
- Existing users with blank or null `preferred_locale` should be updated to 'en'
- Application should no longer crash when accessing users with blank locale values
- All users should have a valid locale value

# Sample Files

- Migration: `db/migrate/20250923223123_set_default_preferred_locale_for_users.rb`
- Affects: `users` table `preferred_locale` column

# Notes

- This migration addresses a production issue where users with blank `preferred_locale` values were causing application crashes
- The migration updates existing data and sets a database-level default for future records
- No breaking changes - this only affects users with blank locale values
- Tested in development environment