### PR TITLE
Add tenant configurable query limits

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,7 +40,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: 03ec05c112421670b9d8bfd190beab642e736e77
+  revision: 19f5ecd3a4ccb1f9e5b5df9a7da31f13280ed303
   branch: main
   specs:
     hyrax (5.2.0)

--- a/app/models/concerns/account_settings.rb
+++ b/app/models/concerns/account_settings.rb
@@ -54,6 +54,8 @@ module AccountSettings
     setting :shared_login, type: 'boolean', disabled: true
     setting :smtp_settings, type: 'hash', private: true, default: {}
     setting :solr_collection_options, type: 'hash', default: solr_collection_options
+    setting :solr_max_results, type: 'string', default: '10000'
+    setting :solr_rows_per_request, type: 'string', default: '1000'
     setting :ssl_configured, type: 'boolean', default: true, private: true
     setting :weekly_email_list, type: 'array', disabled: true
     setting :yearly_email_list, type: 'array', disabled: true
@@ -77,6 +79,9 @@ module AccountSettings
                 message: "must be numeric"
               },
               if: -> { google_analytics_property_id.present? }
+    validates :solr_rows_per_request, :solr_max_results,
+              format: { with: /\A\d+\z/, message: "must be a positive integer" },
+              allow_blank: true
 
     after_initialize :initialize_settings
   end
@@ -297,6 +302,8 @@ module AccountSettings
       config.contact_email = contact_email
       config.geonames_username = geonames_username
       config.uploader[:maxFileSize] = file_size_limit.to_i
+      config.solr_rows_per_request = solr_rows_per_request.to_i if solr_rows_per_request.present?
+      config.solr_max_results = solr_max_results.to_i if solr_max_results.present?
       # Configure Discogs API credentials for Questioning Authority
       if File.exist?(Rails.root.join('config', 'discogs-genres.yml')) &&
          File.exist?(Rails.root.join('config', 'discogs-formats.yml')) &&

--- a/app/models/concerns/account_settings.rb
+++ b/app/models/concerns/account_settings.rb
@@ -304,15 +304,17 @@ module AccountSettings
       config.uploader[:maxFileSize] = file_size_limit.to_i
       config.solr_rows_per_request = solr_rows_per_request.to_i if solr_rows_per_request.present?
       config.solr_max_results = solr_max_results.to_i if solr_max_results.present?
-      # Configure Discogs API credentials for Questioning Authority
-      if File.exist?(Rails.root.join('config', 'discogs-genres.yml')) &&
-         File.exist?(Rails.root.join('config', 'discogs-formats.yml')) &&
-         discogs_user_token.present?
-
-        Qa::Authorities::Discogs::GenericAuthority.discogs_user_token = discogs_user_token
-      end
+      configure_discogs_authority
       configure_hyrax_analytics_settings(config)
     end
+  end
+
+  def configure_discogs_authority
+    return unless discogs_user_token.present? &&
+                  File.exist?(Rails.root.join('config', 'discogs-genres.yml')) &&
+                  File.exist?(Rails.root.join('config', 'discogs-formats.yml'))
+
+    Qa::Authorities::Discogs::GenericAuthority.discogs_user_token = discogs_user_token
   end
 
   def configure_devise

--- a/config/locales/simple_form.de.yml
+++ b/config/locales/simple_form.de.yml
@@ -38,6 +38,8 @@ de:
         public_demo_tenant: Dieses Konto soll als öffentlicher Demo-Mandant für Testzwecke gekennzeichnet werden. Diese Einstellung kann nach der Erstellung nicht mehr geändert werden.
         search_only: Für reine Suchkonten muss mindestens ein vollständiges Konto für die mandantenübergreifende Suche ausgewählt werden.
         shared_login: Gemeinsamen Login aktivieren oder deaktivieren
