### PR TITLE
Restore & refactor edit_fields partials

### DIFF
--- a/app/views/oers/edit_fields/_resource_type.html.erb
+++ b/app/views/oers/edit_fields/_resource_type.html.erb
@@ -6,13 +6,13 @@
 <% if Hyrax.config.flexible? %>
   <%= render partial: 'records/edit_fields/default',
              locals: { f: f,
-                       key: :resource_type,
+                       key: key,
                        controlled_vocab_config: controlled_vocabulary_options_for(:oer_resource_type) } %>
 <% else %>
-  <%= f.input :resource_type,
+  <%= f.input key,
       as: :select,
       collection: Hyrax::OerTypesService.select_all_options,
-      label: label_for(term: :resource_type, record_class: f.object.class),
-      hint: hint_for(term: :resource_type, record_class: f.object.class),
+      label: label_for(term: key, record_class: f.object.class),
+      hint: hint_for(term: key, record_class: f.object.class),
       input_html: { class: 'form-control', multiple: true } %>
 <% end %>

--- a/app/views/records/edit_fields/_controlled_vocab_select.html.erb
+++ b/app/views/records/edit_fields/_controlled_vocab_select.html.erb
@@ -5,7 +5,7 @@
       label: label_for(term: key, record_class: record.class),
       hint: hint_for(term: key, record_class: record.class),
       input_html: { class: 'form-control', multiple: true, name: "#{f.object_name}[#{key}][]" },
-      include_blank: true,
+      include_blank: !f.object.required?(key),
       selected: f.object.send(key).first,
       required: f.object.required?(key) %>
 <% else %>

--- a/app/views/records/edit_fields/_language.html.erb
+++ b/app/views/records/edit_fields/_language.html.erb
@@ -1,0 +1,2 @@
+<%# OVERRIDE: Hyrax v5.2.0 to support flexible metadata controlled vocabulary %>
+<%= render 'records/edit_fields/default', f: f, key: key %>

--- a/app/views/records/edit_fields/_large_text_default.html.erb
+++ b/app/views/records/edit_fields/_large_text_default.html.erb
@@ -1,0 +1,5 @@
+<% if f.object.multiple? key %>
+  <%= f.input key, as: :multi_value, input_html: { rows: '14', type: 'textarea'}, required: f.object.required?(key) %>
+<% else %>
+  <%= f.input key, as: :text, input_html: { rows: '14' }, required: f.object.required?(key) %>
+<% end %>

--- a/app/views/records/edit_fields/_license.html.erb
+++ b/app/views/records/edit_fields/_license.html.erb
@@ -1,0 +1,2 @@
+<%# OVERRIDE: Hyrax v5.2.0 to support flexible metadata controlled vocabulary %>
+<%= render 'records/edit_fields/default', f: f, key: key %>

--- a/app/views/records/edit_fields/_resource_type.html.erb
+++ b/app/views/records/edit_fields/_resource_type.html.erb
@@ -6,10 +6,10 @@
 <% if Hyrax.config.flexible? %>
   <%= render partial: 'records/edit_fields/default', locals: { f: f, key: :resource_type } %>
 <% else %>
-  <%= f.input :resource_type,
+  <%= f.input key,
       as: :select,
       collection: Hyrax::ResourceTypesService.select_options,
-      label: label_for(term: :resource_type, record_class: f.object.class),
-      hint: hint_for(term: :resource_type, record_class: f.object.class),
+      label: label_for(term: key, record_class: f.object.class),
+      hint: hint_for(term: key, record_class: f.object.class),
       input_html: { class: 'form-control', multiple: true } %>
 <% end %>

--- a/app/views/records/edit_fields/_rights_statement.html.erb
+++ b/app/views/records/edit_fields/_rights_statement.html.erb
@@ -1,0 +1,2 @@
+<%# OVERRIDE: Hyrax v5.2.0 to support flexible metadata controlled vocabulary %>
+<%= render 'records/edit_fields/default', f: f, key: key %>

--- a/app/views/records/edit_fields/_subject.html.erb
+++ b/app/views/records/edit_fields/_subject.html.erb
@@ -1,0 +1,2 @@
+<%# OVERRIDE: Hyrax v5.2.0 to support flexible metadata controlled vocabulary %>
+<%= render 'records/edit_fields/default', f: f, key: key %>

--- a/app/views/records/edit_fields/_table_of_contents.html.erb
+++ b/app/views/records/edit_fields/_table_of_contents.html.erb
@@ -1,5 +1,1 @@
-<% if curation_concern.to_rdf_representation == 'Oer' %>
-  <%= f.input :table_of_contents, as: :multi_value,
-    hint: t("hyrax.oer.hints.table_of_contents"),
-    input_html: { rows: '14', type: 'textarea'}, required: f.object.required?(key) %>
-<% end %>
+<%= render 'records/edit_fields/large_text_default', f: f, key: key %>

--- a/app/views/records/show_fields/_license.html.erb
+++ b/app/views/records/show_fields/_license.html.erb
@@ -1,3 +1,4 @@
+<%# Todo: determine if this is this needed? %>
 <% service = Hyrax::LicenseService.new %>
 <% record.license.each do |r| %>
   <%= link_to_field('license', r, service.label(r)) %> <%= iconify_auto_link(r, false) %><br />


### PR DESCRIPTION
## Summary

This commit restores the edit_fields partials that were removed in a previous commit, and refactors them to work more fully with the M3 profile settings. We are overriding the Hyrax partials in order to add create behavior which more fully reflects the M3 settings.

Longer-term, we may want to move this logic back into Hyrax.

## Notes

Re: m3 profiles (I found the following, which may feed into documentation)…

**Cardinality:** controls whether the “add another” option shows on the form
**Data_type:** used as a short-circuit in determine_multiplicity to automatically say something is multiple… but this does not carry through into the form. Also used in type wrapping in SchemaLoader::AttributeDefinition#type to wrap the Valkyrie type. This causes a bit of fragility in the process
**Form: multiple: true (or false)** the way to control whether controlled vocabularies display a dropdown or allow multi-select (this is needed if you are using simple_form and want to check multiple on the form’s object)

Ideally this could be combined to work together better, but for how this is how it works.

**Proposal:** Hyrax’s flexible_schema.rb could be modified as follows to get rid of the short circuit and hopefully ensure that cardinality can also correctly answer `multiple?` in the edit_fields partials.
```
def values_map(values)
    values['type'] = lookup_type(values['range'])
    values['predicate'] = values['property_uri']
    values['index_keys'] = values['indexing']
    values['context'] = values.dig('available_on', 'context')
    values['multiple'] = determine_multiplicity(values)

    normalize_form_attributes(values)

    values['form'] ||= {}
    values['form']['multiple'] = values['multiple'] unless values['form'].key?('multiple')

    values
  end

  def determine_multiplicity(values)
    if values.key?('data_type')
      return values['data_type'] == 'array' unless values.dig('cardinality', 'maximum')
      max = values['cardinality']['maximum']
      return max.to_i > 1
    end
    return values['multi_value'] if values.key?('multi_value')

    if (card = values['cardinality'])
      max = card['maximum']
      return max.nil? || max.to_i > 1
    end

    false
  end
```