### PR TITLE
Run tests against 6.2-stable branch if it's going to stay around

### DIFF
--- a/.github/workflows/build-test-lint.yaml
+++ b/.github/workflows/build-test-lint.yaml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - 6.2-stable
   pull_request:
     branches:
       - main
+      - 6.2-stable
   workflow_dispatch:
     inputs:
       debug_step:


### PR DESCRIPTION
Avoid accidental introduction of bugs - run tests on PRs against current development branch & on merges to it.

@samvera/hyku-code-reviewers
