### PR TITLE
:bug: Fix validation to handle inconsistent naming conventions

### DIFF
--- a/app/services/hyrax/flexible_schema_validators/class_validator.rb
+++ b/app/services/hyrax/flexible_schema_validators/class_validator.rb
@@ -56,18 +56,11 @@ module Hyrax
         classes_with_records = []
         checked_models = Set.new
 
-        classes_to_check.reject! do |class_name|
-          counterpart = if class_name.end_with?('Resource')
-                          class_name.chomp('Resource')
-                        else
-                          "#{class_name}Resource"
-                        end
-          profile_classes.include?(counterpart)
-        end
-
         classes_to_check.each do |class_name|
           model_class = resolve_model_class(class_name)
           next unless model_class
+
+          next if profile_classes.include?(model_class.to_s)
 
           model_identifier = model_class.to_s
           next if checked_models.include?(model_identifier)

--- a/spec/services/hyrax/flexible_schema_validators/class_validator_spec.rb
+++ b/spec/services/hyrax/flexible_schema_validators/class_validator_spec.rb
@@ -1,0 +1,260 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::FlexibleSchemaValidators::ClassValidator do
+  subject(:validator) { described_class.new(profile, required_classes, errors) }
+
+  let(:profile) { {} }
+  let(:required_classes) { ['AdminSetResource', 'CollectionResource', 'Hyrax::FileSet'] }
+  let(:errors) { [] }
+
+  describe '#initialize' do
+    it 'sets instance variables' do
+      expect(validator.instance_variable_get(:@profile)).to eq(profile)
+      expect(validator.instance_variable_get(:@required_classes)).to eq(required_classes)
+      expect(validator.instance_variable_get(:@errors)).to eq(errors)
+    end
+  end
+
+  describe '#validate_availability!' do
+    let(:profile) do
+      {
+        'classes' => {
+          'GenericWorkResource' => { 'display_label' => 'Generic Work' },
+          'InvalidWorkType' => { 'display_label' => 'Invalid Work' }
+        },
+        'properties' => {
+          'title' => {
+            'available_on' => {
+              'class' => ['AnotherInvalidWorkType']
+            }
+          }
+        }
+      }
+    end
+
+    before do
+      allow(Hyrax.config).to receive(:registered_curation_concern_types).and_return(['GenericWork'])
+    end
+
+    it 'adds error for invalid classes in profile classes' do
+      validator.validate_availability!
+      expect(errors.first).to include('InvalidWorkType')
+    end
+
+    it 'adds error for invalid classes in available_on' do
+      validator.validate_availability!
+      expect(errors.first).to include('AnotherInvalidWorkType')
+    end
+
+    it 'combines all invalid classes in one error message' do
+      validator.validate_availability!
+      expect(errors.first).to eq('Invalid classes: InvalidWorkType, AnotherInvalidWorkType.')
+    end
+
+    it 'does not add error when all classes are valid' do
+      profile['classes'].delete('InvalidWorkType')
+      profile['properties']['title']['available_on']['class'] = ['GenericWorkResource']
+
+      validator.validate_availability!
+      expect(errors).to be_empty
+    end
+
+    it 'handles nil properties' do
+      profile['classes'].delete('InvalidWorkType')
+      profile['properties'] = nil
+      validator.validate_availability!
+      expect(errors).to be_empty
+    end
+
+    it 'strips Resource suffix when checking against registered types' do
+      profile['classes'] = { 'GenericWorkResource' => { 'display_label' => 'Generic Work' } }
+      profile['properties'] = {}
+
+      validator.validate_availability!
+      expect(errors).to be_empty
+    end
+
+    it 'excludes required classes from validation' do
+      profile['classes'] = { 'AdminSetResource' => { 'display_label' => 'Admin Set' } }
+      profile['properties'] = {}
+
+      validator.validate_availability!
+      expect(errors).to be_empty
+    end
+  end
+
+  describe '#validate_references!' do
+    let(:profile) do
+      {
+        'classes' => {
+          'GenericWorkResource' => { 'display_label' => 'Generic Work' }
+        },
+        'properties' => {
+          'title' => {
+            'available_on' => {
+              'class' => ['GenericWorkResource', 'UndefinedClass']
+            }
+          },
+          'creator' => {
+            'available_on' => {
+              'class' => ['AnotherUndefinedClass']
+            }
+          }
+        }
+      }
+    end
+
+    it 'adds error for undefined classes' do
+      validator.validate_references!
+      expect(errors).to include('Classes referenced in `available_on` but not defined in `classes`: UndefinedClass, AnotherUndefinedClass.')
+    end
+
+    it 'does not add error when all referenced classes are defined' do
+      profile['classes']['UndefinedClass'] = { 'display_label' => 'Undefined' }
+      profile['classes']['AnotherUndefinedClass'] = { 'display_label' => 'Another Undefined' }
+
+      validator.validate_references!
+      expect(errors).to be_empty
+    end
+
+    it 'handles empty properties' do
+      profile['properties'] = {}
+
+      validator.validate_references!
+      expect(errors).to be_empty
+    end
+
+    it 'handles nil properties' do
+      profile['properties'] = nil
+
+      validator.validate_references!
+      expect(errors).to be_empty
+    end
+  end
+
+  describe '#validate_existing_records!' do
+    let(:profile) do
+      {
+        'classes' => {
+          'GenericWorkResource' => { 'display_label' => 'Generic Work' }
+        },
+        'properties' => {}
+      }
+    end
+
+    before do
+      allow(Hyrax.config).to receive(:registered_curation_concern_types).and_return(['GenericWork', 'Image'])
+      allow(Hyrax.query_service).to receive(:count_all_of_model).and_return(0)
+    end
+
+    it 'adds error for classes with existing records' do
+      allow(Hyrax.query_service).to receive(:count_all_of_model)
+        .with(model: ImageResource).and_return(1)
+
+      validator.validate_existing_records!
+      expect(errors).to include('Classes with existing records cannot be removed from the profile: ImageResource.')
+    end
+
+    it 'does not add error when no classes have existing records' do
+      validator.validate_existing_records!
+      expect(errors).to be_empty
+    end
+
+    it 'queries for a model only once, even with aliases' do
+      stub_const('Image', Class.new)
+      allow(Hyrax.config).to receive(:registered_curation_concern_types).and_return(['Image'])
+      profile['classes'] = {}
+
+      expect(Hyrax.query_service).to receive(:count_all_of_model).with(model: Image).once.and_return(0)
+      expect(Hyrax.query_service).to receive(:count_all_of_model).with(model: AdminSetResource).once.and_return(0)
+      expect(Hyrax.query_service).to receive(:count_all_of_model).with(model: CollectionResource).once.and_return(0)
+      expect(Hyrax.query_service).to receive(:count_all_of_model).with(model: Hyrax::FileSet).once.and_return(0)
+
+      validator.validate_existing_records!
+    end
+
+    it 'handles counterpart classes correctly' do
+      profile['classes']['Image'] = { 'display_label' => 'Image' }
+
+      validator.validate_existing_records!
+      expect(errors).to be_empty
+    end
+
+    it 'logs error when query service fails' do
+      allow(Hyrax.query_service).to receive(:count_all_of_model)
+        .with(model: ImageResource).and_raise(StandardError, 'Database error')
+      allow(Rails.logger).to receive(:error)
+
+      validator.validate_existing_records!
+      expect(Rails.logger).to have_received(:error).with('Error checking records for ImageResource: Database error')
+    end
+
+    it 'skips classes that cannot be resolved' do
+      allow(validator).to receive(:resolve_model_class).and_return(nil)
+
+      validator.validate_existing_records!
+      expect(errors).to be_empty
+    end
+  end
+
+  describe '#potential_existing_classes' do
+    it 'includes required classes' do
+      expect(validator.send(:potential_existing_classes)).to include(*required_classes)
+    end
+
+    it 'includes registered curation concern types' do
+      allow(Hyrax.config).to receive(:registered_curation_concern_types).and_return(['GenericWork', 'Image'])
+
+      classes = validator.send(:potential_existing_classes)
+      expect(classes).to include('GenericWork', 'GenericWorkResource', 'Image', 'ImageResource')
+    end
+
+    it 'removes duplicates' do
+      allow(Hyrax.config).to receive(:registered_curation_concern_types).and_return(['GenericWork'])
+
+      classes = validator.send(:potential_existing_classes)
+      expect(classes.uniq).to eq(classes)
+    end
+  end
+
+  describe '#resolve_model_class' do
+    context 'with configured models' do
+      {
+        'Hyrax::FileSet' => :file_set_model,
+        'Hyrax::AdminSet' => :admin_set_model,
+        'Hyrax::Collection' => :collection_model
+      }.each do |class_name, config_key|
+        it "resolves #{class_name} using #{config_key}" do
+          model = stub_const(class_name, Class.new)
+          allow(Hyrax.config).to receive(config_key).and_return(class_name)
+
+          result = validator.send(:resolve_model_class, class_name)
+          expect(result).to eq(model)
+        end
+      end
+    end
+
+    it 'resolves class name directly' do
+      stub_const('GenericWorkResource', Class.new)
+
+      result = validator.send(:resolve_model_class, 'GenericWorkResource')
+      expect(result).to eq(GenericWorkResource)
+    end
+
+    it 'falls back to base name when direct resolution fails' do
+      stub_const('TestWork', Class.new)
+
+      # Test with a class name that doesn't exist directly but has a base name that does
+      result = validator.send(:resolve_model_class, 'TestWorkResource')
+      expect(result).to eq(TestWork)
+    end
+
+    it 'returns nil when both direct and base name resolution fail' do
+      allow(Rails.logger).to receive(:warn)
+
+      result = validator.send(:resolve_model_class, 'InvalidClass')
+      expect(result).to be_nil
+      expect(Rails.logger).to have_received(:warn).with('Could not resolve model class for: InvalidClass')
+    end
+  end
+end


