### PR TITLE
Adds m3 profile rake tasks

### DIFF
--- a/lib/tasks/flexible_schema_initialize.rake
+++ b/lib/tasks/flexible_schema_initialize.rake
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+namespace :hyku do
+  namespace :flexible_schema do
+    desc 'Create default flexible schema for each full (non-search-only) tenant unless one already exists'
+    task initialize: :environment do
+      Account.full_accounts.each do |account|
+        switch!(account)
+        puts "Initializing flexible schema for tenant: #{account.cname}"
+        Hyrax::FlexibleSchema.create_default_schema
+      end
+    end
+  end
+end

--- a/lib/tasks/reset.rake
+++ b/lib/tasks/reset.rake
@@ -13,12 +13,27 @@ namespace :reset do
 
   desc 'reset work and collection data from a single tenant, any argument that works with switch!() will work here'
   task :works_and_collections, [:account] => [:environment] do |_t, args|
-    raise "You must speficy a name, cname or id of an account" if args[:account].blank?
+    raise "You must specify a name, cname or id of an account" if args[:account].blank?
 
     confirm("You are about to delete all works and collections from #{args[:account]}, this is not reversable!")
     switch!(args[:account])
     Rake::Task["hyrax:reset:works_and_collections"].reenable
     Rake::Task["hyrax:reset:works_and_collections"].invoke
+  end
+
+  desc 'Remove all flexible schemas across all tenants'
+  task all_flexible_schemas: [:environment] do
+    confirm('You are about to delete all flexible schemas across all accounts, this is not reversable!')
+    Account.find_each do |account|
+      switch!(account)
+      count = Hyrax::FlexibleSchema.count
+      puts "=" * 60
+      puts "Tenant:    #{account.cname} (#{Apartment::Tenant.current})"
+      puts "Found:     #{count} flexible schema(s)"
+      deleted = Hyrax::FlexibleSchema.destroy_all
+      puts "Destroyed: #{deleted.size} flexible schema(s)"
+      puts "=" * 60
+    end
   end
 
   def confirm(action)


### PR DESCRIPTION
# Summary

Adds rake tasks for m3 profiles:

- `rake hyku:flexible_schema:initialize` adds a default m3 profile to each tenant that doesn't have one.
- `rake reset:all_flexible_schemas` removes all flexible schemas from all tenants (useful for testing but VERY dangerous in real life!)