### PR TITLE
:bug: Fix collection title showing jQuery .text on first Add 

### DIFF
--- a/app/assets/javascripts/hyrax/relationships/control.es6
+++ b/app/assets/javascripts/hyrax/relationships/control.es6
@@ -33,8 +33,31 @@ export default class RelationshipsControl {
   }
 
   init() {
+    this.ensureSelect2();
     this.bindAddButton();
     this.displayMembers();
+  }
+
+  /**
+   * Ensure Select2 is initialized on collection dropdowns before reading selection
+   * via select2('data'). Without this, the first "Add" can receive a jQuery object
+   * (so data.text is jQuery.fn.text) and the row shows minified JS instead of the title.
+   * Matches upstream Hyrax RelationshipsControl#ensureSelect2.
+   */
+  ensureSelect2() {
+    let collectionSelect = this.input.filter('.collection-select2, select[name="member_of_collection_ids"]')
+    // Select2 3.x stores the instance on .data('select2'); 4.x may also use select2-hidden-accessible
+    if (collectionSelect.length > 0 && !collectionSelect.data('select2') && !collectionSelect.hasClass('select2-hidden-accessible')) {
+      let dropdownParent = collectionSelect.closest('.modal-body')
+      let options = {
+        placeholder: collectionSelect.data('placeholder') || 'Select',
+        allowClear: true
+      }
+      if (dropdownParent.length > 0) {
+        options.dropdownParent = dropdownParent
+      }
+      collectionSelect.select2(options)
+    }
   }
 
   validate() {


### PR DESCRIPTION

# Summary

Initialize collection Select2 in `RelationshipsControl#init` before `select2('data')` so the first “Add” shows the collection title, not minified jQuery.

## Ticket Number

https://github.com/notch8/hykuup_knapsack/issues/656

## BEFORE

<img width="751" height="350" alt="image" src="https://github.com/user-attachments/assets/bc2f581b-8491-4576-9a87-c949ea3e69fd" />

## Expected Behavior

First “Add” on the work Relationships → Collections row shows the real collection name.

<img width="741" height="491" alt="image" src="https://github.com/user-attachments/assets/be7a58da-3b60-4e7a-a9a8-45c14989ff42" />


## Notes

**Root cause in Hyku:** Your `control.es6` is an old Hyku copy from Hyrax 2.5. Current Hyrax adds `ensureSelect2()` in `init()` so the collection `<select>` always gets Select2 before anyone reads `select2('data')`. That method was missing from the Hyku override.

ref: 
- https://github.com/samvera/hyrax/blob/main/app/assets/javascripts/hyrax/relationships/control.es6#L33

@samvera/hyku-code-reviewers
