### PR TITLE
💄 Uniform property rendering for all work types

### DIFF
--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -4,7 +4,11 @@
 <% if Hyrax.config.flexible? %>
   <% view_options_for(presenter).each do |field, options| %>
     <% view_options = conform_options(field, options) %>
-    <%= presenter.attribute_to_html(conform_field(field, options), view_options) unless view_options[:admin_only] && !current_user.admin?  %>
+    <% if field == :admin_note %>
+      <%= presenter.attribute_to_html(conform_field(field, options), view_options) if presenter.editor? %>
+    <% else %>
+      <%= presenter.attribute_to_html(conform_field(field, options), view_options) unless view_options[:admin_only] && !current_user&.admin?  %>
+    <% end %>
   <% end %>
 <% else %>
   <%# Copied from hyrax-doi v0.2.0 %>

--- a/app/views/hyrax/etds/_attribute_rows.html.erb
+++ b/app/views/hyrax/etds/_attribute_rows.html.erb
@@ -3,16 +3,14 @@
 <%# hyrax-doi doesn't work post hyrax v3.0.0 %>
 <% if Hyrax.config.flexible? %>
   <% view_options_for(presenter).each do |field, options| %>
-    <% value = presenter.public_send(field) %>
-    <% render_attribute = value.present? && (value.is_a?(Enumerable) ? value.any?(&:present?) : true) %>
+    <% view_options = conform_options(field, options) %>
     <% if field == :admin_note %>
-      <%= presenter.attribute_to_html(:admin_note, options) if presenter.editor? && render_attribute %>
-    <% elsif render_attribute %>
-      <% view_options = conform_options(field, options) %>
-      <%= presenter.attribute_to_html(conform_field(field, options), view_options) unless view_options[:admin_only] && !current_user.admin?  %>
+      <%= presenter.attribute_to_html(conform_field(field, options), view_options) if presenter.editor? %>
+    <% else %>
+      <%= presenter.attribute_to_html(conform_field(field, options), view_options) unless view_options[:admin_only] && !current_user&.admin?  %>
     <% end %>
   <% end %>
-  <% else %>
+<% else %>
   <%= presenter.attribute_to_html(:admin_note, html_dl: true) if presenter.editor? %>
   <%= presenter.attribute_to_html(:creator, render_as: :faceted, label: label_for(term: :creator, record_class: Etd), html_dl: true) %>
   <%= presenter.attribute_to_html(:contributor, render_as: :faceted, html_dl: true) %>
@@ -40,4 +38,4 @@
   <%= presenter.attribute_to_html(:advisor, label: label_for(term: :advisor, record_class: Etd), html_dl: true) %>
   <%= presenter.attribute_to_html(:committee_member, label: label_for(term: :committee_member, record_class: Etd), html_dl: true) %>
   <%= presenter.attribute_to_html(:department, label: label_for(term: :department, record_class: Etd), html_dl: true) %>
-  <% end %>
+<% end %>

--- a/app/views/hyrax/oers/_attribute_rows.html.erb
+++ b/app/views/hyrax/oers/_attribute_rows.html.erb
@@ -3,13 +3,11 @@
 <%# hyrax-doi doesn't work post hyrax v3.0.0 %>
 <% if Hyrax.config.flexible? %>
   <% view_options_for(presenter).each do |field, options| %>
-    <% value = presenter.public_send(field) %>
-    <% render_attribute = value.present? && (value.is_a?(Enumerable) ? value.any?(&:present?) : true) %>
+    <% view_options = conform_options(field, options) %>
     <% if field == :admin_note %>
-      <%= presenter.attribute_to_html(:admin_note, options) if presenter.editor? && render_attribute %>
-    <% elsif render_attribute %>
-      <% view_options = conform_options(field, options) %>
-      <%= presenter.attribute_to_html(conform_field(field, options), view_options) unless view_options[:admin_only] && !current_user.admin?  %>
+      <%= presenter.attribute_to_html(conform_field(field, options), view_options) if presenter.editor? %>
+    <% else %>
+      <%= presenter.attribute_to_html(conform_field(field, options), view_options) unless view_options[:admin_only] && !current_user&.admin?  %>
     <% end %>
   <% end %>
 <% else %>


### PR DESCRIPTION
This commit standardizes the rendering of properties across the base Hyrax views as well as ETD and OER work types to ensure properties that to not have a view key in flexible metadata profiles are not rendered in the view.

Also fixes a bug where a logged out user got an error message for works that had admin_only properties.

Ref:
- https://github.com/notch8/palni_palci_knapsack/issues/499


@samvera/hyku-code-reviewers
