### PR TITLE
Improve search results performance - reduce N+1 queries on search results page

### DIFF
--- a/app/services/group_aware_role_checker.rb
+++ b/app/services/group_aware_role_checker.rb
@@ -12,16 +12,25 @@ module GroupAwareRoleChecker
 
   private
 
+  def current_user_hyrax_groups(site_instance)
+    @current_user_hyrax_groups ||= {}
+    @current_user_hyrax_groups[site_instance.id] ||= current_user.hyrax_groups
+  end
+
   # Check for the presence of the passed role_name in the User's Roles and
   # the User's Hyrax::Group's Roles.
   def group_aware_role?(role_name)
     return false if current_user.new_record?
-    return true if current_user.has_role?(role_name, Site.instance)
 
-    current_user.hyrax_groups.each do |group|
-      return true if group.site_role?(role_name)
-    end
+    @group_aware_role_cache ||= {}
 
-    false
+    site_instance = Site.instance
+
+    cache_key = [role_name, site_instance.id]
+    return @group_aware_role_cache[cache_key] if @group_aware_role_cache.key?(cache_key)
+
+    @group_aware_role_cache[cache_key] =
+      current_user.has_role?(role_name, site_instance) ||
+      current_user_hyrax_groups(site_instance).any? { |group| group.site_role?(role_name) }
   end
 end

--- a/app/services/group_aware_role_checker.rb
+++ b/app/services/group_aware_role_checker.rb
@@ -27,7 +27,7 @@ module GroupAwareRoleChecker
 
     site_instance = Site.instance
 
-    memo_key = [role_name, site_instance.id]
+    memo_key = [role_name, site_instance.id, current_user.id || current_user.object_id]
     return @group_role_memo[memo_key] if @group_role_memo.key?(memo_key)
 
     @group_role_memo[memo_key] =

--- a/app/services/group_aware_role_checker.rb
+++ b/app/services/group_aware_role_checker.rb
@@ -13,8 +13,8 @@ module GroupAwareRoleChecker
   private
 
   def current_user_hyrax_groups(site_instance)
-    @current_user_hyrax_groups ||= {}
-    @current_user_hyrax_groups[site_instance.id] ||= current_user.hyrax_groups
+    @current_user_hyrax_groups_memo ||= {}
+    @current_user_hyrax_groups_memo[site_instance.id] ||= current_user.hyrax_groups
   end
 
   # Check for the presence of the passed role_name in the User's Roles and
@@ -22,14 +22,14 @@ module GroupAwareRoleChecker
   def group_aware_role?(role_name)
     return false if current_user.new_record?
 
-    @group_aware_role_cache ||= {}
+    @group_role_memo ||= {}
 
     site_instance = Site.instance
 
-    cache_key = [role_name, site_instance.id]
-    return @group_aware_role_cache[cache_key] if @group_aware_role_cache.key?(cache_key)
+    memo_key = [role_name, site_instance.id]
+    return @group_role_memo[memo_key] if @group_role_memo.key?(memo_key)
 
-    @group_aware_role_cache[cache_key] =
+    @group_role_memo[memo_key] =
       current_user.has_role?(role_name, site_instance) ||
       current_user_hyrax_groups(site_instance).any? { |group| group.site_role?(role_name) }
   end

--- a/app/services/group_aware_role_checker.rb
+++ b/app/services/group_aware_role_checker.rb
@@ -14,7 +14,8 @@ module GroupAwareRoleChecker
 
   def current_user_hyrax_groups(site_instance)
     @current_user_hyrax_groups_memo ||= {}
-    @current_user_hyrax_groups_memo[site_instance.id] ||= current_user.hyrax_groups
+    cache_key = [site_instance.id, current_user.id || current_user.object_id]
+    @current_user_hyrax_groups_memo[cache_key] ||= current_user.hyrax_groups
   end
 
   # Check for the presence of the passed role_name in the User's Roles and

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -52,6 +52,10 @@ RSpec.describe CatalogController do
     end
   end
   describe 'memoization isolation' do
+    after do
+      allow(Site).to receive(:instance).and_call_original
+    end
+
     let(:role_name) { RolesService::DEFAULT_ROLES.first } # "admin"
     let(:site_one) { FactoryBot.create(:site, application_name: "Site One") }
     let(:site_two) { FactoryBot.create(:site, application_name: "Site Two") }
