### PR TITLE
🐛 OER resource type override

### DIFF
--- a/app/helpers/hyrax/form_helper_behavior.rb
+++ b/app/helpers/hyrax/form_helper_behavior.rb
@@ -10,11 +10,15 @@ module Hyrax
       Hyrax::ControlledVocabularies.remote_authorities[source_name]
     end
 
-    def controlled_vocabulary_options_for(property_name, _record_class)
+    def controlled_vocabulary_options_for(property_name, record_class)
       # TODO: Metadata property overrides for specific classes will soon be available in Hyrax
-      # Temporary workaround to support Pals OER override
-      source = property_name == :resource_type && record_class.name.start_with?('Oer') ? 'oer_types' : controlled_vocabulary_source_for(property_name)
-      # source = controlled_vocabulary_source_for(property_name)
+      # Temporary workaround to support OER override
+      source = if record_class.present? && property_name == :resource_type && record_class.name.start_with?('Oer')
+                 'oer_types'
+               else
+                 controlled_vocabulary_source_for(property_name)
+               end
+
       return unless source
 
       # Only ensure Discogs credentials if we have a valid token


### PR DESCRIPTION
🐛 oer_type config/authority for resource_type

This commit allows OER works to use a different controlled vocabulary
for resource_type property than non-OER works.
OER works use the 'oer_types' authority, while non-OER works use the
default resource_type authority.

Ref:
- https://github.com/notch8/palni_palci_knapsack/issues/499

@samvera/hyku-code-reviewers
