### PR TITLE
I31 cropping bug

### DIFF
--- a/app/assets/stylesheets/hyku.scss
+++ b/app/assets/stylesheets/hyku.scss
@@ -754,3 +754,14 @@ dd {
     }
 }
 /* End blacklight advanced search */
+
+// Style instruction hints for file inputs with left border accent
+.form-group .help-block.border-left-accent {
+    border-left: 3px solid #007bff;
+    padding-left: 1rem;
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+    margin-bottom: 0.75rem;
+    font-size: 0.875rem;
+    color: #6c757d;
+}

--- a/app/views/hyrax/admin/appearances/_banner_image_form.html.erb
+++ b/app/views/hyrax/admin/appearances/_banner_image_form.html.erb
@@ -2,7 +2,7 @@
   <div class="card-body">
     <% require_image = @form.banner_image? ? false : true %>
     <%# Upload Banner Image %>
-    <%= f.input :banner_image, as: :file, wrapper: :vertical_file_input, required: require_image, hint: t('hyrax.admin.appearances.show.forms.banner_image.hint').html_safe, input_html: { name: 'admin_appearance[banner_image]' } %>
+    <%= f.input :banner_image, as: :file, wrapper: :vertical_file_input, required: require_image, hint: t('hyrax.admin.appearances.show.forms.banner_image.hint').html_safe, hint_html: { class: 'border-left-accent' }, input_html: { name: 'admin_appearance[banner_image]' } %>
     <%= f.input :banner_image_text, required: true, as: :text, label: 'Banner image alt text' %>
     <!-- Image preview and cropping area -->
     <button type="button" id="activate-cropper" class="btn btn-primary" style=<%= @form.banner_image.url ? "display:block;" : "display:none;" %>>Crop Image</button>
@@ -29,15 +29,21 @@
 <%# TODO: move this into the assets folder and make it work %>
 <script>
  var cropper;
+ var originalMimeType = 'image/jpeg';
+ var cropperActivated = false;
 
  document.getElementById('activate-cropper').addEventListener('click', function() {
    var image = document.getElementById('image');
    if (image.src) {
+     if (cropper) {
+       cropper.destroy();
+     }
      cropper = new Cropper(image, {
        initialAspectRatio: 16 / 9,
        aspectRatio: NaN,
        zoomOnWheel: false
      });
+     cropperActivated = true;
    }
  });
 
