### PR TITLE
Fix flaky CreateLargeDerivativesJob spec by setting test queue adapter

### DIFF
--- a/spec/jobs/create_large_derivatives_job_spec.rb
+++ b/spec/jobs/create_large_derivatives_job_spec.rb
@@ -1,6 +1,19 @@
 # frozen_string_literal: true
 
 RSpec.describe CreateLargeDerivativesJob, type: :job do
+  before do
+    ActiveJob::Base.queue_adapter = :test
+    allow(FileSet).to receive(:find).with(id).and_return(file_set)
+    allow(file_set).to receive(:id).and_return(id)
+    # Short-circuit irrelevant logic
+    allow(file_set).to receive(:reload)
+    allow(file_set).to receive(:update_index)
+  end
+
+  after do
+    clear_enqueued_jobs
+  end
+
   let(:id)       { '123' }
   let(:file_set) { FileSet.new }
   let(:file) do
@@ -9,14 +22,6 @@ RSpec.describe CreateLargeDerivativesJob, type: :job do
       f.original_name = 'video.mp4'
       f.save!
     end
-  end
-
-  before do
-    allow(FileSet).to receive(:find).with(id).and_return(file_set)
-    allow(file_set).to receive(:id).and_return(id)
-    # Short-circuit irrelevant logic
-    allow(file_set).to receive(:reload)
-    allow(file_set).to receive(:update_index)
   end
 
   it 'runs in the :auxiliary queue' do


### PR DESCRIPTION
Issue:
- https://github.com/samvera/hyku/issues/2794

Set ActiveJob queue adapter to :test in the spec's before block to ensure consistent behavior between local and CI environments. The spec was failing intermittently in CI when a different queue adapter was used that doesn't properly support the have_enqueued_job matcher with queue name checking.

Also add after block to clear enqueued jobs to prevent test pollution.

