### PR TITLE
Lazy load authority services

### DIFF
--- a/app/services/hyrax/accessibility_features_service.rb
+++ b/app/services/hyrax/accessibility_features_service.rb
@@ -5,6 +5,10 @@ module Hyrax
       @authority ||= Qa::Authorities::Local.subauthority_for('accessibility_features')
     end
 
+    def self.authority=(val)
+      @authority = val
+    end
+
     def self.select_all_options
       authority.all.map do |element|
         [element[:label], element[:id]]

--- a/app/services/hyrax/accessibility_hazards_service.rb
+++ b/app/services/hyrax/accessibility_hazards_service.rb
@@ -5,6 +5,10 @@ module Hyrax
       @authority ||= Qa::Authorities::Local.subauthority_for('accessibility_hazards')
     end
 
+    def self.authority=(val)
+      @authority = val
+    end
+
     def self.select_all_options
       authority.all.map do |element|
         [element[:label], element[:id]]

--- a/app/services/hyrax/audience_service.rb
+++ b/app/services/hyrax/audience_service.rb
@@ -5,6 +5,10 @@ module Hyrax
       @authority ||= Qa::Authorities::Local.subauthority_for('audience')
     end
 
+    def self.authority=(val)
+      @authority = val
+    end
+
     def self.select_all_options
       authority.all.map do |element|
         [element[:label], element[:id]]

--- a/app/services/hyrax/discipline_service.rb
+++ b/app/services/hyrax/discipline_service.rb
@@ -5,6 +5,10 @@ module Hyrax
       @authority ||= Qa::Authorities::Local.subauthority_for('discipline')
     end
 
+    def self.authority=(val)
+      @authority = val
+    end
+
     def self.select_all_options
       authority.all.map do |element|
         [element[:label], element[:id]]

--- a/app/services/hyrax/education_levels_service.rb
+++ b/app/services/hyrax/education_levels_service.rb
@@ -5,6 +5,10 @@ module Hyrax
       @authority ||= Qa::Authorities::Local.subauthority_for('education_levels')
     end
 
+    def self.authority=(val)
+      @authority = val
+    end
+
     def self.select_all_options
       authority.all.map do |element|
         [element[:label], element[:id]]

--- a/app/services/hyrax/learning_resource_types_service.rb
+++ b/app/services/hyrax/learning_resource_types_service.rb
@@ -5,6 +5,10 @@ module Hyrax
       @authority ||= Qa::Authorities::Local.subauthority_for('learning_resource_types')
     end
 
+    def self.authority=(val)
+      @authority = val
+    end
+
     def self.select_all_options
       authority.all.map do |element|
         [element[:label], element[:id]]

--- a/app/services/hyrax/oer_types_service.rb
+++ b/app/services/hyrax/oer_types_service.rb
@@ -5,6 +5,10 @@ module Hyrax
       @authority ||= Qa::Authorities::Local.subauthority_for('oer_types')
     end
 
+    def self.authority=(val)
+      @authority = val
+    end
+
     def self.select_all_options
       authority.all.map do |element|
         [element[:label], element[:id]]


### PR DESCRIPTION
## Summary

Refs https://github.com/samvera/hyrax/pull/7392

**Needed for knapsack apps:** Adjust authority to be lazy-loaded rather than eager loaded. This avoids Qa::InvalidSubAuthority errors when services are autoloaded before initializers have registered all authority paths.