### PR TITLE
Bump hyrax to include #7470 (strip default locale from URLs)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,7 +40,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: bb662edae452785df62d7d2b634e9326bb9ab816
+  revision: 7f0e346a37c15330dd664ecfac203aa8e7d5c416
   branch: main
   specs:
     hyrax (5.2.0)

--- a/spec/controllers/hyku/invitations_controller_spec.rb
+++ b/spec/controllers/hyku/invitations_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Hyku::InvitationsController, type: :controller do
 
   describe '#after_invite_path_for' do
     it "returns admin_users_path" do
-      expect(subject.after_invite_path_for(nil)).to eq Hyrax::Engine.routes.url_helpers.admin_users_path(locale: 'en')
+      expect(subject.after_invite_path_for(nil)).to eq Hyrax::Engine.routes.url_helpers.admin_users_path
     end
   end
 
@@ -28,7 +28,7 @@ RSpec.describe Hyku::InvitationsController, type: :controller do
       created_user = User.find_by(email: 'user@guest.org')
       expect(created_user.roles.map(&:name)).to include('manager')
       expect(created_user.roles.map(&:resource_type).uniq).to contain_exactly('Site', 'Hyrax::Group')
-      expect(response).to redirect_to Hyrax::Engine.routes.url_helpers.admin_users_path(locale: 'en')
+      expect(response).to redirect_to Hyrax::Engine.routes.url_helpers.admin_users_path
       expect(flash[:notice]).to eq 'An invitation email has been sent to user@guest.org.'
     end
 

--- a/spec/controllers/hyku/registrations_controller_spec.rb
+++ b/spec/controllers/hyku/registrations_controller_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Hyku::RegistrationsController, type: :controller do
             password_confirmation: "password"
           }
         }
-        expect(response).to redirect_to Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en')
+        expect(response).to redirect_to Hyrax::Engine.routes.url_helpers.dashboard_path
         expect(flash[:notice]).to eq 'Welcome! You have signed up successfully.'
       end
     end

--- a/spec/controllers/hyrax/admin/appearances_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/appearances_controller_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Hyrax::Admin::AppearancesController, type: :controller, singleten
           expect(Site.instance.banner_image?).to be false
           f = fixture_file_upload('/images/nypl-hydra-of-lerna.jpg', 'image/jpg')
           post :update, params: { admin_appearance: { banner_image: f } }
-          expect(response).to redirect_to(hyrax.admin_appearance_path(locale: 'en'))
+          expect(response).to redirect_to(hyrax.admin_appearance_path)
           expect(flash[:notice]).to include("The appearance was successfully updated")
           expect(Site.instance.banner_image?).to be true
         end
@@ -54,14 +54,14 @@ RSpec.describe Hyrax::Admin::AppearancesController, type: :controller, singleten
           expect(Site.instance.directory_image?).to be false
           f = fixture_file_upload('/images/nypl-hydra-of-lerna.jpg', 'image/jpg')
           post :update, params: { admin_appearance: { directory_image: f } }
-          expect(response).to redirect_to(hyrax.admin_appearance_path(locale: 'en'))
+          expect(response).to redirect_to(hyrax.admin_appearance_path)
           expect(flash[:notice]).to include("The appearance was successfully updated")
           expect(Site.instance.directory_image?).to be true
         end
 
         it "redirects to the site" do
           put :update, params: { admin_appearance: valid_attributes }
-          expect(response).to redirect_to(hyrax.admin_appearance_path(locale: 'en'))
+          expect(response).to redirect_to(hyrax.admin_appearance_path)
         end
       end
 

--- a/spec/controllers/sites_controller_spec.rb
+++ b/spec/controllers/sites_controller_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe SitesController, type: :controller, singletenant: true do
         expect(Site.instance.banner_image?).to be true
         expect(ContentBlock.find_by(name: 'banner_image_text')).not_to be nil
         post :update, params: { id: Site.instance.id, remove_banner_image: 'Remove banner image' }
