### PR TITLE
🐛 Show page properties should have view options

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,7 +142,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: 52bb262f7af0c29c3bdf893013f5ae3e135bacb6
+  revision: cc1509bb38025942436635a4776976d1f46435b7
   branch: 5.0-flexible
   specs:
     hyrax (5.0.5)

--- a/config/metadata_profiles/m3_profile.yaml
+++ b/config/metadata_profiles/m3_profile.yaml
@@ -589,7 +589,7 @@ properties:
     cardinality:
       minimum: 0
       maximum: 1
-    data_type: string
+    data_type: array
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:


### PR DESCRIPTION
Fixes a bug where flexible metadata properties that do not contain view options are rendering on the show page.

This change bumps Hyrax 5.0-flexible to the current version and updates m3 profile label property to data_type array so it won't store a `[""]` value rendering the label with an empty value.

<details>
<summary>Before</summary>

<img width="1504" height="938" alt="Screenshot 2025-11-04 at 1 16 03 PM" src="https://github.com/user-attachments/assets/fd067025-ca12-4891-bfa3-72d90a4bfc37" />

</details>

<details>
<summary>After</summary>

<img width="1615" height="871" alt="Screenshot 2025-12-09 at 9 49 56 PM" src="https://github.com/user-attachments/assets/2acd88c4-501a-4868-b8df-0cc62e3318f8" />

</details>

Ref:
- https://github.com/samvera/hyku/issues/2775

@samvera/hyku-code-reviewers