@@ -97,8 +101,9 @@ RSpec.describe CatalogController do
       expect(third_ability.admin?).to be false # populate the memoization on the new instance
       third_cache = third_ability.instance_variable_get(:@group_role_memo)
       site_id = Site.instance.id
-      expect(second_cache[["admin", site_id]]).to be true
-      expect(third_cache[["admin", site_id]]).to be false
+      admin_role = RolesService::ADMIN_ROLE
+      expect(second_cache[[admin_role, site_id, second_ability.current_user.id]]).to be true
+      expect(third_cache[[admin_role, site_id, third_ability.current_user.id]]).to be false
       expect(second_cache).not_to eq(third_cache)
     end
   end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -51,4 +51,55 @@ RSpec.describe CatalogController do
       end
     end
   end
+  describe 'memoization isolation' do
+    let(:role_name) { RolesService::DEFAULT_ROLES.first } # "admin"
+    let(:site_one) { FactoryBot.create(:site, application_name: "Site One") }
+    let(:site_two) { FactoryBot.create(:site, application_name: "Site Two") }
+    let(:user) { FactoryBot.create(:user) }
+
+    describe 'multi-tenancy: memo does not bleed across site switches' do
+      it 're-evaluates the role check after Site.instance changes within the same Ability instance' do
+        user.add_role(role_name, site_one)
+        ability = Ability.new(user)
+
+        allow(Site).to receive(:instance).and_return(site_one)
+        # Warm the cache under site_one — user has the role here
+        expect(ability.public_send("#{role_name}?")).to be true
+
+        # Simulate a tenant switch on the same Ability instance
+        allow(Site).to receive(:instance).and_return(site_two)
+        # The cache key includes site_instance.id, so this must re-evaluate.
+        expect(ability.public_send("#{role_name}?")).to be false
+      end
+    end
+    it 'scopes memoization for group_role_memo to the Ability instance lifetime' do
+      sign_in create(:admin)
+
+      get :index
+      first_ability = controller.current_ability
+      first_ability.admin? # populate the memoization
+      first_cache = first_ability.instance_variable_get(:@group_role_memo)
+      expect(first_cache).not_to be_empty
+
+      get :index
+      second_ability = controller.current_ability
+      second_ability.admin? # populate the memoization on the new instance
+      second_cache = second_ability.instance_variable_get(:@group_role_memo)
+      expect(second_cache).not_to be_empty
+
+      expect(first_ability.object_id).not_to eq(second_ability.object_id)
+
+      # Become a regular user - session should not persist
+      sign_in create(:user, display_name: "Regular user")
+
+      get :index
+      third_ability = controller.current_ability
+      expect(third_ability.admin?).to be false # populate the memoization on the new instance
+      third_cache = third_ability.instance_variable_get(:@group_role_memo)
+      site_id = Site.instance.id
+      expect(second_cache[["admin", site_id]]).to be true
+      expect(third_cache[["admin", site_id]]).to be false
+      expect(second_cache).not_to eq(third_cache)
+    end
+  end
 end

--- a/spec/features/catalog_query_count_spec.rb
+++ b/spec/features/catalog_query_count_spec.rb
@@ -35,36 +35,70 @@ RSpec.describe 'Catalog query performance', type: :feature, clean: true, js: fal
     count
   end
 
-  let(:solr) { Blacklight.default_index.connection }
-  let(:admin) { create(:admin) }
-  let(:works_5) { 5.times.map { |i| make_work("Memoization Test Work #{i}") } }
-  let(:collections_3) { 3.times.map { |i| make_collection("Memoization Test Collection #{i}") } }
+  def count_uncached_queries(&block)
+    queries = []
+    counter = ->(*args) { queries << args[4] }
+    ActiveSupport::Notifications.subscribed(counter, "sql.active_record", &block)
+    queries.count { |payload| !(payload[:cached]) }
+  end
 
-  before { login_as admin }
+  let(:solr) { Blacklight.default_index.connection }
+  let(:works_5) { Array.new(5) { |i| make_work("Memoization Test Work #{i}") } }
+  let(:collections_3) { Array.new(3) { |i| make_collection("Memoization Test Collection #{i}") } }
 
   after do
     solr.delete_by_query('title_tesim:Memoization*')
     solr.commit
   end
 
