### PR TITLE
Add Hyku-specific redirects feature specs

### DIFF
--- a/spec/forms/redirects_form_property_spec.rb
+++ b/spec/forms/redirects_form_property_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# This spec verifies that the ResourceForm exposes a `redirects` property
+# when the redirects feature is enabled. The form partial
+# `_form_redirects.html.erb` calls `f.object.redirects` (line 21), so
+# the form MUST have this property — not just `redirects_attributes`.
+#
+# Context: In HYRAX_FLEXIBLE=false mode (the default in this test suite),
+# Hyrax::Schema(:redirects) adds the attribute to the model but
+# RedirectsFieldBehavior only adds `redirects_attributes` (virtual) to
+# the form. The form crashes with NoMethodError when the Aliases tab
+# tries to render.
+#
+# Upstream bug: RedirectsFieldBehavior.included needs to also define
+# `property :redirects` on the form when redirects_enabled? is true.
+#
+# See: spec/redirects_testing/TEST_RESULTS_PASS1.md for the full bug report.
+RSpec.describe 'Redirects form property', type: :model do
+  before do
+    allow(Hyrax.config).to receive(:redirects_enabled?).and_return(true)
+  end
+
+  describe 'GenericWorkResource model' do
+    it 'has the redirects attribute' do
+      expect(GenericWorkResource.new).to respond_to(:redirects)
+    end
+  end
+
+  describe 'ResourceForm for GenericWorkResource' do
+    let(:resource) { GenericWorkResource.new }
+    let(:form) { Hyrax::Forms::ResourceForm.for(resource) }
+
+    it 'has the redirects_attributes virtual property from RedirectsFieldBehavior' do
+      expect(form).to respond_to(:redirects_attributes)
+    end
+
+    it 'has the redirects property so _form_redirects.html.erb can render' do
+      expect(form).to respond_to(:redirects),
+        "Expected #{form.class} to respond to :redirects, but it doesn't. " \
+        "The model (#{resource.class}) does respond to :redirects. " \
+        "RedirectsFieldBehavior needs to add `property :redirects` to the form " \
+        "when redirects_enabled? is true, not just `redirects_attributes`."
+    end
+  end
+end

--- a/spec/lib/hyrax/transactions/collection_update_decorator_spec.rb
+++ b/spec/lib/hyrax/transactions/collection_update_decorator_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::Transactions::CollectionUpdateDecorator do
+  let(:decorated_steps) { Hyrax::Transactions::CollectionUpdate.new.steps }
+
+  describe 'DEFAULT_STEPS' do
+    it 'includes save_collection_thumbnail after save_collection_logo' do
+      steps = described_class::DEFAULT_STEPS
+      logo_index = steps.index('collection_resource.save_collection_logo')
+      thumb_index = steps.index('collection_resource.save_collection_thumbnail')
+
+      expect(logo_index).to be_present
+      expect(thumb_index).to be_present
+      expect(thumb_index).to eq(logo_index + 1)
+    end
+
+    it 'preserves upstream sync_redirect_paths step' do
+      steps = described_class::DEFAULT_STEPS
+      expect(steps).to include('collection_resource.sync_redirect_paths')
+    end
+
+    it 'preserves upstream save_acl step' do
+      steps = described_class::DEFAULT_STEPS
+      expect(steps).to include('collection_resource.save_acl')
+    end
+
+    it 'is frozen' do
+      expect(described_class::DEFAULT_STEPS).to be_frozen
+    end
+  end
+
+  describe 'step ordering' do
+    it 'runs change_set.apply first' do
+      expect(described_class::DEFAULT_STEPS.first).to eq('change_set.apply')
+    end
+
+    it 'runs sync_redirect_paths last' do
+      expect(described_class::DEFAULT_STEPS.last).to eq('collection_resource.sync_redirect_paths')
+    end
+  end
+end

