### PR TITLE
Fix accessibility issue on admin stats page: add role='presentation' …

### DIFF
--- a/app/views/hyrax/admin/stats/show.html.erb
+++ b/app/views/hyrax/admin/stats/show.html.erb
@@ -5,16 +5,16 @@
 <div class="card tabs">
   <!-- Nav tabs -->
   <ul id="statistics-tabs" class="nav nav-tabs" role="tablist">
-    <li class="nav-item">
+    <li class="nav-item" role="presentation">
       <a class="nav-link active" href="#collections" role="tab" data-toggle="tab">Collections</a>
     </li>
-    <li class="nav-item">
+    <li class="nav-item" role="presentation">
       <a class="nav-link" href="#works" role="tab" data-toggle="tab">Works</a>
     </li>
-    <li class="nav-item">
+    <li class="nav-item" role="presentation">
       <a class="nav-link" href="#downloads" role="tab" data-toggle="tab">Downloads</a>
     </li>
-    <li class="nav-item">
+    <li class="nav-item" role="presentation">
       <a class="nav-link" href="#users" role="tab" data-toggle="tab">Users</a>
     </li>
   </ul>


### PR DESCRIPTION
Add role='presentation' to admin stats tab list items

This pull request addresses an accessibility issue on the admin statistics page (/admin/stats) where ARIA roles were not used within their required contexts. The page uses Bootstrap tabs with a `<ul role="tablist">`, but the `<li>` elements implicitly have role="listitem", which is invalid since listitem must be within a parent with role="list" or role="group"—not tablist.

The fix adds role="presentation" to each <li class="nav-item"> element in the tab navigation. This removes the implicit listitem role, ensuring compliance with ARIA 1.1 specifications and resolving the SIA-R42 rule violation detected by accessibility tools like Siteimprove.

Changes proposed in this pull request:

Modify show.html.erb to add role="presentation" to all four tab list item elements.
Fixes #3056

@samvera/hyku-code-reviewers
