### PR TITLE
🐛 Add #presence check for pdf viewer/download btn

### DIFF
--- a/app/presenters/hyku/work_show_presenter.rb
+++ b/app/presenters/hyku/work_show_presenter.rb
@@ -79,7 +79,7 @@ module Hyku
     # @return [Boolean] Use PDF.js viewer
     def show_pdf_viewer?
       return unless Flipflop.default_pdf_viewer?
-      return unless show_pdf_viewer
+      return unless show_pdf_viewer.presence
       return unless file_set_presenters.any?(&:pdf?)
 
       show_for_pdf?(show_pdf_viewer)
@@ -104,7 +104,7 @@ module Hyku
     def show_pdf_download_button?
       return unless Hyrax.config.display_media_download_link?
       return unless file_set_presenters.any?(&:pdf?)
-      return unless show_pdf_download_button
+      return unless show_pdf_download_button.presence
 
       show_for_pdf?(show_pdf_download_button)
     end

--- a/spec/presenters/hyku/work_show_presenter_spec.rb
+++ b/spec/presenters/hyku/work_show_presenter_spec.rb
@@ -201,6 +201,70 @@ RSpec.describe Hyku::WorkShowPresenter do
     end
   end
 
+  describe "#show_pdf_viewer?" do
+    subject { presenter.show_pdf_viewer? }
+
+    let(:pdf_presenter) { double("IiifFileSetPresenter", pdf?: true) }
+
+    before do
+      allow(Flipflop).to receive(:default_pdf_viewer?).and_return(true)
+      allow(presenter).to receive(:file_set_presenters).and_return([pdf_presenter])
+    end
+
+    context "when show_pdf_viewer returns an empty string" do
+      before { allow(presenter).to receive(:show_pdf_viewer).and_return("") }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when show_pdf_viewer returns true" do
+      before { allow(presenter).to receive(:show_pdf_viewer).and_return(true) }
+
+      it { is_expected.to be true }
+    end
+
+    context "when default_pdf_viewer feature is disabled" do
+      before do
+        allow(Flipflop).to receive(:default_pdf_viewer?).and_return(false)
+        allow(presenter).to receive(:show_pdf_viewer).and_return(true)
+      end
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe "#show_pdf_download_button?" do
+    subject { presenter.show_pdf_download_button? }
+
+    let(:pdf_presenter) { double("IiifFileSetPresenter", pdf?: true) }
+
+    before do
+      allow(Hyrax.config).to receive(:display_media_download_link?).and_return(true)
+      allow(presenter).to receive(:file_set_presenters).and_return([pdf_presenter])
+    end
+
+    context "when show_pdf_download_button returns an empty string" do
+      before { allow(presenter).to receive(:show_pdf_download_button).and_return("") }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when show_pdf_download_button returns true" do
+      before { allow(presenter).to receive(:show_pdf_download_button).and_return(true) }
+
+      it { is_expected.to be true }
+    end
+
+    context "when display_media_download_link is disabled" do
+      before do
+        allow(Hyrax.config).to receive(:display_media_download_link?).and_return(false)
+        allow(presenter).to receive(:show_pdf_download_button).and_return(true)
+      end
+
+      it { is_expected.to be_nil }
+    end
+  end
+
   describe "#valid_child_concerns" do
     let(:enabled_works) { ["GenericWork", "Image"] }
     let(:all_concerns) { [GenericWork, Image, Etd] }


### PR DESCRIPTION
When HYRAX_FLEXIBLE is on the logic then will go through the `Hyrax::WorkShowPresenter#define_dynamic_methods`.  We get in a situation where we would get a `""` back instead of `false` and since `""` is truthy then the pdf viewer/download button will always show. This commit will add a #presence check so `""` will become `nil`.

Ref:
- https://github.com/samvera/hyku/issues/2989
- https://github.com/samvera/hyrax/blob/aced8ad9cd7d2f3520119e3d8fdd282a32cb72d5/app/presenters/hyrax/work_show_presenter.rb#L53
