### PR TITLE
Remove per-field Solr spellcheck.dictionary from catalog search fields

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -247,10 +247,12 @@ class CatalogController < ApplicationController
     # of Solr search fields.
     # creator, title, description, publisher, date_created,
     # subject, language, resource_type, format, identifier, based_near,
+    #
+    # Hyku solr/conf/solrconfig.xml only registers spellcheck dictionaries named
+    # default, author, subject, and title. Omit per-field spellcheck.dictionary here;
+    # unknown names cause Solr errors and Blacklight::Exceptions::InvalidRequest.
     config.add_search_field('contributor') do |field|
       # solr_parameters hash are sent to Solr as ordinary url query params.
-      field.solr_parameters = { "spellcheck.dictionary": "contributor" }
-
       # :solr_local_parameters will be sent using Solr LocalParams
       # syntax, as eg {! qf=$title_qf }. This is neccesary to use
       # Solr parameter de-referencing like $title_qf.
@@ -263,7 +265,6 @@ class CatalogController < ApplicationController
     end
 
     config.add_search_field('creator') do |field|
-      field.solr_parameters = { "spellcheck.dictionary": "creator" }
       solr_name = 'creator_tesim'
       field.solr_local_parameters = {
         qf: solr_name,
@@ -272,9 +273,6 @@ class CatalogController < ApplicationController
     end
 
     config.add_search_field('title') do |field|
-      field.solr_parameters = {
-        "spellcheck.dictionary": "title"
-      }
       solr_name = 'title_tesim'
       field.solr_local_parameters = {
         qf: solr_name,
@@ -284,9 +282,6 @@ class CatalogController < ApplicationController
 
     config.add_search_field('description') do |field|
       field.label = "Abstract or Summary"
-      field.solr_parameters = {
-        "spellcheck.dictionary": "description"
-      }
       solr_name = 'description_tesim'
       field.solr_local_parameters = {
         qf: solr_name,
@@ -295,9 +290,6 @@ class CatalogController < ApplicationController
     end
 
     config.add_search_field('publisher') do |field|
-      field.solr_parameters = {
-        "spellcheck.dictionary": "publisher"
-      }
       solr_name = 'publisher_tesim'
       field.solr_local_parameters = {
         qf: solr_name,
@@ -308,9 +300,6 @@ class CatalogController < ApplicationController
     date_fields = ['date_created_tesim', 'sorted_date_isi', 'sorted_month_isi']
 
     config.add_search_field('date_created') do |field|
-      field.solr_parameters = {
-        "spellcheck.dictionary": "date_created"
-      }
       field.solr_local_parameters = {
         qf: date_fields.join(' '),
         pf: date_fields.join(' ')
@@ -318,9 +307,6 @@ class CatalogController < ApplicationController
     end
 
     config.add_search_field('subject') do |field|
-      field.solr_parameters = {
-        "spellcheck.dictionary": "subject"
-      }
       solr_name = 'subject_tesim'
       field.solr_local_parameters = {
         qf: solr_name,
@@ -329,9 +315,6 @@ class CatalogController < ApplicationController
     end
 
     config.add_search_field('language') do |field|
-      field.solr_parameters = {
-        "spellcheck.dictionary": "language"
-      }
       solr_name = 'language_tesim'
       field.solr_local_parameters = {
         qf: solr_name,
@@ -340,9 +323,6 @@ class CatalogController < ApplicationController
     end
 
     config.add_search_field('resource_type') do |field|
-      field.solr_parameters = {
-        "spellcheck.dictionary": "resource_type"
-      }
       solr_name = 'resource_type_tesim'
       field.solr_local_parameters = {
         qf: solr_name,
@@ -352,9 +332,6 @@ class CatalogController < ApplicationController
 
     config.add_search_field('format') do |field|
       field.include_in_advanced_search = false
-      field.solr_parameters = {
-        "spellcheck.dictionary": "format"
-      }
       solr_name = 'format_tesim'
       field.solr_local_parameters = {
         qf: solr_name,
@@ -364,9 +341,6 @@ class CatalogController < ApplicationController
 
     config.add_search_field('identifier') do |field|
       field.include_in_advanced_search = false
-      field.solr_parameters = {
-        "spellcheck.dictionary": "identifier"
-      }
       solr_name = 'id_tesim'
       field.solr_local_parameters = {
         qf: solr_name,
@@ -376,9 +350,6 @@ class CatalogController < ApplicationController
 
     config.add_search_field('based_near_label') do |field|
       field.label = "Location"
-      field.solr_parameters = {
-        "spellcheck.dictionary": "based_near_label"
-      }
       solr_name = 'based_near_label_tesim'
       field.solr_local_parameters = {
         qf: solr_name,
@@ -387,9 +358,6 @@ class CatalogController < ApplicationController
     end
 
     config.add_search_field('keyword') do |field|
-      field.solr_parameters = {
-        "spellcheck.dictionary": "keyword"
-      }
       solr_name = 'keyword_tesim'
       field.solr_local_parameters = {
         qf: solr_name,

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -249,8 +249,11 @@ class CatalogController < ApplicationController
     # subject, language, resource_type, format, identifier, based_near,
     #
     # Hyku solr/conf/solrconfig.xml only registers spellcheck dictionaries named
-    # default, author, subject, and title. Omit per-field spellcheck.dictionary here;
+    # default, author, subject, and title. Omit per-field spellcheck.dictionary here, unless it is also added to the solrconfig.xml;
     # unknown names cause Solr errors and Blacklight::Exceptions::InvalidRequest.
+    # To add per-field spellcheck, add e.g.
+    # field.solr_parameters = { "spellcheck.dictionary": "contributor" }
+    # inside the add_search_field block
     config.add_search_field('contributor') do |field|
       # solr_parameters hash are sent to Solr as ordinary url query params.
       # :solr_local_parameters will be sent using Solr LocalParams

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -1,6 +1,33 @@
 # frozen_string_literal: true
 
 RSpec.describe CatalogController do
+  # Hyku solr/conf/solrconfig.xml does not define per-field spellcheck dictionaries
+  # (e.g. creator, publisher); sending them caused Solr errors / Blacklight InvalidRequest.
+  describe "search field Solr params (spellcheck regression)" do
+    %w[
+      contributor
+      creator
+      title
+      description
+      publisher
+      date_created
+      subject
+      language
+      resource_type
+      format
+      identifier
+      based_near_label
+      keyword
+    ].each do |key|
+      it "does not set spellcheck.dictionary on #{key} search field" do
+        field = described_class.blacklight_config.search_fields[key]
+        expect(field).to be_present, "expected search_fields['#{key}'] to exist"
+        solr_keys = (field.solr_parameters || {}).stringify_keys.keys
+        expect(solr_keys).not_to include("spellcheck.dictionary")
+      end
+    end
+  end
+
   describe "GET /show" do
     let(:file_set) { create(:file_set) }
 

--- a/spec/requests/catalog_controller_spec.rb
+++ b/spec/requests/catalog_controller_spec.rb
@@ -57,9 +57,6 @@ RSpec.describe CatalogController, type: :request, clean: true, multitenant: true
     before do
       host! "http://#{cross_search_tenant_account.cname}/"
       black_light_config.add_search_field('title') do |field|
-        field.solr_parameters = {
-          "spellcheck.dictionary": "title"
-        }
         solr_name = 'title_tesim'
         field.solr_local_parameters = {
           qf: solr_name,


### PR DESCRIPTION
## Summary

Ref ticket # https://github.com/notch8/palni_palci_knapsack/issues/592

Removes `spellcheck.dictionary` from Blacklight catalog search field configs so Solr is not asked for named spellcheck dictionaries that Hyku's default Solr configset does not define.

## Problem

Fielded catalog searches (e.g. work-show links with `search_field=creator` and a `q` value) sent `spellcheck.dictionary=creator` (and similar for other fields). Solr responded with errors such as "Specified dictionaries do not exist," leading to RSolr HTTP errors, `Blacklight::Exceptions::InvalidRequest`, and the "Sorry, I don't understand your search" behavior while results were wrong or unscoped.

## Solution

Drop `field.solr_parameters = { "spellcheck.dictionary": … }` from the shared catalog search fields in `hyrax-webapp/app/controllers/catalog_controller.rb` and from the knapsack `catalog_controller_decorator` loop (including `format`). Blacklight still sets `spellcheck.q` where appropriate; only the invalid per-field dictionary names are removed.

## Testing

- [ ] `/catalog?search_field=creator&q=…` (and another field, e.g. keyword) returns 200 and scoped results, no Solr spellcheck dictionary errors in logs.

## Notes

Sites that configure matching named spellcheck dictionaries in Solr can reintroduce `spellcheck.dictionary` in a local override if they want field-specific spellcheck.