### PR TITLE
Update to released version of bulkrax 9.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'blacklight_range_limit', '~> 8.5'
 gem 'bolognese', '>= 1.9.10'
 gem 'bootstrap', '~> 4.6'
 gem 'bootstrap-datepicker-rails'
-gem 'bulkrax', github: 'samvera-labs/bulkrax', branch: 'main'
+gem 'bulkrax', '~> 9.4'
 gem 'byebug', group: %i[development test]
 gem 'capybara', group: %i[test]
 gem 'capybara-screenshot', '~> 1.0', group: %i[test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,28 +9,6 @@ GIT
       rubyzip (>= 1.0.0)
 
 GIT
-  remote: https://github.com/samvera-labs/bulkrax.git
-  revision: 370cf9cd324b11a8afcdd10912db2baf59456928
-  branch: main
-  specs:
-    bulkrax (9.3.5)
-      bagit (~> 0.6.0)
-      coderay
-      denormalize_fields
-      iso8601 (~> 0.9.0)
-      kaminari
-      language_list (~> 1.2, >= 1.2.1)
-      libxml-ruby (~> 5.0)
-      loofah (>= 2.2.3)
-      marcel
-      oai (>= 0.4, < 2.x)
-      rack (>= 2.0.6)
-      rails (>= 5.1.6, < 8.0.0)
-      rdf (>= 2.0.2, < 4.0)
-      rubyzip
-      simple_form
-
-GIT
   remote: https://github.com/samvera-labs/hyku_knapsack.git
   revision: ca70becc31bf82950b003a1a8441e861fac753cb
   branch: required_for_knapsack_instances
@@ -401,6 +379,22 @@ GEM
       signet (~> 0.8)
       typhoeus
     builder (3.3.0)
+    bulkrax (9.4.0)
+      bagit (~> 0.6.0)
+      coderay
+      denormalize_fields
+      iso8601 (~> 0.9.0)
+      kaminari
+      language_list (~> 1.2, >= 1.2.1)
+      libxml-ruby (~> 5.0)
+      loofah (>= 2.2.3)
+      marcel
+      oai (>= 0.4, < 2.x)
+      rack (>= 2.0.6)
+      rails (>= 5.1.6, < 8.0.0)
+      rdf (>= 2.0.2, < 4.0)
+      rubyzip
+      simple_form
     byebug (12.0.0)
     cancancan (3.6.1)
     capybara (3.40.0)
@@ -1673,7 +1667,7 @@ DEPENDENCIES
   bolognese (>= 1.9.10)
   bootstrap (~> 4.6)
   bootstrap-datepicker-rails
-  bulkrax!
+  bulkrax (~> 9.4)
   byebug
   capybara
   capybara-screenshot (~> 1.0)


### PR DESCRIPTION
# Summary

Updates bulkrax to from branch main to 9.4.0, to bringing in guided import functionality in a released version (via a feature flipper).
