### PR TITLE
🐛 Fix date sort indexing with flexible

### DIFF
--- a/app/indexers/concerns/hyku_indexing.rb
+++ b/app/indexers/concerns/hyku_indexing.rb
@@ -27,10 +27,7 @@ module HykuIndexing
         solr_doc['title_ssi'] = SortTitle.new(object.title.first).alphabetical
         solr_doc['depositor_ssi'] = object.depositor
         solr_doc['creator_ssi'] = object.creator&.first
-        if object.respond_to?(:date_created)
-          solr_doc[CatalogController.created_field] =
-            Array(object.date_created).first
-        end
+        solr_doc[CatalogController.created_field] ||= Array(object.try(:date_created)).first
         add_date(solr_doc)
       end
     end


### PR DESCRIPTION
This commit will make it so that if a user is using `:date` instead of `:date_created` for their sorting and then in their m3 profile adding `date_created_ssi` to their indexing for `:date`, it won't be overwritten by `HykuIndexing`.

Ref:
- https://github.com/notch8/hykuup_knapsack/issues/641
