### PR TITLE
Update uploads directory cleanups to include more directories

### DIFF
--- a/app/services/uploads_cleanup_service.rb
+++ b/app/services/uploads_cleanup_service.rb
@@ -63,7 +63,7 @@ class UploadsCleanupService
       return
     end
 
-    Rails.logger.debug "Enqueueing cleanup for #{tenant} → #{uploads_path}"
+    Rails.logger.info "Enqueueing cleanup for #{tenant} → #{uploads_path}"
     CleanupUploadFilesJob.perform_later(
       delete_ingested_after_days: @delete_ingested_after_days,
       uploads_path: uploads_path,
@@ -117,7 +117,7 @@ class UploadsCleanupService
       return
     end
 
-    Rails.logger.debug "Enqueueing orphaned tenant cleanup for #{tenant_id} → #{uploads_path} " \
+    Rails.logger.info "Enqueueing orphaned tenant cleanup for #{tenant_id} → #{uploads_path} " \
          "(all files older than #{@delete_all_after_days} days)"
     CleanupUploadFilesJob.perform_later(
       delete_ingested_after_days: @delete_all_after_days,

--- a/app/services/uploads_cleanup_service.rb
+++ b/app/services/uploads_cleanup_service.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+# Orchestrates per-tenant Hyrax upload staging cleanup by enqueueing
+# CleanupUploadFilesJob for every tenant that has local staging files.
+#
+# Two scenarios are handled:
+#
+# 1. Known tenants (including those that have since switched to S3): always
+#    checks the local filesystem path so that staging files left behind after
+#    an S3 migration are not silently ignored.
+#
+# 2. Extra / legacy base paths (EXTRA_UPLOAD_PATHS): scans additional upload
+#    root directories for UUID-named subdirectories. Useful when HYRAX_UPLOAD_PATH
+#    changed and old files are sitting at the former location.
+#
+# See lib/tasks/uploads_cleanup.rake for usage and ENV-variable documentation.
+class UploadsCleanupService
+  TENANT_UUID_PATTERN = /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i
+
+  def initialize(
+    delete_ingested_after_days: 180,
+    delete_all_after_days: 730,
+    extra_upload_paths: [],
+    include_orphaned_tenant_dirs: false
+  )
+    @delete_ingested_after_days = delete_ingested_after_days
+    @delete_all_after_days = delete_all_after_days
+    @extra_upload_paths = Array(extra_upload_paths).map(&:to_s).reject(&:empty?)
+    @include_orphaned_tenant_dirs = include_orphaned_tenant_dirs
+    @queued_paths = Set.new
+  end
+
+  def run
+    clean_known_tenants
+    @extra_upload_paths.each { |path| scan_extra_path(path) }
+  end
+
+  private
+
+  def clean_known_tenants
+    Account.find_each { |account| enqueue_tenant_cleanup(local_staging_root(account.tenant), account.tenant) }
+  end
+
+  # Returns the local filesystem path for a tenant's Hyrax upload staging tree.
+  # Used regardless of whether the tenant currently uses S3, because files from
+  # before an S3 migration are still on disk and must be cleaned up.
+  def local_staging_root(tenant)
+    if ENV['HYRAX_UPLOAD_PATH'].present?
+      File.join(ENV['HYRAX_UPLOAD_PATH'], tenant)
+    else
+      Rails.root.join('public', 'uploads', tenant).to_s
+    end
+  end
+
+  # Enqueue CleanupUploadFilesJob for +uploads_path+ if the CarrierWave staging
+  # subdirectory exists. No-ops if the path was already queued this run.
+  def enqueue_tenant_cleanup(uploads_path, tenant)
+    return if @queued_paths.include?(uploads_path)
+
+    staging_dir = File.join(uploads_path, CleanupUploadFilesJob::CARRIERWAVE_SUBDIR)
+    unless Dir.exist?(staging_dir)
+      Rails.logger.debug "Skipping #{tenant}: no staging directory at #{staging_dir}"
+      return
+    end
+
+    Rails.logger.debug "Enqueueing cleanup for #{tenant} → #{uploads_path}"
+    CleanupUploadFilesJob.perform_later(
+      delete_ingested_after_days: @delete_ingested_after_days,
+      uploads_path: uploads_path,
+      delete_all_after_days: @delete_all_after_days,
+      tenant: tenant
+    )
+    @queued_paths << uploads_path
+  end
+
+  # Walk +base_path+ for UUID-named subdirectories and enqueue cleanup for each.
+  def scan_extra_path(base_path)
+    unless Dir.exist?(base_path)
+      Rails.logger.debug "Skipping extra path #{base_path}: directory not found"
+      return
+    end
+
+    known_tenants = Account.pluck(:tenant).to_set
+
+    Dir.children(base_path).sort.each do |entry|
+      next unless TENANT_UUID_PATTERN.match?(entry)
+
+      dir = File.join(base_path, entry)
+      next unless File.directory?(dir)
+
+      if known_tenants.include?(entry)
+        enqueue_tenant_cleanup(dir, entry)
+      elsif @include_orphaned_tenant_dirs
+        enqueue_orphaned_cleanup(dir, entry)
+      else
+        Rails.logger.debug "Skipping orphaned tenant dir #{entry} (pass INCLUDE_ORPHANED_TENANT_DIRS=true to clean)"
+      end
+    end
+
+    # Handle files stored directly under base_path with no tenant subdirectory. This happens
+    # when Apartment::Tenant.current returned nil/empty at upload time, causing File.join to
+    # collapse the tenant segment and write staging files directly into the upload root.
+    enqueue_orphaned_cleanup(base_path, "(no tenant)") if @include_orphaned_tenant_dirs
+  end
+
+  # Enqueue cleanup for a UUID directory whose tenant schema no longer exists.
+  # Since no DB lookup is possible, CleanupSubDirectoryJob will never find a matching
+  # Hyrax::UploadedFile record and will treat every file as orphaned. The only threshold
+  # that matters is delete_all_after_days; delete_ingested_after_days is set to the same
+  # value for consistency. The caller must opt in via include_orphaned_tenant_dirs.
+  def enqueue_orphaned_cleanup(uploads_path, tenant_id)
+    return if @queued_paths.include?(uploads_path)
+
+    staging_dir = File.join(uploads_path, CleanupUploadFilesJob::CARRIERWAVE_SUBDIR)
+    unless Dir.exist?(staging_dir)
+      Rails.logger.debug "Skipping orphaned tenant #{tenant_id}: no staging directory at #{staging_dir}"
+      return
+    end
+
+    Rails.logger.debug "Enqueueing orphaned tenant cleanup for #{tenant_id} → #{uploads_path} " \
+         "(all files older than #{@delete_all_after_days} days)"
+    CleanupUploadFilesJob.perform_later(
+      delete_ingested_after_days: @delete_all_after_days,
+      uploads_path: uploads_path,
+      delete_all_after_days: @delete_all_after_days,
+      tenant: nil
+    )
+    @queued_paths << uploads_path
+  end
+end

--- a/lib/tasks/uploads_cleanup.rake
+++ b/lib/tasks/uploads_cleanup.rake
@@ -4,35 +4,42 @@
 # or any other queue adapter; no GoodJob-specific APIs.
 
 namespace :hyku do
-  desc "Enqueue per-tenant Hyrax upload staging cleanup (DELETE_INGESTED_AFTER_DAYS, DELETE_ALL_AFTER_DAYS); skips S3 tenants"
+  desc <<~DESC
+    Enqueue per-tenant Hyrax upload staging cleanup.
+
+    Always checks the local filesystem path for every tenant—including tenants that have
+    since switched to S3—so that staging files from before an S3 migration are not skipped.
+
+    Options (all via environment variables):
+
+      DELETE_INGESTED_AFTER_DAYS    Delete staging files whose Hyrax::UploadedFile record shows
+                                    they have been ingested, if older than N days. (default: 180)
+
+      DELETE_ALL_AFTER_DAYS         Delete all remaining staging files (including orphans) older
+                                    than N days. (default: 730)
+
+      EXTRA_UPLOAD_PATHS            Comma-separated list of additional upload base directories to
+                                    scan. Useful when HYRAX_UPLOAD_PATH has changed and old files
+                                    remain at the former location.
+
+      INCLUDE_ORPHANED_TENANT_DIRS  Set to "true" to also clean UUID subdirectories in
+                                    EXTRA_UPLOAD_PATHS that do not match any active tenant (e.g.
+                                    deleted tenants). Files older than DELETE_ALL_AFTER_DAYS are
+                                    removed. (default: false)
+
+    Example – one-time cleanup after an HYRAX_UPLOAD_PATH migration:
+
+      DELETE_ALL_AFTER_DAYS=60 \\
+      EXTRA_UPLOAD_PATHS=/old/samvera/uploads \\
+      INCLUDE_ORPHANED_TENANT_DIRS=true \\
+      bin/rails hyku:cleanup_uploads
+  DESC
   task cleanup_uploads: :environment do
-    ingested = ENV.fetch("DELETE_INGESTED_AFTER_DAYS", "180").to_i
-    delete_all = ENV.fetch("DELETE_ALL_AFTER_DAYS", "730").to_i
-
-    Account.find_each do |account|
-      Apartment::Tenant.switch(account.tenant) do
-        if Site.account&.s3_bucket.present?
-          puts "Skipping #{account.tenant}: S3 uploads (no local staging tree)"
-          next
-        end
-
-        uploads_path = Hyrax.config.upload_path.call
-        uploads_path = uploads_path.to_s
-
-        unless Dir.exist?(uploads_path)
-          puts "Skipping #{account.tenant}: #{uploads_path} does not exist"
-          next
-        end
-
-        puts "Enqueueing cleanup for #{account.tenant} → #{uploads_path}"
-
-        CleanupUploadFilesJob.perform_later(
-          delete_ingested_after_days: ingested,
-          uploads_path: uploads_path,
-          delete_all_after_days: delete_all,
-          tenant: account.tenant
-        )
-      end
-    end
+    UploadsCleanupService.new(
+      delete_ingested_after_days: ENV.fetch("DELETE_INGESTED_AFTER_DAYS", "180").to_i,
+      delete_all_after_days: ENV.fetch("DELETE_ALL_AFTER_DAYS", "730").to_i,
+      extra_upload_paths: ENV.fetch("EXTRA_UPLOAD_PATHS", "").split(",").map(&:strip).reject(&:empty?),
+      include_orphaned_tenant_dirs: ActiveModel::Type::Boolean.new.cast(ENV.fetch("INCLUDE_ORPHANED_TENANT_DIRS", "false"))
+    ).run
   end
 end

--- a/spec/services/uploads_cleanup_service_spec.rb
+++ b/spec/services/uploads_cleanup_service_spec.rb
@@ -116,7 +116,12 @@ RSpec.describe UploadsCleanupService do
 
         service.run
 
-        expect(CleanupUploadFilesJob).to have_received(:perform_later).once
+        expect(CleanupUploadFilesJob).not_to have_received(:perform_later).with(
+          hash_including(uploads_path: "#{legacy_base}/not-a-uuid")
+        )
+        expect(CleanupUploadFilesJob).not_to have_received(:perform_later).with(
+          hash_including(uploads_path: "#{legacy_base}/cache")
+        )
       end
 
       context 'when the same path appears in both the main loop and extra paths' do

--- a/spec/services/uploads_cleanup_service_spec.rb
+++ b/spec/services/uploads_cleanup_service_spec.rb
@@ -1,0 +1,244 @@
+# frozen_string_literal: true
+
+RSpec.describe UploadsCleanupService do
+  subject(:service) do
+    described_class.new(
+      delete_ingested_after_days: 180,
+      delete_all_after_days: 730,
+      extra_upload_paths: extra_upload_paths,
+      include_orphaned_tenant_dirs: include_orphaned
+    )
+  end
+
+  let(:extra_upload_paths) { [] }
+  let(:include_orphaned) { false }
+
+  let(:tenant_id) { '11111111-1111-1111-1111-111111111111' }
+  let(:account) { instance_double(Account, tenant: tenant_id) }
+  let(:base_path) { '/app/samvera/uploads' }
+  let(:tenant_path) { "#{base_path}/#{tenant_id}" }
+  let(:staging_dir) { "#{tenant_path}/hyrax/uploaded_file/file" }
+
+  before do
+    allow(CleanupUploadFilesJob).to receive(:perform_later)
+    allow(Account).to receive(:find_each).and_yield(account)
+    allow(Dir).to receive(:exist?).and_call_original
+    allow(Dir).to receive(:exist?).with(staging_dir).and_return(true)
+    allow($stdout).to receive(:puts)
+
+    ENV['HYRAX_UPLOAD_PATH'] = base_path
+  end
+
+  after { ENV.delete('HYRAX_UPLOAD_PATH') }
+
+  describe '#run' do
+    context 'when the tenant has a local staging directory' do
+      it 'enqueues CleanupUploadFilesJob with the correct parameters' do
+        service.run
+
+        expect(CleanupUploadFilesJob).to have_received(:perform_later).with(
+          delete_ingested_after_days: 180,
+          uploads_path: tenant_path,
+          delete_all_after_days: 730,
+          tenant: tenant_id
+        )
+      end
+    end
+
+    context 'when the tenant has no local staging directory' do
+      before { allow(Dir).to receive(:exist?).with(staging_dir).and_return(false) }
+
+      it 'does not enqueue a job' do
+        service.run
+
+        expect(CleanupUploadFilesJob).not_to have_received(:perform_later)
+      end
+    end
+
+    context 'when the tenant now uses S3 but has leftover local staging files' do
+      # Previously the rake task skipped S3 tenants entirely; we must still clean local leftovers.
+      it 'enqueues cleanup for the local path regardless of S3 config' do
+        service.run
+
+        expect(CleanupUploadFilesJob).to have_received(:perform_later).with(
+          hash_including(uploads_path: tenant_path, tenant: tenant_id)
+        )
+      end
+    end
+
+    context 'when HYRAX_UPLOAD_PATH is not set' do
+      let(:rails_uploads) { Rails.root.join('public', 'uploads', tenant_id).to_s }
+      let(:rails_staging) { File.join(rails_uploads, 'hyrax/uploaded_file/file') }
+
+      before do
+        ENV.delete('HYRAX_UPLOAD_PATH')
+        allow(Dir).to receive(:exist?).with(staging_dir).and_return(false)
+        allow(Dir).to receive(:exist?).with(rails_staging).and_return(true)
+      end
+
+      it 'falls back to public/uploads/{tenant}' do
+        service.run
+
+        expect(CleanupUploadFilesJob).to have_received(:perform_later).with(
+          hash_including(uploads_path: rails_uploads)
+        )
+      end
+    end
+
+    context 'with EXTRA_UPLOAD_PATHS' do
+      let(:legacy_base) { '/old/samvera/uploads' }
+      let(:extra_upload_paths) { [legacy_base] }
+      let(:other_tenant_id) { '22222222-2222-2222-2222-222222222222' }
+      let(:other_tenant_path) { "#{legacy_base}/#{other_tenant_id}" }
+      let(:other_staging_dir) { "#{other_tenant_path}/hyrax/uploaded_file/file" }
+
+      before do
+        allow(Dir).to receive(:exist?).with(legacy_base).and_return(true)
+        allow(Dir).to receive(:exist?).with(other_staging_dir).and_return(true)
+        allow(Dir).to receive(:children).with(legacy_base).and_return([other_tenant_id])
+        allow(File).to receive(:directory?).and_call_original
+        allow(File).to receive(:directory?).with(other_tenant_path).and_return(true)
+        allow(Account).to receive(:pluck).with(:tenant).and_return([tenant_id, other_tenant_id])
+      end
+
+      it 'enqueues cleanup for UUID dirs matching known tenants' do
+        service.run
+
+        expect(CleanupUploadFilesJob).to have_received(:perform_later).with(
+          hash_including(uploads_path: other_tenant_path, tenant: other_tenant_id)
+        )
+      end
+
+      it 'does not enqueue for non-UUID directory names' do
+        allow(Dir).to receive(:children).with(legacy_base).and_return(['not-a-uuid', 'cache', other_tenant_id])
+        allow(File).to receive(:directory?).with("#{legacy_base}/not-a-uuid").and_return(true)
+        allow(File).to receive(:directory?).with("#{legacy_base}/cache").and_return(true)
+
+        service.run
+
+        expect(CleanupUploadFilesJob).to have_received(:perform_later).once
+      end
+
+      context 'when the same path appears in both the main loop and extra paths' do
+        let(:extra_upload_paths) { [base_path] }
+
+        before do
+          allow(Dir).to receive(:children).with(base_path).and_return([tenant_id])
+          allow(File).to receive(:directory?).with(tenant_path).and_return(true)
+          allow(Account).to receive(:pluck).with(:tenant).and_return([tenant_id])
+        end
+
+        it 'enqueues the path only once' do
+          service.run
+
+          expect(CleanupUploadFilesJob).to have_received(:perform_later).once
+        end
+      end
+
+      context 'when there are files stored directly under the base path (null/empty tenant context)' do
+        # When Apartment::Tenant.current returned nil/empty at upload time, File.join collapses
+        # the tenant segment and CarrierWave writes staging files straight into the upload root,
+        # producing directories like /app/samvera/uploads/hyrax/uploaded_file/file/97/ instead of
+        # /app/samvera/uploads/{tenant-uuid}/hyrax/uploaded_file/file/97/.
+        let(:null_tenant_staging) { "#{legacy_base}/hyrax/uploaded_file/file" }
+
+        before do
+          allow(Dir).to receive(:children).with(legacy_base).and_return([])
+          allow(Dir).to receive(:exist?).with(null_tenant_staging).and_return(true)
+          allow(Account).to receive(:pluck).with(:tenant).and_return([tenant_id])
+        end
+
+        context 'when include_orphaned_tenant_dirs is false' do
+          it 'does not enqueue cleanup for the base path' do
+            service.run
+
+            expect(CleanupUploadFilesJob).not_to have_received(:perform_later).with(
+              hash_including(uploads_path: legacy_base)
+            )
+          end
+        end
+
+        context 'when include_orphaned_tenant_dirs is true' do
+          let(:include_orphaned) { true }
+
+          it 'enqueues cleanup for the base path with nil tenant' do
+            service.run
+
+            expect(CleanupUploadFilesJob).to have_received(:perform_later).with(
+              delete_ingested_after_days: 730,
+              uploads_path: legacy_base,
+              delete_all_after_days: 730,
+              tenant: nil
+            )
+          end
+        end
+      end
+
+      context 'when the extra path directory does not exist' do
+        let(:extra_upload_paths) { ['/nonexistent/path'] }
+
+        before { allow(Dir).to receive(:exist?).with('/nonexistent/path').and_return(false) }
+
+        it 'skips gracefully without raising' do
+          expect { service.run }.not_to raise_error
+        end
+
+        it 'does not enqueue jobs for the missing path' do
+          service.run
+
+          expect(CleanupUploadFilesJob).to have_received(:perform_later).once # main loop only
+        end
+      end
+
+      context 'with orphaned tenant dirs (tenant no longer in Account table)' do
+        let(:orphaned_id) { '33333333-3333-3333-3333-333333333333' }
+        let(:orphaned_path) { "#{legacy_base}/#{orphaned_id}" }
+        let(:orphaned_staging) { "#{orphaned_path}/hyrax/uploaded_file/file" }
+
+        before do
+          allow(Dir).to receive(:children).with(legacy_base).and_return([orphaned_id])
+          allow(File).to receive(:directory?).with(orphaned_path).and_return(true)
+          allow(Dir).to receive(:exist?).with(orphaned_staging).and_return(true)
+          allow(Account).to receive(:pluck).with(:tenant).and_return([tenant_id])
+        end
+
+        context 'when include_orphaned_tenant_dirs is false (default)' do
+          it 'skips the orphaned directory' do
+            service.run
+
+            expect(CleanupUploadFilesJob).not_to have_received(:perform_later).with(
+              hash_including(uploads_path: orphaned_path)
+            )
+          end
+        end
+
+        context 'when include_orphaned_tenant_dirs is true' do
+          let(:include_orphaned) { true }
+
+          it 'enqueues cleanup with nil tenant and delete_all_after_days as both thresholds' do
+            service.run
+
+            expect(CleanupUploadFilesJob).to have_received(:perform_later).with(
+              delete_ingested_after_days: 730,
+              uploads_path: orphaned_path,
+              delete_all_after_days: 730,
+              tenant: nil
+            )
+          end
+
+          context 'when the orphaned staging directory does not exist' do
+            before { allow(Dir).to receive(:exist?).with(orphaned_staging).and_return(false) }
+
+            it 'skips the orphaned directory' do
+              service.run
+
+              expect(CleanupUploadFilesJob).not_to have_received(:perform_later).with(
+                hash_including(uploads_path: orphaned_path)
+              )
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/uploads_cleanup_service_spec.rb
+++ b/spec/services/uploads_cleanup_service_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe UploadsCleanupService do
         it 'does not enqueue jobs for the missing path' do
           service.run
 
-          expect(CleanupUploadFilesJob).to have_received(:perform_later).once # main loop only
+          expect(CleanupUploadFilesJob).not_to have_received(:perform_later).with('/nonexistent/path')
         end
       end
 


### PR DESCRIPTION
This cleans up tenants that have since moved to S3, allows you to pass in past directories, and deletes orphaned tenant directories (ones that were created without a tenant ID)

