### PR TITLE
Update to new nginx-ingress

### DIFF
--- a/ops/demo-deploy.tmpl.yaml
+++ b/ops/demo-deploy.tmpl.yaml
@@ -47,6 +47,7 @@ extraVolumeMounts: &volMounts
 
 ingress:
   enabled: true
+  ingressClassName: "nginx-ingress"
   hosts:
     - host: hykudemo.org
       paths:
@@ -59,7 +60,7 @@ ingress:
   annotations:
     {
       kubernetes.io/ingress.class: "nginx",
-      nginx.ingress.kubernetes.io/proxy-body-size: "0",
+      nginx.org/client-max-body-size: "0",
       cert-manager.io/cluster-issuer: letsencrypt-production-dns,
     }
   tls:

--- a/ops/iiif-deploy.tmpl.yaml
+++ b/ops/iiif-deploy.tmpl.yaml
@@ -49,6 +49,7 @@ extraVolumeMounts: &volMounts
 
 ingress:
   enabled: true
+  ingressClassName: "nginx-ingress"
   hosts:
     - host: hyku-iiif.$BASE_URL
       paths:
@@ -60,8 +61,7 @@ ingress:
           pathType: ImplementationSpecific
   annotations:
     {
-      kubernetes.io/ingress.class: "nginx",
-      nginx.ingress.kubernetes.io/proxy-body-size: "0",
+      nginx.org/client-max-body-size: "0",
       cert-manager.io/cluster-issuer: letsencrypt-production-dns,
     }
   tls:

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -49,6 +49,7 @@ extraVolumeMounts: &volMounts
 
 ingress:
   enabled: true
+  ingressClassName: "nginx-ingress"
   hosts:
     - host: hykustaging.org
       paths:
@@ -60,8 +61,7 @@ ingress:
           pathType: ImplementationSpecific
   annotations:
     {
-      kubernetes.io/ingress.class: "nginx",
-      nginx.ingress.kubernetes.io/proxy-body-size: "0",
+      nginx.org/client-max-body-size: "0",
       cert-manager.io/cluster-issuer: letsencrypt-production-dns,
     }
   tls:


### PR DESCRIPTION
This has already been applied via kubectl, this aligns with what is currently deployed.

Notch8 is migrating to the F5 NGINX Ingress Controller (see https://docs.nginx.com/nginx-ingress-controller/)

@samvera/hyku-code-reviewers
