### PR TITLE
Scope GroupAwareRoleChecker memo by user and site

### DIFF
--- a/app/services/group_aware_role_checker.rb
+++ b/app/services/group_aware_role_checker.rb
@@ -27,7 +27,7 @@ module GroupAwareRoleChecker
 
     site_instance = Site.instance
 
-    memo_key = [role_name, site_instance.id]
+    memo_key = [role_name, site_instance.id, current_user.id || current_user.object_id]
     return @group_role_memo[memo_key] if @group_role_memo.key?(memo_key)
 
     @group_role_memo[memo_key] =

--- a/app/services/group_aware_role_checker.rb
+++ b/app/services/group_aware_role_checker.rb
@@ -14,7 +14,8 @@ module GroupAwareRoleChecker
 
   def current_user_hyrax_groups(site_instance)
     @current_user_hyrax_groups_memo ||= {}
-    @current_user_hyrax_groups_memo[site_instance.id] ||= current_user.hyrax_groups
+    cache_key = [site_instance.id, current_user.id || current_user.object_id]
+    @current_user_hyrax_groups_memo[cache_key] ||= current_user.hyrax_groups
   end
 
   # Check for the presence of the passed role_name in the User's Roles and

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -52,6 +52,10 @@ RSpec.describe CatalogController do
     end
   end
   describe 'memoization isolation' do
+    after do
+      allow(Site).to receive(:instance).and_call_original
+    end
+
     let(:role_name) { RolesService::DEFAULT_ROLES.first } # "admin"
     let(:site_one) { FactoryBot.create(:site, application_name: "Site One") }
     let(:site_two) { FactoryBot.create(:site, application_name: "Site Two") }
@@ -97,8 +101,9 @@ RSpec.describe CatalogController do
       expect(third_ability.admin?).to be false # populate the memoization on the new instance
       third_cache = third_ability.instance_variable_get(:@group_role_memo)
       site_id = Site.instance.id
-      expect(second_cache[["admin", site_id]]).to be true
-      expect(third_cache[["admin", site_id]]).to be false
+      admin_role = RolesService::ADMIN_ROLE
+      expect(second_cache[[admin_role, site_id, second_ability.current_user.id]]).to be true
+      expect(third_cache[[admin_role, site_id, third_ability.current_user.id]]).to be false
       expect(second_cache).not_to eq(third_cache)
     end
   end

--- a/spec/services/group_aware_role_checker_spec.rb
+++ b/spec/services/group_aware_role_checker_spec.rb
@@ -78,5 +78,38 @@ RSpec.describe GroupAwareRoleChecker, clean: true do
       expect(queries_second_role).to be < abilities_warmup_count
       expect(queries_second_role).to be <= queries_first_role
     end
+
+    # Regression for reviewer scenario: memo keyed only by site id would leak user A's
+    # hyrax_groups to user B when the same checker object is reused with a different current_user.
+    describe 'test_n_plus_one_exploration: hyrax_groups cache must not cross users on the same site' do
+      subject(:checker) do
+        Class.new do
+          include GroupAwareRoleChecker
+          attr_accessor :current_user
+        end.new
+      end
+
+      let(:site_instance_one) { FactoryBot.create(:site, application_name: 'Shared site for memo test') }
+      let(:user_one) { FactoryBot.create(:user) }
+      let(:user_two) { FactoryBot.create(:user) }
+
+      before do
+        allow(Site).to receive(:instance).and_return(site_instance_one)
+        FactoryBot.create(:group, name: 'memo-test-group-one', member_users: [user_one])
+        FactoryBot.create(:group, name: 'memo-test-group-two', member_users: [user_two])
+      end
+
+      it 'returns the second user\'s groups after current_user changes (same site, same checker)' do
+        checker.current_user = user_one
+        groups_for_user_one = checker.send(:current_user_hyrax_groups, site_instance_one)
+
+        checker.current_user = user_two
+        groups_for_user_two = checker.send(:current_user_hyrax_groups, site_instance_one)
+
+        expect(groups_for_user_one.map(&:id)).to match_array(user_one.reload.hyrax_groups.map(&:id))
+        expect(groups_for_user_two.map(&:id)).to match_array(user_two.reload.hyrax_groups.map(&:id))
+        expect(groups_for_user_two.map(&:id)).not_to match_array(groups_for_user_one.map(&:id))
+      end
+    end
   end
 end

--- a/spec/services/group_aware_role_checker_spec.rb
+++ b/spec/services/group_aware_role_checker_spec.rb
@@ -44,6 +44,10 @@ RSpec.describe GroupAwareRoleChecker, clean: true do
   end
 
   describe 'query memoization' do
+    after do
+      allow(Site).to receive(:instance).and_call_original
+    end
+
     let(:role_name) { RolesService::DEFAULT_ROLES.first }
     let(:site_instance_one) { FactoryBot.create(:site, application_name: "First site instance") }
 
@@ -109,6 +113,31 @@ RSpec.describe GroupAwareRoleChecker, clean: true do
         expect(groups_for_user_one.map(&:id)).to match_array(user_one.reload.hyrax_groups.map(&:id))
         expect(groups_for_user_two.map(&:id)).to match_array(user_two.reload.hyrax_groups.map(&:id))
         expect(groups_for_user_two.map(&:id)).not_to match_array(groups_for_user_one.map(&:id))
+      end
+    end
+
+    describe 'test_n_plus_one_exploration: group_role memo must not cross users on the same site' do
+      subject(:checker) do
+        Class.new do
+          include GroupAwareRoleChecker
+          attr_accessor :current_user
+        end.new
+      end
+
+      let(:site_instance_one) { FactoryBot.create(:site, application_name: 'Shared site for group_role memo') }
+      let(:user_without_admin) { FactoryBot.create(:user) }
+      let(:user_with_admin) { FactoryBot.create(:admin) }
+
+      before do
+        allow(Site).to receive(:instance).and_return(site_instance_one)
+      end
+
+      it 'recomputes the role after current_user changes (same site, same checker)' do
+        checker.current_user = user_without_admin
+        expect(checker.public_send("#{RolesService::ADMIN_ROLE}?")).to be false
+
+        checker.current_user = user_with_admin.reload
+        expect(checker.public_send("#{RolesService::ADMIN_ROLE}?")).to be true
       end
     end
   end


### PR DESCRIPTION
Stacked on #3034: narrows memo keys so hyrax groups (and optionally role memo) cannot mix users on the same site if one checker instance is reused, matching @orangewolf’s review.