### PR TITLE
🐛 Fix video embed solr field

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -62,7 +62,6 @@ class SolrDocument
   attribute :library_catalog_identifier, Solr::String, 'library_catalog_identifier_tesim'
   attribute :chronology_note, Solr::String, 'chronology_note_tesim'
   attribute :based_near, Solr::Array, 'based_near_tesim'
-  attribute :video_embed, Solr::String, 'video_embed_tesi'
 
   field_semantics.merge!(
     contributor: 'contributor_tesim',
@@ -119,5 +118,9 @@ class SolrDocument
   def query(query, **opts)
     result = Hyrax::SolrService.post(query, **opts)
     result.fetch('response').fetch('docs', [])
+  end
+
+  def video_embed
+    self['video_embed_tesi'] || first('video_embed_tesim')
   end
 end

--- a/config/metadata/with_video_embed.yaml
+++ b/config/metadata/with_video_embed.yaml
@@ -9,4 +9,4 @@ attributes:
       required: false
       multiple: false
     index_keys:
-      - "video_embed_tesim"
+      - "video_embed_tesi"


### PR DESCRIPTION
This commit will fix embed links not showing because there was a inconsistency between `video_embed_tesi` and `video_embed_tesim`.  This change will support both because we realize some apps indexed it as `_tesim` and we wouldn't want to break that.

Ref:
- https://github.com/notch8/hykuup_knapsack/issues/560
