### PR TITLE
Support editor-only attribute rows

### DIFF
--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -4,13 +4,11 @@
 <% if Hyrax.config.flexible? %>
   <% view_options_for(presenter).each do |field, options| %>
     <% view_options = conform_options(field, options) %>
-
-    <%# can add metadata property called admin_note that is restricted to any editor role %>
-    <%# can add indexing.admin_only to restrict any property to admins %>
+    <%# keeps admin_note behavior for backward compatibility... should be in metadata but may not be %>
     <% if field == :admin_note %>
       <%= presenter.attribute_to_html(conform_field(field, options), view_options) if presenter.editor? %>
     <% else %>
-      <%= presenter.attribute_to_html(conform_field(field, options), view_options) unless view_options[:admin_only] && !current_user&.admin?  %>
+      <%= presenter.attribute_to_html(conform_field(field, options), view_options) if field_visible?(view_options, presenter) %>
     <% end %>
   <% end %>
 <% else %>

--- a/app/views/hyrax/etds/_attribute_rows.html.erb
+++ b/app/views/hyrax/etds/_attribute_rows.html.erb
@@ -7,7 +7,7 @@
     <% if field == :admin_note %>
       <%= presenter.attribute_to_html(conform_field(field, options), view_options) if presenter.editor? %>
     <% else %>
-      <%= presenter.attribute_to_html(conform_field(field, options), view_options) unless view_options[:admin_only] && !current_user&.admin?  %>
+      <%= presenter.attribute_to_html(conform_field(field, options), view_options) if field_visible?(view_options, presenter) %>
     <% end %>
   <% end %>
 <% else %>

--- a/app/views/hyrax/oers/_attribute_rows.html.erb
+++ b/app/views/hyrax/oers/_attribute_rows.html.erb
@@ -7,7 +7,7 @@
     <% if field == :admin_note %>
       <%= presenter.attribute_to_html(conform_field(field, options), view_options) if presenter.editor? %>
     <% else %>
-      <%= presenter.attribute_to_html(conform_field(field, options), view_options) unless view_options[:admin_only] && !current_user&.admin?  %>
+      <%= presenter.attribute_to_html(conform_field(field, options), view_options) if field_visible?(view_options, presenter) %>
     <% end %>
   <% end %>
 <% else %>

--- a/app/views/themes/community_show/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/themes/community_show/hyrax/base/_attribute_rows.html.erb
@@ -6,10 +6,9 @@
   # Convert to array for splitting
   fields_array = all_fields.to_a
 
-  # Filter out admin-only fields if user is not admin
+  # Filter out admin-only and editor-only fields per Hyrax's view-visibility rules
   fields_array.select! do |field, options|
-    is_admin_only = options && (options[:admin_only] || options['admin_only'])
-    !is_admin_only || current_user.try(:admin?)
+    field_visible?(conform_options(field, options), presenter)
   end
 
   half = (fields_array.count / 2.0).ceil


### PR DESCRIPTION
## Summary

Hyku overrides Hyrax's partials... need to bring up the corresponding changes from Hyrax.
