### PR TITLE
🐛 Move controlled_vocab_mappings to initializers

### DIFF
--- a/app/helpers/hyrax/form_helper_behavior.rb
+++ b/app/helpers/hyrax/form_helper_behavior.rb
@@ -3,11 +3,11 @@
 module Hyrax
   module FormHelperBehavior
     def controlled_vocabulary_service_for(source_name)
-      Hyrax::ControlledVocabularies::SERVICES[source_name]&.safe_constantize
+      Hyrax::ControlledVocabularies.services[source_name]&.safe_constantize
     end
 
     def remote_authority_config_for(source_name)
-      Hyrax::ControlledVocabularies::REMOTE_AUTHORITIES[source_name]
+      Hyrax::ControlledVocabularies.remote_authorities[source_name]
     end
 
     def controlled_vocabulary_options_for(property_name, _record_class)
@@ -43,16 +43,7 @@ module Hyrax
     def controlled_vocabulary_mapping_for(property_name)
       # Maps property names in when flexible=false to their corresponding controlled vocabulary service keys
       # Hyku: config/initializers/hyrax_controlled_vocabularies.rb
-      controlled_vocab_mappings = {
-        'audience' => 'audiences',
-        'discipline' => 'disciplines',
-        'education_level' => 'education_levels',
-        'learning_resource_type' => 'learning_resource_types',
-        'license' => 'licenses',
-        'resource_type' => 'resource_types',
-        'rights_statement' => 'rights_statements'
-      }
-      controlled_vocab_mappings[property_name.to_s]
+      Hyrax::ControlledVocabularies.controlled_vocab_mappings[property_name.to_s]
     end
 
     def local_vocabulary_options_for(source)

--- a/config/initializers/hyrax_controlled_vocabularies.rb
+++ b/config/initializers/hyrax_controlled_vocabularies.rb
@@ -2,86 +2,104 @@
 
 module Hyrax
   module ControlledVocabularies
-    SERVICES = {
-      'audience' => 'Hyrax::AudienceService',
-      'discipline' => 'Hyrax::DisciplineService',
-      'education_levels' => 'Hyrax::EducationLevelsService',
-      'learning_resource_types' => 'Hyrax::LearningResourceTypesService',
-      'oer_types' => 'Hyrax::OerTypesService',
-      'licenses' => 'Hyrax::LicenseService',
-      'resource_types' => 'Hyrax::ResourceTypesService',
-      'rights_statements' => 'Hyrax::RightsStatementService'
-    }.freeze
+    class << self
+      def controlled_vocab_mappings
+        {
+          'audience' => 'audience',
+          'discipline' => 'discipline',
+          'education_level' => 'education_levels',
+          'learning_resource_type' => 'learning_resource_types',
+          'license' => 'licenses',
+          'resource_type' => 'resource_types',
+          'rights_statement' => 'rights_statements'
+        }.freeze
+      end
 
