### PR TITLE
Add flexible metadata profiles menu option

### DIFF
--- a/app/views/hyrax/dashboard/sidebar/_configuration.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_configuration.html.erb
@@ -52,5 +52,10 @@
       <span class="fa fa-users" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.roles_service_jobs') %></span>
     <% end %>
   <% end %>
+  <%# TODO: potentially temporary Hyku override to show metadata partial here %>
+  <%# Bulkrax overrides the repository contents menu so it doesn't appear in Hyku %>
+  <% if current_account && !current_account.search_only %>
+    <%= render 'hyrax/dashboard/sidebar/metadata', menu: menu %>
+  <% end %>
   <%= render 'hyrax/dashboard/sidebar/menu_partials', menu: menu, section: :configuration %>
 <% end %>


### PR DESCRIPTION
## Summary

Bulkrax injects its options into the Hyrax dashboard sidebar by overriding the repository contents menu partial. In Hyku, the repository contents menu doesn't display the flexible metadata profiles option, so this commit adds it directly to the Hyku dashboard sidebar configuration menu partial.

TODO: Consider a better way to inject menu options that works across Hyrax and Hyku.

