### PR TITLE
🐛 Fix video duration

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,7 +52,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: 18f4997d2c7187a8fce6a5d9a2eff1b61dfeeea0
+  revision: 8f7f0b5588367445fd57470946c4b2e836d0d208
   branch: main
   specs:
     hyrax (5.2.0)

--- a/app/presenters/concerns/hyrax/iiif_av/displays_content_decorator.rb
+++ b/app/presenters/concerns/hyrax/iiif_av/displays_content_decorator.rb
@@ -57,7 +57,7 @@ module Hyrax
       def video_display_content(url, label = '', mime_type: solr_document.mime_type)
         width = solr_document.width&.try(:to_i) || 320
         height = solr_document.height&.try(:to_i) || 240
-        duration = conformed_duration_in_seconds
+        duration = conformed_duration
         IIIFManifest::V3::DisplayContent.new(
           url,
           label:,
@@ -85,7 +85,7 @@ module Hyrax
       end
 
       def audio_display_content(url, label = '', mime_type: solr_document.mime_type)
-        duration = conformed_duration_in_seconds
+        duration = conformed_duration
         IIIFManifest::V3::DisplayContent.new(
           url,
           label:,
@@ -93,20 +93,6 @@ module Hyrax
           type: 'Sound',
           format: mime_type
         )
-      end
-
-      def conformed_duration_in_seconds
-        if Array(solr_document.duration)&.first&.count(':') == 3
-          # takes care of milliseconds like ["0:0:01:001"]
-          Time.zone.parse(Array(solr_document.duration).first.sub(/.*\K:/, '.')).seconds_since_midnight
-        elsif Array(solr_document.duration)&.first&.include?(':')
-          # if solr_document.duration evaluates to something like ["0:01:00"] which will get converted to seconds
-          Time.zone.parse(Array(solr_document.duration).first).seconds_since_midnight
-        else
-          # handles cases if solr_document.duration evaluates to something like ['25 s']
-          Array(solr_document.duration).first.try(:to_f)
-        end ||
-          400.0
       end
     end
   end


### PR DESCRIPTION
This commit will fix the video duration for IIIF AV manifests by using Hyrax's #conformed_duration method which will return the correct duration.  The problem was that characterization returned duration in milliseconds but original the duration conformed to seconds so we were at 1000x the correct duration.

Ref:
- https://github.com/samvera/hyku/issues/2934

### Before
<img width="1150" height="544" alt="image" src="https://github.com/user-attachments/assets/1f544724-0ff6-4d06-b086-90ab6dd68f8c" />

### After
<img width="1134" height="551" alt="image" src="https://github.com/user-attachments/assets/d4c417b9-0e56-49f9-8499-d8d104538c30" />

