### PR TITLE
Scrub text before indexing

### DIFF
--- a/app/indexers/concerns/hyku_indexing.rb
+++ b/app/indexers/concerns/hyku_indexing.rb
@@ -3,6 +3,7 @@
 ##
 # A mixin for all additional Hyku applicable indexing; both Valkyrie and ActiveFedora friendly.
 module HykuIndexing
+  include ScrubText
   # TODO: Once we've fully moved to Valkyrie, remove the generate_solr_document and move `#to_solr`
   #      to a more conventional method def (e.g. `def to_solr`).  However, we need to tap into two
   #      different inheritance paths based on ActiveFedora or Valkyrie
@@ -54,7 +55,7 @@ module HykuIndexing
     return [] if members.blank?
 
     text_file_sets = members.select { |fs| fs.file_set? && fs.original_file&.mime_type == 'text/plain' }
-    text_file_sets.map { |fs| fs.original_file&.content }
+    text_file_sets.map { |fs| scrub_text(fs.original_file&.content) }
   end
 
   def extract_text_from_child_works(object)

--- a/app/indexers/concerns/scrub_text.rb
+++ b/app/indexers/concerns/scrub_text.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+## remove non-UTF-8 characters from a text string
+module ScrubText
+  def scrub_text(text)
+    text.tr("\n", ' ')
+        .squeeze(' ')
+        .encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
+  end
+end

--- a/app/indexers/hyku/indexers/file_set_indexer.rb
+++ b/app/indexers/hyku/indexers/file_set_indexer.rb
@@ -4,6 +4,7 @@ module Hyku
   module Indexers
     class FileSetIndexer < Hyrax::Indexers::FileSetIndexer
       include Hyrax::Indexer(:bulkrax_metadata) unless Hyrax.config.flexible?
+      include ScrubText
 
       def to_solr
         return super unless Flipflop.default_pdf_viewer?
@@ -27,9 +28,7 @@ module Hyku
             pdftotext.read
           end
 
-          text.tr("\n", ' ')
-              .squeeze(' ')
-              .encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '') # remove non-UTF-8 characters
+          scrub_text(text)
         rescue Errno::ENOENT => e
           raise e unless e.message.include?("No such file or directory - pdftotext")
           Rails.logger.warn("`pdfinfo' is not installed; unable to extract text from the PDF's content")


### PR DESCRIPTION
## Summary

Ref https://github.com/notch8/hykuup_knapsack/issues/553

Sanitizes the text to remove non-UTF-8 characters from a text string during indexing.