-  it 'does not issue proportionally more queries for more results' do
-    # baseline: 1 work
-    solr.add([works_5.first])
-    solr.commit
-    queries_for_1 = count_queries { visit '/catalog?q=Memoization+Test' }
-    expect(page).to have_content('Memoization Test Work 0')
+  context "as an admin user" do
+    let(:admin) { create(:admin) }
 
-    # realistic: 5 works + 3 collections (mixed result page, admin user)
-    solr.add(works_5 + collections_3)
-    solr.commit
-    queries_for_mixed = count_queries { visit '/catalog?q=Memoization+Test' }
-    expect(page).to have_content('Memoization Test Work 0')
-    expect(page).to have_content('Memoization Test Collection 0')
+    before { login_as admin }
+    it 'does not issue proportionally more queries for more results' do
+      # baseline: 1 work
+      solr.add([works_5.first])
+      solr.commit
+      queries_for_one = count_queries { visit '/catalog?q=Memoization+Test' }
+      uncached_for_one = count_uncached_queries { visit '/catalog?q=Memoization+Test' }
 
-    puts "Queries for 1 work (admin): #{queries_for_1}"
-    puts "Queries for 5 works + 3 collections (admin): #{queries_for_mixed}"
-    puts "Delta: #{queries_for_mixed - queries_for_1}"
+      expect(page).to have_content('Memoization Test Work 0')
 
-    expect(queries_for_mixed).to be < 400
+      # realistic: 5 works + 3 collections (mixed result page, admin user)
+      solr.add(works_5 + collections_3)
+      solr.commit
+      queries_for_mixed = count_queries { visit '/catalog?q=Memoization+Test' }
+      uncached_for_mixed = count_uncached_queries { visit '/catalog?q=Memoization+Test' }
+      expect(page).to have_content('Memoization Test Work 0')
+      expect(page).to have_content('Memoization Test Collection 0')
+
+      puts "Queries for 1 work (admin): #{queries_for_one} (#{uncached_for_one} uncached)"
+      puts "Queries for 5 works + 3 collections (admin): #{queries_for_mixed} (#{uncached_for_mixed} uncached)"
+      puts "Total delta: #{queries_for_mixed - queries_for_one}, Uncached delta: #{uncached_for_mixed - uncached_for_one}"
+
+      expect(queries_for_mixed).to be < 400
+    end
+  end
+  context 'unauthenticated user' do
+    it 'does not issue proportionally more queries for more results' do
+      solr.add([works_5.first])
+      solr.commit
+      queries_for_one = count_queries { visit '/catalog?q=Memoization+Test' }
+      uncached_for_one = count_uncached_queries { visit '/catalog?q=Memoization+Test' }
+      expect(page).to have_content('Memoization Test Work 0')
+
+      solr.add(works_5 + collections_3)
+      solr.commit
+      queries_for_mixed = count_queries { visit '/catalog?q=Memoization+Test' }
+      uncached_for_mixed = count_uncached_queries { visit '/catalog?q=Memoization+Test' }
+      expect(page).to have_content('Memoization Test Work 0')
+      expect(page).to have_content('Memoization Test Collection 0')
+
+      puts "Queries for 1 work (anon): #{queries_for_one} (#{uncached_for_one} uncached)"
+      puts "Queries for 5 works + 3 collections (anon): #{queries_for_mixed} (#{uncached_for_mixed} uncached)"
+      puts "Total delta: #{queries_for_mixed - queries_for_one}, Uncached delta: #{uncached_for_mixed - uncached_for_one}"
+
+      expect(queries_for_mixed).to be < 350
+    end
   end
 end

--- a/spec/features/catalog_query_count_spec.rb
+++ b/spec/features/catalog_query_count_spec.rb
@@ -65,8 +65,6 @@ RSpec.describe 'Catalog query performance', type: :feature, clean: true, js: fal
     puts "Queries for 5 works + 3 collections (admin): #{queries_for_mixed}"
     puts "Delta: #{queries_for_mixed - queries_for_1}"
 
