### PR TITLE
Remove the annotation of nginx form the ing

### DIFF
--- a/ops/demo-deploy.tmpl.yaml
+++ b/ops/demo-deploy.tmpl.yaml
@@ -59,7 +59,6 @@ ingress:
           pathType: ImplementationSpecific
   annotations:
     {
-      kubernetes.io/ingress.class: "nginx",
       nginx.org/client-max-body-size: "0",
       cert-manager.io/cluster-issuer: letsencrypt-production-dns,
     }


### PR DESCRIPTION
Remove the annotation of nginx from the ing since we move to the alt more updated way to call it in the deploy `ingressClassName`


This is currently reflected live