### PR TITLE
BACKPORT: Allow use of VIPS instead of Imagemagick for RIIIF

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,7 +93,7 @@ gem 'redcarpet' # for Markdown constant
 gem 'redis-actionpack'
 gem 'redis-namespace', '~> 1.10' # Hyrax v5 relies on 1.5; but we'd like to have the #clear method so we need 1.10 or greater.
 gem 'redlock', '>= 0.1.2', '< 2.0' # lock redlock per https://github.com/samvera/hyrax/pull/5961
-gem 'riiif', '~> 2.0'
+gem 'riiif', git: 'https://github.com/sul-dlss/riiif.git', ref: '9a375'
 gem 'rolify'
 gem 'rsolr', '~> 2.0'
 gem 'rspec', group: %i[development test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -227,6 +227,17 @@ GIT
       nokogiri (~> 1.5)
       omniauth (>= 1.2, < 3)
 
+GIT
+  remote: https://github.com/sul-dlss/riiif.git
+  revision: 9a37564c3842d703bb9df195038eaf7fb037b5df
+  ref: 9a375
+  specs:
+    riiif (2.7.0)
+      deprecation (>= 1.0.0)
+      iiif-image-api (>= 0.1.0)
+      railties (>= 4.2, < 9)
+      ruby-vips
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -1211,11 +1222,7 @@ GEM
     retriable (3.1.2)
     reverse_markdown (2.1.1)
       nokogiri
-    rexml (3.4.2)
-    riiif (2.4.0)
-      deprecation (>= 1.0.0)
-      iiif-image-api (>= 0.1.0)
-      railties (>= 4.2, < 8)
+    rexml (3.4.4)
     rolify (6.0.1)
     rsolr (2.6.0)
       builder (>= 2.1.2)
@@ -1287,6 +1294,9 @@ GEM
     ruby-saml (1.18.1)
       nokogiri (>= 1.13.10)
       rexml
+    ruby-vips (2.2.5)
+      ffi (~> 1.12)
+      logger
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     sass (3.7.4)
@@ -1592,7 +1602,7 @@ DEPENDENCIES
   redis-actionpack
   redis-namespace (~> 1.10)
   redlock (>= 0.1.2, < 2.0)
-  riiif (~> 2.0)
+  riiif!
   rolify
   rsolr (~> 2.0)
   rspec

--- a/config/initializers/riiif.rb
+++ b/config/initializers/riiif.rb
@@ -38,6 +38,7 @@ Rails.application.reloader.to_prepare do
   Riiif.unauthorized_image = Rails.root.join('app', 'assets', 'images', 'us_404.svg')
 
   Riiif::Engine.config.cache_duration = 1.year
+  Riiif::Engine.config.use_vips = true
 end
 
 module Hyrax


### PR DESCRIPTION
Backport of https://github.com/samvera/hyku/pull/2810

In order to use VIPs in an existing application that already uses riiif:
1. Update your version of the riiif gem to one that supports VIPS (currently ref `9a375`)
2. In your application's `config/initializers/riiif.rb` within the `Rails.application.reloader.to_prepare do` add the line `Riiif::Engine.config.use_vips = true`

- Currently the VIPs-configurable version of RIIIF is not released, have to use a reference. In communication with folks at Stanford to request a release.

Connected to https://github.com/samvera/hyrax/issues/7287
See also https://github.com/samvera/hyrax/pull/7289

Changes proposed in this pull request:
* Use VIPS for IIIF rather than ImageMagick - significantly faster.

@samvera/hyku-code-reviewers