@@ -46,18 +52,19 @@
  inputImage.addEventListener('change', function(e) {
    var files = e.target.files;
    if (files && files.length) {
+     // Store original mime type to preserve format
+     originalMimeType = files[0].type || 'image/jpeg';
      var reader = new FileReader();
      reader.onload = function(e) {
        var image = document.getElementById('image');
        image.src = e.target.result;
        if (cropper) {
          cropper.destroy();
+         cropper = null;
        }
-       cropper = new Cropper(image, {
-         initialAspectRatio: 16 / 9,
-         aspectRatio: NaN,
-         zoomOnWheel: false
-       });
+       cropperActivated = false;
+       // Show the Crop Image button
+       document.getElementById('activate-cropper').style.display = 'block';
      };
      reader.readAsDataURL(files[0]);
    }
@@ -73,9 +80,14 @@ document.querySelector('.banner-submit').addEventListener('click', function(e) {
     }
   }
 
-  if (cropper) {
+  if (cropper && cropperActivated) {
     e.preventDefault();
     $('#spinner').show();
+
+    // Determine file extension and mime type based on original format
+    var extension = originalMimeType === 'image/png' ? 'png' : originalMimeType === 'image/gif' ? 'gif' : 'jpg';
+    var mimeType = originalMimeType === 'image/png' ? 'image/png' : originalMimeType === 'image/gif' ? 'image/gif' : 'image/jpeg';
+    var quality = originalMimeType === 'image/png' || originalMimeType === 'image/gif' ? undefined : 0.95;
 
     cropper.getCroppedCanvas({
       imageSmoothingEnabled: true,
@@ -83,7 +95,7 @@ document.querySelector('.banner-submit').addEventListener('click', function(e) {
     }).toBlob(function(blob) {
       var formData = new FormData(bannerForm);
       formData.delete('admin_appearance[banner_image]');
-      formData.append('admin_appearance[banner_image]', blob, "<%= current_account.name %>-cropped.jpg");
+      formData.append('admin_appearance[banner_image]', blob, "<%= j current_account.name %>-cropped." + extension);
 
       $.ajax('/admin/appearance', {
         method: 'POST',
@@ -92,14 +104,15 @@ document.querySelector('.banner-submit').addEventListener('click', function(e) {
         contentType: false,
         success() {
           $('#spinner').hide();
+          cropperActivated = false;
           window.location.reload();
         },
         error() {
           $('#spinner').hide();
-          alert('Failed to save cropped banner. Please try again.');
+          alert('<%= j t("hyrax.admin.appearances.show.forms.banner_image.cropped_save_error") %>');
         },
       });
-    }, 'image/jpeg', 0.95);
+    }, mimeType, quality);
   }
 });
 

--- a/app/views/hyrax/admin/appearances/_default_images_form.html.erb
+++ b/app/views/hyrax/admin/appearances/_default_images_form.html.erb
@@ -1,10 +1,10 @@
 <%= simple_form_for @form, url: admin_appearance_path do |f| %>
   <div class="card-body">
-    <%= f.input :default_collection_image, as: :file, wrapper: :vertical_file_input, hint: t('hyrax.admin.appearances.show.forms.default_images.hint'), required: false %>
+    <%= f.input :default_collection_image, as: :file, wrapper: :vertical_file_input, required: false, hint: t('hyrax.admin.appearances.show.forms.default_images.hint'), hint_html: { class: 'border-left-accent' } %>
     <%= f.input :default_collection_image_text, as: :text, label: 'Default collection image alt text', required: false %>
     <%= image_tag @form.default_collection_image.url, class: "img-fluid" if @form.default_collection_image? %>
 
-    <%= f.input :default_work_image, as: :file, wrapper: :vertical_file_input, hint: t('hyrax.admin.appearances.show.forms.default_images.hint'), required: false %>
+    <%= f.input :default_work_image, as: :file, wrapper: :vertical_file_input, required: false, hint: t('hyrax.admin.appearances.show.forms.default_images.hint'), hint_html: { class: 'border-left-accent' } %>
     <%= f.input :default_work_image_text, as: :text, label: 'Default work image alt text', required: false %>
     <%= image_tag @form.default_work_image.url, class: "img-fluid" if @form.default_work_image? %>
   </div>

--- a/app/views/hyrax/admin/appearances/_directory_image_form.html.erb
+++ b/app/views/hyrax/admin/appearances/_directory_image_form.html.erb
@@ -2,7 +2,7 @@
   <div class="card-body">
     <% require_image = @form.directory_image? ? false : true %>
     <%# Upload Directory Image %>
-    <%= f.input :directory_image, as: :file, wrapper: :vertical_file_input, required: require_image, hint: t('hyrax.admin.appearances.show.forms.directory_image.hint') %>
+    <%= f.input :directory_image, as: :file, wrapper: :vertical_file_input, required: require_image, hint: t('hyrax.admin.appearances.show.forms.directory_image.hint'), hint_html: { class: 'border-left-accent' } %>
     <%= f.input :directory_image_text, required: true, as: :text, label: 'Directory image alt text' %>
     <%= image_tag @form.directory_image.url, class: "img-fluid" if @form.directory_image? %>
   </div>

--- a/app/views/hyrax/admin/appearances/_favicon_form.html.erb
+++ b/app/views/hyrax/admin/appearances/_favicon_form.html.erb
@@ -1,7 +1,7 @@
 <%= simple_form_for @form, url: admin_appearance_path do |f| %>
   <div class="card-body">
     <% require_image = @form.favicon? ? false : true %>
-    <%= f.input :favicon, as: :file, wrapper: :vertical_file_input, hint: t('hyrax.admin.appearances.show.forms.favicon.hint') %>
+    <%= f.input :favicon, as: :file, wrapper: :vertical_file_input, required: require_image, hint: t('hyrax.admin.appearances.show.forms.favicon.hint'), hint_html: { class: 'border-left-accent' } %>
     <%= image_tag @form.favicon.url, class: "img-fluid" if @form.favicon? %>
   </div>
   <div class="card-footer">

--- a/app/views/hyrax/admin/appearances/_logo_image_form.html.erb
+++ b/app/views/hyrax/admin/appearances/_logo_image_form.html.erb
@@ -2,7 +2,7 @@
   <div class="card-body">
     <% require_image = @form.logo_image? ? false : true %>
     <%# Upload Logo Image %>
-    <%= f.input :logo_image, as: :file, wrapper: :vertical_file_input, required: require_image, hint: t('hyrax.admin.appearances.show.forms.logo_image.hint') %>
+    <%= f.input :logo_image, as: :file, wrapper: :vertical_file_input, required: require_image, hint: t('hyrax.admin.appearances.show.forms.logo_image.hint'), hint_html: { class: 'border-left-accent' } %>
     <%= f.input :logo_image_text, required: true, as: :text, label: 'Logo image alt text' %>
     <%= image_tag @form.logo_image.url, class: "img-fluid" if @form.logo_image? %>
   </div>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -373,7 +373,10 @@ de:
             active_tabs_background_color:
               hint: Hover-Farbe für Homepage-Tabs.
             banner_image:
-              hint: Um ein Bild als Masthead-Hintergrund zu verwenden, sollten Sie ein Bild (JPG, GIF oder PNG) verwenden, das mindestens 120 Pixel hoch und 1200 Pixel breit ist. Verwenden Sie für optimale Ergebnisse ein Bild mit einer Breite von mindestens 1800 Pixel.
+              hint: |
+                Um ein Bild als Masthead-Hintergrund zu verwenden, sollten Sie ein Bild (JPG, GIF oder PNG) verwenden, das mindestens 120 Pixel hoch und 1200 Pixel breit ist. Verwenden Sie für optimale Ergebnisse ein Bild mit einer Breite von mindestens 1800 Pixel.<br/>
+                Zum Zuschneiden: Klicken Sie auf "Crop Image", passen Sie die Auswahl an und klicken Sie dann auf "Save changes". Das Banner passt sich dem Fenster an. Um einen Zuschnitt rückgängig zu machen, verwenden Sie "Remove banner image" und laden Sie dann das Original erneut hoch.
+              cropped_save_error: Fehler beim Speichern des zugeschnittenen Banners. Bitte versuchen Sie es erneut.
             collection_banner_text_color:
               hint: Die Farbe für den Text (Titel und Datum der letzten Aktualisierung) im Sammlungsbanner.
             custom_css:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -234,8 +234,9 @@ en:
               hint: Hover color for homepage tabs.
             banner_image:
               hint: |
-                To use an image as a masthead background, you should use an image (JPG, GIF or PNG) that is at least 120 pixels tall and 1200 pixels wide. For best results, use an image at least 1800 pixels wide.<br/>
-                To crop: click "Crop Image", adjust the selection, then click "Save changes" to apply the crop. The banner dynamically resizes with the window size. To restore the full image after cropping, reupload the original image.
+                To use an image as a masthead background, use an image (JPG, GIF or PNG) at least 120 pixels tall and 1200 pixels wide. For best results, use at least 1800 pixels wide.<br/>
+                To crop: click "Crop Image", adjust the selection, then click "Save changes" to apply the crop. The banner resizes with the window. To undo a crop, use "Remove banner image" then re-upload the original.
+              cropped_save_error: Failed to save cropped banner. Please try again.
             collection_banner_text_color:
               hint: The color for the text (title, and last updated date) inside of the collection banner.
             custom_css:
@@ -245,7 +246,7 @@ en:
               hint: Work interaction (edit, feature, etc.) buttons; work views on collection page and search filter button.
             default_images:
               alert: Please upload at least one file before submitting.
-              hint: For default images, you should use an image (JPG, GIF or PNG) that has equal height and width dimensions (100 pixels wide and 100 pixels tall)
+              hint: For default images, you should use an image (JPG, GIF or PNG) that has equal height and width dimensions (100 pixels wide and 100 pixels tall).
             directory_image:
               hint: To use an image as the directory image, you should use an image (JPG, GIF or PNG) that is no taller than the header and no wider than 400 pixels wide.
             facet_panel_background_color:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -374,7 +374,10 @@ es:
             active_tabs_background_color:
               hint: Color al pasar el mouse sobre las pestañas de la página de inicio.
             banner_image:
-              hint: Para usar una imagen como fondo de cabecera, debe usar una imagen (JPG, GIF o PNG) que tenga al menos 120 píxeles de alto y 1200 píxeles de ancho. Para obtener mejores resultados, use una imagen de al menos 1800 píxeles de ancho.
+              hint: |
+                Para usar una imagen como fondo de cabecera, debe usar una imagen (JPG, GIF o PNG) que tenga al menos 120 píxeles de alto y 1200 píxeles de ancho. Para obtener mejores resultados, use una imagen de al menos 1800 píxeles de ancho.<br/>
+                Para recortar: haga clic en "Crop Image", ajuste la selección y luego haga clic en "Save changes". El banner se redimensiona con la ventana. Para deshacer un recorte, use "Remove banner image" y luego vuelva a cargar el original.
+              cropped_save_error: Error al guardar el banner recortado. Por favor, inténtelo de nuevo.
             collection_banner_text_color:
               hint: El color del texto (título y fecha de última actualización) dentro del banner de la colección.
             custom_css:
@@ -384,7 +387,7 @@ es:
               hint: Botones de interacción de trabajo (editar, función, etc.); vistas de trabajo en la página de colección y botón de filtro de búsqueda.
             default_images:
               alert: Cargue al menos un archivo antes de enviarlo.
-              hint: Para las imágenes predeterminadas, debe usar una imagen (JPG, GIF o PNG) que tenga las mismas dimensiones de alto y ancho (100 píxeles de ancho y 100 píxeles de alto)
+              hint: Para las imágenes predeterminadas, debe usar una imagen (JPG, GIF o PNG) que tenga las mismas dimensiones de alto y ancho (100 píxeles de ancho y 100 píxeles de alto).
             directory_image:
               hint: La imagen del directorio debe usar una imagen (JPG, GIF o PNG). El ancho de la imagen no debe ser más ancho que el doble de la altura.
             facet_panel_background_color:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -374,7 +374,10 @@ fr:
             active_tabs_background_color:
               hint: Couleur de survol pour les onglets de la page d'accueil.
             banner_image:
-              hint: Pour utiliser une image comme arrière-plan d'une bannière Masthead, vous devez utiliser une image (JPG, GIF ou PNG) d'au moins 120 pixels de haut et 1 200 pixels de large. Pour de meilleurs résultats, utilisez une image d'au moins 1800 pixels de large.
+              hint: |
+                Pour utiliser une image comme arrière-plan d'une bannière Masthead, vous devez utiliser une image (JPG, GIF ou PNG) d'au moins 120 pixels de haut et 1 200 pixels de large. Pour de meilleurs résultats, utilisez une image d'au moins 1800 pixels de large.<br/>
+                Pour recadrer : cliquez sur "Crop Image", ajustez la sélection, puis cliquez sur "Save changes". La bannière se redimensionne avec la fenêtre. Pour annuler un recadrage, utilisez "Remove banner image" puis téléchargez à nouveau l'original.
+              cropped_save_error: Échec de l'enregistrement du bannière recadrée. Veuillez réessayer.
             collection_banner_text_color:
               hint: La couleur du texte (titre et date de la dernière mise à jour) à l'intérieur de la bannière de collection.
             custom_css:
@@ -384,7 +387,7 @@ fr:
               hint: Boutons d'interaction de travail (édition, fonctionnalité, etc.) ; vues de travail sur la page de collection et le bouton de filtre de recherche.
             default_images:
               alert: Veuillez télécharger au moins un fichier avant de soumettre.
-              hint: Pour les images par défaut, vous devez utiliser une image (JPG, GIF ou PNG) qui a des dimensions de hauteur et de largeur égales (100 pixels de large et 100 pixels de haut)
+              hint: Pour les images par défaut, vous devez utiliser une image (JPG, GIF ou PNG) qui a des dimensions de hauteur et de largeur égales (100 pixels de large et 100 pixels de haut).
             directory_image:
               hint: L'image du répertoire doit utiliser une image (JPG, GIF ou PNG). La largeur de l'image ne doit pas être plus large que 2x la hauteur.
             facet_panel_background_color:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -374,7 +374,10 @@ it:
             active_tabs_background_color:
               hint: Colore al passaggio del mouse sulle schede della home page.
             banner_image:
-              hint: Per utilizzare un'immagine come sfondo di masthead, è necessario utilizzare un'immagine (JPG, GIF o PNG) alta almeno 120 pixel e larga 1200 pixel. Per risultati ottimali, utilizzare un'immagine larga almeno 1800 pixel.
+              hint: |
+                Per utilizzare un'immagine come sfondo di masthead, è necessario utilizzare un'immagine (JPG, GIF o PNG) alta almeno 120 pixel e larga 1200 pixel. Per risultati ottimali, utilizzare un'immagine larga almeno 1800 pixel.<br/>
+                Per ritagliare: fare clic su "Crop Image", regolare la selezione, quindi fare clic su "Save changes". Il banner si ridimensiona con la finestra. Per annullare un ritaglio, utilizzare "Remove banner image" e poi ricaricare l'originale.
+              cropped_save_error: Impossibile salvare il banner ritagliato. Riprova.
             collection_banner_text_color:
               hint: Il colore del testo (titolo e data dell'ultimo aggiornamento) all'interno del banner della raccolta.
             custom_css:
@@ -384,7 +387,7 @@ it:
               hint: Pulsanti di interazione con il lavoro (modifica, funzionalità, ecc.); viste di lavoro sulla pagina di raccolta e sul pulsante del filtro di ricerca.
             default_images:
               alert: Carica almeno un file prima di inviarlo.
-              hint: Per le immagini predefinite, è necessario utilizzare un'immagine (JPG, GIF o PNG) che abbia le stesse dimensioni in altezza e larghezza (100 pixel in larghezza e 100 pixel in altezza)
+              hint: Per le immagini predefinite, è necessario utilizzare un'immagine (JPG, GIF o PNG) che abbia le stesse dimensioni in altezza e larghezza (100 pixel in larghezza e 100 pixel in altezza).
             directory_image:
               hint: L'immagine della directory deve utilizzare un'immagine (JPG, GIF o PNG). La larghezza dell'immagine non dovrebbe essere più ampia di 2 volte l'altezza.
             facet_panel_background_color:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -257,7 +257,10 @@ pt-BR:
             active_tabs_background_color:
               hint: Cor de foco para abas da página inicial.
             banner_image:
-              hint: Para usar uma imagem como plano de fundo do cabeçalho, você deve usar uma imagem (JPG, GIF ou PNG) com pelo menos 120 pixels de altura e 1200 pixels de largura. Para obter melhores resultados, use uma imagem com pelo menos 1800 pixels de largura.
+              hint: |
+                Para usar uma imagem como plano de fundo do cabeçalho, você deve usar uma imagem (JPG, GIF ou PNG) com pelo menos 120 pixels de altura e 1200 pixels de largura. Para obter melhores resultados, use uma imagem com pelo menos 1800 pixels de largura.<br/>
+                Para recortar: clique em "Crop Image", ajuste a seleção e clique em "Save changes". O banner redimensiona com a janela. Para desfazer um recorte, use "Remove banner image" e faça upload do original novamente.
+              cropped_save_error: Falha ao salvar o banner recortado. Por favor, tente novamente.
             collection_banner_text_color:
               hint: A cor do texto (título e data da última atualização) dentro do banner da coleção.
             custom_css:
@@ -267,7 +270,7 @@ pt-BR:
               hint: Botões de interação do trabalho (editar, recurso, etc.); exibições de trabalho na página de coleção e botão de filtro de pesquisa.
             default_images:
               alert: Faça upload de pelo menos um arquivo antes de enviar.
-              hint: Para imagens padrão, você deve usar uma imagem (JPG, GIF ou PNG) que tenha dimensões iguais de altura e largura (100 pixels de largura e 100 pixels de altura)
+              hint: Para imagens padrão, você deve usar uma imagem (JPG, GIF ou PNG) que tenha dimensões iguais de altura e largura (100 pixels de largura e 100 pixels de altura).
             directory_image:
               hint: A imagem do diretório deve usar uma imagem (JPG, GIF ou PNG). A largura da imagem não deve ser maior que 2x a altura.
             facet_panel_background_color:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -374,7 +374,10 @@ zh:
             active_tabs_background_color:
               hint: 主页标签的悬停颜色。
             banner_image:
-              hint: 要将图像用作标头广告背景，您应该使用至少120像素高和1200像素宽的图像（JPG，GIF或PNG）。为了获得最佳效果，请使用至少1800像素宽的图像。
+              hint: |
+                要将图像用作标头广告背景，您应该使用至少120像素高和1200像素宽的图像（JPG，GIF或PNG）。为了获得最佳效果，请使用至少1800像素宽的图像。<br/>
+                要裁剪：点击"Crop Image"，调整选择，然后点击"Save changes"。横幅会随窗口调整大小。要撤消裁剪，请使用"Remove banner image"，然后重新上传原始图像。
+              cropped_save_error: 保存裁剪后的横幅失败。请重试。
             collection_banner_text_color:
               hint: 集合横幅内文本（标题和上次更新日期）的颜色。
             custom_css:
@@ -384,7 +387,7 @@ zh:
               hint: 工作交互（编辑、功能等）按钮；收藏页面和搜索过滤器按钮上的工作视图。
             default_images:
               alert: 请至少上传一个文件，然后再提交。
-              hint: 对于默认图像，您应该使用高度和宽度尺寸（宽度为100像素，高度为100像素）的图像（JPG，GIF或PNG）
+              hint: 对于默认图像，您应该使用高度和宽度尺寸（宽度为100像素，高度为100像素）的图像（JPG，GIF或PNG）。
             directory_image:
               hint: 要将图像用作目录图像，应使用高度不超过标题且宽度不超过 400 像素的图像（JPG、GIF 或 PNG）。
             facet_panel_background_color:


### PR DESCRIPTION
# Summary

Fixes banner image cropping functionality and improves consistency of appearance form styling across all image upload tabs.

## Ticket Number

- https://github.com/notch8/hyku-community-issues/issues/31

# Screenshots / Video

### Before: Banner crop selection was not being applied when saved. The cropped image would not display correctly on the frontend.

### After: Banner crop is properly saved and applied. All image upload tabs now have consistent styled instruction boxes.
<img width="2704" height="1471" alt="image" src="https://github.com/user-attachments/assets/587b0f03-875a-4f0a-af28-459fef53ce30" />
<img width="2704" height="1471" alt="image" src="https://github.com/user-attachments/assets/d3d9e70e-0972-4ece-95e8-067b2df212fa" />

<img width="2704" height="1471" alt="image" src="https://github.com/user-attachments/assets/e6d61f88-93c0-4d3d-b6fa-8702c1d5942c" />

<img width="2704" height="1471" alt="image" src="https://github.com/user-attachments/assets/ae0ae06f-1108-4c83-9527-70d39ecb0223" />

# Expected Behavior

1. When a user uploads a banner image, clicks "Crop Image", adjusts the selection, and clicks "Save changes", the cropped version should be saved and displayed on the site.

2. The cropped image should match exactly what was selected in the cropping interface.

3. All image upload tabs (Logo, Favicon, Banner Image, Directory Image, Default Images) should display instructions in a consistent styled blue information box at the top of each form.

4. Instructions should be clear and non-redundant, with detailed guidance in the info box and no duplicate hints under file inputs.