### PR DESCRIPTION
# Summary

Fix validation to handle inconsistent M3 profile class naming conventions. The validator currently only checks for `"#{work_type}Resource"` variants, missing existing records when profiles use direct model class names (e.g., `MobiusWork` instead of `MobiusWorkResource`).

## Ticket Number

Discovered in: 
- https://github.com/notch8/hykuup_knapsack/issues/525

## Screenshots / Video

#### BEFORE

From hykuup knapsack I am in a tenant that has a MobiusWork type created. I uploaded a profile that did not have MobiusWork defined. It should've failed validation but it passed. 

**Root Cause**
The potential_existing_classes method assumes all work types have a corresponding "#{work_type}Resource" class:
end

```
# Current (buggy) logic
Hyrax.config.registered_curation_concern_types.each do |concern_type|
  classes << "#{concern_type}Resource"  # Assumes this always exists!
end
```

This assumption breaks when:

- Work types don't follow the "Resource" suffix convention
- Profiles use actual model class names instead of profile class names
- Future developers create work types without "Resource" variants

<img width="1338" height="756" alt="image" src="https://github.com/user-attachments/assets/ca959799-bf41-43a9-9a50-4b222d7f6158" />


#### AFTER

<img width="1351" height="654" alt="image" src="https://github.com/user-attachments/assets/ada84c1a-7c51-4a5f-b159-6fb6d47ad6b5" />


## Expected Behavior

Validation should detect existing records regardless of whether profiles use:
- `WorkTypeResource` naming (e.g., `ImageResource`)  
- `WorkType` naming (e.g., `MobiusWork`)

## Sample Files

**Bug scenario:**
```yaml
# Profile excludes MobiusWork but database has MobiusWork records
classes:
  GenericWorkResource:
    display_label: Generic Work
  # MobiusWork missing - should fail but doesn't
```

**Result:** Validation incorrectly passes, allowing silent data loss.

**Fixed behavior:**
```yaml
# Same profile
classes:
  GenericWorkResource:
    display_label: Generic Work
  # MobiusWork still missing
```

**Result:** Validation correctly fails with "Classes with existing records cannot be removed from the profile: MobiusWork."

## Notes

- Currently works in core Hyku because each work type has both `work_type.rb` and `work_type_resource.rb`
- This fix future-proofs validation for any naming convention
- No breaking changes - existing functionality unchanged
- Improves robustness of profile validation system