### PR TITLE
🐛 Fix FileSet show page from breaking

### DIFF
--- a/app/helpers/blacklight/catalog_helper_behavior_decorator.rb
+++ b/app/helpers/blacklight/catalog_helper_behavior_decorator.rb
@@ -34,6 +34,8 @@ module Blacklight
     # rubocop:enable Metrics/MethodLength
 
     def thumbnail_url(document)
+      document = document.try(:solr_document) || document
+
       cname = document['account_cname_tesim']&.first
       return super if cname.nil?
 

--- a/app/indexers/concerns/hyku_indexing.rb
+++ b/app/indexers/concerns/hyku_indexing.rb
@@ -53,7 +53,7 @@ module HykuIndexing
 
     return [] if members.blank?
 
-    text_file_sets = object.members.select { |fs| fs.file_set? && fs.original_file&.mime_type == 'text/plain' }
+    text_file_sets = members.select { |fs| fs.file_set? && fs.original_file&.mime_type == 'text/plain' }
     text_file_sets.map { |fs| fs.original_file&.content }
   end
 


### PR DESCRIPTION
Sometimes the `document` is actually a presenter, so if it responds to `#solr_document` then we should get the SolrDocument.  If it doesn't then we use the SolrDocument that is passed in.
