### PR TITLE
Fix search tenant flexble metadata

### DIFF
--- a/app/services/hyrax/quick_classification_query_decorator.rb
+++ b/app/services/hyrax/quick_classification_query_decorator.rb
@@ -30,7 +30,7 @@ module Hyrax
       # Search-only tenants don't have their own flexible metadata profiles
       # They should use the basic available_works configuration
       return available_works if Site.account&.search_only?
-      
+
       profile = Hyrax::FlexibleSchema.current_version
       return available_works unless profile
 

--- a/app/services/hyrax/quick_classification_query_decorator.rb
+++ b/app/services/hyrax/quick_classification_query_decorator.rb
@@ -27,6 +27,10 @@ module Hyrax
       available_works = Site.instance.available_works
       return available_works unless Hyrax.config.flexible?
 
+      # Search-only tenants don't have their own flexible metadata profiles
+      # They should use the basic available_works configuration
+      return available_works if Site.account&.search_only?
+      
       profile = Hyrax::FlexibleSchema.current_version
       return available_works unless profile
 

--- a/spec/services/hyrax/quick_classification_query_decorator_spec.rb
+++ b/spec/services/hyrax/quick_classification_query_decorator_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Hyrax::QuickClassificationQuery, type: :decorator do
   let(:available_works) { ['GenericWork', 'Image', 'SomeOtherWork'] }
 
   before do
+    allow(Site).to receive(:instance).and_return(site)
     allow(site).to receive(:available_works).and_return(available_works)
   end
 
@@ -20,6 +21,70 @@ RSpec.describe Hyrax::QuickClassificationQuery, type: :decorator do
   describe '#all?' do
     it 'uses Site.instance.available_works instead of Hyrax.config.registered_curation_concern_types' do
       expect(subject.all?).to eq true
+    end
+  end
+
+  describe '#filtered_available_works' do
+    context 'when HYRAX_FLEXIBLE is false' do
+      before { allow(Hyrax.config).to receive(:flexible?).and_return(false) }
+
+      it 'returns Site.instance.available_works' do
+        expect(subject.send(:filtered_available_works)).to eq available_works
+      end
+    end
+
+    context 'when HYRAX_FLEXIBLE is true' do
+      before { allow(Hyrax.config).to receive(:flexible?).and_return(true) }
+
+      context 'with a search-only tenant' do
+        let(:account) { create(:account, search_only: true) }
+
+        before do
+          allow(Site).to receive(:account).and_return(account)
+        end
+
+        it 'returns Site.instance.available_works without trying to access flexible schema' do
+          # Should not call Hyrax::FlexibleSchema.current_version for search-only tenants
+          expect(Hyrax::FlexibleSchema).not_to receive(:current_version)
+          expect(subject.send(:filtered_available_works)).to eq available_works
+        end
+      end
+
+      context 'with a regular tenant' do
+        let(:account) { create(:account, search_only: false) }
+        let(:mock_profile) do
+          {
+            'classes' => {
+              'GenericWorkResource' => {},
+              'ImageResource' => {}
+            }
+          }
+        end
+
+        before do
+          allow(Site).to receive(:account).and_return(account)
+          allow(Hyrax::FlexibleSchema).to receive(:current_version).and_return(mock_profile)
+          allow(Hyrax.config).to receive(:registered_curation_concern_types).and_return(['GenericWork', 'Image', 'Etd'])
+        end
+
+        it 'filters available works based on flexible metadata profile' do
+          # Should return intersection of available_works and profile work types
+          expect(subject.send(:filtered_available_works)).to eq ['GenericWork', 'Image']
+        end
+      end
+
+      context 'when flexible schema current_version returns nil' do
+        let(:account) { create(:account, search_only: false) }
+
+        before do
+          allow(Site).to receive(:account).and_return(account)
+          allow(Hyrax::FlexibleSchema).to receive(:current_version).and_return(nil)
+        end
+
+        it 'returns Site.instance.available_works' do
+          expect(subject.send(:filtered_available_works)).to eq available_works
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #2728 

Simple check in the decorator to address issues in ticket https://github.com/samvera/hyku/issues/2728

Changes proposed in this pull request:
Addition of return to filtered_available_works "      return available_works if Site.account&.search_only?"

Updated spec tests.

@samvera/hyku-code-reviewers