+        solr_max_results: Maximale Anzahl von Dokumenten, die Hyrax aus paginierten Abfragen zurückgibt (z. B. im Dropdown „Zur Sammlung hinzufügen"). Ein Überschreiten dieses Werts erzeugt eine Warnmeldung und kürzt das Ergebnis. Standardwert 10000.
+        solr_rows_per_request: Seitengröße für jede Solr-Anfrage innerhalb der paginierten Abfragen von Hyrax. Standardwert 1000.
         ssl_configured: Setzen Sie es auf wahr, wenn Sie https verwenden
         weekly_email_list: Liste von E-Mail-Adressen, an die der wöchentliche Bericht gesendet wird. Lassen Sie jeweils ein Leerzeichen zwischen den E-Mails
         yearly_email_list: Liste von E-Mail-Adressen, an die der jährliche Bericht gesendet wird. Lassen Sie jeweils ein Leerzeichen zwischen den E-Mails

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -38,6 +38,8 @@ en:
         name: A single or hyphenated name used for technical aspects of the repository (e.g., "acme" or "acme-library").
         oai_admin_email: OAI endpoint contact email address
         shared_login: Enable or disable shared login
+        solr_max_results: Maximum total documents Hyrax will return from paginated fetches (e.g. the "Add to Collection" dropdown). Exceeding this logs a warning and truncates. Default 10000.
+        solr_rows_per_request: Page size for each Solr request inside Hyrax's paginated fetches. Default 1000.
         ssl_configured: Set it true if using https
         weekly_email_list: List of email addresses to email the weekly report. Leave a single space between each email
         yearly_email_list: List of email addresses to email the yearly report. Leave a single space between each email

--- a/config/locales/simple_form.es.yml
+++ b/config/locales/simple_form.es.yml
@@ -38,6 +38,8 @@ es:
         public_demo_tenant: Marque esta cuenta como inquilino de demostración público para pruebas. Esto no se puede cambiar después de crearla.
         search_only: Las cuentas de solo búsqueda requieren que se seleccione al menos una cuenta completa a continuación para la búsqueda entre inquilinos.
         shared_login: Habilitar o deshabilitar inicio de sesión compartido
+        solr_max_results: Número máximo de documentos que Hyrax devolverá en las consultas paginadas (por ejemplo, el menú desplegable «Agregar a la colección»). Superar este valor registra una advertencia y trunca los resultados. Valor predeterminado 10000.
+        solr_rows_per_request: Tamaño de página para cada solicitud de Solr dentro de las consultas paginadas de Hyrax. Valor predeterminado 1000.
         ssl_configured: Establézcalo como verdadero si está utilizando https
         weekly_email_list: Lista de direcciones de correo electrónico para enviar el informe semanal. Deje un espacio entre cada correo electrónico
         yearly_email_list: Lista de direcciones de correo electrónico para enviar el informe anual. Deje un espacio entre cada correo electrónico

--- a/config/locales/simple_form.fr.yml
+++ b/config/locales/simple_form.fr.yml
@@ -38,6 +38,8 @@ fr:
         public_demo_tenant: Marquez ce compte comme un compte de démonstration public à des fins de test. Cette option ne pourra plus être modifiée après sa création.
         search_only: Les comptes de recherche uniquement nécessitent la sélection d'au moins un compte complet ci-dessous pour la recherche inter-locataires.
         shared_login: Activer ou désactiver la connexion partagée
+        solr_max_results: Nombre maximal de documents renvoyés par les récupérations paginées de Hyrax (par exemple, le menu déroulant « Ajouter à la collection »). Dépasser cette valeur entraîne un avertissement et une troncature. Par défaut 10000.
+        solr_rows_per_request: Taille de page pour chaque requête Solr dans les récupérations paginées de Hyrax. Par défaut 1000.
         ssl_configured: Mettez-le sur vrai si vous utilisez https
         weekly_email_list: Liste des adresses e-mail pour envoyer le rapport hebdomadaire. Laissez un espace entre chaque e-mail
         yearly_email_list: Liste des adresses e-mail pour envoyer le rapport annuel. Laissez un espace entre chaque e-mail

--- a/config/locales/simple_form.it.yml
+++ b/config/locales/simple_form.it.yml
@@ -38,6 +38,8 @@ it:
         public_demo_tenant: Contrassegna questo account come tenant demo pubblico per i test. Questa impostazione non può essere modificata dopo la creazione.
         search_only: Per gli account di sola ricerca è necessario selezionare almeno un account completo qui sotto per la ricerca tra tenant.
         shared_login: Abilita o disabilita l'accesso condiviso
+        solr_max_results: Numero massimo di documenti restituiti da Hyrax nelle query paginate (ad esempio il menu a tendina «Aggiungi alla raccolta»). Il superamento di questo valore registra un avviso e tronca i risultati. Valore predefinito 10000.
+        solr_rows_per_request: Dimensione di pagina per ogni richiesta Solr all'interno delle query paginate di Hyrax. Valore predefinito 1000.
         ssl_configured: Impostalo su vero se stai utilizzando https
         weekly_email_list: Lista di indirizzi email ai quali inviare il rapporto settimanale. Lascia uno spazio tra ogni email
         yearly_email_list: Lista di indirizzi email ai quali inviare il rapporto annuale. Lascia uno spazio tra ogni email

--- a/config/locales/simple_form.pt-BR.yml
+++ b/config/locales/simple_form.pt-BR.yml
@@ -38,6 +38,8 @@ pt-BR:
         public_demo_tenant: Marque esta conta como um locatário de demonstração público para testes. Esta configuração não poderá ser alterada após a criação.
         search_only: Contas somente para pesquisa exigem que pelo menos uma conta completa seja selecionada abaixo para pesquisa entre locatários.
         shared_login: Habilitar ou desabilitar login compartilhado
+        solr_max_results: Número máximo de documentos que o Hyrax retorna em consultas paginadas (por exemplo, no menu suspenso «Adicionar à coleção»). Ultrapassar esse valor registra um aviso e trunca os resultados. Valor padrão 10000.
+        solr_rows_per_request: Tamanho da página para cada requisição Solr dentro das consultas paginadas do Hyrax. Valor padrão 1000.
         ssl_configured: Defina como verdadeiro se estiver usando https
         weekly_email_list: Lista de endereços de e-mail para enviar o relatório semanal. Deixe um espaço único entre cada e-mail
         yearly_email_list: Lista de endereços de e-mail para enviar o relatório anual. Deixe um espaço único entre cada e-mail

--- a/config/locales/simple_form.zh.yml
+++ b/config/locales/simple_form.zh.yml
@@ -38,6 +38,8 @@ zh:
         public_demo_tenant: 将此帐户标记为用于测试的公共演示租户。创建后无法更改此设置。
         search_only: 仅搜索帐户需要在下面至少选择一个完整帐户才能进行跨租户搜索。
         shared_login: 启用或禁用共享登录
+        solr_max_results: Hyrax 分页查询（例如"添加到集合"下拉菜单）返回的最大文档数。超过此值将记录警告并截断结果。默认值 10000。
+        solr_rows_per_request: Hyrax 分页查询中每个 Solr 请求的页面大小。默认值 1000。
         ssl_configured: 如果使用https，请将其设置为true
         weekly_email_list: 每周报告的电子邮件地址列表。每个电子邮件之间留一个空格
         yearly_email_list: 每年报告的电子邮件地址列表。每个电子邮件之间留一个空格

--- a/spec/models/concerns/account_settings_spec.rb
+++ b/spec/models/concerns/account_settings_spec.rb
@@ -48,6 +48,8 @@ RSpec.describe AccountSettings do
                                                                                 s3_bucket
                                                                                 smtp_settings
                                                                                 solr_collection_options
+                                                                                solr_max_results
+                                                                                solr_rows_per_request
                                                                                 ssl_configured]
       end
       # rubocop:enable RSpec/ExampleLength


### PR DESCRIPTION
# Summary

Fixes an issue where the various collection dropdowns for creating relationships were capped at 100 collections.

- Updates Hyrax to bring in fix https://github.com/samvera/hyrax/pull/7416
- adds tenant options to customize the new config variables to ensure that all collections are included

# Screenshots

### Settings options

<img width="1261" height="238" alt="Screenshot 2026-04-17 at 6 45 28 PM" src="https://github.com/user-attachments/assets/bdb02b06-d5f1-4cc5-80ed-0f5e16c3affd" />

### Limits number of collections available to select 

I set the values intentionally low here to demonstrate how the settings work. In use, an admin would be able to adjust the number loaded per page and the total number loaded to ensure that all collections are loaded. 

<img width="588" height="416" alt="Screenshot 2026-04-17 at 6 46 17 PM" src="https://github.com/user-attachments/assets/c37864e2-b0ea-4b65-8973-6b6b86688ff7" />

<img width="349" height="238" alt="Screenshot 2026-04-17 at 6 46 29 PM" src="https://github.com/user-attachments/assets/b4146b93-4bb8-4237-aede-9b96b8c03381" />
