### PR TITLE
Collection banner text styling

### DIFF
--- a/app/assets/stylesheets/hyku.scss
+++ b/app/assets/stylesheets/hyku.scss
@@ -536,13 +536,14 @@ span.constraint-value p,
 
 .hyc-banner {
     padding: 15px;
-    .hyc-bugs .hyc-created-by,
-    .hyc-bugs .hyc-last-updated,
+
     .hyc-title {
         padding: 0;
     }
 
-    .hyc-item-count {
+    .hyc-item-count,
+    .hyc-created-by,
+    .hyc-last-updated {
         background: rgba(255, 255, 255, 0.75);
         border-radius: 0.5em;
         color: #333;

--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -65,7 +65,7 @@
       <% end %>
 
       <% unless @presenter.total_viewable_items.blank? %>
-        <div class="hyc-bugs d-flex space-between">
+        <div class="d-flex space-between">
           <% unless @presenter.creator.blank? %>
               <div class="hyc-created-by">Created by: <%= @presenter.creator.first %></div>
           <% end %>

--- a/app/views/shared/_appearance_styles.html.erb
+++ b/app/views/shared/_appearance_styles.html.erb
@@ -214,9 +214,7 @@ body.public-facing .card-body > .facet-limit-active {
 }
 
 /* COLLECTION STYLES */
-body.public-facing .hyc-banner .hyc-title h1,
-body.public-facing .hyc-last-updated,
-body.public-facing .hyc-created-by {
+body.public-facing .hyc-banner .hyc-title h1 {
   color: <%= appearance.collection_banner_text_color %> !important;
 }
 


### PR DESCRIPTION
## Summary

Removes `hyc-bug` from `created_by` and `last_updated` styles to ensure they display the same as the items count. The colors and drop shadows are now only for the collection title, ensuring that the smaller text is consistent and readable. 

Also adds a background to these two attributes, to ensure that they remain visible on top of a banner image.

## Before

### With banner image
<img width="1155" height="274" alt="Screenshot 2026-02-02 at 3 30 46 PM" src="https://github.com/user-attachments/assets/138dc414-e01b-4bbf-93d2-a709f7629c5d" />

### Without banner image
<img width="1173" height="270" alt="Screenshot 2026-02-02 at 3 31 08 PM" src="https://github.com/user-attachments/assets/b64211d0-ca2a-477c-b192-f77d1a219775" />

## After

### With banner image
<img width="1154" height="307" alt="Screenshot 2026-02-02 at 3 20 58 PM" src="https://github.com/user-attachments/assets/47bd5c70-025d-4075-b9b7-b48387e8c792" />

### Without banner image
<img width="1190" height="266" alt="Screenshot 2026-02-02 at 3 32 41 PM" src="https://github.com/user-attachments/assets/1b21905b-1b80-4104-962c-cea15a226d37" />