-    # With memoization, ability checks should not scale linearly with result count.
-    # Without the fix this was ~440+ queries for 5 results.
     expect(queries_for_mixed).to be < 400
   end
 end

--- a/spec/features/catalog_query_count_spec.rb
+++ b/spec/features/catalog_query_count_spec.rb
@@ -15,6 +15,19 @@ RSpec.describe 'Catalog query performance', type: :feature, clean: true, js: fal
     }
   end
 
+  def make_collection(title)
+    {
+      'has_model_ssim' => 'Collection',
+      id: SecureRandom.uuid,
+      'title_tesim' => [title],
+      'suppressed_bsi' => false,
+      'read_access_group_ssim' => ['public'],
+      'edit_access_group_ssim' => ['admin'],
+      'visibility_ssi' => 'open',
+      'collection_type_gid_ssim' => ['gid://hyku/Hyrax::CollectionType/1']
+    }
+  end
+
   def count_queries(&block)
     count = 0
     counter = ->(*, **) { count += 1 }
@@ -23,23 +36,37 @@ RSpec.describe 'Catalog query performance', type: :feature, clean: true, js: fal
   end
 
   let(:solr) { Blacklight.default_index.connection }
-  let(:user) { create(:user) }
-  let(:works_5) { 5.times.map { |i| make_work("Memoization Test #{i}") } }
+  let(:admin) { create(:admin) }
+  let(:works_5) { 5.times.map { |i| make_work("Memoization Test Work #{i}") } }
+  let(:collections_3) { 3.times.map { |i| make_collection("Memoization Test Collection #{i}") } }
 
-  before { login_as user }
+  before { login_as admin }
 
-  it 'keeps total query count for a page of results under a reasonable threshold' do
-    solr.add(works_5)
+  after do
+    solr.delete_by_query('title_tesim:Memoization*')
     solr.commit
+  end
 
-    queries = count_queries { visit '/catalog?q=Memoization+Test' }
-    expect(page).to have_content('Memoization Test 0')
-
-    solr.delete_by_id(works_5.map { |w| w[:id] })
+  it 'does not issue proportionally more queries for more results' do
+    # baseline: 1 work
+    solr.add([works_5.first])
     solr.commit
+    queries_for_1 = count_queries { visit '/catalog?q=Memoization+Test' }
+    expect(page).to have_content('Memoization Test Work 0')
 
-    # On main without memoization this was ~440 queries for 5 results.
-    # With GroupAwareRoleChecker memoization this should be well under 350.
-    expect(queries).to be < 350
+    # realistic: 5 works + 3 collections (mixed result page, admin user)
+    solr.add(works_5 + collections_3)
+    solr.commit
+    queries_for_mixed = count_queries { visit '/catalog?q=Memoization+Test' }
+    expect(page).to have_content('Memoization Test Work 0')
+    expect(page).to have_content('Memoization Test Collection 0')
+
+    puts "Queries for 1 work (admin): #{queries_for_1}"
+    puts "Queries for 5 works + 3 collections (admin): #{queries_for_mixed}"
+    puts "Delta: #{queries_for_mixed - queries_for_1}"
+
+    # With memoization, ability checks should not scale linearly with result count.
+    # Without the fix this was ~440+ queries for 5 results.
+    expect(queries_for_mixed).to be < 400
   end
 end

--- a/spec/features/catalog_query_count_spec.rb
+++ b/spec/features/catalog_query_count_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Catalog query performance', type: :feature, clean: true, js: false do
+  def make_work(title)
+    {
+      'has_model_ssim' => 'GenericWork',
+      id: SecureRandom.uuid,
+      'title_tesim' => [title],
+      'admin_set_tesim' => ['Default Admin Set'],
+      'suppressed_bsi' => false,
+      'read_access_group_ssim' => ['public'],
+      'edit_access_group_ssim' => ['admin'],
+      'edit_access_person_ssim' => ['fake@example.com'],
+      'visibility_ssi' => 'open'
+    }
+  end
+
+  def count_queries(&block)
+    count = 0
+    counter = ->(*, **) { count += 1 }
+    ActiveSupport::Notifications.subscribed(counter, "sql.active_record", &block)
+    count
+  end
+
+  let(:solr) { Blacklight.default_index.connection }
+  let(:user) { create(:user) }
+  let(:works_5) { 5.times.map { |i| make_work("Memoization Test #{i}") } }
+
+  before { login_as user }
+
+  it 'keeps total query count for a page of results under a reasonable threshold' do
+    solr.add(works_5)
+    solr.commit
+
+    queries = count_queries { visit '/catalog?q=Memoization+Test' }
+    expect(page).to have_content('Memoization Test 0')
+
+    solr.delete_by_id(works_5.map { |w| w[:id] })
+    solr.commit
+
+    # On main without memoization this was ~440 queries for 5 results.
+    # With GroupAwareRoleChecker memoization this should be well under 350.
+    expect(queries).to be < 350
+  end
+end

