### PR TITLE
🐛 suppress_link: true passed as a URL option

### DIFF
--- a/app/views/themes/cultural_repository/hyrax/homepage/_featured_fields.html.erb
+++ b/app/views/themes/cultural_repository/hyrax/homepage/_featured_fields.html.erb
@@ -1,7 +1,7 @@
 <% # Note: overriding Hyrax v5.0.0rc2 for client theming -- removed item keywords and depositor from partial %>
   <div>
     <%= link_to [main_app, featured] do %>
-      <%= render_thumbnail_tag(featured, {suppress_link: true}, class: 'img-fluid mx-auto d-block') %>
+      <%= render_thumbnail_tag(featured, {class: 'img-fluid mx-auto d-block'}, {suppress_link: true}) %>
     <% end %>
     <div class="featured-item-title">
       <span class="sr-only"><%= t('hyrax.homepage.featured_works.document.title_label') %></span>

--- a/app/views/themes/cultural_repository/hyrax/homepage/_recent_document.html.erb
+++ b/app/views/themes/cultural_repository/hyrax/homepage/_recent_document.html.erb
@@ -1,7 +1,7 @@
 <%# OVERRIDE Hyrax v5.0.0rc2 template for client theming and shared search %>
 <div class="recently-uploaded col-6 col-md-2">
   <%= link_to [main_app, recent_document] do %>
-    <%= render_thumbnail_tag(recent_document, {suppress_link: true}, class: 'img-fluid center-block') %>
+    <%= render_thumbnail_tag(recent_document, {class: 'img-fluid center-block'}, {suppress_link: true}) %>
   <% end %>
   <div class="recent-doc-title">
     <%= link_to generate_work_url(recent_document, request, params) do %>

--- a/app/views/themes/institutional_repository/hyrax/homepage/_recent_document.html.erb
+++ b/app/views/themes/institutional_repository/hyrax/homepage/_recent_document.html.erb
@@ -2,7 +2,7 @@
 <h3 class="sr-only"><%= t('hyrax.homepage.recently_uploaded.document.title_label') %></h3>
 <div class="recently-uploaded col-6 col-md-6 pt-3 pb-3">
   <%= link_to generate_work_url(recent_document, request) do %>
-    <%= render_thumbnail_tag recent_document, {class: 'img-fluid mx-auto d-block'}, {suppress_link: true} %>
+    <%= render_thumbnail_tag(recent_document, {class: 'img-fluid mx-auto d-block'}, {suppress_link: true}) %>
     <div class="recent-doc-title">
       <h3><%= markdown(recent_document.title_or_label) %></h3>
     </div>

--- a/app/views/themes/neutral_repository/_featured_carousel.html.erb
+++ b/app/views/themes/neutral_repository/_featured_carousel.html.erb
@@ -12,7 +12,7 @@
       <% work = SolrDocument.find(featured_work.work_id) %>
       <div class="carousel-item h-100 bg-light <%= order.zero? ? 'active' : '' %>">
         <%= link_to [main_app, work] do %>
-          <%= render_thumbnail_tag(work, {suppress_link: true, class: 'w-100 h-100'}) %>
+          <%= render_thumbnail_tag(work, {class: 'w-100 h-100'}, {suppress_link: true}) %>
         <% end %>
         <div class="carousel-caption">
           <h3 class="carousel-opacity p-2">


### PR DESCRIPTION
This commit fixes a bug where an extra empty link tag appears before each item image on the featured and recent works sections of the homepage on the institutional and cultural repository themes. The bug was caused by the `suppress_link: true` option being passed as the second argument to the `render_thumbnail_tag` helper instead of the third argument, which caused it to be treated as an image option and not a URL option.

All instances of `render_thumbnail_tag` were checked and updated to ensure that `suppress_link: true` is passed as the third argument.

app/helpers/blacklight/catalog_helper_behavior_decorator.rb
```ruby
render_thumbnail_tag(document, image_options = {}, url_options = {})
```

Ref:
- https://github.com/samvera/hyku/issues/2877

@samvera/hyku-code-reviewers