--- a/spec/requests/redirects/reserved_prefixes_spec.rb
+++ b/spec/requests/redirects/reserved_prefixes_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Hyku reserved redirect prefixes', type: :request do
+  # Hyku adds tenant-host routes to Hyrax.config.reserved_redirect_prefixes
+  # in config/initializers/hyrax.rb so they cannot be claimed as redirect
+  # aliases. This spec verifies those additions are present.
+
+  let(:prefixes) { Hyrax.config.reserved_redirect_prefixes }
+
+  describe 'Hyku-specific prefixes' do
+    %w[
+      /authorities
+      /bookmarks
+      /browse
+      /exporters
+      /identity_providers
+      /importers
+      /jobs
+      /single_signon
+      /status
+      /sword
+    ].each do |prefix|
+      it "includes #{prefix}" do
+        expect(prefixes).to include(prefix)
+      end
+    end
+  end
+
+  describe 'admin-host-only routes are excluded' do
+    # /account and /proprietor are scoped to Account.admin_host via
+    # constraints and never reach a tenant host, so they should NOT
+    # be reserved on tenant hosts.
+    %w[/account /proprietor].each do |prefix|
+      it "does not include #{prefix}" do
+        expect(prefixes).not_to include(prefix)
+      end
+    end
+  end
+
+  describe 'upstream Hyrax defaults are still present' do
+    %w[/admin /dashboard /catalog /concern].each do |prefix|
+      it "includes #{prefix}" do
+        expect(prefixes).to include(prefix)
+      end
+    end
+  end
+end

--- a/spec/requests/redirects/route_placement_spec.rb
+++ b/spec/requests/redirects/route_placement_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Redirects catch-all route placement', type: :request do
+  # The redirects catch-all route must be the last application-defined route
+  # in routes.rb so that every other route gets first crack at matching.
+  # (Rails may append framework routes like ActiveStorage/ActionMailbox after it.)
+
+  let(:all_routes) { Rails.application.routes.routes.to_a }
+  let(:catch_all) { all_routes.find { |r| r.path.spec.to_s.include?('*alias_path') } }
+
+  describe 'catch-all route exists and is configured correctly' do
+    it 'has a catch-all route with *alias_path' do
+      expect(catch_all).to be_present
+    end
+
+    it 'routes to hyrax/redirects#show' do
+      expect(catch_all.defaults[:controller]).to eq('hyrax/redirects')
+      expect(catch_all.defaults[:action]).to eq('show')
+    end
+
+    it 'appears after all application-defined routes' do
+      catch_all_index = all_routes.index(catch_all)
+      # Every route before the catch-all should be a non-glob application route
+      # or an engine-mounted route — none should be the redirects catch-all.
+      # Routes after it are only Rails framework routes (ActiveStorage, ActionMailbox, etc.)
+      routes_after = all_routes[(catch_all_index + 1)..]
+      app_routes_after = routes_after.reject do |r|
+        path = r.path.spec.to_s
+        path.start_with?('/rails/') || path == '/'
+      end
+      expect(app_routes_after).to be_empty,
+        "Expected no application routes after the catch-all, but found: " \
+        "#{app_routes_after.map { |r| r.path.spec.to_s }.join(', ')}"
+    end
+  end
+
+  describe 'real Hyku routes take priority over the catch-all' do
+    # These routes exist before the catch-all in routes.rb.
+    # We verify the router recognizes them as their intended controllers,
+    # not as the catch-all redirect resolver.
+
+    it 'routes /status to status#index, not the catch-all' do
+      route = Rails.application.routes.recognize_path('/status', method: :get)
+      expect(route[:controller]).to eq('status')
+      expect(route[:action]).to eq('index')
+    end
+
+    it 'routes /catalog to catalog#index, not the catch-all' do
+      route = Rails.application.routes.recognize_path('/catalog', method: :get)
+      expect(route[:controller]).to eq('catalog')
+    end
+
+    it 'routes /bookmarks to bookmarks#index, not the catch-all' do
+      route = Rails.application.routes.recognize_path('/bookmarks', method: :get)
+      expect(route[:controller]).to eq('bookmarks')
+    end
+  end
+end

