### PR TITLE
Adds the pagination active class to btn-primary

### DIFF
--- a/app/views/shared/_appearance_styles.html.erb
+++ b/app/views/shared/_appearance_styles.html.erb
@@ -72,7 +72,8 @@ body.public-facing .nav-tabs > li.nav-item > a:focus {
 }
 
 /* PRIMARY BUTTON STYLES */
-body.public-facing .btn-primary {
+body.public-facing .btn-primary,
+body.public-facing .page-item.active > .page-link {
   background-color: <%= appearance.primary_button_background_color %> !important;
   border-color: <%= appearance.primary_button_border_color %> !important;
   color: <%= appearance.primary_button_text_color %> !important;


### PR DESCRIPTION
## Summary
Pagination active was always using the default bootstrap styles, this change makes it use the same styles as btn-primary.

## Screenshots

### primary button
<img width="332" height="183" alt="Screenshot 2026-02-02 at 5 31 56 PM" src="https://github.com/user-attachments/assets/9d62059f-f730-44d0-a952-46cc4167a00e" />

### catalog page pagination
<img width="403" height="131" alt="Screenshot 2026-02-02 at 5 32 11 PM" src="https://github.com/user-attachments/assets/144a88c2-78be-44ac-8aa3-287a5e41fa0c" />

### work show page pagination
<img width="370" height="148" alt="Screenshot 2026-02-02 at 5 32 00 PM" src="https://github.com/user-attachments/assets/e62be325-a33c-4e48-8d32-5570d76f5493" />
