### PR TITLE
Fix missing default FlexibleSchema

### DIFF
--- a/config/metadata_profiles/m3_profile.yaml
+++ b/config/metadata_profiles/m3_profile.yaml
@@ -1574,7 +1574,6 @@ properties:
     available_on:
       class:
         - Hyrax::FileSet
-        - FileSet
         - CollectionResource
         - GenericWorkResource
         - ImageResource

--- a/spec/models/hyrax/flexible_schema_spec.rb
+++ b/spec/models/hyrax/flexible_schema_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Hyrax::FlexibleSchema, type: :model do
+  it 'has a valid .current_schema' do
+    described_class.create_default_schema
+
+    # The existence of a non-nil ID is pressumed to ensure that a valid schema was loaded
+    expect(described_class.current_schema_id).to be_present
+  end
+end


### PR DESCRIPTION
**ISSUE**
The default metadata profile YAML file had an invalid class listed and would not validate. This caused the default schema loader to silently fail.

**RESOLUTION**
* Remove the invalid line from the metadata profile.
* Add a test to ensure the default profile loads succesfully

NOTE: this test ignores HYRAX_FLEXIBLE since we're just testing that the defaulting mechanism works, not that it's actually being used.

@samvera/hyku-code-reviewers