-    REMOTE_AUTHORITIES = {
-      'loc/subjects' => {
-        url: "/authorities/search/loc/subjects",
-        type: 'autocomplete'
-      },
-      'loc/names' => {
-        url: "/authorities/search/loc/names",
-        type: 'autocomplete'
-      },
-      'loc/genre_forms' => {
-        url: "/authorities/search/loc/genreForms",
-        type: 'autocomplete'
-      },
-      'loc/countries' => {
-        url: "/authorities/search/loc/countries",
-        type: 'autocomplete'
-      },
-      'getty/aat' => {
-        url: "/authorities/search/getty/aat",
-        type: 'autocomplete'
-      },
-      'getty/tgn' => {
-        url: "/authorities/search/getty/tgn",
-        type: 'autocomplete'
-      },
-      'getty/ulan' => {
-        url: "/authorities/search/getty/ulan",
-        type: 'autocomplete'
-      },
-      'geonames' => {
-        url: "/authorities/search/geonames",
-        type: 'autocomplete'
-      },
-      'fast' => {
-        url: "/authorities/search/assign_fast/topical",
-        type: 'autocomplete'
-      },
-      'fast/all' => {
-        url: "/authorities/search/assign_fast/all",
-        type: 'autocomplete'
-      },
-      'fast/personal' => {
-        url: "/authorities/search/assign_fast/personal",
-        type: 'autocomplete'
-      },
-      'fast/corporate' => {
-        url: "/authorities/search/assign_fast/corporate",
-        type: 'autocomplete'
-      },
-      'fast/geographic' => {
-        url: "/authorities/search/assign_fast/geographic",
-        type: 'autocomplete'
-      },
-      'mesh' => {
-        url: "/authorities/search/local/mesh",
-        type: 'autocomplete'
-      },
-      'discogs' => {
-        url: "/authorities/search/discogs/all",
-        type: 'autocomplete'
-      },
-      'discogs/release' => {
-        url: "/authorities/search/discogs/release",
-        type: 'autocomplete'
-      },
-      'discogs/master' => {
-        url: "/authorities/search/discogs/master",
-        type: 'autocomplete'
-      }
-    }.freeze
+      def services
+        {
+          'audience' => 'Hyrax::AudienceService',
+          'discipline' => 'Hyrax::DisciplineService',
+          'education_levels' => 'Hyrax::EducationLevelsService',
+          'learning_resource_types' => 'Hyrax::LearningResourceTypesService',
+          'oer_types' => 'Hyrax::OerTypesService',
+          'licenses' => 'Hyrax::LicenseService',
+          'resource_types' => 'Hyrax::ResourceTypesService',
+          'rights_statements' => 'Hyrax::RightsStatementService'
+        }.freeze
+      end
+
+      def remote_authorities
+        {
+          'loc/subjects' => {
+            url: "/authorities/search/loc/subjects",
+            type: 'autocomplete'
+          },
+          'loc/names' => {
+            url: "/authorities/search/loc/names",
+            type: 'autocomplete'
+          },
+          'loc/genre_forms' => {
+            url: "/authorities/search/loc/genreForms",
+            type: 'autocomplete'
+          },
+          'loc/countries' => {
+            url: "/authorities/search/loc/countries",
+            type: 'autocomplete'
+          },
+          'getty/aat' => {
+            url: "/authorities/search/getty/aat",
+            type: 'autocomplete'
+          },
+          'getty/tgn' => {
+            url: "/authorities/search/getty/tgn",
+            type: 'autocomplete'
+          },
+          'getty/ulan' => {
+            url: "/authorities/search/getty/ulan",
+            type: 'autocomplete'
+          },
+          'geonames' => {
+            url: "/authorities/search/geonames",
+            type: 'autocomplete'
+          },
+          'fast' => {
+            url: "/authorities/search/assign_fast/topical",
+            type: 'autocomplete'
+          },
+          'fast/all' => {
+            url: "/authorities/search/assign_fast/all",
+            type: 'autocomplete'
+          },
+          'fast/personal' => {
+            url: "/authorities/search/assign_fast/personal",
+            type: 'autocomplete'
+          },
+          'fast/corporate' => {
+            url: "/authorities/search/assign_fast/corporate",
+            type: 'autocomplete'
+          },
+          'fast/geographic' => {
+            url: "/authorities/search/assign_fast/geographic",
+            type: 'autocomplete'
+          },
+          'mesh' => {
+            url: "/authorities/search/local/mesh",
+            type: 'autocomplete'
+          },
+          'discogs' => {
+            url: "/authorities/search/discogs/all",
+            type: 'autocomplete'
+          },
+          'discogs/release' => {
+            url: "/authorities/search/discogs/release",
+            type: 'autocomplete'
+          },
+          'discogs/master' => {
+            url: "/authorities/search/discogs/master",
+            type: 'autocomplete'
+          }
+        }.freeze
+      end
+    end
   end
 end

