### PR TITLE
Updates bulkrax to 9.4.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -379,7 +379,7 @@ GEM
       signet (~> 0.8)
       typhoeus
     builder (3.3.0)
-    bulkrax (9.4.2)
+    bulkrax (9.4.3)
       bagit (~> 0.6.0)
       coderay
       denormalize_fields


### PR DESCRIPTION
Update bulkrax version to 9.4.3

bugfix to:
- remove stray migration issue
- capture errors in an importer status when import job fails to prevent hanging pending import status for unknown reasons