### PR TITLE
🎁 Remote language vocabulary search support

### DIFF
--- a/app/assets/javascripts/hyrax/autocomplete/linked_data.es6
+++ b/app/assets/javascripts/hyrax/autocomplete/linked_data.es6
@@ -1,0 +1,77 @@
+// OVERRIDE Hyrax v5.2.0 to change the autocomplete message prompt for language code authorities
+// Library of Congress language code authorities (loc/languages and loc/iso639-2) require 3 characters to search
+
+// Autocomplete for linked data elements using a select2 autocomplete widget
+// After selecting something, the selected item is immutable
+export default class LinkedData {
+  constructor(element, url) {
+    this.url = url
+    this.element = element
+    this.activate()
+  }
+
+  activate() {
+    this.element
+      .select2(this.options(this.element))
+      .on("change", (e) => { this.selected(e) })
+  }
+
+  // Called when a choice is made
+  selected(e) {
+    let result = this.element.select2("data")
+    this.element.select2("destroy")
+    this.element.val(result.label).attr("readonly", "readonly")
+    // Adding d-block class to the remove button to show it after a selection is made.
+    let removeButton = this.element.closest('.field-wrapper').find('.input-group-btn.field-controls .remove')
+    removeButton.addClass('d-block')
+    this.setIdentifier(result.id)
+  }
+
+  // Store the uri in the associated hidden id field
+  setIdentifier(uri) {
+    this.element.closest('.field-wrapper').find('[data-id]').val(uri)
+  }
+
+  options(element) {
+    // Sets a three character minimum for language code authorities
+    const languageAuthority = this.url && (
+      this.url.includes('/loc/languages') ||
+      this.url.includes('/loc/iso639-2')
+    )
+
+    // placeholder: $(this).attr("value") || "Search for a location",
+    return {
+      minimumInputLength: languageAuthority ? 3 : 2,
+      language: languageAuthority ? {
+        inputTooShort: function () {
+          return 'Please enter a 3 character language code'
+        }
+      } : undefined,
+      id: function (object) {
+        return object.id
+      },
+      text: function (object) {
+        return object.label
+      },
+      initSelection: function (element, callback) {
+        var data = {
+          id: element.val(),
+          label: element[0].dataset.label || element.val()
+        }
+        callback(data)
+      },
+      ajax: {
+        url: this.url,
+        dataType: "json",
+        data: function (term, page) {
+          return {
+            q: term
+          }
+        },
+        results: function (data, page) {
+          return { results: data }
+        }
+      }
+    }
+  }
+}

--- a/config/initializers/hyrax_controlled_vocabularies.rb
+++ b/config/initializers/hyrax_controlled_vocabularies.rb
@@ -3,6 +3,7 @@
 # rubocop:disable Metrics/ModuleLength
 module Hyrax
   module ControlledVocabularies
+    # rubocop:disable Metrics/ClassLength
     class << self
       def controlled_vocab_mappings
         {
@@ -49,6 +50,14 @@ module Hyrax
           },
           'loc/languages' => {
             url: "/authorities/search/loc/languages",
+            type: 'autocomplete'
+          },
+          'loc/iso639-1' => {
+            url: "/authorities/search/loc/iso639-1",
+            type: 'autocomplete'
+          },
+          'loc/iso639-2' => {
+            url: "/authorities/search/loc/iso639-2",
             type: 'autocomplete'
           },
           'getty/aat' => {
@@ -106,6 +115,7 @@ module Hyrax
         }.freeze
       end
     end
+    # rubocop:enable Metrics/ClassLength
   end
 end
 # rubocop:enable Metrics/ModuleLength

--- a/docs/controlled-vocabularies.md
+++ b/docs/controlled-vocabularies.md
@@ -8,10 +8,13 @@ The flexible metadata system automatically detects controlled vocabularies based
 
 1. **Profile Import**: When you import a metadata profile, the system reads the `controlled_values.sources` array
 2. **Form Generation**: The form builder checks if the source is a local authority file or remote authority service
+   - The default partial `app/views/records/edit_fields/_default.html.erb` determines if the controlled vocabulary type is `select` for local vocabulary or `autocomplete` for remote vocabulary
 3. **Rendering**:
    - Local vocabularies render as dropdown select fields with predefined options
    - Remote authorities render as autocomplete text inputs that query external services
 4. **Data Attributes**: Remote authorities get `data-autocomplete` and `data-autocomplete-url` attributes for JavaScript functionality
+   - The autocomplete form functionality is managed in Hyrax at `app/assets/javascripts/hyrax/autocomplete` and uses the [select2 autocomplete widget](https://github.com/argerim/select2-rails)
+   - Hyku overrides some of the autocomplete functionality in `editor.es6` and `linked_data.es6`
 
 **Important Limitation**: Hyku currently supports only **one vocabulary source per field**. If you specify multiple sources in the `sources` array, only the first non-null source will be used. To use different vocabulary sources, create separate fields for each source.
 
@@ -78,7 +81,11 @@ Remote vocabularies query external services through the Questioning Authority ge
 - `loc/names` - Library of Congress Name Authority File
 - `loc/genre_forms` - Library of Congress Genre/Form Terms
 - `loc/countries` - Library of Congress Countries
-- `loc/languages` - Library of Congress Languages
+- `loc/iso639-1` - Library of Congress major/common languages
+- `loc/iso639-2` - Library of Congress bibliographic standard for languages
+  - Requires three character language code in the form for lookup
+- `loc/languages` - Library of Congress language superset of ISO-639-2 and also includes historical variants
+  - Requires three character language code in the form for lookup
 - `getty/aat` - Getty Art & Architecture Thesaurus
 - `getty/tgn` - Getty Thesaurus of Geographic Names
 - `getty/ulan` - Getty Union List of Artist Names
@@ -254,6 +261,10 @@ GeoNames geographical database integration requires a free username:
 - Geographical place name autocomplete
 - Global coverage of cities, countries, regions, and landmarks
 - Standardized geographic authority data
+
+### Library of Congress Language
+
+The `loc/iso639-2` and `loc/languages` require the user to submit a three letter language code in the form in order to return an autocompleted language. The autocomplete functionality is managed in Hyrax and overridden in Hyku to support the three character form submission.
 
 ### Usage in Profile YAML
 


### PR DESCRIPTION
This commit adds additional controlled vocabulary sources for Library of Congress languages. The `loc/iso639-2` and `loc/languages` vocabularies require the user to enter a three character language code to autocomplete so the linked data autocomplete JavaScript was overridden to handle these specific authorities.

`loc/iso639-1`: two letter lookup, only major/common languages
`loc/iso639-2`: three letter lookup, LOC bibliographic standard
`loc/languages`: three letter lookup, superset of ISO-639-2 and also includes historical variants

<img width="1647" height="812" alt="Screenshot 2025-11-17 at 1 59 51 PM" src="https://github.com/user-attachments/assets/349e70d5-03a6-4a7d-95e5-7025d719741b" />

<img width="1695" height="834" alt="Screenshot 2025-11-17 at 1 59 59 PM" src="https://github.com/user-attachments/assets/08d27e46-ac08-4c2e-b47f-5723f8641c25" />

Ref:
- https://github.com/notch8/wvu_knapsack/issues/77

@samvera/hyku-code-reviewers
