### PR TITLE
🐛 Fix avatar thumb and medium versions not found

### DIFF
--- a/app/uploaders/hyku/favicon_uploader.rb
+++ b/app/uploaders/hyku/favicon_uploader.rb
@@ -13,8 +13,19 @@ module Hyku
     # 196×196	favicon-196.png Chrome for Android home screen icon
     # rubocop:enable Style/AsciiComments
 
-    versions.delete(:medium)
-    versions.delete(:thumb)
+    # Needed here to override Hyrax::AvatarUploader's whitelist even though these
+    #   versions don't get created
+    version :medium do
+      def extension_whitelist
+        %w[png ico]
+      end
+    end
+
+    version :thumb do
+      def extension_whitelist
+        %w[png ico]
+      end
+    end
 
     [32, 57, 76, 96, 128, 192, 228, 196, 120, 152, 180].each do |i|
       version "v#{i}".to_sym do


### PR DESCRIPTION
This commit will fix a bug introduced by creating the `Hyku::FaviconUploader` which deleted the `thumb` and `medium` versions from the `Hyrax::AvatarUploader` since it's not needed.  This then caused the avatar images to not be found when the `thumb` and `medium`.

Ultimately it would be nice to not inherit from `Hyrax::AvatarUploader` at all, but there seems to be a bug or at least unexpected behavior in CarrierWave where renaming the file doesn't work correctly if we're inheriting straight from `CarrierWave::Uploader::Base`.
