### PR TITLE
[i35] - Add public_demo_tenant flag to accounts for "sandbox" concept

### DIFF
--- a/app/controllers/proprietor/accounts_controller.rb
+++ b/app/controllers/proprietor/accounts_controller.rb
@@ -114,7 +114,7 @@ module Proprietor
     def account_params
       params.require(:account).permit(
         :name,
-        :sandbox,
+        :public_demo_tenant,
         :search_only,
         admin_emails: [],
         full_account_cross_searches_attributes: [:id, :_destroy, :full_account_id, full_account_attributes: [:id]]

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -6,7 +6,7 @@ class Account < ApplicationRecord
   include AccountEndpoints
   include AccountSettings
   include AccountCname
-  attr_readonly :tenant, :sandbox
+  attr_readonly :tenant, :public_demo_tenant
 
   has_many :sites, dependent: :destroy
   has_many :domain_names, dependent: :destroy
@@ -35,8 +35,8 @@ class Account < ApplicationRecord
   scope :is_public, -> { where(is_public: true) }
   scope :sorted_by_name, -> { order("name ASC") }
   scope :full_accounts, -> { where(search_only: false) }
-  scope :sandbox, -> { where(sandbox: true) }
-  scope :non_sandbox, -> { where(sandbox: false) }
+  scope :public_demo_tenants, -> { where(public_demo_tenant: true) }
+  scope :non_public_demo_tenants, -> { where(public_demo_tenant: false) }
 
   before_validation do
     self.tenant ||= SecureRandom.uuid

--- a/app/views/proprietor/accounts/edit.html.erb
+++ b/app/views/proprietor/accounts/edit.html.erb
@@ -26,7 +26,7 @@
 
           <%= f.input :is_public %>
 
-          <%= f.input :sandbox, disabled: true, hint: "This field cannot be changed after account creation" %>
+          <%= f.input :public_demo_tenant, disabled: true, hint: "This field cannot be changed after account creation" %>
 
           <%= f.input :tenant, readonly: @account.persisted? %>
 

--- a/app/views/proprietor/accounts/index.html.erb
+++ b/app/views/proprietor/accounts/index.html.erb
@@ -16,7 +16,7 @@
             <tr>
               <th><%= t('.tenant') %></th>
               <th><%= t('.cname') %></th>
-              <th><%= t('.sandbox') %></th>
+              <th><%= t('.public_demo_tenant') %></th>
               <th><%= t('.actions') %></th>
             </tr>
           </thead>
@@ -26,7 +26,7 @@
               <tr>
                 <td><%= account.tenant %></td>
                 <td><%= account.cname %></td>
-                <td><%= account.sandbox? ? '✓' : '' %></td>
+                <td><%= account.public_demo_tenant? ? '✓' : '' %></td>
                 <td class="col-md-2">
                   <%= link_to t('.manage'), [:proprietor, account] %>&nbsp;|&nbsp;
                   <%= link_to t('helpers.action.edit'), [:edit, :proprietor, account] %>&nbsp;|&nbsp;

--- a/app/views/proprietor/accounts/new.html.erb
+++ b/app/views/proprietor/accounts/new.html.erb
@@ -20,7 +20,7 @@
 
           <%= f.input :name %>
 
-          <%= f.input :sandbox, hint: "Mark this account as a sandbox for testing. This cannot be changed after creation." %>
+          <%= f.input :public_demo_tenant, hint: "Mark this account as a public demo tenant for testing. This cannot be changed after creation." %>
 
           <div class="form-group">
             <%= f.input :search_only, wrapper: false %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -500,7 +500,7 @@ de:
         create_new: Neuen Account erstellen
         header: Konten
         manage: Verwalten
-        sandbox: Testumgebung
+        public_demo_tenant: Öffentlicher Demo-Mandant
         tenant: Mieter (UUID)
       new:
         header: Erstellen Sie ein neues Repository

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -346,7 +346,7 @@ en:
         create_new: Create new account
         header: Accounts
         manage: Manage
-        sandbox: Sandbox
+        public_demo_tenant: Public demo tenant
         tenant: Tenant (UUID)
       new:
         header: Create a new repository

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -497,7 +497,7 @@ es:
         create_new: Crear una nueva cuenta
         header: Cuentas
         manage: Gestionar
-        sandbox: Entorno de prueba
+        public_demo_tenant: Inquilino de demostración pública
         tenant: Inquilino (UUID)
       new:
         header: Crea un nuevo repositorio

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -502,7 +502,7 @@ fr:
         create_new: Créer un nouveau compte
         header: Comptes
         manage: Gérer
-        sandbox: Environnement de test
+        public_demo_tenant: Locataire de démonstration publique
         tenant: Locataire (UUID)
       new:
         header: Créer un nouveau référentiel

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -497,7 +497,7 @@ it:
         create_new: Crea un nuovo account
         header: conti
         manage: Gestire
-        sandbox: Ambiente di test
+        public_demo_tenant: Tenant demo pubblico
         tenant: Locatario (UUID)
       new:
         header: Crea un nuovo repository

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -380,7 +380,7 @@ pt-BR:
         create_new: Criar nova conta
         header: Contas
         manage: Gerir
-        sandbox: Ambiente de teste
+        public_demo_tenant: Inquilino de demonstração pública
         tenant: Locatário (UUID)
       new:
         header: Crie um novo repositório

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -497,7 +497,7 @@ zh:
         create_new: 建立新帐户
         header: 帐目
         manage: 管理
-        sandbox: 测试环境
+        public_demo_tenant: 公共演示租户
         tenant: 租户（UUID）
       new:
         header: 创建一个新的仓库

--- a/db/migrate/20260130193420_add_sandbox_to_accounts.rb
+++ b/db/migrate/20260130193420_add_sandbox_to_accounts.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-class AddSandboxToAccounts < ActiveRecord::Migration[7.2]
-  def change
-    add_column :accounts, :sandbox, :boolean, default: false, null: false
-  end
-end

--- a/db/migrate/20260202120000_add_public_demo_tenant_to_accounts.rb
+++ b/db/migrate/20260202120000_add_public_demo_tenant_to_accounts.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPublicDemoTenantToAccounts < ActiveRecord::Migration[7.2]
+  def change
+    add_column :accounts, :public_demo_tenant, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_01_30_193420) do
+ActiveRecord::Schema[7.2].define(version: 2026_02_02_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pgcrypto"
@@ -39,7 +39,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_01_30_193420) do
     t.jsonb "settings", default: {}
     t.bigint "data_cite_endpoint_id"
     t.boolean "search_only", default: false
