### PR TITLE
:bug: Fix zeitwork deployment error

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -150,7 +150,7 @@ module Hyku
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
-    config.autoload_lib(ignore: %w[assets tasks middleware])
+    config.autoload_lib(ignore: %w[assets tasks middleware rubocop])
     config.add_autoload_paths_to_load_path = true
 
     ##


### PR DESCRIPTION
Added rubocop to the ignore list so Zeitwerk won't autoload lib/rubocop

Otherwise, deployments errored with

```
"/usr/local/bundle/gems/zeitwerk-2.7.3/lib/zeitwerk/loader/callbacks.rb:31:in `on_file_autoloaded': expected file /app/samvera/hyrax-webapp/lib/rubocop/custom_cops.rb to define constant Rubocop::CustomCops, but didn't (Zeitwerk::NameError)
      raise Zeitwerk::NameError.new(msg, cref.cname)"
```

<img width="1920" height="942" alt="Screenshot 2025-11-19 at 07-47-05 Rancher - r2-friends - hyku-demo-hyrax" src="https://github.com/user-attachments/assets/59bc5f56-288f-4cc1-bd3e-6093c5c6e8c7" />

