### PR TITLE
⚙️ Adds controlled vocabulary support for language

### DIFF
--- a/app/views/records/edit_fields/_language.html.erb
+++ b/app/views/records/edit_fields/_language.html.erb
@@ -1,0 +1,3 @@
+<%# OVERRIDE: Hyrax 5.2.0 to allow for remote controlled vocabulary via flexible metadata profile %>
+
+<%= render 'records/edit_fields/default', f: f, key: key %>

--- a/config/initializers/hyrax_controlled_vocabularies.rb
+++ b/config/initializers/hyrax_controlled_vocabularies.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/ModuleLength
 module Hyrax
   module ControlledVocabularies
     class << self
@@ -44,6 +45,10 @@ module Hyrax
           },
           'loc/countries' => {
             url: "/authorities/search/loc/countries",
+            type: 'autocomplete'
+          },
+          'loc/languages' => {
+            url: "/authorities/search/loc/languages",
             type: 'autocomplete'
           },
           'getty/aat' => {
@@ -103,3 +108,4 @@ module Hyrax
     end
   end
 end
+# rubocop:enable Metrics/ModuleLength

--- a/docs/controlled-vocabularies.md
+++ b/docs/controlled-vocabularies.md
@@ -1,6 +1,6 @@
 # Controlled Vocabularies in Hyku
 
-Hyku supports both local and remote controlled vocabularies for form fields through the flexible metadata system. When `HYRAX_FLEXIBLE` is enabled, you can specify controlled vocabularies directly in your metadata profile YAML files by configuring the `controlled_values.sources` array for any property.
+Hyku supports both local and remote controlled vocabularies for form fields through the flexible metadata system. When `HYRAX_FLEXIBLE` is enabled, you can specify controlled vocabularies directly in your metadata profile YAML files by configuring the `controlled_values.sources` array for most properties.
 
 ## How It Works
 
@@ -78,6 +78,7 @@ Remote vocabularies query external services through the Questioning Authority ge
 - `loc/names` - Library of Congress Name Authority File
 - `loc/genre_forms` - Library of Congress Genre/Form Terms
 - `loc/countries` - Library of Congress Countries
+- `loc/languages` - Library of Congress Languages
 - `getty/aat` - Getty Art & Architecture Thesaurus
 - `getty/tgn` - Getty Thesaurus of Geographic Names
 - `getty/ulan` - Getty Union List of Artist Names
@@ -92,7 +93,7 @@ Remote vocabularies query external services through the Questioning Authority ge
 - `discogs/release` - Music releases
 - `discogs/master` - Master releases
 
-**Note**: Authority names use the slash format consistent with Questioning Authority documentation. These match exactly with the configured mappings in the application.
+**Note**: Authority names use the slash format consistent with [Questioning Authority](https://github.com/samvera/questioning_authority) documentation. These match exactly with the configured mappings in the application.
 
 ### MeSH (Requires Setup)
 
@@ -437,7 +438,7 @@ A UI for managing local vocabularies through the admin dashboard is planned to m
 ### Adding Remote Vocabularies
 
 1. Ensure the Questioning Authority gem supports the remote service
-2. Add the authority mapping to the `remote_authority_config_for` method in `app/helpers/hyrax/form_helper_behavior.rb`
+2. Add the authority mapping to the `remote_authorities` method in `config/initializers/hyrax_controlled_vocabularies.rb`
 3. Use the authority name in your metadata profile's `sources` array
 
 ## Technical Implementation


### PR DESCRIPTION
Adds the ability to use the Library of Congress controlled vocabulary for languages in a flexible metadata profile.

The controlled vocabulary is integrated via Samvera's questioning_authority gem in loc_subauthority.rb

To use the controlled vocabulary in the flexible metadata profile:

```yml
controlled_values:
  format: http://www.w3.org/2001/XMLSchema#string
  sources:
  - loc/languages
```

<img width="1521" height="870" alt="Screenshot 2025-11-14 at 2 02 34 PM" src="https://github.com/user-attachments/assets/918fc0c1-c9cd-44da-a156-2b3990abb227" />

Ref:
- https://github.com/notch8/wvu_knapsack/issues/77

@samvera/hyku-code-reviewers
