### PR TITLE
Tolerate off-authority values in render and forms

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ gem 'good_job', '~> 4.10' # Updated for Rails 7.2 compatibility
 gem 'googleauth', '~> 1.9.0'
 gem 'google-protobuf'
 gem 'grpc'
-gem 'hyrax', github: 'samvera/hyrax', ref: '8994ebab95ac3fcf853982a7e944a5adf0d28624'
+gem 'hyrax', github: 'samvera/hyrax', branch: 'main'
 gem 'hyrax-doi', github: 'samvera-labs/hyrax-doi', branch: 'rails_hyrax_upgrade'
 gem 'hyrax-iiif_av', github: 'samvera-labs/hyrax-iiif_av', branch: 'rails_hyrax_upgrade'
 gem 'i18n-debug', require: false, group: %i[development test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,8 +40,8 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: 8994ebab95ac3fcf853982a7e944a5adf0d28624
-  ref: 8994ebab95ac3fcf853982a7e944a5adf0d28624
+  revision: c2b18e57523a7ec9bc6c4aabb51d15151adcb5d3
+  branch: main
   specs:
     hyrax (5.2.0)
       active-fedora (~> 15.0)

--- a/app/services/hyrax/accessibility_features_service.rb
+++ b/app/services/hyrax/accessibility_features_service.rb
@@ -1,31 +1,9 @@
 # frozen_string_literal: true
 module Hyrax
   module AccessibilityFeaturesService
-    def self.authority
-      @authority ||= Qa::Authorities::Local.subauthority_for('accessibility_features')
-    end
+    extend Hyrax::AuthorityService
 
-    def self.authority=(val)
-      @authority = val
-    end
-
-    def self.select_all_options
-      authority.all.map do |element|
-        [element[:label], element[:id]]
-      end
-    end
-
-    def self.label(id)
-      authority.find(id).fetch('term')
-    end
-
-    ##
-    # @param [String, nil] id identifier of the resource type
-    #
-    # @return [String] a schema.org type. Gives the default type if `id` is nil.
-    def self.microdata_type(id)
-      return Hyrax.config.microdata_default_type if id.nil?
-      Microdata.fetch("accessibility_feature_type.#{id}", default: Hyrax.config.microdata_default_type)
-    end
+    authority_name 'accessibility_features'
+    microdata_namespace 'accessibility_feature_type.'
   end
 end

--- a/app/services/hyrax/accessibility_hazards_service.rb
+++ b/app/services/hyrax/accessibility_hazards_service.rb
@@ -1,32 +1,9 @@
 # frozen_string_literal: true
 module Hyrax
   module AccessibilityHazardsService
-    def self.authority
-      @authority ||= Qa::Authorities::Local.subauthority_for('accessibility_hazards')
-    end
+    extend Hyrax::AuthorityService
 
-    def self.authority=(val)
-      @authority = val
-    end
-
-    def self.select_all_options
-      authority.all.map do |element|
-        [element[:label], element[:id]]
-      end
-    end
-
-    def self.label(id)
-      authority.find(id).fetch('term')
-    end
-
-    ##
-    # @param [String, nil] id identifier of the resource type
-    #
-    # @return [String] a schema.org type. Gives the default type if `id` is nil.
-    def self.microdata_type(id)
-      return Hyrax.config.microdata_default_type if id.nil?
-
-      Microdata.fetch("accessibility_hazard_type.#{id}", default: Hyrax.config.microdata_default_type)
-    end
+    authority_name 'accessibility_hazards'
+    microdata_namespace 'accessibility_hazard_type.'
   end
 end

--- a/app/services/hyrax/audience_service.rb
+++ b/app/services/hyrax/audience_service.rb
@@ -1,31 +1,9 @@
 # frozen_string_literal: true
 module Hyrax
   module AudienceService
-    def self.authority
-      @authority ||= Qa::Authorities::Local.subauthority_for('audience')
-    end
+    extend Hyrax::AuthorityService
 
-    def self.authority=(val)
-      @authority = val
-    end
-
-    def self.select_all_options
-      authority.all.map do |element|
-        [element[:label], element[:id]]
-      end
-    end
-
-    def self.label(id)
-      authority.find(id).fetch('term')
-    end
-
-    ##
-    # @param [String, nil] id identifier of the resource type
-    #
-    # @return [String] a schema.org type. Gives the default type if `id` is nil.
-    def self.microdata_type(id)
-      return Hyrax.config.microdata_default_type if id.nil?
-      Microdata.fetch("type.#{id}", default: Hyrax.config.microdata_default_type)
-    end
+    authority_name 'audience'
+    microdata_namespace 'type.'
   end
 end

--- a/app/services/hyrax/discipline_service.rb
+++ b/app/services/hyrax/discipline_service.rb
@@ -1,31 +1,9 @@
 # frozen_string_literal: true
 module Hyrax
   module DisciplineService
-    def self.authority
-      @authority ||= Qa::Authorities::Local.subauthority_for('discipline')
-    end
+    extend Hyrax::AuthorityService
 
-    def self.authority=(val)
-      @authority = val
-    end
-
-    def self.select_all_options
-      authority.all.map do |element|
-        [element[:label], element[:id]]
-      end
-    end
-
-    def self.label(id)
-      authority.find(id).fetch('term')
-    end
-
-    ##
-    # @param [String, nil] id identifier of the resource type
-    #
-    # @return [String] a schema.org type. Gives the default type if `id` is nil.
-    def self.microdata_type(id)
-      return Hyrax.config.microdata_default_type if id.nil?
-      Microdata.fetch("type.#{id}", default: Hyrax.config.microdata_default_type)
-    end
+    authority_name 'discipline'
+    microdata_namespace 'type.'
   end
 end

--- a/app/services/hyrax/education_levels_service.rb
+++ b/app/services/hyrax/education_levels_service.rb
@@ -1,31 +1,9 @@
 # frozen_string_literal: true
 module Hyrax
   module EducationLevelsService
-    def self.authority
-      @authority ||= Qa::Authorities::Local.subauthority_for('education_levels')
-    end
+    extend Hyrax::AuthorityService
 
-    def self.authority=(val)
-      @authority = val
-    end
-
-    def self.select_all_options
-      authority.all.map do |element|
-        [element[:label], element[:id]]
-      end
-    end
-
-    def self.label(id)
-      authority.find(id).fetch('term')
-    end
-
-    ##
-    # @param [String, nil] id identifier of the resource type
-    #
-    # @return [String] a schema.org type. Gives the default type if `id` is nil.
-    def self.microdata_type(id)
-      return Hyrax.config.microdata_default_type if id.nil?
-      Microdata.fetch("type.#{id}", default: Hyrax.config.microdata_default_type)
-    end
+    authority_name 'education_levels'
+    microdata_namespace 'type.'
   end
 end

--- a/app/services/hyrax/learning_resource_types_service.rb
+++ b/app/services/hyrax/learning_resource_types_service.rb
@@ -1,31 +1,9 @@
 # frozen_string_literal: true
 module Hyrax
   module LearningResourceTypesService
-    def self.authority
-      @authority ||= Qa::Authorities::Local.subauthority_for('learning_resource_types')
-    end
+    extend Hyrax::AuthorityService
 
-    def self.authority=(val)
-      @authority = val
-    end
-
-    def self.select_all_options
-      authority.all.map do |element|
-        [element[:label], element[:id]]
-      end
-    end
-
-    def self.label(id)
-      authority.find(id).fetch('term')
-    end
-
-    ##
-    # @param [String, nil] id identifier of the resource type
-    #
-    # @return [String] a schema.org type. Gives the default type if `id` is nil.
-    def self.microdata_type(id)
-      return Hyrax.config.microdata_default_type if id.nil?
-      Microdata.fetch("type.#{id}", default: Hyrax.config.microdata_default_type)
-    end
+    authority_name 'learning_resource_types'
+    microdata_namespace 'type.'
   end
 end

--- a/app/services/hyrax/oer_types_service.rb
+++ b/app/services/hyrax/oer_types_service.rb
@@ -1,31 +1,9 @@
 # frozen_string_literal: true
 module Hyrax
   module OerTypesService
-    def self.authority
-      @authority ||= Qa::Authorities::Local.subauthority_for('oer_types')
-    end
+    extend Hyrax::AuthorityService
 
-    def self.authority=(val)
-      @authority = val
-    end
-
-    def self.select_all_options
-      authority.all.map do |element|
-        [element[:label], element[:id]]
-      end
-    end
-
-    def self.label(id)
-      authority.find(id).fetch('term')
-    end
-
-    ##
-    # @param [String, nil] id identifier of the resource type
-    #
-    # @return [String] a schema.org type. Gives the default type if `id` is nil.
-    def self.microdata_type(id)
-      return Hyrax.config.microdata_default_type if id.nil?
-      Microdata.fetch("type.#{id}", default: Hyrax.config.microdata_default_type)
-    end
+    authority_name 'oer_types'
+    microdata_namespace 'type.'
   end
 end

--- a/app/views/catalog/_index_list_default.html.erb
+++ b/app/views/catalog/_index_list_default.html.erb
@@ -1,18 +1,24 @@
-<%# OVERRIDE Hyrax 5.0.1 to enable markdown for index field values in search results %>
-<%# OVERRIDE Hyrax 5.0.1 to handle search only accounts %>
-<%# OVERRIDE Hyrax 5.0.1 display label only when a property has a value, to prevent blank metadata %>
+<%# OVERRIDE Hyrax v5.2.0 %>
+<%#   - enable markdown for index field values in search results %>
+<%#   - handle search only accounts %>
+<%#   - display label only when a property has a value, to prevent blank metadata %>
+<%#   - compute field_value inside the should_render check so a bad authority %>
+<%#     value cannot raise during catalog rendering before the field is even %>
+<%#     decided to render %>
 
 <div class="ol-md-9 col-lg-6">
   <div class="metadata">
     <dl>
       <% doc_presenter = index_presenter(document) %>
       <% index_fields(document).each do |field_name, field| -%>
-      <% field_value = doc_presenter.field_value(field) %>
-        <% if should_render_index_field?(document, field) && field_value.present? %>
-          <div class="row">
-            <dt class="col-5 text-right" data-solr-field-name="<%= field_name %>"><%= render_index_field_label document, field: field_name %></dt>
-            <dd class="col-7"><%= markdown(field_value) %></dd>
-          </div>
+        <% if should_render_index_field?(document, field) %>
+          <% field_value = doc_presenter.field_value(field) %>
+          <% if field_value.present? %>
+            <div class="row">
+              <dt class="col-5 text-right" data-solr-field-name="<%= field_name %>"><%= render_index_field_label document, field: field_name %></dt>
+              <dd class="col-7"><%= markdown(field_value) %></dd>
+            </div>
+          <% end %>
         <% end %>
       <% end %>
       <% if current_account.search_only %>

--- a/app/views/records/edit_fields/_controlled_vocab_select.html.erb
+++ b/app/views/records/edit_fields/_controlled_vocab_select.html.erb
@@ -1,17 +1,28 @@
+<% base_options = controlled_vocab_config[:options] %>
+<% service = controlled_vocab_config[:service] %>
+<% current_values = Array.wrap(f.object.send(key)).select(&:present?) %>
+<% augmented_options =
+     if service.respond_to?(:include_current_value)
+       current_values.reduce(base_options) do |opts, value|
+         service.include_current_value(value, nil, opts, { class: [] }).first
+       end
+     else
+       base_options
+     end %>
 <% if f.object.multiple? key %>
   <%= f.input key,
       as: :select,
-      collection: controlled_vocab_config[:options],
+      collection: augmented_options,
       label: label_for(term: key, record_class: record.class),
       hint: hint_for(term: key, record_class: record.class),
       input_html: { class: 'form-control', multiple: true, name: "#{f.object_name}[#{key}][]" },
       include_blank: !f.object.required?(key),
-      selected: f.object.send(key).first,
+      selected: current_values,
       required: f.object.required?(key) %>
 <% else %>
   <%= f.input key,
       as: :select,
-      collection: controlled_vocab_config[:options],
+      collection: augmented_options,
       label: label_for(term: key, record_class: record.class),
       hint: hint_for(term: key, record_class: record.class),
       include_blank: true,

--- a/app/views/records/show_fields/_license.html.erb
+++ b/app/views/records/show_fields/_license.html.erb
@@ -1,5 +1,5 @@
 <%# Todo: determine if this is this needed? %>
 <% service = Hyrax::LicenseService.new %>
 <% record.license.each do |r| %>
-  <%= link_to_field('license', r, service.label(r)) %> <%= iconify_auto_link(r, false) %><br />
+  <%= link_to_field('license', r, service.label(r) { r }) %> <%= iconify_auto_link(r, false) %><br />
 <% end %>

--- a/spec/services/hyrax/accessibility_features_service_spec.rb
+++ b/spec/services/hyrax/accessibility_features_service_spec.rb
@@ -15,6 +15,42 @@ RSpec.describe Hyrax::AccessibilityFeaturesService do
     it "fetches the term" do
       expect(subject).to eq("Alternative Text")
     end
+
+    context "when the id is not in the authority" do
+      it "falls back to the id" do
+        expect(described_class.label("not-a-known-feature")).to eq "not-a-known-feature"
+      end
+    end
+  end
+
+  describe ".active?" do
+    it "is true for a known term" do
+      expect(described_class.active?("Alternative Text")).to be true
+    end
+
+    it "is false for an id not in the authority" do
+      expect(described_class.active?("not-a-known-feature")).to be false
+    end
+  end
+
+  describe ".include_current_value" do
+    let(:render_opts) { [] }
+    let(:html_opts)   { { class: 'moomin' } }
+
+    it "preserves an off-authority value as a forced-select option" do
+      expect(described_class.include_current_value("not-a-known-feature", :idx, render_opts, html_opts))
+        .to eq [[['not-a-known-feature', 'not-a-known-feature']], { class: 'moomin force-select' }]
+    end
+
+    it "leaves the options untouched for a known term" do
+      expect(described_class.include_current_value("Alternative Text", :idx, render_opts.dup, html_opts.dup))
+        .to eq [render_opts, html_opts]
+    end
+
+    it "leaves the options untouched when the value is blank" do
+      expect(described_class.include_current_value("", :idx, render_opts.dup, html_opts.dup))
+        .to eq [render_opts, html_opts]
+    end
   end
 
   describe ".microdata_type" do

--- a/spec/services/hyrax/accessibility_hazards_service_spec.rb
+++ b/spec/services/hyrax/accessibility_hazards_service_spec.rb
@@ -15,6 +15,42 @@ RSpec.describe Hyrax::AccessibilityHazardsService do
     it "fetches the term" do
       expect(subject).to eq("Flashing")
     end
+
+    context "when the id is not in the authority" do
+      it "falls back to the id" do
+        expect(described_class.label("not-a-known-hazard")).to eq "not-a-known-hazard"
+      end
+    end
+  end
+
+  describe ".active?" do
+    it "is true for a known term" do
+      expect(described_class.active?("Flashing")).to be true
+    end
+
+    it "is false for an id not in the authority" do
+      expect(described_class.active?("not-a-known-hazard")).to be false
+    end
+  end
+
+  describe ".include_current_value" do
+    let(:render_opts) { [] }
+    let(:html_opts)   { { class: 'moomin' } }
+
+    it "preserves an off-authority value as a forced-select option" do
+      expect(described_class.include_current_value("not-a-known-hazard", :idx, render_opts, html_opts))
+        .to eq [[['not-a-known-hazard', 'not-a-known-hazard']], { class: 'moomin force-select' }]
+    end
+
+    it "leaves the options untouched for a known term" do
+      expect(described_class.include_current_value("Flashing", :idx, render_opts.dup, html_opts.dup))
+        .to eq [render_opts, html_opts]
+    end
+
+    it "leaves the options untouched when the value is blank" do
+      expect(described_class.include_current_value("", :idx, render_opts.dup, html_opts.dup))
+        .to eq [render_opts, html_opts]
+    end
   end
 
   describe ".microdata_type" do

--- a/spec/services/hyrax/audience_service_spec.rb
+++ b/spec/services/hyrax/audience_service_spec.rb
@@ -13,5 +13,41 @@ RSpec.describe Hyrax::AudienceService do
     subject { described_class.label("Instructor") }
 
     it { is_expected.to eq 'Instructor' }
+
+    context "when the id is not in the authority" do
+      it "falls back to the id" do
+        expect(described_class.label("not-a-known-audience")).to eq "not-a-known-audience"
+      end
+    end
+  end
+
+  describe "active?" do
+    it "is true for a known term" do
+      expect(described_class.active?("Instructor")).to be true
+    end
+
+    it "is false for an id not in the authority" do
+      expect(described_class.active?("not-a-known-audience")).to be false
+    end
+  end
+
+  describe "include_current_value" do
+    let(:render_opts) { [] }
+    let(:html_opts)   { { class: 'moomin' } }
+
+    it "preserves an off-authority value as a forced-select option" do
+      expect(described_class.include_current_value("not-a-known-audience", :idx, render_opts, html_opts))
+        .to eq [[['not-a-known-audience', 'not-a-known-audience']], { class: 'moomin force-select' }]
+    end
+
+    it "leaves the options untouched for a known term" do
+      expect(described_class.include_current_value("Instructor", :idx, render_opts.dup, html_opts.dup))
+        .to eq [render_opts, html_opts]
+    end
+
+    it "leaves the options untouched when the value is blank" do
+      expect(described_class.include_current_value("", :idx, render_opts.dup, html_opts.dup))
+        .to eq [render_opts, html_opts]
+    end
   end
 end

--- a/spec/services/hyrax/discipline_service_spec.rb
+++ b/spec/services/hyrax/discipline_service_spec.rb
@@ -13,5 +13,41 @@ RSpec.describe Hyrax::DisciplineService do
     subject { described_class.label("Computing and Information - Computer Science") }
 
     it { is_expected.to eq 'Computing and Information - Computer Science' }
+
+    context "when the id is not in the authority" do
+      it "falls back to the id" do
+        expect(described_class.label("not-a-known-discipline")).to eq "not-a-known-discipline"
+      end
+    end
+  end
+
+  describe "active?" do
+    it "is true for a known term (discipline authority has no active flag, so unflagged is active)" do
+      expect(described_class.active?("Computing and Information - Computer Science")).to be true
+    end
+
+    it "is false for an id not in the authority" do
+      expect(described_class.active?("not-a-known-discipline")).to be false
+    end
+  end
+
+  describe "include_current_value" do
+    let(:render_opts) { [] }
+    let(:html_opts)   { { class: 'moomin' } }
+
+    it "preserves an off-authority value as a forced-select option" do
+      expect(described_class.include_current_value("not-a-known-discipline", :idx, render_opts, html_opts))
+        .to eq [[['not-a-known-discipline', 'not-a-known-discipline']], { class: 'moomin force-select' }]
+    end
+
+    it "leaves the options untouched for a known term" do
+      expect(described_class.include_current_value("Computing and Information - Computer Science", :idx, render_opts.dup, html_opts.dup))
+        .to eq [render_opts, html_opts]
+    end
+
+    it "leaves the options untouched when the value is blank" do
+      expect(described_class.include_current_value("", :idx, render_opts.dup, html_opts.dup))
+        .to eq [render_opts, html_opts]
+    end
   end
 end

--- a/spec/services/hyrax/education_levels_service_spec.rb
+++ b/spec/services/hyrax/education_levels_service_spec.rb
@@ -13,5 +13,41 @@ RSpec.describe Hyrax::EducationLevelsService do
     subject { described_class.label("Career / Technical") }
 
     it { is_expected.to eq 'Career / Technical' }
+
+    context "when the id is not in the authority" do
+      it "falls back to the id" do
+        expect(described_class.label("not-a-known-level")).to eq "not-a-known-level"
+      end
+    end
+  end
+
+  describe "active?" do
+    it "is true for a known term" do
+      expect(described_class.active?("Career / Technical")).to be true
+    end
+
+    it "is false for an id not in the authority" do
+      expect(described_class.active?("not-a-known-level")).to be false
+    end
+  end
+
+  describe "include_current_value" do
+    let(:render_opts) { [] }
+    let(:html_opts)   { { class: 'moomin' } }
+
+    it "preserves an off-authority value as a forced-select option" do
+      expect(described_class.include_current_value("not-a-known-level", :idx, render_opts, html_opts))
+        .to eq [[['not-a-known-level', 'not-a-known-level']], { class: 'moomin force-select' }]
+    end
+
+    it "leaves the options untouched for a known term" do
+      expect(described_class.include_current_value("Career / Technical", :idx, render_opts.dup, html_opts.dup))
+        .to eq [render_opts, html_opts]
+    end
+
+    it "leaves the options untouched when the value is blank" do
+      expect(described_class.include_current_value("", :idx, render_opts.dup, html_opts.dup))
+        .to eq [render_opts, html_opts]
+    end
   end
 end

--- a/spec/services/hyrax/learning_resource_types_service_spec.rb
+++ b/spec/services/hyrax/learning_resource_types_service_spec.rb
@@ -13,5 +13,41 @@ RSpec.describe Hyrax::LearningResourceTypesService do
     subject { described_class.label("Reading") }
 
     it { is_expected.to eq 'Reading' }
+
+    context "when the id is not in the authority" do
+      it "falls back to the id" do
+        expect(described_class.label("not-a-known-resource-type")).to eq "not-a-known-resource-type"
+      end
+    end
+  end
+
+  describe "active?" do
+    it "is true for a known term" do
+      expect(described_class.active?("Reading")).to be true
+    end
+
+    it "is false for an id not in the authority" do
+      expect(described_class.active?("not-a-known-resource-type")).to be false
+    end
+  end
+
+  describe "include_current_value" do
+    let(:render_opts) { [] }
+    let(:html_opts)   { { class: 'moomin' } }
+
+    it "preserves an off-authority value as a forced-select option" do
+      expect(described_class.include_current_value("not-a-known-resource-type", :idx, render_opts, html_opts))
+        .to eq [[['not-a-known-resource-type', 'not-a-known-resource-type']], { class: 'moomin force-select' }]
+    end
+
+    it "leaves the options untouched for a known term" do
+      expect(described_class.include_current_value("Reading", :idx, render_opts.dup, html_opts.dup))
+        .to eq [render_opts, html_opts]
+    end
+
+    it "leaves the options untouched when the value is blank" do
+      expect(described_class.include_current_value("", :idx, render_opts.dup, html_opts.dup))
+        .to eq [render_opts, html_opts]
+    end
   end
 end

--- a/spec/services/hyrax/oer_types_service_spec.rb
+++ b/spec/services/hyrax/oer_types_service_spec.rb
@@ -13,5 +13,41 @@ RSpec.describe Hyrax::OerTypesService do
     subject { described_class.label("MovingImage") }
 
     it { is_expected.to eq 'MovingImage' }
+
+    context "when the id is not in the authority" do
+      it "falls back to the id" do
+        expect(described_class.label("not-a-known-oer-type")).to eq "not-a-known-oer-type"
+      end
+    end
+  end
+
+  describe "active?" do
+    it "is true for a known term" do
+      expect(described_class.active?("MovingImage")).to be true
+    end
+
+    it "is false for an id not in the authority" do
+      expect(described_class.active?("not-a-known-oer-type")).to be false
+    end
+  end
+
+  describe "include_current_value" do
+    let(:render_opts) { [] }
+    let(:html_opts)   { { class: 'moomin' } }
+
+    it "preserves an off-authority value as a forced-select option" do
+      expect(described_class.include_current_value("not-a-known-oer-type", :idx, render_opts, html_opts))
+        .to eq [[['not-a-known-oer-type', 'not-a-known-oer-type']], { class: 'moomin force-select' }]
+    end
+
+    it "leaves the options untouched for a known term" do
+      expect(described_class.include_current_value("MovingImage", :idx, render_opts.dup, html_opts.dup))
+        .to eq [render_opts, html_opts]
+    end
+
+    it "leaves the options untouched when the value is blank" do
+      expect(described_class.include_current_value("", :idx, render_opts.dup, html_opts.dup))
+        .to eq [render_opts, html_opts]
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Catalog, admin set, and collection pages render even when a work has a free-text or unknown value in an authority-backed field, and edit forms preserve such values on save instead of silently dropping them.
- Refs notch8/palni_palci_knapsack#619

## Details
This depends on samvera/hyrax#7441, which adds the `Hyrax::AuthorityService` mixin (with `authority_name` and `microdata_namespace` macros) that the seven module-level Hyku authority services use. 

- The catalog index list override nests `field_value` inside the `should_render_index_field?` check so a bad value in one field can no longer raise during rendering of sibling fields. 
- The seven module-level authority services (accessibility features, accessibility hazards, audience, discipline, education levels, learning resource types, oer types) collapse onto the new `Hyrax::AuthorityService` macros, gaining tolerant `label`, `active?`, and `include_current_value` for free. 
- The controlled-vocabulary select partial augments its option collection with each off-authority value already present on the record, so unknown values stay selected and round-trip on save. 
- The license show field partial passes an explicit fallback to `service.label` as a defensive fallback.