### PR TITLE
Add metadata fields to file set show

### DIFF
--- a/app/assets/javascripts/hyrax/app.js.erb
+++ b/app/assets/javascripts/hyrax/app.js.erb
@@ -24,6 +24,7 @@ Hyrax = {
         this.sidebar();
         this.batchSelect();
         this.internationalizationHelper();
+        this.fileSetEditor();
     },
 
     // The AdminSet edit page
@@ -88,6 +89,15 @@ Hyrax = {
         if (element.length > 0) {
           var Editor = require('hyrax/editor');
           new Editor(element).init();
+        }
+    },
+
+    // The file set edit page
+    fileSetEditor: function () {
+        var element = $("[data-behavior='file-set-form']");
+        if (element.length > 0) {
+            var Editor = require('hyrax/editor');
+            new Editor(element).init();
         }
     },
 

--- a/app/assets/stylesheets/hyrax.scss
+++ b/app/assets/stylesheets/hyrax.scss
@@ -49,3 +49,9 @@
 a {
   overflow-wrap: anywhere;
 }
+
+.file-show-term {
+  dt {
+    break-inside: avoid;
+  }
+}

--- a/app/presenters/hyrax/file_set_presenter_decorator.rb
+++ b/app/presenters/hyrax/file_set_presenter_decorator.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# OVERRIDE Hyrax v5.2.0 to add custom metadata partial for file set show page
+module Hyrax
+  module FileSetPresenterDecorator
+    def show_partials
+      super + ['metadata']
+    end
+  end
+end
+
+Hyrax::FileSetPresenter.prepend(Hyrax::FileSetPresenterDecorator)

--- a/app/views/hyrax/file_sets/_metadata.html.erb
+++ b/app/views/hyrax/file_sets/_metadata.html.erb
@@ -1,0 +1,40 @@
+<%#
+  Add metadata fields to file set show
+  @see Hyrax::FileSetPresenterDecorator
+%>
+
+<h2><%= t('.metadata') %></h2>
+<dl class="file-show-term file-show-details">
+  <% if Hyrax.config.flexible? %>
+    <% view_options_for(@presenter).each do |field, options| %>
+      <% next if options["admin_only"] && !current_user&.admin? %>
+      <% next if field == :admin_note && !@presenter.editor? %>
+      <% values = Array(@presenter.try(field)).reject(&:blank?) %>
+      <% next if values.empty? %>
+      <% label = options["display_label"][I18n.locale.to_s] || t(options["display_label"]["default"]) %>
+      <div class="row">
+        <dt class="col-5"><%= label %></dt>
+        <dd class="col-7"><%= auto_link(values.join(', '), html: { target: '_blank' }) %></dd>
+      </div>
+    <% end %>
+  <% else %>
+    <% { description: nil, creator: nil, license: nil, subject: nil, keyword: nil,
+         date_created: nil, related_url: nil, resource_type: nil }.each_key do |field| %>
+      <% values = Array(@presenter.try(field)).reject(&:blank?) %>
+      <% next if values.empty? %>
+      <div class="row">
+        <dt class="col-5"><%= t("blacklight.search.fields.show.#{field}_tesim", default: field.to_s.humanize) %></dt>
+        <dd class="col-7"><%= auto_link(values.join(', '), html: { target: '_blank' }) %></dd>
+      </div>
+    <% end %>
+  <% end %>
+
+  <% [:embargo_release_date, :lease_expiration_date].each do |field| %>
+    <% value = @presenter.try(field) %>
+    <% next unless value.present? %>
+    <div class="row">
+      <dt class="col-5"><%= t("blacklight.search.fields.show.#{field}_dtsi", default: field.to_s.humanize) %></dt>
+      <dd class="col-7"><%= value %></dd>
+    </div>
+  <% end %>
+</dl>

--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -822,6 +822,8 @@ de:
         versions_title: Frühere Versionen anzeigen
       groups_description:
         description_html: Die Liste der Gruppen in der Dropdown-Liste mit der Bezeichnung "Gruppe auswählen" ist eine Liste der vom Benutzer verwalteten Gruppen, in denen Sie Mitglied sind. Sie können eine bestimmte Gruppe auswählen und eine Zugriffsebene für eine Datei in %{application_name} zuweisen, ähnlich wie beim Hinzufügen von Benutzerzugriffsebenen.
+      metadata:
+        metadata: Metadaten
     footer:
       copyright_html: "<strong>Copyright © 2019 - %{current_year} Samvera lizenziert</strong> unter der Apache Lizenz, Version 2.0"
       service_html: Ein Dienst von <a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a> .

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -828,6 +828,8 @@ en:
         versions_title: Display previous versions
       groups_description:
         description_html: The list of groups in the drop-down marked "Select a group" is a list of User Managed Groups that you are a member of.  You may select a specific group and assign an access level for a file within %{application_name}, similarly to adding user access levels.
+      metadata:
+        metadata: Metadata
     footer:
       copyright_html: "<strong>Copyright &copy; 2019 - %{current_year} Samvera</strong> Licensed under the Apache License, Version 2.0"
       service_html: A service of <a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a>.

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -823,6 +823,8 @@ es:
         versions_title: Mostrar versiones anteriores
       groups_description:
         description_html: La lista de grupos en el menú desplegable marcado "Seleccionar un grupo" es una lista de grupos administrados por usuarios de los que es miembro. Puede seleccionar un grupo específico y asignar un nivel de acceso para un archivo dentro de %{application_name}, de manera similar a agregar niveles de acceso de usuario.
