### PR TITLE
Ensure bulkrax_identifier is present and findable on FileSets

### DIFF
--- a/config/metadata_profiles/m3_profile.yaml
+++ b/config/metadata_profiles/m3_profile.yaml
@@ -1574,6 +1574,7 @@ properties:
     available_on:
       class:
         - Hyrax::FileSet
+        - FileSet
         - CollectionResource
         - GenericWorkResource
         - ImageResource
@@ -1591,7 +1592,7 @@ properties:
       default: Bulkrax Identifier
     index_documentation: displayable, searchable
     indexing:
-      - "bulkrax_identifier_tesi"
+      - "bulkrax_identifier_tesim"
       - "bulkrax_identifier_ssi"
     form:
       display: false


### PR DESCRIPTION
Refs https://github.com/notch8/hykuup_knapsack/issues/454


Ensure bulkrax_identifier is present and findable on FileSets

- Uses consistent Solr field value for bulkrax_identifier `bulkrax_identifier_tesim` rather than `bulkrax_identifier_tesi`
- Makes bulkrax_identifier available on FileSet via configuration

@samvera/hyku-code-reviewers