--- a/spec/helpers/hyrax/form_helper_behavior_spec.rb
+++ b/spec/helpers/hyrax/form_helper_behavior_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Hyrax::FormHelperBehavior, type: :helper do
       end
 
       it 'returns controlled vocabulary service keys' do
-        expect(helper.send(:controlled_vocabulary_source_for, :audience)).to eq('audiences')
-        expect(helper.send(:controlled_vocabulary_source_for, :discipline)).to eq('disciplines')
+        expect(helper.send(:controlled_vocabulary_source_for, :audience)).to eq('audience')
+        expect(helper.send(:controlled_vocabulary_source_for, :discipline)).to eq('discipline')
         expect(helper.send(:controlled_vocabulary_source_for, :education_level)).to eq('education_levels')
         expect(helper.send(:controlled_vocabulary_source_for, 'learning_resource_type')).to eq('learning_resource_types')
         expect(helper.send(:controlled_vocabulary_source_for, :license)).to eq('licenses')

--- a/spec/services/controlled_vocabularies_spec.rb
+++ b/spec/services/controlled_vocabularies_spec.rb
@@ -96,8 +96,8 @@ RSpec.describe 'Controlled Vocabularies Integration', type: :service do
   describe 'Local Controlled Vocabularies' do
     context 'when HYRAX_FLEXIBLE is enabled' do
       it 'loads local vocabulary services correctly' do
-        expect(Hyrax::ControlledVocabularies::SERVICES).to include('audience')
-        expect(Hyrax::ControlledVocabularies::SERVICES['audience']).to eq('Hyrax::AudienceService')
+        expect(Hyrax::ControlledVocabularies.services).to include('audience')
+        expect(Hyrax::ControlledVocabularies.services['audience']).to eq('Hyrax::AudienceService')
       end
 
       it 'provides local vocabulary options through service' do
@@ -123,8 +123,8 @@ RSpec.describe 'Controlled Vocabularies Integration', type: :service do
 
         it 'maps local vocabulary to known services' do
           source = 'audience'
-          expect(Hyrax::ControlledVocabularies::SERVICES).to have_key(source)
-          service_class = Hyrax::ControlledVocabularies::SERVICES[source].constantize
+          expect(Hyrax::ControlledVocabularies.services).to have_key(source)
+          service_class = Hyrax::ControlledVocabularies.services[source].constantize
           expect(service_class).to respond_to(:select_all_options)
         end
       end
@@ -134,14 +134,14 @@ RSpec.describe 'Controlled Vocabularies Integration', type: :service do
   describe 'Remote Controlled Vocabularies' do
     context 'when HYRAX_FLEXIBLE is enabled' do
       it 'loads remote vocabulary authorities correctly' do
-        expect(Hyrax::ControlledVocabularies::REMOTE_AUTHORITIES).to include('loc/subjects')
-        authority_config = Hyrax::ControlledVocabularies::REMOTE_AUTHORITIES['loc/subjects']
+        expect(Hyrax::ControlledVocabularies.remote_authorities).to include('loc/subjects')
+        authority_config = Hyrax::ControlledVocabularies.remote_authorities['loc/subjects']
         expect(authority_config[:url]).to eq('/authorities/search/loc/subjects')
         expect(authority_config[:type]).to eq('autocomplete')
       end
 
       it 'includes common remote authorities' do
-        remote_authorities = Hyrax::ControlledVocabularies::REMOTE_AUTHORITIES
+        remote_authorities = Hyrax::ControlledVocabularies.remote_authorities
 
         # Library of Congress authorities
         expect(remote_authorities).to have_key('loc/subjects')
@@ -169,8 +169,8 @@ RSpec.describe 'Controlled Vocabularies Integration', type: :service do
 
         it 'maps remote vocabulary to known authorities' do
           source = 'loc/subjects'