+      metadata:
+        metadata: Metadatos
     footer:
       copyright_html: "<strong>Copyright &copy; 2019 - %{current_year} Samvera</strong> bajo licencia de Apache, Version 2.0"
       service_html: Un servicio de <a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a>.

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -821,6 +821,8 @@ fr:
         versions_title: Afficher les versions précédentes
       groups_description:
         description_html: La liste des groupes dans la liste déroulante intitulée «Sélectionnez un groupe» est une liste des groupes gérés par l'utilisateur dont vous êtes membre. Vous pouvez sélectionner un groupe spécifique et attribuer un niveau d'accès à un fichier dans %{application_name}, de la même manière que l'ajout de niveaux d'accès utilisateur.
+      metadata:
+        metadata: Métadonnées
     footer:
       copyright_html: "<strong>Copyright © 2019 - %{current_year} Samvera</strong> Licence sous Licence Apache, Version 2.0"
       service_html: Un service de <a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a> .

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -823,6 +823,8 @@ it:
         versions_title: Visualizza le versioni precedenti
       groups_description:
         description_html: L'elenco dei gruppi nel menu a discesa contrassegnato "Seleziona un gruppo" è un elenco di gruppi gestiti dall'utente di cui sei membro. È possibile selezionare un gruppo specifico e assegnare un livello di accesso per un file all'interno di %{application_name}, in modo simile all'aggiunta dei livelli di accesso dell'utente.
+      metadata:
+        metadata: Metadati
     footer:
       copyright_html: "<strong>Copyright © 2019 - %{current_year} Samvera</strong> Licenza sotto la licenza Apache, versione 2.0"
       service_html: Un servizio di <a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a> .

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -823,6 +823,8 @@ pt-BR:
         versions_title: Exibir versões anteriores
       groups_description:
         description_html: A lista de grupos no menu suspenso marcado "Selecionar um grupo" é uma lista de Grupos gerenciados por usuários dos quais você é membro. Você pode selecionar um grupo específico e atribuir um nível de acesso a um arquivo no %{application_name}, da mesma forma que adiciona níveis de acesso do usuário.
+      metadata:
+        metadata: Metadados
     footer:
       copyright_html: "<strong>Copyright © 2019 - %{current_year} Samvera Licenciado</strong> sob a Licença Apache, Versão 2.0"
       service_html: Um serviço de <a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a> .

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -823,6 +823,8 @@ zh:
         versions_title: 显示以前的版本
       groups_description:
         description_html: 标记为“选择组”的下拉列表中的组列表是您所属的用户管理组的列表。您可以选择特定的组并为%{application_name}中的文件分配访问级别，类似于添加用户访问级别。
+      metadata:
+        metadata: 元数据
     footer:
       copyright_html: "<strong>版权所有 &copy; 2019 - %{current_year} Samvera</strong> 根据Apache许可证2.0版许可"
       service_html: 的服务<a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a>.

--- a/spec/views/hyrax/file_sets/_metadata.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/_metadata.html.erb_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+RSpec.describe 'hyrax/file_sets/_metadata.html.erb', type: :view do
+  let(:doc) do
+    {
+      'has_model_ssim' => ['FileSet'],
+      :id => '123',
+      'creator_tesim' => ['Jane Smith'],
+      'keyword_tesim' => ['cats', 'dogs'],
+      'license_tesim' => ['https://creativecommons.org/licenses/by/4.0/']
+    }
+  end
+  let(:solr_doc) { SolrDocument.new(doc) }
+  let(:ability) { double }
+  let(:presenter) { Hyrax::FileSetPresenter.new(solr_doc, ability) }
+
+  before do
+    assign(:presenter, presenter)
+  end
+
+  context 'when not using flexible metadata' do
+    before do
+      allow(Hyrax.config).to receive(:flexible?).and_return(false)
+      render
+    end
+
+    it 'renders creator' do
+      expect(rendered).to have_selector('dd', text: 'Jane Smith')
+    end
+
+    it 'renders multiple keyword values joined' do
+      expect(rendered).to have_selector('dd', text: 'cats, dogs')
+    end
+
+    it 'renders license as a link' do
+      expect(rendered).to have_selector('dd a[href="https://creativecommons.org/licenses/by/4.0/"]')
+    end
+  end
+
+  context 'when using flexible metadata' do
+    before do
+      allow(Hyrax.config).to receive(:flexible?).and_return(true)
+      allow(view).to receive(:view_options_for).and_return(
+        {
+          creator: { 'display_label' => { 'en' => 'Creator', 'default' => 'Creator' } },
+          keyword: { 'display_label' => { 'en' => 'Keyword', 'default' => 'Keyword' } },
+          license: { 'display_label' => { 'en' => 'License', 'default' => 'License' } }
+        }
+      )
+      render
+    end
+
+    it 'renders creator from flexible schema' do
+      expect(rendered).to have_selector('dd', text: 'Jane Smith')
+    end
+
+    it 'renders multiple keyword values joined' do
+      expect(rendered).to have_selector('dd', text: 'cats, dogs')
+    end
+
+    it 'renders license as a link' do
+      expect(rendered).to have_selector('dd a[href="https://creativecommons.org/licenses/by/4.0/"]')
+    end
+  end
+end


### PR DESCRIPTION
<img width="1262" height="875" alt="image" src="https://github.com/user-attachments/assets/797f6b41-0da7-45cb-afd4-adf2ee586c7a" />

This commit will add metadata fields to the file set show page.

Depends on:
- https://github.com/samvera/hyrax/pull/7371

To fully resolve:
- https://github.com/samvera/hyku/issues/2930