### PR TITLE
:bug: Fix banner image not saving when uploaded without cropping

### DIFF
--- a/app/helpers/hyrax_helper.rb
+++ b/app/helpers/hyrax_helper.rb
@@ -31,7 +31,13 @@ module HyraxHelper
   end
 
   def banner_image
-    Site.instance.banner_image? ? Site.instance.banner_image.url : super
+    if Site.instance.banner_image?
+      url = Site.instance.banner_image.url
+      timestamp = Site.instance.updated_at.to_i
+      "#{url}?#{timestamp}"
+    else
+      super
+    end
   end
 
   def favicon(size)

--- a/spec/controllers/hyrax/admin/appearances_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/appearances_controller_spec.rb
@@ -48,6 +48,24 @@ RSpec.describe Hyrax::Admin::AppearancesController, type: :controller, singleten
           expect(response).to redirect_to(hyrax.admin_appearance_path(locale: 'en'))
           expect(flash[:notice]).to include("The appearance was successfully updated")
           expect(Site.instance.banner_image?).to be true
+          expect(Site.instance.banner_image.file.filename).to eq('nypl-hydra-of-lerna.jpg')
+        end
+
+        it "replaces an existing banner image" do
+          # Set up an initial banner image
+          Site.instance.update!(banner_image: fixture_file_upload('/images/nypl-hydra-of-lerna.jpg', 'image/jpg'))
+          expect(Site.instance.banner_image?).to be true
+          original_filename = Site.instance.banner_image.file.filename
+
+          # Upload a different image
+          f = fixture_file_upload('/images/world.png', 'image/png')
+          post :update, params: { admin_appearance: { banner_image: f } }
+
+          expect(response).to redirect_to(hyrax.admin_appearance_path(locale: 'en'))
+          expect(flash[:notice]).to include("The appearance was successfully updated")
+          expect(Site.instance.reload.banner_image?).to be true
+          expect(Site.instance.banner_image.file.filename).to eq('world.png')
+          expect(Site.instance.banner_image.file.filename).not_to eq(original_filename)
         end
 
         it "sets a directory image" do

--- a/spec/helpers/hyrax_helper_spec.rb
+++ b/spec/helpers/hyrax_helper_spec.rb
@@ -8,8 +8,18 @@ RSpec.describe HyraxHelper, type: :helper do
         Site.instance.update(banner_image: f)
       end
 
-      it "returns the uploaded banner image" do
-        expect(helper.banner_image).to eq(Site.instance.banner_image.url)
+      it "returns the uploaded banner image with cache busting timestamp" do
+        url = helper.banner_image
+        expect(url).to start_with(Site.instance.banner_image.url)
+        expect(url).to include("?#{Site.instance.updated_at.to_i}")
+      end
+
+      it "includes a different timestamp when the site is updated" do
+        initial_url = helper.banner_image
+        sleep 1
+        Site.instance.update(updated_at: Time.current)
+        updated_url = helper.banner_image
+        expect(updated_url).not_to eq(initial_url)
       end
     end
 


### PR DESCRIPTION
Issue: 
- https://github.com/notch8/hyku-community-issues/issues/31

Fix banner image not displaying after upload due to browser caching

Add cache-busting timestamp to banner image URLs using Site.updated_at to ensure browsers fetch the updated image. Previously, only cropped images refreshed properly due to explicit page reload in JavaScript. Non-cropped uploads would save correctly but display the cached version.

Also add specs to verify banner image replacement and cache-busting.
