### PR TITLE
⚙️ Allow PALS OER override resource types

### DIFF
--- a/app/helpers/hyrax/form_helper_behavior.rb
+++ b/app/helpers/hyrax/form_helper_behavior.rb
@@ -11,7 +11,10 @@ module Hyrax
     end
 
     def controlled_vocabulary_options_for(property_name, _record_class)
-      source = controlled_vocabulary_source_for(property_name)
+      # TODO: Metadata property overrides for specific classes will soon be available in Hyrax
+      # Temporary workaround to support Pals OER override
+      source = property_name == :resource_type && record_class.name.start_with?('Oer') ? 'oer_types' : controlled_vocabulary_source_for(property_name)
+      # source = controlled_vocabulary_source_for(property_name)
       return unless source
 
       # Only ensure Discogs credentials if we have a valid token


### PR DESCRIPTION
This commit provides a work around to allow the OER class to override the resource types for controlled vocabularies with flexible metadata.

TODO: Metadata property overrides for specific classes will soon be available in Hyrax and this code should be updated at that time.

Ref:
- https://github.com/notch8/palni_palci_knapsack/issues/499

@samvera/hyku-code-reviewers