--- a/spec/views/hyrax/dashboard/collections/_form_redirects_tab_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_form_redirects_tab_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+# Hyku overrides the collection form partial to add a Redirects tab.
+# This spec verifies the tab appears when the feature is active and
+# the form is a persisted ResourceForm whose model carries :redirects.
+RSpec.describe 'hyrax/dashboard/collections/_form.html.erb', type: :view do
+  let(:collection) { FactoryBot.valkyrie_create(:hyku_collection, with_permission_template: true) }
+  let(:collection_form) { Hyrax::Forms::ResourceForm.for(resource: collection) }
+  let(:banner_info) { { file: "", alttext: "" } }
+  let(:logo_info) { [] }
+
+  before do
+    controller.request.path_parameters[:id] = collection.id.to_s
+    assign(:form, collection_form)
+    assign(:collection, collection)
+    assign(:banner_info, banner_info)
+    assign(:logo_info, logo_info)
+
+    # Stub collection type helpers that the form checks for persisted collections
+    allow(view).to receive(:collection_brandable?).and_return(false)
+    allow(view).to receive(:collection_discoverable?).and_return(false)
+    allow(view).to receive(:collection_sharable?).and_return(false)
+    allow(view).to receive(:thumbnail_label_for).and_return('Default thumbnail')
+
+    allow(collection_form).to receive(:display_additional_fields?).and_return(false)
+  end
+
+  context 'when redirects feature is active and model supports redirects', clean: true do
+    before do
+      allow(Hyrax.config).to receive(:redirects_active?).and_return(true)
+      allow(collection).to receive(:respond_to?).and_call_original
+      allow(collection).to receive(:respond_to?).with(:redirects).and_return(true)
+      # Stub the inner Hyrax partial so we only test Hyku's tab structure,
+      # not Hyrax's form_redirects partial (which needs a real redirects attribute).
+      stub_template 'hyrax/base/_form_redirects.html.erb' => '<div class="stubbed-redirects-form">redirects form</div>'
+    end
+
+    it 'renders the Redirects tab link' do
+      render
+      expect(rendered).to have_link('Aliases', href: '#redirects')
+    end
+
+    it 'renders the redirects tab pane' do
+      render
+      expect(rendered).to have_selector('div#redirects.tab-pane')
+    end
+  end
+
+  context 'when redirects feature is inactive', clean: true do
+    before do
+      allow(Hyrax.config).to receive(:redirects_active?).and_return(false)
+    end
+
+    it 'does not render the Redirects tab link' do
+      render
+      expect(rendered).not_to have_link('Aliases', href: '#redirects')
+    end
+
+    it 'does not render the redirects tab pane' do
+      render
+      expect(rendered).not_to have_selector('div#redirects')
+    end
+  end
+
+  context 'when the collection is not persisted', clean: true do
+    let(:collection) { FactoryBot.build(:collection_resource) }
+
+    before do
+      allow(Hyrax.config).to receive(:redirects_active?).and_return(true)
+      controller.request.path_parameters[:id] = 'new'
+    end
+
+    it 'does not render the Redirects tab (tabs only appear on edit)' do
+      render
+      expect(rendered).not_to have_link('Aliases', href: '#redirects')
+    end
+  end
+end


### PR DESCRIPTION
RSpec specs covering the Hyku-side wiring for the redirects feature:

- Reserved redirect prefixes: verifies Hyku's 10 added prefixes (/authorities, /bookmarks, /browse, etc.) and admin-host exclusions
- Route catch-all placement: verifies *alias_path route exists, is last, and real Hyku routes take priority
- Collection update decorator: verifies save_collection_thumbnail is inserted correctly and upstream steps are preserved
- Collection form redirects tab: verifies Aliases tab renders when feature is active and hides when inactive
- Form property: verifies ResourceForm has :redirects property when redirects_enabled? is true (regression test for the non-flexible mode form crash)

33 examples in total covering Hyku-specific code only; upstream Hyrax behavior is tested in the Hyrax gem's own CI.

