### PR TITLE
Merge duplicate Flipflop groups by name in features UI.

### DIFF
--- a/app/views/hyrax/admin/features/index.html.erb
+++ b/app/views/hyrax/admin/features/index.html.erb
@@ -1,6 +1,13 @@
 <%
   # OVERRIDE Hyrax 5.2.0 to make the default PDF viewer switch more intuitive and some styling changes.
   # Instead of saying on/off it says PDF.js/IIIF Print.
+  #
+  # OVERRIDE: Flipflop builds @feature_set.grouped_features from each `group :name` block in config.
+  # Hyrax and Hyku can each register `group :experimental_features` in separate config files, which
+  # creates two distinct group objects with the same name. The stock template iterates by group
+  # identity, so the admin UI showed duplicate "Experimental features" sections. We merge rows by
+  # group name before rendering so same-named groups appear once.
+
 %>
 
 <% provide :page_header do %>
@@ -21,7 +28,19 @@
               </tr>
             </thead>
             <tbody>
-            <% @feature_set.grouped_features.each do |group, features| -%>
+            <%# BEGIN OVERRIDE: merge Flipflop groups that share the same group name %>
+            <% grouped_features = @feature_set.grouped_features.each_with_object([]) do |(group, features), acc| %>
+              <% group_key = group&.name || :default %>
+              <% existing_group = acc.find { |entry| entry[:key] == group_key } %>
+              <% if existing_group %>
+                <% existing_group[:features].concat(features) %>
+              <% else %>
+                <% acc << { key: group_key, group: group, features: features.to_a } %>
+              <% end %>
+            <% end %>
+            <% grouped_features.each do |entry| -%>
+              <% group = entry[:group] %>
+              <% features = entry[:features] %>
               <% if @feature_set.grouped? -%>
                 <tr class="group">
                   <td></td>
@@ -67,6 +86,7 @@
               </tr>
               <% end -%>
             <% end -%>
+            <%# END OVERRIDE: merge Flipflop groups that share the same group name %>
             </tbody>
           </table>
         </div>


### PR DESCRIPTION
# Summary

This PR updates the Hyku override for the Hyrax admin Features page so feature groups are merged by group name before rendering.  
It fixes the duplicate "Experimental features" sections that appear when both Hyrax and Hyku define `group :experimental_features` in separate `config/features.rb` files.

It also adds explicit override documentation in the partial, including:
- a top-level explanation of why the merge is needed
- `BEGIN OVERRIDE` and `END OVERRIDE` comments around the merge logic block

## Ticket Number

`i620`  
Related upstream context: [Hyrax PR #7420](https://github.com/samvera/hyrax/pull/7420)

# Screenshots / Video

- Before: two separate "Experimental features" sections in Admin > Features

<details> 

<img width="2704" height="2998" alt="image" src="https://github.com/user-attachments/assets/bb41856e-653d-41e2-9b9c-8653613bfcb5" />

</details>

- After: one combined "Experimental features" section containing both Hyrax and Hyku experimental flags

<details>

<img width="2704" height="1454" alt="simplesnap-4-28-2026_at_13-17-04" src="https://github.com/user-attachments/assets/c0416ff5-121a-41ed-8db0-d3dcbdba5c69" />

</details>

# Expected Behavior 

In Admin > Features, flags from same-named Flipflop groups should render in a single section, even if they were defined in different files or engines.

# Sample Files

- `app/views/hyrax/admin/features/index.html.erb`

# Notes

- This is a UI-level fix in the Hyku override template.
- It does not change Flipflop internals or feature registration behavior.
- Existing unrelated local changes in `Gemfile` and `Gemfile.lock` are not part of this PR.
**- This will not take effect until hyrax is updated and shares the same group name as other features**