-        expect(response).to redirect_to('/admin/appearance?locale=en')
+        expect(response).to redirect_to('/admin/appearance')
         expect(flash[:notice]).to include("The appearance was successfully updated")
         expect(Site.instance.banner_image?).to be false
         expect(ContentBlock.find_by(name: 'banner_image_text')).to be nil
@@ -63,7 +63,7 @@ RSpec.describe SitesController, type: :controller, singletenant: true do
       it "#update with remove_favicon deletes a favicon" do
         expect(Site.instance.favicon?).to be true
         post :update, params: { id: Site.instance.id, remove_favicon: 'Remove favicon' }
-        expect(response).to redirect_to('/admin/appearance?locale=en')
+        expect(response).to redirect_to('/admin/appearance')
         expect(flash[:notice]).to include("The appearance was successfully updated")
         expect(Site.instance.favicon?).to be false
       end
@@ -81,7 +81,7 @@ RSpec.describe SitesController, type: :controller, singletenant: true do
         expect(Site.instance.directory_image?).to be true
         expect(ContentBlock.find_by(name: 'directory_image_text')).not_to be nil
         post :update, params: { id: Site.instance.id, remove_directory_image: 'Remove directory image' }
-        expect(response).to redirect_to('/admin/appearance?locale=en')
+        expect(response).to redirect_to('/admin/appearance')
         expect(flash[:notice]).to include("The appearance was successfully updated")
         expect(Site.instance.directory_image?).to be false
         expect(ContentBlock.find_by(name: 'directory_image_text')).to be nil
@@ -99,7 +99,7 @@ RSpec.describe SitesController, type: :controller, singletenant: true do
           expect(Site.instance.directory_image?).to be true
           expect(ContentBlock.find_by(name: 'directory_image_text')).not_to be nil
           post :update, params: { id: Site.instance.id, remove_directory_image: 'Remove directory image' }
-          expect(response).to redirect_to('/admin/appearance?locale=en')
+          expect(response).to redirect_to('/admin/appearance')
           expect(flash[:error]).to include("Updating the appearance was unsuccessful")
           expect(Site.instance.directory_image?).to be true
           expect(ContentBlock.find_by(name: 'directory_image_text')).not_to be nil
@@ -122,7 +122,7 @@ RSpec.describe SitesController, type: :controller, singletenant: true do
         expect(ContentBlock.find_by(name: 'logo_image_text')).not_to be nil
         expect(Site.instance.logo_image?).to be true
         post :update, params: { id: Site.instance.id, remove_logo_image: 'Remove logo image' }
-        expect(response).to redirect_to('/admin/appearance?locale=en')
+        expect(response).to redirect_to('/admin/appearance')
         expect(flash[:notice]).to include("The appearance was successfully updated")
         expect(Site.instance.logo_image?).to be false
         expect(ContentBlock.find_by(name: 'logo_image_text')).to be nil

--- a/spec/features/appearance_theme_spec.rb
+++ b/spec/features/appearance_theme_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe 'Admin can select home page theme', type: :feature, js: true, cle
       click_button "search-submit-header"
       expect(page).to have_css('a.view-type-gallery.active')
       click_link "List"
-      expect(page).to have_current_path('/catalog?locale=en&q=llama&search_field=all_fields&utf8=✓&view=list')
+      expect(page).to have_current_path('/catalog?q=llama&search_field=all_fields&utf8=✓&view=list')
     end
 
     it 'defaults to list view when no theme is selected' do

--- a/spec/features/collection_editor_role_spec.rb
+++ b/spec/features/collection_editor_role_spec.rb
@@ -365,15 +365,15 @@ RSpec.describe 'actions permitted by the collection_editor role', type: :feature
   def check_tr_data_attributes(id, type)
     url_fragment = get_url_fragment(type)
     expect(page).to have_selector("tr[data-id='#{id}'][data-colls-hash]")