-          expect(Hyrax::ControlledVocabularies::REMOTE_AUTHORITIES).to have_key(source)
-          authority_config = Hyrax::ControlledVocabularies::REMOTE_AUTHORITIES[source]
+          expect(Hyrax::ControlledVocabularies.remote_authorities).to have_key(source)
+          authority_config = Hyrax::ControlledVocabularies.remote_authorities[source]
           expect(authority_config[:type]).to eq('autocomplete')
           expect(authority_config[:url]).to be_present
         end
@@ -196,9 +196,9 @@ RSpec.describe 'Controlled Vocabularies Integration', type: :service do
         audience_sources = profile['properties']['audience']['controlled_values']['sources']
         subject_sources = profile['properties']['subject']['controlled_values']['sources']
 
-        expect(Hyrax::ControlledVocabularies::SERVICES).to have_key(audience_sources.first)
+        expect(Hyrax::ControlledVocabularies.services).to have_key(audience_sources.first)
 
-        expect(Hyrax::ControlledVocabularies::REMOTE_AUTHORITIES).to have_key(subject_sources.first)
+        expect(Hyrax::ControlledVocabularies.remote_authorities).to have_key(subject_sources.first)
       end
 
       it 'validates that controlled vocabulary services exist' do
@@ -207,7 +207,7 @@ RSpec.describe 'Controlled Vocabularies Integration', type: :service do
       end
 
       it 'validates that remote authorities are configured' do
-        remote_auth = Hyrax::ControlledVocabularies::REMOTE_AUTHORITIES['loc/subjects']
+        remote_auth = Hyrax::ControlledVocabularies.remote_authorities['loc/subjects']
         expect(remote_auth).to be_present
         expect(remote_auth[:url]).to start_with('/authorities/search/')
         expect(remote_auth[:type]).to eq('autocomplete')
@@ -223,8 +223,8 @@ RSpec.describe 'Controlled Vocabularies Integration', type: :service do
       end
 
       it 'still has access to controlled vocabulary configurations' do
-        expect(Hyrax::ControlledVocabularies::SERVICES).to be_present
-        expect(Hyrax::ControlledVocabularies::REMOTE_AUTHORITIES).to be_present
+        expect(Hyrax::ControlledVocabularies.services).to be_present
+        expect(Hyrax::ControlledVocabularies.remote_authorities).to be_present
       end
     end
   end
@@ -277,8 +277,8 @@ RSpec.describe 'Controlled Vocabularies Integration', type: :service do
       ]
 
       expected_local_services.each do |service|
-        expect(Hyrax::ControlledVocabularies::SERVICES).to have_key(service)
-        service_class = Hyrax::ControlledVocabularies::SERVICES[service].constantize
+        expect(Hyrax::ControlledVocabularies.services).to have_key(service)
+        service_class = Hyrax::ControlledVocabularies.services[service].constantize
 
         # Handle different service patterns:
         # 1. Module-based services with select_all_options (most Hyku services)
@@ -324,8 +324,8 @@ RSpec.describe 'Controlled Vocabularies Integration', type: :service do
       ]
 
       expected_remote_authorities.each do |authority|
-        expect(Hyrax::ControlledVocabularies::REMOTE_AUTHORITIES).to have_key(authority)
-        config = Hyrax::ControlledVocabularies::REMOTE_AUTHORITIES[authority]
+        expect(Hyrax::ControlledVocabularies.remote_authorities).to have_key(authority)
+        config = Hyrax::ControlledVocabularies.remote_authorities[authority]
         expect(config[:url]).to be_present
         expect(config[:type]).to eq('autocomplete')
       end


### PR DESCRIPTION
This commit converts the controlled_vocab_mappings hash to a method in the ControlledVocabularies initializer to allow for custom controlled vocab overrides as well as converts the SERVICES and REMOTE_AUTHORITIES consts to methods to follow better OOP practices.

Ref:
- https://github.com/notch8/hykuup_knapsack/issues/531

@samvera/hyku-code-reviewers
