### PR TITLE
Skip gzip compression for /downloads

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -281,7 +281,11 @@ module Hyku
 
     # Gzip all responses.  We probably could do this in an upstream proxy, but
     # configuring Nginx on Elastic Beanstalk is a pain.
-    config.middleware.use Rack::Deflater
+    config.middleware.use Rack::Deflater,
+      if: lambda { |env, _status, _headers, _body|
+        # Don't compress downloads route
+        !env['PATH_INFO']&.start_with?('/downloads')
+      }
 
     # The locale is set by a query parameter, so if it's not found render 404
     config.action_dispatch.rescue_responses["I18n::InvalidLocale"] = :not_found


### PR DESCRIPTION
`Rack::Deflater` was compressing all responses, including file downloads.  Gzip compression breaks HTTP range requests because byte offsets in the request refer to the original file, not the compressed stream.  This prevents PDF.js from streaming large PDFs and instead forces full downloads and A/V content seeking.
