### PR TITLE
Add Zeitwerk initializer to help it find IIIFManifest

### DIFF
--- a/config/initializers/zeitwerk.rb
+++ b/config/initializers/zeitwerk.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+Rails.autoloaders.main.inflector.inflect(
+  # Needed to let Zeitwerk find our overrides for the IIIFManifest gem
+  "iiif_manifest" => "IIIFManifest"
+)


### PR DESCRIPTION
Since the capitalization is non-standard, Zeitwerk doesn't know where to find it.

On deploy, we were getting the following error:
```log
! Unable to load application: NameError: uninitialized constant IiifManifest::ManifestBuilderDecorator::CanvasBuilderDecorator
bundler: failed to load command: puma (/usr/local/bundle/bin/puma)
/usr/local/bundle/gems/zeitwerk-2.7.3/lib/zeitwerk/cref.rb:62:in `const_get': uninitialized constant IiifManifest::ManifestBuilderDecorator::CanvasBuilderDecorator (NameError)

    @mod.const_get(@cname, false)
```

@samvera/hyku-code-reviewers