-    expect(page).to have_selector("tr[data-post-url='/dashboard/collections/#{id}/within?locale=en']")
-    expect(page).to have_selector("tr[data-post-delete-url='/#{url_fragment}/#{id}?locale=en']")
+    expect(page).to have_selector("tr[data-post-url='/dashboard/collections/#{id}/within']")
+    expect(page).to have_selector("tr[data-post-delete-url='/#{url_fragment}/#{id}']")
   end
 
   # check data attributes have been transferred from table row to the modal
   def check_modal_data_attributes(id, type)
     url_fragment = get_url_fragment(type)
     expect(page).to have_selector("div[data-id='#{id}']")
-    expect(page).to have_selector("div[data-post-delete-url='/#{url_fragment}/#{id}?locale=en']")
+    expect(page).to have_selector("div[data-post-delete-url='/#{url_fragment}/#{id}']")
   end
 
   def get_url_fragment(type)

--- a/spec/features/collection_manager_role_spec.rb
+++ b/spec/features/collection_manager_role_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe 'actions permitted by the collection_manager role', type: :featur
       within('div#collection-empty-to-delete-modal') do
         click_button('Delete')
       end
-      expect(page).to have_current_path('/dashboard/my/collections?locale=en')
+      expect(page).to have_current_path('/dashboard/my/collections')
 
       visit '/dashboard/collections'
 
@@ -340,7 +340,7 @@ RSpec.describe 'actions permitted by the collection_manager role', type: :featur
       within('div#collection-empty-to-delete-modal') do
         click_button('Delete')
       end
-      expect(page).to have_current_path('/dashboard/my/collections?locale=en')
+      expect(page).to have_current_path('/dashboard/my/collections')
 
       visit '/dashboard/collections'
 
@@ -553,15 +553,15 @@ RSpec.describe 'actions permitted by the collection_manager role', type: :featur
   def check_tr_data_attributes(id, type)
     url_fragment = get_url_fragment(type)
     expect(page).to have_selector("tr[data-id='#{id}'][data-colls-hash]")
-    expect(page).to have_selector("tr[data-post-url='/dashboard/collections/#{id}/within?locale=en']")
-    expect(page).to have_selector("tr[data-post-delete-url='/#{url_fragment}/#{id}?locale=en']")
+    expect(page).to have_selector("tr[data-post-url='/dashboard/collections/#{id}/within']")
+    expect(page).to have_selector("tr[data-post-delete-url='/#{url_fragment}/#{id}']")
   end
 
   # check data attributes have been transferred from table row to the modal
   def check_modal_data_attributes(id, type)
     url_fragment = get_url_fragment(type)
     expect(page).to have_selector("div[data-id='#{id}']")
-    expect(page).to have_selector("div[data-post-delete-url='/#{url_fragment}/#{id}?locale=en']")
+    expect(page).to have_selector("div[data-post-delete-url='/#{url_fragment}/#{id}']")
   end
 
   def get_url_fragment(type)

--- a/spec/features/collection_reader_role_spec.rb
+++ b/spec/features/collection_reader_role_spec.rb
@@ -282,15 +282,15 @@ RSpec.describe 'actions permitted by the collection_reader role', type: :feature
   def check_tr_data_attributes(id, type)
     url_fragment = get_url_fragment(type)
     expect(page).to have_selector("tr[data-id='#{id}'][data-colls-hash]")
-    expect(page).to have_selector("tr[data-post-url='/dashboard/collections/#{id}/within?locale=en']")
-    expect(page).to have_selector("tr[data-post-delete-url='/#{url_fragment}/#{id}?locale=en']")
+    expect(page).to have_selector("tr[data-post-url='/dashboard/collections/#{id}/within']")
+    expect(page).to have_selector("tr[data-post-delete-url='/#{url_fragment}/#{id}']")
   end
 
   # check data attributes have been transferred from table row to the modal
   def check_modal_data_attributes(id, type)
     url_fragment = get_url_fragment(type)
     expect(page).to have_selector("div[data-id='#{id}']")
