### PR TITLE
Sort "View all collections" by collection title

### DIFF
--- a/app/views/hyrax/homepage/_featured_collection_section.html.erb
+++ b/app/views/hyrax/homepage/_featured_collection_section.html.erb
@@ -27,7 +27,7 @@
 <ul class="list-inline collection-highlights-list">
   <li>
     <%= link_to t('hyrax.homepage.admin_sets.link'),
-                main_app.search_catalog_path(f: { generic_type_sim: ['Collection']}),
+                main_app.search_catalog_path(f: { generic_type_sim: ['Collection']}, sort: "#{CatalogController.title_field} asc"),
                 class: 'btn btn-secondary mt-1' %>
   </li>
 </ul>

--- a/app/views/themes/cultural_repository/hyrax/homepage/_featured_collection_section.html.erb
+++ b/app/views/themes/cultural_repository/hyrax/homepage/_featured_collection_section.html.erb
@@ -29,7 +29,7 @@
 <ul class="list-inline collection-highlights-list">
   <li>
     <%= link_to t('hyrax.homepage.admin_sets.link'),
-                main_app.search_catalog_path(f: { generic_type_sim: ['Collection']}),
+                main_app.search_catalog_path(f: { generic_type_sim: ['Collection']}, sort: "#{CatalogController.title_field} asc"),
                 class: 'btn btn-secondary mt-1' %>
   </li>
 </ul>

--- a/app/views/themes/institutional_repository/hyrax/homepage/_featured_collection_section.html.erb
+++ b/app/views/themes/institutional_repository/hyrax/homepage/_featured_collection_section.html.erb
@@ -29,7 +29,7 @@
 <ul class="list-inline collection-highlights-list">
   <li>
     <%= link_to t('hyrax.homepage.admin_sets.link'),
-                main_app.search_catalog_path(f: { generic_type_sim: ['Collection']}),
+                main_app.search_catalog_path(f: { generic_type_sim: ['Collection']}, sort: "#{CatalogController.title_field} asc"),
                 class: 'btn btn-secondary mt-1' %>
   </li>
 </ul>

--- a/app/views/themes/neutral_repository/hyrax/homepage/_featured_collection_section.html.erb
+++ b/app/views/themes/neutral_repository/hyrax/homepage/_featured_collection_section.html.erb
@@ -29,7 +29,7 @@
 <ul class="list-inline collection-highlights-list">
   <li>
     <%= link_to t('hyrax.homepage.admin_sets.link'),
-                main_app.search_catalog_path(f: { generic_type_sim: ['Collection']}),
+                main_app.search_catalog_path(f: { generic_type_sim: ['Collection']}, sort: "#{CatalogController.title_field} asc"),
                 class: 'btn btn-secondary mt-1' %>
   </li>
 </ul>

--- a/spec/views/hyrax/homepage/_featured_collection_section.html.erb_spec.rb
+++ b/spec/views/hyrax/homepage/_featured_collection_section.html.erb_spec.rb
@@ -39,4 +39,9 @@ RSpec.describe "hyrax/homepage/_featured_collection_section.html.erb", type: :vi
       is_expected.to have_selector('form')
     end
   end
+
+  it 'links to all collections, sorted by title' do
+    render
+    is_expected.to have_link('View all collections', href: /sort=title_ssi\+asc/)
+  end
 end

--- a/spec/views/themes/cultural_repository/_featured_collection_section.html.erb_spec.rb
+++ b/spec/views/themes/cultural_repository/_featured_collection_section.html.erb_spec.rb
@@ -77,4 +77,8 @@ RSpec.describe "themes/cultural_repository/hyrax/homepage/_featured_collection_s
       expect(rendered).to have_link(t('hyrax.homepage.admin_sets.link'))
     end
   end
+  it 'links to all collections, sorted by title' do
+    render
+    expect(rendered).to have_link('View all collections', href: /sort=title_ssi\+asc/)
+  end
 end

--- a/spec/views/themes/institutional_repository/_featured_collection_section.html.erb_spec.rb
+++ b/spec/views/themes/institutional_repository/_featured_collection_section.html.erb_spec.rb
@@ -77,4 +77,9 @@ RSpec.describe "themes/institutional_repository/hyrax/homepage/_featured_collect
       expect(rendered).to have_link(t('hyrax.homepage.admin_sets.link'))
     end
   end
+
+  it 'links to all collections, sorted by title' do
+    render
+    expect(rendered).to have_link('View all collections', href: /sort=title_ssi\+asc/)
+  end
 end

--- a/spec/views/themes/neutral_repository/_featured_collection_section.html.erb_spec.rb
+++ b/spec/views/themes/neutral_repository/_featured_collection_section.html.erb_spec.rb
@@ -77,4 +77,9 @@ RSpec.describe "themes/neutral_repository/hyrax/homepage/_featured_collection_se
       expect(rendered).to have_link(t('hyrax.homepage.admin_sets.link'))
     end
   end
+
+  it 'links to all collections, sorted by title' do
+    render
+    expect(rendered).to have_link('View all collections', href: /sort=title_ssi\+asc/)
+  end
 end


### PR DESCRIPTION
Connected to https://github.com/notch8/palni_palci_knapsack/issues/543

Sorts "View all collections" by collection title, ascending.

Otherwise it defaults to "relevance", which is not very meaningful for "all collections".