-    t.boolean "sandbox", default: false, null: false
+    t.boolean "public_demo_tenant", default: false, null: false
     t.index ["cname", "tenant"], name: "index_accounts_on_cname_and_tenant"
     t.index ["cname"], name: "index_accounts_on_cname", unique: true
     t.index ["data_cite_endpoint_id"], name: "index_accounts_on_data_cite_endpoint_id"

--- a/spec/controllers/proprietor/accounts_controller_spec.rb
+++ b/spec/controllers/proprietor/accounts_controller_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe Proprietor::AccountsController, type: :controller, multitenant: t
     end
   end
 
-  describe 'sandbox functionality' do
+  describe 'public_demo_tenant functionality' do
     let(:user) { FactoryBot.create(:superadmin) }
     let(:account) { FactoryBot.create(:account) }
 
@@ -208,31 +208,31 @@ RSpec.describe Proprietor::AccountsController, type: :controller, multitenant: t
     end
 
     describe 'POST #create' do
-      context 'with sandbox parameter' do
-        it 'creates a sandbox account' do
-          post :create, params: { account: valid_attributes.merge(sandbox: true) }
-          expect(Account.last.sandbox).to be true
+      context 'with public_demo_tenant parameter' do
+        it 'creates a public demo tenant account' do
+          post :create, params: { account: valid_attributes.merge(public_demo_tenant: true) }
+          expect(Account.last.public_demo_tenant).to be true
         end
 
-        it 'creates a non-sandbox account by default' do
+        it 'creates a non-public-demo-tenant account by default' do
           post :create, params: { account: valid_attributes }
-          expect(Account.last.sandbox).to be false
+          expect(Account.last.public_demo_tenant).to be false
         end
       end
     end
 
     describe 'PUT #update' do
-      let(:sandbox_account) { FactoryBot.create(:account, sandbox: true) }
-      let(:production_account) { FactoryBot.create(:account, sandbox: false) }
+      let(:public_demo_account) { FactoryBot.create(:account, public_demo_tenant: true) }
+      let(:production_account) { FactoryBot.create(:account, public_demo_tenant: false) }
 
-      it 'does not allow changing sandbox flag on existing sandbox account' do
-        put :update, params: { id: sandbox_account.to_param, account: { sandbox: false } }
-        expect(sandbox_account.reload.sandbox).to be true
+      it 'does not allow changing public_demo_tenant flag on existing public demo account' do
+        put :update, params: { id: public_demo_account.to_param, account: { public_demo_tenant: false } }
+        expect(public_demo_account.reload.public_demo_tenant).to be true
       end
 
-      it 'does not allow changing sandbox flag on existing production account' do
-        put :update, params: { id: production_account.to_param, account: { sandbox: true } }
-        expect(production_account.reload.sandbox).to be false
+      it 'does not allow changing public_demo_tenant flag on existing production account' do
+        put :update, params: { id: production_account.to_param, account: { public_demo_tenant: true } }
+        expect(production_account.reload.public_demo_tenant).to be false
       end
     end
 

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -705,44 +705,44 @@ RSpec.describe Account, type: :model do
     end
   end
 