--- a/spec/services/group_aware_role_checker_spec.rb
+++ b/spec/services/group_aware_role_checker_spec.rb
@@ -78,5 +78,38 @@ RSpec.describe GroupAwareRoleChecker, clean: true do
       expect(queries_second_role).to be < abilities_warmup_count
       expect(queries_second_role).to be <= queries_first_role
     end
+
+    # Regression for reviewer scenario: memo keyed only by site id would leak user A's
+    # hyrax_groups to user B when the same checker object is reused with a different current_user.
+    describe 'test_n_plus_one_exploration: hyrax_groups cache must not cross users on the same site' do
+      subject(:checker) do
+        Class.new do
+          include GroupAwareRoleChecker
+          attr_accessor :current_user
+        end.new
+      end
+
+      let(:site_instance_one) { FactoryBot.create(:site, application_name: 'Shared site for memo test') }
+      let(:user_one) { FactoryBot.create(:user) }
+      let(:user_two) { FactoryBot.create(:user) }
+
+      before do
+        allow(Site).to receive(:instance).and_return(site_instance_one)
+        FactoryBot.create(:group, name: 'memo-test-group-one', member_users: [user_one])
+        FactoryBot.create(:group, name: 'memo-test-group-two', member_users: [user_two])
+      end
+
+      it 'returns the second user\'s groups after current_user changes (same site, same checker)' do
+        checker.current_user = user_one
+        groups_for_user_one = checker.send(:current_user_hyrax_groups, site_instance_one)
+
+        checker.current_user = user_two
+        groups_for_user_two = checker.send(:current_user_hyrax_groups, site_instance_one)
+
+        expect(groups_for_user_one.map(&:id)).to match_array(user_one.reload.hyrax_groups.map(&:id))
+        expect(groups_for_user_two.map(&:id)).to match_array(user_two.reload.hyrax_groups.map(&:id))
+        expect(groups_for_user_two.map(&:id)).not_to match_array(groups_for_user_one.map(&:id))
+      end
+    end
   end
 end

--- a/spec/services/group_aware_role_checker_spec.rb
+++ b/spec/services/group_aware_role_checker_spec.rb
@@ -42,4 +42,41 @@ RSpec.describe GroupAwareRoleChecker, clean: true do
       end
     end
   end
+
+  describe 'query memoization' do
+    let(:role_name) { RolesService::DEFAULT_ROLES.first }
+    let(:site_instance_one) { FactoryBot.create(:site, application_name: "First site instance") }
+
+    before do
+      allow(Site).to receive(:instance).and_return(site_instance_one)
+    end
+
+    def count_queries(&block)
+      count = 0
+      counter = ->(*, **) { count += 1 }
+      ActiveSupport::Notifications.subscribed(counter, "sql.active_record", &block)
+      count
+    end
+
+    it 'does not issue additional queries on repeated calls to the same role check' do
+      # warm up any lazy-loaded associations
+      user.ability
+      count_queries { user.ability.public_send("#{role_name}?") }
+      queries_for_second_call = count_queries { user.ability.public_send("#{role_name}?") }
+      expect(queries_for_second_call).to eq(0)
+    end
+
+    it 'does not issue additional queries when checking multiple roles' do
+      abilities_warmup_count = count_queries { user.ability }
+
+      queries_first_role = count_queries { user.ability.public_send("#{RolesService::DEFAULT_ROLES.first}?") }
+
+      queries_second_role = count_queries { user.ability.public_send("#{RolesService::DEFAULT_ROLES.second}?") }
+
+      # Second role check may query once to check that specific role,
+      # but should not re-query hyrax_groups
+      expect(queries_second_role).to be < abilities_warmup_count
+      expect(queries_second_role).to be <= queries_first_role
+    end
+  end
 end

