### PR TITLE
🎁 Update gallery view styles and grid breakpoints

### DIFF
--- a/app/assets/stylesheets/hyku.scss
+++ b/app/assets/stylesheets/hyku.scss
@@ -728,22 +728,6 @@ dd {
             display: none;
         }
     }
-
-    .document {
-        .document-thumbnail {
-            .img-thumbnail {
-                padding: 0.25rem;
-                background-color: #fff;
-                border: 1px solid #dee2e6;
-                border-radius: 0.25rem;
-            }
-        }
-    }
-}
-
-// adds bootstrap class to element
-.documents-gallery {
-    @extend .row-cols-lg-4;
 }
 
 // pagination

--- a/app/assets/stylesheets/themes/gallery_view.scss
+++ b/app/assets/stylesheets/themes/gallery_view.scss
@@ -1,31 +1,26 @@
-.gallery {
-  div.thumbnail {
-    img {
-      height: 200px;
-      object-fit: cover;
-      width:  200px;
+// Catalog index gallery view
+// Gallery view can be set as the default search results in dashboard < appearance < themes
+// Gallery view can be selected on the view-type-group on the search results page
+
+body.catalog.catalog-index {
+  .documents-gallery {
+    .document {
+      padding: 0.5rem;
+
+      .thumbnail-container {
+        border: 1px solid #dee2e6;
+        padding: 0.25rem;
+        border-radius: 0.25rem;
+      }
+
+      .document-thumbnail {
+        // extend the img-thumbnail class from bootstrap
+        .img-thumbnail {
+          height: 300px;
+          width: 250px;
+          object-fit: cover;
+        }
+      }
     }
-  }
-
-  .thumbnail {
-    background-color: transparent !important;
-    border: none !important;
-    border-radius: 0 !important;
-  }
-
-  .thumbnail > img,
-  .thumbnail a > img {
-    height: 200px !important;
-  }
-
-  .document {
-    background-color: #fff;
-    border: 1px solid #ddd;
-    border-radius: 4px;
-    margin: 15px;
-  }
-
-  #documents .document {
-    border-bottom: 1px solid #ddd !important;
   }
 }

--- a/app/views/catalog/_document_gallery.html.erb
+++ b/app/views/catalog/_document_gallery.html.erb
@@ -1,0 +1,11 @@
+<%# OVERRIDE Blacklight Gallery v6.0.0 to use row-cols-lg-3 rather than row-cols-md-3 %>
+
+<% view_config = local_assigns[:view_config] || blacklight_config&.view_config(document_index_view_type) %>
+<div class="container foo">
+  <%# OVERRIDE begin %>
+  <div id="documents" class="<%= (Array(view_config.classes || 'row-cols-2 row-cols-lg-3') + ["row documents-#{view_config.key}"]).join(' ') %>">
+  <%# OVERRIDE end %>
+    <% document_presenters = Blacklight::VERSION > '8' ? documents.map { |doc| document_presenter(doc) } : documents %>
+    <%= render view_config.document_component.with_collection(document_presenters, counter_offset: @response&.start || 0) %>
+  </div>
+</div>


### PR DESCRIPTION
Improvements to the Gallery View for the Search Results Catalog

- Gallery view can be set as the default search results in dashboard < appearance < themes
- Gallery view can be selected on the view-type button on the search results page

Changes to the Gallery View:
- Ensures all thumbnails are a consistent size
- Change gallery grid breakpoint from md to lg (row-cols-md-3 → row-cols-lg-3) to avoid search results becoming too cramped on medium screens
- Remove unused styles in the `gallery_view.scss` file
- Moves all gallery styles into the `gallery_view.scss` file
- Added border for each gallery item for better visual separation

Ref:
- https://github.com/notch8/wvu_knapsack/issues/102

<details>
<summary>Before</summary>

<img width="3358" height="5686" alt="image" src="https://github.com/user-attachments/assets/0bc182af-ae51-4e9f-958e-40d282b764ca" />

</details>
<details>
<summary>After: Full screen</summary>

<img width="3358" height="5790" alt="image" src="https://github.com/user-attachments/assets/db1f8c06-9627-40cd-8617-e616cce482ca" />

</details>
<details>
<summary>After: Mobile view</summary>

<img width="490" height="947" alt="Screenshot 2025-12-15 at 1 45 46 PM" src="https://github.com/user-attachments/assets/6c5ab449-718f-4a12-97e4-e50670130cfa" />

</details>


@samvera/hyku-code-reviewers
