### PR TITLE
Allow use of VIPS instead of Imagemagick for RIIIF

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,7 +90,7 @@ gem 'redcarpet' # for Markdown constant
 gem 'redis-actionpack'
 gem 'redis-namespace', '~> 1.10' # Hyrax v5 relies on 1.5; but we'd like to have the #clear method so we need 1.10 or greater.
 gem 'redlock', '>= 0.1.2', '< 2.0' # lock redlock per https://github.com/samvera/hyrax/pull/5961
-gem 'riiif', '~> 2.1'
+gem 'riiif', git: 'https://github.com/sul-dlss/riiif.git', ref: '9a375'
 gem 'rolify'
 gem 'ros-apartment', require: 'apartment' # Rails 7.2 compatible apartment fork - drop-in replacement
 gem 'rsolr', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,6 +135,17 @@ GIT
       nokogiri (~> 1.5)
       omniauth (>= 1.2, < 3)
 
+GIT
+  remote: https://github.com/sul-dlss/riiif.git
+  revision: 9a37564c3842d703bb9df195038eaf7fb037b5df
+  ref: 9a375
+  specs:
+    riiif (2.7.0)
+      deprecation (>= 1.0.0)
+      iiif-image-api (>= 0.1.0)
+      railties (>= 4.2, < 9)
+      ruby-vips
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -1311,10 +1322,6 @@ GEM
     reverse_markdown (3.0.0)
       nokogiri
     rexml (3.4.4)
-    riiif (2.7.0)
-      deprecation (>= 1.0.0)
-      iiif-image-api (>= 0.1.0)
-      railties (>= 4.2, < 9)
     rolify (6.0.1)
     ros-apartment (3.2.0)
       activerecord (>= 6.1.0, < 8.1)
@@ -1394,6 +1401,9 @@ GEM
     ruby-saml (1.18.1)
       nokogiri (>= 1.13.10)
       rexml
+    ruby-vips (2.2.5)
+      ffi (~> 1.12)
+      logger
     ruby2_keywords (0.0.5)
     rubyzip (3.1.0)
     sass (3.7.4)
@@ -1722,7 +1732,7 @@ DEPENDENCIES
   redis-actionpack
   redis-namespace (~> 1.10)
   redlock (>= 0.1.2, < 2.0)
-  riiif (~> 2.1)
+  riiif!
   rolify
   ros-apartment
   rsolr (~> 2.0)

--- a/config/initializers/riiif.rb
+++ b/config/initializers/riiif.rb
@@ -30,4 +30,5 @@ Rails.application.reloader.to_prepare do
   Riiif.unauthorized_image = Rails.root.join('app', 'assets', 'images', 'us_404.svg')
 
   Riiif::Engine.config.cache_duration = 1.year
+  Riiif::Engine.config.use_vips = true
 end


### PR DESCRIPTION
In order to use VIPs in an existing application that already uses riiif:
1. Update your version of the riiif gem to one that supports VIPS (currently ref `9a375`)
2. In your application's `config/initializers/riiif.rb` within the `Rails.application.reloader.to_prepare do` add the line `Riiif::Engine.config.use_vips = true`

- Currently the VIPs-configurable version of RIIIF is not released, have to use a reference. In communication with folks at Stanford to request a release.

Connected to https://github.com/samvera/hyrax/issues/7287
See also https://github.com/samvera/hyrax/pull/7289

@samvera/hyku-code-reviewers
