### PR TITLE
🐛 App breaks when searching with empty query

### DIFF
--- a/spec/helpers/hyrax/form_helper_behavior_spec.rb
+++ b/spec/helpers/hyrax/form_helper_behavior_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::FormHelperBehavior, type: :helper do
+  describe '#controlled_vocabulary_source_for' do
+    context 'when flexible=false' do
+      before do
+        allow(Hyrax.config).to receive(:flexible?).and_return(false)
+      end
+
+      it 'returns controlled vocabulary service keys' do
+        expect(helper.send(:controlled_vocabulary_source_for, :audience)).to eq('audiences')
+        expect(helper.send(:controlled_vocabulary_source_for, :discipline)).to eq('disciplines')
+        expect(helper.send(:controlled_vocabulary_source_for, :education_level)).to eq('education_levels')
+        expect(helper.send(:controlled_vocabulary_source_for, 'learning_resource_type')).to eq('learning_resource_types')
+        expect(helper.send(:controlled_vocabulary_source_for, :license)).to eq('licenses')
+        expect(helper.send(:controlled_vocabulary_source_for, :resource_type)).to eq('resource_types')
+        expect(helper.send(:controlled_vocabulary_source_for, :rights_statement)).to eq('rights_statements')
+      end
+    end
+  end
+end


### PR DESCRIPTION
In v6.2 when `flexible=false`, the controlled vocabulary fields rendered a text field in the new/edit forms rather than a dropdown. This allowed the user to enter data that did not match a predefined mapping (e.g. `term: "In Copyright"`) defined in the `hyku/config/authorities` yml files. Controlled vocabulary maps the term from the form dropdown to the id that is persisted (e.g. `id: http://rightsstatements.org/vocab/InC/1.0/`). The incorrect data caused a KeyError the catalog search resulting in the application breaking.

This commit adds hardcoded mappings from the form property to the controlled vocabulary service key. Most of keys are the pluralized version of the form property but since that is not always the case, it was decided that hardcoding would prevent possible errors.

Future optimizations can include using the existing SERVICES mapping rather than hardcoding the values but at this point being explicit is an advantage.

Ref:
- https://github.com/notch8/hykuup_knapsack/issues/531

@samvera/hyku-code-reviewers
