### PR TITLE
Keep OAI working for ActiveFedora models

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -154,8 +154,10 @@ class SolrDocument
   def field_semantics
     if Hyrax.config.flexible_classes.include?(hydra_model.to_s)
       build_field_semantics(flexible_schema_data)
-    else
+    elsif hydra_model.respond_to?(:schema)
       build_field_semantics(standard_schema_data)
+    else
+      basic_mappings
     end
   end
 
@@ -189,6 +191,26 @@ class SolrDocument
         index_keys: property_hash['indexing']
       }
     end
+  end
+
+  def basic_mappings
+    {
+      contributor: ['contributor_tesim'],
+      coverage: [],
+      creator: ['creator_tesim'],
+      date: ['date_created_tesim'],
+      description: ['description_tesim'],
+      format: ['format_tesim'],
+      identifier: ['identifier_tesim'],
+      language: ['language_tesim'],
+      publisher: ['publisher_tesim'],
+      relation: ['nesting_collection__pathnames_ssim'],
+      rights: ['rights_statement_tesim', 'rights_notes_tesim', 'license_tesim'],
+      source: [],
+      subject: ['subject_tesim'],
+      title: ['title_tesim'],
+      type: ['human_readable_type_tesim']
+    }
   end
 
   def dc_mappings


### PR DESCRIPTION
## Summary

[Prior OAI enhancements](https://github.com/samvera/hyku/pull/2839) broke the feed for ActiveFedora models (when VALKYRIE_TRANSITION=false)

With this change, a repo with ActiveFedora models and using VALKYRIE_TRANSITION=false will not get an error page.

## Screenshots

<details>
<summary>Before this change</summary>

<img width="1625" height="3378" alt="screencapture-bcd-hyku-localhost-direct-catalog-oai-2025-12-05-16_24_57" src="https://github.com/user-attachments/assets/334a96dd-f214-4b18-9067-1d955729a856" />

</details>

<details>
<summary>After this change</summary>

<img width="1625" height="1342" alt="screencapture-bcd-hyku-localhost-direct-catalog-oai-2025-12-05-16_26_05" src="https://github.com/user-attachments/assets/72b5c79d-9261-46e3-8248-090d4744288f" />

</details>