### PR TITLE
Select only _tesim fields for OAI feed

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -167,7 +167,7 @@ class SolrDocument
       next unless qualified_name
 
       property = qualified_name.split(':').last.to_sym
-      index_keys = item[:index_keys]
+      index_keys = Array(item[:index_keys]).select { |k| k.to_s.end_with?('_tesim') }
       next unless mappings.key?(property) && index_keys.present?
 
       mappings[property] |= index_keys


### PR DESCRIPTION
## Summary

With flexible metadata, the m3 profile can have multiple terms indexing a given property. 

When we select all indexed fields for a property, we can get duplication of values in the OAI feed. This change selects only the _tesim fields for the OAI feed, which are the fields that are used for display, and should prevent the duplication.

## Behavior before

https://demo.palni-palci-knapsack-friends.notch8.cloud/catalog/oai?verb=ListRecords&metadataPrefix=oai_dc 
<img width="1220" height="331" alt="Screenshot 2026-04-02 at 10 59 42 AM" src="https://github.com/user-attachments/assets/c2b139d6-9fac-4e49-8ba6-64538be31097" />

