### PR TITLE
Update solr to 8.11.2 to address CVE-2021-44228

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,8 @@ CMD ./bin/web
 FROM hyku-web AS hyku-worker
 CMD ./bin/worker
 
-FROM solr:8.3 AS hyku-solr
+# Use a Solr version with patched Log4j to address CVE-2021-44228
+FROM solr:8.11.2 AS hyku-solr
 ENV SOLR_USER="solr" \
     SOLR_GROUP="solr"
 USER root


### PR DESCRIPTION
# Solr image: Log4j 2.x fix (CVE-2021-44228)

## Summary

Updates the Hyku Solr Docker image to use **`solr:8.11.2`**, which ships with patched Log4j 2.x libraries, mitigating **CVE-2021-44228** (“Log4Shell”) and related Log4j issues in the Solr runtime.

This aligns with upstream guidance for addressing CVE-2021-44228.

## Changes

- Dockerfile: `FROM solr:8.11.2 AS hyku-solr` (replacing the previous Solr base image tag).

## Rationale

Apache Solr 8.11.2 was released with updated Log4j dependencies. Pinning this tag aligns the container build with a Solr release that addresses critical Log4j vulnerabilities and satisfies common security scanning and deployment policies.

## Verification

### Tested

**Before (Solr 8.3.1 in container)** — `docker compose exec solr bash` then:

```bash
find /opt/solr-8.3.1 -iname "*log4j*"
```

Example output showed Log4j **2.11.2** on the classpath, including:

- `/opt/solr-8.3.1/server/lib/ext/log4j-slf4j-impl-2.11.2.jar`
- `/opt/solr-8.3.1/server/lib/ext/log4j-1.2-api-2.11.2.jar`
- `/opt/solr-8.3.1/server/lib/ext/log4j-api-2.11.2.jar`
- `/opt/solr-8.3.1/server/lib/ext/log4j-core-2.11.2.jar`
- `/opt/solr-8.3.1/server/lib/ext/log4j-web-2.11.2.jar`
- `/opt/solr-8.3.1/contrib/prometheus-exporter/lib/log4j-slf4j-impl-2.11.2.jar`
- `/opt/solr-8.3.1/contrib/prometheus-exporter/lib/log4j-api-2.11.2.jar`
- `/opt/solr-8.3.1/contrib/prometheus-exporter/lib/log4j-core-2.11.2.jar`
- License / checksum entries under `/opt/solr-8.3.1/licenses/` for the same versions
- Config: `/opt/solr-8.3.1/server/resources/log4j2.xml`, `log4j2-console.xml`

**After (`solr:8.11.2`)** — run the same style of check inside the new image (path may be `/opt/solr-8.11.2` or similar). Primary Solr server Log4j artifacts should include **`log4j-core-2.17.1.jar`** and **`log4j-api-2.17.1.jar`**.

Checklist:

- [ ] Image builds; Solr starts.
- [ ] `find` confirms `log4j-core-2.17.1.jar` and `log4j-api-2.17.1.jar` for the main server libs (and note any other `log4j-*` paths if present).

## Acknowledgments

We are grateful to **West Virginia University** for running security scanning against this repository, reporting the finding to us, and supporting remediation work that benefits the wider Hyku community.

## References

- [CVE-2021-44228](https://nvd.nist.gov/vuln/detail/CVE-2021-44228)
- [Apache Solr security / advisories](https://solr.apache.org/security.html) — follow current upstream recommendations for your Solr major version.