### PR TITLE
No creator on admin set form

### DIFF
--- a/config/metadata_profiles/m3_profile.yaml
+++ b/config/metadata_profiles/m3_profile.yaml
@@ -161,7 +161,6 @@ properties:
   creator:
     available_on:
       class:
-        - AdminSetResource
         - Hyrax::FileSet
         - CollectionResource
         - GenericWorkResource
@@ -185,6 +184,36 @@ properties:
     form:
       required: true
       primary: true
+    mappings:
+      simple_dc_pmh: dc:creator
+    property_uri: http://purl.org/dc/elements/1.1/creator
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Julie Allinson
+    view:
+      render_as: linked
+      html_dl: true
+  creator_hidden:
+    name: creator
+    available_on:
+      class:
+        - AdminSetResource
+    cardinality:
+      minimum: 0
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: blacklight.search.fields.show.creator_tesim
+    index_documentation: displayable, searchable
+    indexing:
+      - creator_sim
+      - creator_tesim
+      - facetable
+    form:
+      display: false
     mappings:
       simple_dc_pmh: dc:creator
     property_uri: http://purl.org/dc/elements/1.1/creator

--- a/spec/fixtures/files/m3_profile.yaml
+++ b/spec/fixtures/files/m3_profile.yaml
@@ -136,7 +136,6 @@ properties:
   creator:
     available_on:
       class:
-        - AdminSetResource
         - CollectionResource
         - Hyrax::FileSet
         - GenericWorkResource
@@ -150,6 +149,27 @@ properties:
         - "null"
     display_label:
       default: Creator
+    indexing:
+      - "creator_sim"
+      - "creator_tesim"
+    property_uri: http://purl.org/dc/elements/1.1/creator
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - Julie Allinson
+  creator_hidden:
+    name: creator
+    available_on:
+      class:
+        - AdminSetResource
+    data_type: array
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+        - "null"
+    display_label:
+      default: Creator
+    form:
+      display: false
     indexing:
       - "creator_sim"
       - "creator_tesim"


### PR DESCRIPTION
## Summary

Updates m3 profiles to remove creator from the flexible admin set form since it is not settable from the UI (setting happens via a transaction step). 

