### PR TITLE
Update Hyrax to include Google Scholar work - 6.2 version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,7 +142,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: 0995cc5261b098eb9de59f695836a712081223ca
+  revision: cc1509bb38025942436635a4776976d1f46435b7
   branch: 5.0-flexible
   specs:
     hyrax (5.0.5)


### PR DESCRIPTION
Fixes https://github.com/notch8/hykuup_knapsack/issues/583

Updates Hyrax to include more fields for Google Scholar indexing

See [Hyrax diff](https://github.com/samvera/hyrax/compare/0995cc5261b098eb9de59f695836a712081223ca...cc1509bb38025942436635a4776976d1f46435b7)


@samvera/hyku-code-reviewers