-    expect(page).to have_selector("div[data-post-delete-url='/#{url_fragment}/#{id}?locale=en']")
+    expect(page).to have_selector("div[data-post-delete-url='/#{url_fragment}/#{id}']")
   end
 
   def get_url_fragment(type)

--- a/spec/features/collection_type_spec.rb
+++ b/spec/features/collection_type_spec.rb
@@ -37,14 +37,14 @@ RSpec.describe 'collection_type', type: :feature, js: true, clean: true do
       expect(page).to have_content 'Collection Type'
 
       expect(page).to have_link('Edit', count: 3)
-      expect(page).to have_link('Edit', href: hyrax.edit_admin_collection_type_path(admin_set_type.id, locale: 'en'))
+      expect(page).to have_link('Edit', href: hyrax.edit_admin_collection_type_path(admin_set_type.id))
       expect(page).to have_link(
         'Edit',
-        href: hyrax.edit_admin_collection_type_path(user_collection_type.id, locale: 'en')
+        href: hyrax.edit_admin_collection_type_path(user_collection_type.id)
       )
       expect(page).to have_link(
         'Edit',
-        href: hyrax.edit_admin_collection_type_path(exhibit_collection_type.id, locale: 'en')
+        href: hyrax.edit_admin_collection_type_path(exhibit_collection_type.id)
       )
       expect(page).to have_button('Delete', count: 2) # 1: Collection Type, 2: delete modal
     end

--- a/spec/features/splash_spec.rb
+++ b/spec/features/splash_spec.rb
@@ -14,6 +14,6 @@ RSpec.describe "The splash page", type: :feature, clean: true, multitenant: true
 
   it "shows a link to login" do
     visit '/'
-    expect(page).to have_link 'Login to get started', href: main_app.new_user_session_path(locale: 'en')
+    expect(page).to have_link 'Login to get started', href: main_app.new_user_session_path
   end
 end


### PR DESCRIPTION
## Summary

- Bumps the `hyrax` pin to `7f0e346a37c15330dd664ecfac203aa8e7d5c416`, the merge commit of samvera/hyrax#7470.
- That upstream PR makes `Hyrax::Controller#default_url_options` only emit `locale: I18n.locale` when the active locale differs from `I18n.default_locale`, so default-locale URLs no longer carry `?locale=en`.

Refs: notch8/hykuup_knapsack#677
Upstream: samvera/hyrax#7470

## Why

Hyku's sitemap entries, canonical tags, and outbound links were all rendering as `?locale=en` even for default-locale visitors. Googlebot picked those locale-parameterized URLs up as canonical, which led to foreign-language variants ranking ahead of English results on Truman (the original symptom in #677). The companion canonical-tag work already landed in #3067; this bump is the URL-level cleanup that needs to land before those canonicals start emitting (otherwise the canonicals themselves would re-declare `?locale=en` URLs as authoritative).

## Behavior

| Active locale | Before | After |
| --- | --- | --- |
| `I18n.default_locale` (`en`) | `{ locale: :en }` appended to every URL | `{}` |
| non-default (e.g. `:es`) | `{ locale: :es }` | `{ locale: :es }` (unchanged) |

## Test plan

- [x] Verified live on `dev-hyku.localhost.direct` with this lockfile applied:
  - `/dashboard?locale=en`: 0 of 45 anchors carry `?locale=en` other than the language-switcher itself.
  - `/catalog?locale=es`: in-app links correctly carry `?locale=es` (`/about?locale=es`, `/single_signon?locale=es`, etc.).
- [x] CI green.
- [ ] After merge + deploy, hand off to Truman ops to resubmit the sitemap in Search Console and monitor `site:truman.digitalmobius.org inurl:locale=` trend over 2-6 weeks. (in hyku up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)