### PR TITLE
Log a warning if someone may have an invalid Solr password

### DIFF
--- a/app/jobs/create_solr_collection_job.rb
+++ b/app/jobs/create_solr_collection_job.rb
@@ -94,9 +94,28 @@ class CreateSolrCollectionJob < ApplicationJob
     @solr_url = @solr_url.ends_with?('/') ? @solr_url : "#{@solr_url}/"
   end
 
+  # This builds the URL differently from config/blacklight.yml
+  # That would have to be a separate refactor
   def solr_url_parts
-    "http://#{ENV.fetch('SOLR_ADMIN_USER', 'admin')}:#{ENV.fetch('SOLR_ADMIN_PASSWORD', 'admin')}" \
-      "@#{ENV.fetch('SOLR_HOST', 'solr')}:#{ENV.fetch('SOLR_PORT', '8983')}/solr/"
+    password = check_credential_encoding(env_variable: 'SOLR_ADMIN_PASSWORD', default: 'admin')
+    user = check_credential_encoding(env_variable: 'SOLR_ADMIN_USER', default: 'admin')
+    URI::HTTP.build(
+      userinfo: "#{user}:#{password}",
+      host: ENV.fetch('SOLR_HOST', 'solr'),
+      port: ENV.fetch('SOLR_PORT', 8983).to_i,
+      path: '/solr/'
+    ).to_s
+  end
+
+  def check_credential_encoding(env_variable:, default:)
+    credential = ENV.fetch(env_variable, default)
+    credential_encoded = URI.encode_www_form_component(credential)
+    if credential != credential_encoded
+      Rails.logger.warn("#{env_variable} contains characters that may require URL encoding. " \
+                        "If you experience Solr authentication errors, URL encode the value in " \
+                        "#{env_variable} and in SOLR_URL if it is set.")
+    end
+    credential
   end
 
   def add_solr_endpoint_to_account(account, name)

--- a/spec/jobs/create_solr_collection_job_spec.rb
+++ b/spec/jobs/create_solr_collection_job_spec.rb
@@ -4,11 +4,10 @@ RSpec.describe CreateSolrCollectionJob do
   let(:account) { FactoryBot.create(:account) }
   let(:client) { double }
 
-  before do
-    allow(Blacklight.default_index).to receive(:connection).and_return(client)
-  end
-
   describe '#perform' do
+    before do
+      allow(Blacklight.default_index).to receive(:connection).and_return(client)
+    end
     it 'creates a new collection for an account' do
       expect(client).to receive(:get).with('/solr/admin/collections',
                                            params: { action: 'LIST' }).and_return('collections' => [])
@@ -29,6 +28,49 @@ RSpec.describe CreateSolrCollectionJob do
       expect(client).not_to receive(:get).with('/solr/admin/collections', params: hash_including(action: 'CREATE'))
 
       described_class.perform_now(account)
+    end
+  end
+
+  describe '#solr_url' do
+    context 'with values that need to be escaped' do
+      before do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:fetch).and_call_original
+        allow(ENV).to receive(:[]).with('SOLR_URL').and_return(nil)
+        allow(ENV).to receive(:fetch).with('SOLR_ADMIN_USER', 'admin').and_return('my&admin')
+        allow(ENV).to receive(:fetch).with('SOLR_ADMIN_PASSWORD', 'admin').and_return('5+7')
+        allow(Rails.logger).to receive(:warn).and_call_original
+      end
+
+      it 'leaves the password parts as-is' do
+        expect(described_class.new.send(:solr_url)).to eq('http://my&admin:5+7@solr:8983/solr/')
+      end
+
+      it 'logs a warning to rails' do
+        described_class.new.send(:solr_url)
+        expect(Rails.logger).to have_received(:warn).with("SOLR_ADMIN_PASSWORD contains characters that may require URL encoding. " \
+                        "If you experience Solr authentication errors, URL encode the value in " \
+                        "SOLR_ADMIN_PASSWORD and in SOLR_URL if it is set.")
+      end
+    end
+    context 'with default values for user and password' do
+      before do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:fetch).and_call_original
+        allow(ENV).to receive(:[]).with('SOLR_URL').and_return(nil)
+        allow(ENV).to receive(:fetch).with('SOLR_ADMIN_USER', 'admin').and_return('admin')
+        allow(ENV).to receive(:fetch).with('SOLR_ADMIN_PASSWORD', 'admin').and_return('admin')
+        allow(Rails.logger).to receive(:warn).and_call_original
+      end
+
+      it 'uses default values' do
+        expect(described_class.new.send(:solr_url)).to eq('http://admin:admin@solr:8983/solr/')
+      end
+
+      it 'does not log a warning to rails' do
+        described_class.new.send(:solr_url)
+        expect(Rails.logger).not_to have_received(:warn)
+      end
     end
   end
 


### PR DESCRIPTION
- Refactor generation of solr_url_parts to be more idiomatic
- Checks Solr credential encoding to make sure it's url escaped, if not, logs a warning.

@samvera/hyku-code-reviewers
