### PR TITLE
🐛 Fix depositor ArgumentError on featured works homepage

### DIFF
--- a/app/views/hyrax/homepage/_featured_fields.html.erb
+++ b/app/views/hyrax/homepage/_featured_fields.html.erb
@@ -12,7 +12,7 @@
   </div>
   <% if Flipflop.home_page_recent_document_show_depositor? %>
     <div class="featured-field featured-item-depositor">
-      <span class="featured-label"><%= t('hyrax.homepage.featured_works.document.depositor_label') %>:</span> <%= link_to_profile featured.depositor(t('hyrax.homepage.featured_works.document.depositor_missing')) %>
+      <span class="featured-label"><%= t('hyrax.homepage.featured_works.document.depositor_label') %>:</span> <%= link_to_profile(featured.depositor&.first) || t('hyrax.homepage.featured_works.document.depositor_missing') %>
     </div>
   <% end %>
   <% if Flipflop.home_page_recent_document_show_keyword? %>


### PR DESCRIPTION
# Story: [i33] Error on feature flipper to show depositor on featured works

Resolves issue where `featured.depositor` was being called with an argument when it expects none. The depositor field returns an array, so we now safely extract the first value using `&.first` with a fallback message if no depositor is present.

Ref:
- https://github.com/notch8/hyku-community-issues/issues/33

## Expected Behavior Before Changes

For themes that have featured works on the homepage, using the feature flipper to show the depositor resulted in a error that breaks the application.

## Expected Behavior After Changes

Featured works on the homepage will display the depositor when the feature flipper for "Home page recent document show depositor" is on

## Screenshots / Video

<details>
<summary>Image: error</summary>

<img width="1624" height="980" alt="Screenshot 2026-01-28 at 10 46 08 AM" src="https://github.com/user-attachments/assets/37e6c958-e25a-40df-ba47-c004da1b8297" />

</details>
<details>
<summary>Image: after fix</summary>

<img width="1157" height="568" alt="Screenshot 2026-01-28 at 12 21 32 PM" src="https://github.com/user-attachments/assets/80039d75-d9ec-4b14-81fa-0c9ce731b8d2" />

</details>


@samvera/hyku-code-reviewers
