### PR TITLE
Restore theme color functionality

### DIFF
--- a/app/views/hyrax/admin/appearances/_default_colors_form.html.erb
+++ b/app/views/hyrax/admin/appearances/_default_colors_form.html.erb
@@ -9,6 +9,10 @@
   <% tenant_colors = @form.tenant_colors %>
 
   <div class="card-footer">
+    <% if theme_colors.present? %>
+      <%= link_to t('hyrax.admin.appearances.show.colors.apply_theme_colors'), '#color', class: 'btn btn-secondary apply-theme-colors',
+        data: { theme_colors: theme_colors.to_json } %>
+    <% end %>
     <% button_label = Flipflop.use_tenant_specific_colors? ? t('hyrax.admin.appearances.show.colors.restore_all_tenant_colors') : t('hyrax.admin.appearances.show.colors.restore_all_defaults') %>
     <% if Flipflop.use_tenant_specific_colors? && !tenant_colors.empty? %>
       <%= link_to button_label, '#color', class: 'btn btn-secondary apply-tenant-colors',

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -371,6 +371,7 @@ de:
         show:
           colors:
             apply_changes: Änderungen anwenden
+            apply_theme_colors: Themenfarben anwenden
             restore_all_defaults: Alle Standardeinstellungen wiederherstellen
             restore_all_tenant_colors: Alle Mieterfarben wiederherstellen
             restore_default: Standardeinstellungen wiederherstellen

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -287,6 +287,7 @@ en:
             restore_default: Restore Default
             restore_all_tenant_colors: Restore All Tenant Colors
             restore_all_defaults: Restore All Defaults
+            apply_theme_colors: Apply Theme Colors
             save_as_tenant_colors: Apply Changes and Save as Tenant Colors
             apply_changes: Apply Changes
       roles_service_jobs:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -372,6 +372,7 @@ es:
         show:
           colors:
             apply_changes: Aplicar cambios
+            apply_theme_colors: Aplicar colores del tema
             restore_all_defaults: Restaurar todos los valores predeterminados
             restore_all_tenant_colors: Restaurar todos los colores de los inquilinos
             restore_default: Restaurar valores predeterminados

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -372,6 +372,7 @@ fr:
         show:
           colors:
             apply_changes: Appliquer les modifications
+            apply_theme_colors: Appliquer les couleurs du thème
             restore_all_defaults: Rétablir tous les paramètres par défaut
             restore_all_tenant_colors: Rétablir toutes les couleurs des locataires
             restore_default: Restaurer les paramètres par défaut

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -372,6 +372,7 @@ it:
         show:
           colors:
             apply_changes: Applica modifiche
+            apply_theme_colors: Applica i colori del tema
             restore_all_defaults: Ripristina tutti i valori predefiniti
             restore_all_tenant_colors: Ripristina tutti i colori degli inquilini
             restore_default: Ripristina predefinito

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -255,6 +255,7 @@ pt-BR:
         show:
           colors:
             apply_changes: Aplicar alterações
+            apply_theme_colors: Aplicar cores do tema
             restore_all_defaults: Restaurar todas as configurações padrão
             restore_all_tenant_colors: Restaurar todas as cores dos inquilinos
             restore_default: Restaurar padrão

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -372,6 +372,7 @@ zh:
         show:
           colors:
             apply_changes: 应用更改
+            apply_theme_colors: 应用主题颜色
             restore_all_defaults: 恢复所有默认设置
             restore_all_tenant_colors: 恢复所有租户颜色
             restore_default: 恢复默认设置


### PR DESCRIPTION
## Summary

Button was inadvertently removed during tenant color work.

If home_themes.yml has a theme_custom_colors section under a theme's definition, this will cause buttons to appear when the theme was in use, allowing for a quick way to apply the custom colors. 

When tenant default color feature is being used, all buttons will appear.

## Screenshot
<img width="1043" height="566" alt="Screenshot 2026-03-19 at 6 05 00 PM" src="https://github.com/user-attachments/assets/6e2e8354-7183-40c7-bba3-bed6e3868654" />