--- a/spec/services/group_aware_role_checker_spec.rb
+++ b/spec/services/group_aware_role_checker_spec.rb
@@ -44,6 +44,10 @@ RSpec.describe GroupAwareRoleChecker, clean: true do
   end
 
   describe 'query memoization' do
+    after do
+      allow(Site).to receive(:instance).and_call_original
+    end
+
     let(:role_name) { RolesService::DEFAULT_ROLES.first }
     let(:site_instance_one) { FactoryBot.create(:site, application_name: "First site instance") }
 
@@ -109,6 +113,31 @@ RSpec.describe GroupAwareRoleChecker, clean: true do
         expect(groups_for_user_one.map(&:id)).to match_array(user_one.reload.hyrax_groups.map(&:id))
         expect(groups_for_user_two.map(&:id)).to match_array(user_two.reload.hyrax_groups.map(&:id))
         expect(groups_for_user_two.map(&:id)).not_to match_array(groups_for_user_one.map(&:id))
+      end
+    end
+
+    describe 'test_n_plus_one_exploration: group_role memo must not cross users on the same site' do
+      subject(:checker) do
+        Class.new do
+          include GroupAwareRoleChecker
+          attr_accessor :current_user
+        end.new
+      end
+
+      let(:site_instance_one) { FactoryBot.create(:site, application_name: 'Shared site for group_role memo') }
+      let(:user_without_admin) { FactoryBot.create(:user) }
+      let(:user_with_admin) { FactoryBot.create(:admin) }
+
+      before do
+        allow(Site).to receive(:instance).and_return(site_instance_one)
+      end
+
+      it 'recomputes the role after current_user changes (same site, same checker)' do
+        checker.current_user = user_without_admin
+        expect(checker.public_send("#{RolesService::ADMIN_ROLE}?")).to be false
+
+        checker.current_user = user_with_admin.reload
+        expect(checker.public_send("#{RolesService::ADMIN_ROLE}?")).to be true
       end
     end
   end


### PR DESCRIPTION
In investigating performance issues with a local application, we found some queries that were increasing the number of calls to the database significantly for each additional search result.

This fixes one of those places, the GroupAwareRoleChecker. It memoizes:
- The current user's Hyrax groups, based on the site instance as a memo key
- An overall role memo, using the combination of the role name and the site instance ID as a memo key, to ensure we are not over-memo-izing.

- With memoization, ability checks should not scale linearly with result count.
- Without GroupAwareRoleChecker memoization (main): 462 queries for 5 works + 3 collections (admin user)
- With memoization (this branch): ~390 queries for the same set

@samvera/hyku-code-reviewers

## Query count benchmarks (total / uncached)
From the test - spec/features/catalog_query_count_spec.rb
| Branch                  | User  | 1 result        | 8 results       | Total delta | Uncached delta | 1 result delta from main | 8 results delta from main |
|-------------------------|-------|-----------------|-----------------|-------------|----------------|--------------------------|---------------------------|
| main                    | admin | 263 (53 unc)    | 462 (54 unc)    | 199         | 1              | n/a                      | n/a                       |
| n_plus_one_exploration  | admin | 197 (53 unc)    | 390 (54 unc)    | 193         | 1              | 66                       | 72                        |
| n_plus_two              | admin | 223 (29 unc)    | 406 (30 unc)    | 183         | 1              | 40                       | 56                        |
| combined_branch         | admin | 157 (29 unc)    | 334 (30 unc)    | 177         | 1              | 106                      | 128                       |
|                         |       |                 |                 |             |                |                          |                           |
| main                    | anon  | 170 (46 unc)    | 339 (47 unc)    | 169         | 1              | n/a                      | n/a                       |
| n_plus_one_exploration  | anon  | 170 (46 unc)    | 339 (47 unc)    | 169         | 1              | 0                        | 0                         |
| n_plus_two              | anon  | 92  (22 unc)    | 283 (23 unc)    | 191         | 1              | 78                       | 56                        |
| combined_branch         | anon  | 92  (22 unc)    | 283 (23 unc)    | 191         | 1              | 78                       | 56                        |