-  describe 'sandbox scopes' do
-    let!(:sandbox_account1) { described_class.create!(name: 'sandbox1', sandbox: true) }
-    let!(:sandbox_account2) { described_class.create!(name: 'sandbox2', sandbox: true) }
-    let!(:production_account1) { described_class.create!(name: 'production1', sandbox: false) }
-    let!(:production_account2) { described_class.create!(name: 'production2', sandbox: false) }
+  describe 'public_demo_tenant scopes' do
+    let!(:public_demo_account1) { described_class.create!(name: 'public_demo1', public_demo_tenant: true) }
+    let!(:public_demo_account2) { described_class.create!(name: 'public_demo2', public_demo_tenant: true) }
+    let!(:production_account1) { described_class.create!(name: 'production1', public_demo_tenant: false) }
+    let!(:production_account2) { described_class.create!(name: 'production2', public_demo_tenant: false) }
 
-    describe '.sandbox' do
-      it 'returns only sandbox accounts' do
-        sandbox_accounts = described_class.sandbox
-        expect(sandbox_accounts).to include(sandbox_account1, sandbox_account2)
-        expect(sandbox_accounts).not_to include(production_account1, production_account2)
+    describe '.public_demo_tenants' do
+      it 'returns only public demo tenant accounts' do
+        public_demo_accounts = described_class.public_demo_tenants
+        expect(public_demo_accounts).to include(public_demo_account1, public_demo_account2)
+        expect(public_demo_accounts).not_to include(production_account1, production_account2)
       end
     end
 
-    describe '.non_sandbox' do
-      it 'returns only non-sandbox accounts' do
-        non_sandbox_accounts = described_class.non_sandbox
-        expect(non_sandbox_accounts).to include(production_account1, production_account2)
-        expect(non_sandbox_accounts).not_to include(sandbox_account1, sandbox_account2)
+    describe '.non_public_demo_tenants' do
+      it 'returns only non-public-demo-tenant accounts' do
+        non_public_demo_accounts = described_class.non_public_demo_tenants
+        expect(non_public_demo_accounts).to include(production_account1, production_account2)
+        expect(non_public_demo_accounts).not_to include(public_demo_account1, public_demo_account2)
       end
     end
   end
 
-  describe 'sandbox immutability' do
-    let(:account) { described_class.create!(name: 'test-account', sandbox: true) }
+  describe 'public_demo_tenant immutability' do
+    let(:account) { described_class.create!(name: 'test-account', public_demo_tenant: true) }
 
-    it 'allows setting sandbox on creation' do
-      expect(account.sandbox).to be true
+    it 'allows setting public_demo_tenant on creation' do
+      expect(account.public_demo_tenant).to be true
     end
 
-    it 'sandbox value persists after creation' do
+    it 'public_demo_tenant value persists after creation' do
       account.reload
-      expect(account.sandbox).to be true
+      expect(account.public_demo_tenant).to be true
     end
 
     it 'defaults to false when not specified' do
       default_account = described_class.create!(name: 'default-test')
-      expect(default_account.sandbox).to be false
+      expect(default_account.public_demo_tenant).to be false
     end
   end
 end


### PR DESCRIPTION
Issue:
- https://github.com/notch8/hyku-community-issues/issues/35

Add immutable pubic_demo_tenant boolean field to Account model to support multi-phase sandbox strategy (public demo, personal sandboxes, and partner evaluation tenants). Field is editable only during account creation to prevent accidental marking of production tenants.

Changes:
- Add pubic_demo_tenant column with default false and not null constraint
- Add Account.pubic_demo_tenant and Account.non_pubic_demo_tenant scopes for querying
- Display pubic_demo_tenant checkbox in new/edit forms (readonly after creation)
- Show pubic_demo_tenant indicator in accounts index
- Add comprehensive model and controller specs

This is foundational work for planned features including daily resets for demo tenants and auto-deletion of temporary sandbox accounts.

# proprietor (new) 

<img width="2704" height="1636" alt="image" src="https://github.com/user-attachments/assets/1c0d7591-ab33-4b7d-818a-45f088ebd55f" />




# proprietor (index)

<img width="2704" height="1454" alt="image" src="https://github.com/user-attachments/assets/215aebbd-215e-4f13-8029-3a40253ca95c" />



# proprietor (edit)

### immutable after account creation to prevent accidents in prod

<img width="2704" height="1454" alt="image" src="https://github.com/user-attachments/assets/ee999e0c-ca1c-4a81-a7c6-6301ad672b89" />
