### PR TITLE
Add SOLR_COLLECTION_REPLICAS support to control replicationFactor when creating Solr collections

### DIFF
--- a/bin/solrcloud-assign-configset.sh
+++ b/bin/solrcloud-assign-configset.sh
@@ -7,6 +7,7 @@ fi
 
 solr_config_name="${SOLR_CONFIGSET_NAME:-solrconfig}"
 solr_collection_name="${SOLR_COLLECTION_NAME:-hyrax}"
+solr_collection_replicas="${SOLR_COLLECTION_REPLICAS:-1}"
 
 # Solr Cloud Collection API URLs
 solr_collection_list_url="$SOLR_HOST:$SOLR_PORT/solr/admin/collections?action=LIST"
@@ -21,7 +22,7 @@ while [ $COUNTER -lt 30 ]; do
       exit
     else
       echo "-- Collection ${solr_collection_name} does not exist; creating and setting ${solr_config_name} ConfigSet ..."
-      solr_collection_create_url="$SOLR_HOST:$SOLR_PORT/solr/admin/collections?action=CREATE&name=${solr_collection_name}&collection.configName=${solr_config_name}&numShards=1"
+      solr_collection_create_url="$SOLR_HOST:$SOLR_PORT/solr/admin/collections?action=CREATE&name=${solr_collection_name}&collection.configName=${solr_config_name}&numShards=1&replicationFactor=${solr_collection_replicas}"
       curl $solr_user_settings "$solr_collection_create_url"
       exit
     fi

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -177,6 +177,8 @@ extraEnvVars: &envVars
     value: $SOLR_ADMIN_PASSWORD
   - name: SOLR_COLLECTION_NAME
     value: hyku-staging
+  - name: SOLR_COLLECTION_REPLICAS
+    value: "2"
   - name: SOLR_CONFIGSET_NAME
     value: hyku-staging
   - name: SOLR_HOST


### PR DESCRIPTION
Add `SOLR_COLLECTION_REPLICAS` support to Solr script

This PR introduces the `SOLR_COLLECTION_REPLICAS` variable for the Solr cloud collection setup script. Previously, collections were always created with a single replica (replicationFactor=1), which limited high-availability scenarios.

With this change, you can now set the desired number of replicas via an environment variable or Helm values without modifying the script directly. The default behavior remains 1 replica if the variable is not set.

Changes proposed in this pull request:
- Add  solr_collection_replicas="${SOLR_COLLECTION_REPLICAS:-1}" to script
- Use replicationFactor=$solr_collection_replicas when creating collections
- Keep default behavior at 1 replica if variable not set
