### PR TITLE
🐛 Render translation for Related URL label

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -167,6 +167,7 @@ class CatalogController < ApplicationController
     config.add_index_field 'resource_type_tesim', label: "Resource Type", link_to_facet: 'resource_type_sim', if: :render_in_tenant?
     config.add_index_field 'file_format_tesim', link_to_facet: 'file_format_sim', if: :render_in_tenant?
     config.add_index_field 'identifier_tesim', helper_method: :index_field_link, field_name: 'identifier', if: :render_in_tenant?
+    config.add_index_field 'related_url_tesim', helper_method: :truncate_and_iconify_auto_link, if: :render_in_tenant?
     config.add_index_field 'embargo_release_date_dtsi', label: "Embargo release date", helper_method: :human_readable_date, if: :render_in_tenant?
     config.add_index_field 'lease_expiration_date_dtsi', label: "Lease expiration date", helper_method: :human_readable_date, if: :render_in_tenant?
     config.add_index_field 'learning_resource_type_tesim', label: "Learning resource type", if: :render_in_tenant?


### PR DESCRIPTION
This commit fixes a bug where the Related URL field label was rendering the literal translation value for the property label rather than the human-readable label.
If the flexible metadata view specifies an external link, the value will render a link icon and the URL.


Before:
<img width="1201" height="919" alt="Screenshot 2025-11-05 at 12 59 27 PM" src="https://github.com/user-attachments/assets/bfedd2da-aa9b-4afe-ab69-e254ba3ecc20" />


After:

<img width="1090" height="787" alt="Screenshot 2025-11-05 at 1 26 41 PM" src="https://github.com/user-attachments/assets/91f4274a-4e74-467b-b57a-7e2787d48f2b" />


@samvera/hyku-code-reviewers
