### PR TITLE
Fix inclusion in Riiif::FileDecorator

### DIFF
--- a/app/models/riiif/file_decorator.rb
+++ b/app/models/riiif/file_decorator.rb
@@ -3,12 +3,8 @@
 module Riiif
   module FileDecorator
     extend ActiveSupport::Concern
-
-    included do
-      include ActiveSupport::Benchmarkable
-
-      attr_reader :id
-    end
+    attr_reader :id
+    include ActiveSupport::Benchmarkable
 
     def initialize(input_path, tempfile = nil, id:)
       super(input_path, tempfile)


### PR DESCRIPTION
- I think the `included do` syntax is only for when you have child classes using the concern - our module did not have access to the things in the `included do` block

Original problem:
```log
NameError (undefined local variable or method `id' for an instance of Riiif::File):

app/models/riiif/file_decorator.rb:21:in `extract'
```

@samvera/hyku-code-reviewers
