### PR TITLE
:bug: [i2830] - Fix asset pipeline errors in theme form by adding .jp…

### DIFF
--- a/app/views/hyrax/admin/appearances/_theme_form.html.erb
+++ b/app/views/hyrax/admin/appearances/_theme_form.html.erb
@@ -30,7 +30,7 @@
         </ul>
       </div>
       <div id="home-wireframe" class="col-sm-6">
-        <%= image_tag "themes/default_home/default_home", class: "img-fluid" %>
+        <%= image_tag "themes/default_home/default_home.jpg", class: "img-fluid" %>
       </div>
     </div>
     <hr />
@@ -72,7 +72,7 @@
         </ul>
       </div>
       <div id="show-wireframe" class="col-sm-6">
-        <%= image_tag "themes/default_show/default_show", class: "img-fluid" %>
+        <%= image_tag "themes/default_show/default_show.jpg", class: "img-fluid" %>
       </div>
     </div>
     <hr />


### PR DESCRIPTION
# Summary

Issue: 
- https://github.com/samvera/hyku/issues/2830

Fix missing image extensions in theme form for production assets

Adds .jpg extensions to image_tag calls for default_home and default_show theme images. Sprockets requires exact file paths in production mode, unlike development where it can infer extensions.

https://demo.hykudemo.org/admin/appearance?locale=en

<img width="678" height="400" alt="image" src="https://github.com/user-attachments/assets/28c4c926-2a2f-4cc5-bdf8-a4ee424e0884" />


# Acceptance Criteria

- [ ] Visiting /admin/appearance should not result in an error

# Screenshots or Video
<details>
<summary>AFTER</summary>

<img width="2703" height="1461" alt="image" src="https://github.com/user-attachments/assets/08949130-c707-4a6c-8b4b-415c8cf4df5d" />


</details>

# Testing Instructions

visit https://demo.hykudemo.org/admin/appearance?locale=en

