### PR TITLE
:bug: [i490] Adds guard to display hide_from_catalog_search checkbox

### DIFF
--- a/app/views/hyrax/dashboard/collections/_form_discovery.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_discovery.html.erb
@@ -39,10 +39,12 @@
     </label>
   </div>
   <%# Hide from catalog search option %>
-  <div class="form-check mt-3">
-    <label class="form-check-label <%= disabled %>">
-      <%= f.check_box :hide_from_catalog_search, { disabled: disabled } %>
-      <%= t('.hide_from_catalog_search_html') %>
-    </label>
-  </div>
+  <% if f.object.respond_to?(:hide_from_catalog_search) %>
+    <div class="form-check mt-3">
+      <label class="form-check-label <%= disabled %>">
+        <%= f.check_box :hide_from_catalog_search, { disabled: disabled } %>
+        <%= t('.hide_from_catalog_search_html') %>
+      </label>
+    </div>
+  <% end %>
 </div>


### PR DESCRIPTION
Prevents the application from crashing when creating a new collection, if the hide_from_catalog_search attribute is not defined in the metadata schema.

Issue:
- https://github.com/notch8/palni_palci_knapsack/issues/490

## BEFORE

<img width="720" height="426" alt="image" src="https://github.com/user-attachments/assets/ba295749-2c2c-498d-a6ab-fa223b9eec85" />

## AFTER

### HYRAX_FLEXIBLE=false
#### When not defined

<img width="2704" height="1461" alt="image" src="https://github.com/user-attachments/assets/7d9e1a26-0170-4064-8ec0-8a05dd470080" />

<img width="2704" height="1461" alt="image" src="https://github.com/user-attachments/assets/3756927c-0a12-4efd-b380-1997e8af165e" />

#### When defined in collection_resource.yaml

<img width="674" height="250" alt="image" src="https://github.com/user-attachments/assets/afe2d130-f061-4b60-96b9-3fe780c62ed8" />

#### HYRAX_FLEXIBLE=true
#### When not defined

<img width="2703" height="1461" alt="image" src="https://github.com/user-attachments/assets/3f573e8b-a061-4aba-85dd-0b7153e2fc1a" />

<img width="1341" height="728" alt="image" src="https://github.com/user-attachments/assets/ebcfdcc5-6937-4082-a9b6-8fd8f41a7827" />

#### When defined in collection_resource.yaml


<img width="678" height="399" alt="image" src="https://github.com/user-attachments/assets/5c543ad0-de39-4eca-942c-4960f8e9bf98" />

<img width="2703" height="1461" alt="image" src="https://github.com/user-attachments/assets/b5229e57-4c96-4549-9ef8-77919cfb2fb5" />
