### PR TITLE
uniquely append additional locales

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -393,7 +393,7 @@ module Hyku
 
       # Because we're loading local translations early in the to_prepare block for our decorators,
       # the I18n.load_path is out of order.  This line ensures that we load local translations last.
-      I18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.yml')]
+      I18n.load_path |= Dir[Rails.root.join('config', 'locales', '**', '*.yml')]
 
       ##
       # The first "#valid?" service is the one that we'll use for generating derivatives.


### PR DESCRIPTION
Fixes #2749

Allows locales to be kept in a knapsack

If we attempt to load a locale from say a hyku knapsack then the existing translations get repeated and override the locally loaded ones.

https://github.com/samvera/hyku/blob/main/config/application.rb#L396

Changes proposed in this pull request:

Changing += to |= will work by ensuring the locales in I18n.load_path are unique

@samvera/hyku-code-reviewers
