### PR TITLE
Update to use Hyrax compound metadata

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,8 @@ gem 'blacklight_range_limit', '~> 8.5'
 gem 'bolognese', '>= 1.9.10'
 gem 'bootstrap', '~> 4.6'
 gem 'bootstrap-datepicker-rails'
-gem 'bulkrax', '~> 9.5'
+# gem 'bulkrax', '~> 9.5'
+gem 'bulkrax', github: 'samvera/bulkrax', branch: 'v9.5.0-for-compound'
 gem 'byebug', group: %i[development test]
 gem 'capybara', group: %i[test]
 gem 'capybara-screenshot', '~> 1.0', group: %i[test]
@@ -51,7 +52,7 @@ gem 'good_job', '~> 4.10' # Updated for Rails 7.2 compatibility
 gem 'googleauth', '~> 1.9.0'
 gem 'google-protobuf'
 gem 'grpc'
-gem 'hyrax', github: 'samvera/hyrax', branch: 'nested-compound-metadata-foundation'
+gem 'hyrax', github: 'samvera/hyrax', branch: 'main'
 gem 'hyrax-doi', github: 'samvera-labs/hyrax-doi', branch: 'rails_hyrax_upgrade'
 gem 'i18n-debug', require: false, group: %i[development test]
 gem 'i18n-tasks', group: %i[development test]

--- a/Gemfile
+++ b/Gemfile
@@ -28,8 +28,7 @@ gem 'blacklight_range_limit', '~> 8.5'
 gem 'bolognese', '>= 1.9.10'
 gem 'bootstrap', '~> 4.6'
 gem 'bootstrap-datepicker-rails'
-# gem 'bulkrax', '~> 9.5'
-gem 'bulkrax', github: 'samvera/bulkrax', branch: 'v9.5.0-for-compound'
+gem 'bulkrax', '~> 9.5'
 gem 'byebug', group: %i[development test]
 gem 'capybara', group: %i[test]
 gem 'capybara-screenshot', '~> 1.0', group: %i[test]

--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ gem 'good_job', '~> 4.10' # Updated for Rails 7.2 compatibility
 gem 'googleauth', '~> 1.9.0'
 gem 'google-protobuf'
 gem 'grpc'
-gem 'hyrax', github: 'samvera/hyrax', branch: 'flexible-presenter-schema-hoist'
+gem 'hyrax', github: 'samvera/hyrax', branch: 'main'
 gem 'hyrax-doi', github: 'samvera-labs/hyrax-doi', branch: 'rails_hyrax_upgrade'
 gem 'i18n-debug', require: false, group: %i[development test]
 gem 'i18n-tasks', group: %i[development test]

--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ gem 'good_job', '~> 4.10' # Updated for Rails 7.2 compatibility
 gem 'googleauth', '~> 1.9.0'
 gem 'google-protobuf'
 gem 'grpc'
-gem 'hyrax', github: 'samvera/hyrax', branch: 'main'
+gem 'hyrax', github: 'samvera/hyrax', branch: 'flexible-presenter-schema-hoist'
 gem 'hyrax-doi', github: 'samvera-labs/hyrax-doi', branch: 'rails_hyrax_upgrade'
 gem 'i18n-debug', require: false, group: %i[development test]
 gem 'i18n-tasks', group: %i[development test]

--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ gem 'good_job', '~> 4.10' # Updated for Rails 7.2 compatibility
 gem 'googleauth', '~> 1.9.0'
 gem 'google-protobuf'
 gem 'grpc'
-gem 'hyrax', github: 'samvera/hyrax', branch: 'main'
+gem 'hyrax', github: 'samvera/hyrax', branch: 'nested-compound-metadata-foundation'
 gem 'hyrax-doi', github: 'samvera-labs/hyrax-doi', branch: 'rails_hyrax_upgrade'
 gem 'i18n-debug', require: false, group: %i[development test]
 gem 'i18n-tasks', group: %i[development test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: 032264b64dddeae53aef19746d8ae7974f527fcd
+  revision: 803338e3598a36c30a7142deb93555a230e670a8
   branch: nested-compound-metadata-foundation
   specs:
     hyrax (5.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: d82788ad0afd29730871ab8d6603d5686ddcb541
+  revision: 20b843b3fcfba07c6c57a4f4713375b3d4466566
   branch: nested-compound-metadata-foundation
   specs:
     hyrax (5.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: 4b52b20040c832449cec8f73f0b163beabdedb04
+  revision: d82788ad0afd29730871ab8d6603d5686ddcb541
   branch: nested-compound-metadata-foundation
   specs:
     hyrax (5.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,8 +29,8 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: dc3db70bf55734009a88af6d4d936301440b2395
-  branch: flexible-presenter-schema-hoist
+  revision: 19340f2c311fee87ad09b92274890265ffa59e72
+  branch: main
   specs:
     hyrax (5.2.0)
       active-fedora (~> 15.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,30 +28,8 @@ GIT
       rails (>= 5.2.4.3, < 8.0)
 
 GIT
-  remote: https://github.com/samvera/bulkrax.git
-  revision: 8a6f353f679cb350d5cfd383f2982b4a4de574e8
-  branch: v9.5.0-for-compound
-  specs:
-    bulkrax (9.5.0)
-      bagit (~> 0.6.0)
-      coderay
-      denormalize_fields
-      iso8601 (~> 0.9.0)
-      kaminari
-      language_list (~> 1.2, >= 1.2.1)
-      libxml-ruby (~> 5.0)
-      loofah (>= 2.2.3)
-      marcel
-      oai (>= 0.4, < 2.x)
-      rack (>= 2.0.6)
-      rails (>= 5.1.6, < 8.0.0)
-      rdf (>= 2.0.2, < 4.0)
-      rubyzip
-      simple_form
-
-GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: bb4de94373c31d6a8732aa9d19c79d7d9902d51c
+  revision: 23b1387389ef68d896226e71007e0befa31237cf
   branch: main
   specs:
     hyrax (5.2.0)
@@ -391,6 +369,22 @@ GEM
       signet (~> 0.8)
       typhoeus
     builder (3.3.0)
+    bulkrax (9.5.1)
+      bagit (~> 0.6.0)
+      coderay
+      denormalize_fields
+      iso8601 (~> 0.9.0)
+      kaminari
+      language_list (~> 1.2, >= 1.2.1)
+      libxml-ruby (~> 5.0)
+      loofah (>= 2.2.3)
+      marcel
+      oai (>= 0.4, < 2.x)
+      rack (>= 2.0.6)
+      rails (>= 5.1.6, < 8.0.0)
+      rdf (>= 2.0.2, < 4.0)
+      rubyzip
+      simple_form
     byebug (12.0.0)
     cancancan (3.6.1)
     capybara (3.40.0)
@@ -1663,7 +1657,7 @@ DEPENDENCIES
   bolognese (>= 1.9.10)
   bootstrap (~> 4.6)
   bootstrap-datepicker-rails
-  bulkrax!
+  bulkrax (~> 9.5)
   byebug
   capybara
   capybara-screenshot (~> 1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,8 +29,8 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: 23b1387389ef68d896226e71007e0befa31237cf
-  branch: main
+  revision: dc3db70bf55734009a88af6d4d936301440b2395
+  branch: flexible-presenter-schema-hoist
   specs:
     hyrax (5.2.0)
       active-fedora (~> 15.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: f23f344aae364cba44d20ba88ae812f663d4fd8a
+  revision: 032264b64dddeae53aef19746d8ae7974f527fcd
   branch: nested-compound-metadata-foundation
   specs:
     hyrax (5.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: 803338e3598a36c30a7142deb93555a230e670a8
+  revision: 4b52b20040c832449cec8f73f0b163beabdedb04
   branch: nested-compound-metadata-foundation
   specs:
     hyrax (5.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: 20b843b3fcfba07c6c57a4f4713375b3d4466566
+  revision: 78808191be414f57b3a821cc732d91917ce73632
   branch: nested-compound-metadata-foundation
   specs:
     hyrax (5.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,9 +28,31 @@ GIT
       rails (>= 5.2.4.3, < 8.0)
 
 GIT
+  remote: https://github.com/samvera/bulkrax.git
+  revision: 8a6f353f679cb350d5cfd383f2982b4a4de574e8
+  branch: v9.5.0-for-compound
+  specs:
+    bulkrax (9.5.0)
+      bagit (~> 0.6.0)
+      coderay
+      denormalize_fields
+      iso8601 (~> 0.9.0)
+      kaminari
+      language_list (~> 1.2, >= 1.2.1)
+      libxml-ruby (~> 5.0)
+      loofah (>= 2.2.3)
+      marcel
+      oai (>= 0.4, < 2.x)
+      rack (>= 2.0.6)
+      rails (>= 5.1.6, < 8.0.0)
+      rdf (>= 2.0.2, < 4.0)
+      rubyzip
+      simple_form
+
+GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: 78808191be414f57b3a821cc732d91917ce73632
-  branch: nested-compound-metadata-foundation
+  revision: bb4de94373c31d6a8732aa9d19c79d7d9902d51c
+  branch: main
   specs:
     hyrax (5.2.0)
       active-fedora (~> 15.0)
@@ -369,22 +391,6 @@ GEM
       signet (~> 0.8)
       typhoeus
     builder (3.3.0)
-    bulkrax (9.5.0)
-      bagit (~> 0.6.0)
-      coderay
-      denormalize_fields
-      iso8601 (~> 0.9.0)
-      kaminari
-      language_list (~> 1.2, >= 1.2.1)
-      libxml-ruby (~> 5.0)
-      loofah (>= 2.2.3)
-      marcel
-      oai (>= 0.4, < 2.x)
-      rack (>= 2.0.6)
-      rails (>= 5.1.6, < 8.0.0)
-      rdf (>= 2.0.2, < 4.0)
-      rubyzip
-      simple_form
     byebug (12.0.0)
     cancancan (3.6.1)
     capybara (3.40.0)
@@ -1657,7 +1663,7 @@ DEPENDENCIES
   bolognese (>= 1.9.10)
   bootstrap (~> 4.6)
   bootstrap-datepicker-rails
-  bulkrax (~> 9.5)
+  bulkrax!
   byebug
   capybara
   capybara-screenshot (~> 1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,8 +29,8 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: bb662edae452785df62d7d2b634e9326bb9ab816
-  branch: main
+  revision: f23f344aae364cba44d20ba88ae812f663d4fd8a
+  branch: nested-compound-metadata-foundation
   specs:
     hyrax (5.2.0)
       active-fedora (~> 15.0)

--- a/app/assets/stylesheets/themes/cultural_show.scss
+++ b/app/assets/stylesheets/themes/cultural_show.scss
@@ -49,6 +49,32 @@
     }
   }
 
+  // Style compound cards (view: display: card) to match the relationships box.
+  .hyrax-compound-card {
+    background-color: #f8f8f8;
+    border: 1px solid #ddd;
+    margin-top: 20px;
+    padding: 8px;
+
+    .card-header {
+      background: none;
+      border-bottom: 2px solid #ddd;
+      padding: 0 0 0.25rem;
+    }
+
+    .card-title {
+      margin-bottom: 0;
+    }
+
+    .card-body {
+      padding: 0.5rem 0 0;
+    }
+
+    ul.tabular > li > a {
+      word-break: break-word;
+    }
+  }
+
   .citations-container {
     display: flex;
     justify-content: center;

--- a/app/assets/stylesheets/themes/scholarly_show.scss
+++ b/app/assets/stylesheets/themes/scholarly_show.scss
@@ -40,4 +40,40 @@
       font-weight: 400;
     }
   }
+
+  // Compound cards (view: display: card) render as a flat titled section like
+  // the other work-show-items sections: no card box, no rule, a heading
+  // matching the metadata titles, sub-fields indented like other values.
+  // Selectors are chained / use `!important` to beat the Bootstrap .card and
+  // `body.public-facing .card > .card-header` defaults.
+  .hyrax-compound-card.card {
+    background: none !important;
+    border: 0 !important;
+    border-radius: 0;
+    box-shadow: none !important;
+    margin-top: 1rem;
+    padding: 1rem 0 0;
+
+    > .card-header {
+      background: none !important;
+      border: 0 !important;
+      padding: 0;
+    }
+
+    .card-title {
+      font-size: 1rem;
+      font-weight: 700;
+      margin-bottom: 0.5rem;
+    }
+
+    .card-body {
+      padding: 0;
+    }
+
+    // Indent the sub-field rows to line up with other metadata values
+    // (scholarly indents values via `ul.tabular { padding-inline-start: 20px }`).
+    .hyrax-compound-subfield {
+      padding-left: 20px !important;
+    }
+  }
 }

--- a/app/models/collection_resource.rb
+++ b/app/models/collection_resource.rb
@@ -8,6 +8,9 @@ class CollectionResource < Hyrax::PcdmCollection
     include Hyrax::Schema(:bulkrax_metadata)
     include Hyrax::Schema(:collection_resource)
     include Hyrax::Schema(:with_thumbnail)
+    # In flexible mode the compounds come from the m3 profile; include the static
+    # schema only when the m3 profile is not driving the schema.
+    include Hyrax::Schema(:compound_metadata) unless Hyrax.config.flexible?
   end
   include Hyrax::ArResource
 

--- a/app/models/etd_resource.rb
+++ b/app/models/etd_resource.rb
@@ -11,6 +11,9 @@ class EtdResource < Hyrax::Work
     include Hyrax::Schema(:bulkrax_metadata)
     include Hyrax::Schema(:with_pdf_viewer)
     include Hyrax::Schema(:with_video_embed)
+    # In flexible mode the compounds come from the m3 profile; include the static
+    # schema only when the m3 profile is not driving the schema.
+    include Hyrax::Schema(:compound_metadata) unless Hyrax.config.flexible?
   end
 
   include Hyrax::ArResource

--- a/app/models/generic_work_resource.rb
+++ b/app/models/generic_work_resource.rb
@@ -10,6 +10,9 @@ class GenericWorkResource < Hyrax::Work
     include Hyrax::Schema(:bulkrax_metadata)
     include Hyrax::Schema(:with_pdf_viewer)
     include Hyrax::Schema(:with_video_embed)
+    # In flexible mode the compounds come from the m3 profile; include the static
+    # schema only when the m3 profile is not driving the schema.
+    include Hyrax::Schema(:compound_metadata) unless Hyrax.config.flexible?
   end
 
   include Hyrax::ArResource

--- a/app/models/image_resource.rb
+++ b/app/models/image_resource.rb
@@ -10,6 +10,9 @@ class ImageResource < Hyrax::Work
     include Hyrax::Schema(:bulkrax_metadata)
     include Hyrax::Schema(:with_pdf_viewer)
     include Hyrax::Schema(:with_video_embed)
+    # In flexible mode the compounds come from the m3 profile; include the static
+    # schema only when the m3 profile is not driving the schema.
+    include Hyrax::Schema(:compound_metadata) unless Hyrax.config.flexible?
   end
 
   include Hyrax::ArResource

--- a/app/models/oer_resource.rb
+++ b/app/models/oer_resource.rb
@@ -11,6 +11,9 @@ class OerResource < Hyrax::Work
     include Hyrax::Schema(:bulkrax_metadata)
     include Hyrax::Schema(:with_pdf_viewer)
     include Hyrax::Schema(:with_video_embed)
+    # In flexible mode the compounds come from the m3 profile; include the static
+    # schema only when the m3 profile is not driving the schema.
+    include Hyrax::Schema(:compound_metadata) unless Hyrax.config.flexible?
   end
 
   include Hyrax::ArResource

--- a/app/presenters/hyrax/collection_presenter_decorator.rb
+++ b/app/presenters/hyrax/collection_presenter_decorator.rb
@@ -31,12 +31,16 @@ module Hyrax
     end
 
     # OVERRIDE Hyrax - remove size
+    # Delegate everything except :total_items to Hyrax's `#[]`, which guards a
+    # declared-but-empty compound term (no `<name>_json_ss` reader on the doc)
+    # instead of raising. `:size` never reaches here — Hyku removes it from
+    # `terms` (see the class-method override above).
     def [](key)
       case key
       when :total_items
         total_items
       else
-        solr_document.send key
+        super
       end
     end
 

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -3,6 +3,8 @@
 <%# hyrax-doi doesn't work post hyrax v3.0.0 %>
 <% if Hyrax.config.flexible? %>
   <% view_options_for(presenter).each do |field, options| %>
+    <%# OVERRIDE: mirror upstream Hyrax — card-display compounds render as their own card, not inline %>
+    <% next if compound_card_field?(presenter, field) %>
     <% view_options = conform_options(field, options) %>
     <%# keeps admin_note behavior for backward compatibility... should be in metadata but may not be %>
     <% if field == :admin_note %>

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -52,6 +52,10 @@
       </div>
     </div><!-- /card -->
 
+    <%# OVERRIDE: mirror upstream Hyrax — compounds declared `view: { display: card }`
+        render as their own cards, above the Relationships and Items cards. %>
+    <%= render_compound_cards(@presenter) %>
+
     <div class="card">
       <div class="card-header">
         <h2 class="card-title"><%= t('hyrax.base.show.relationships') %></h2>

--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -3,6 +3,7 @@
 <%# add branding text for banner image %>
 <%# remove duplicate items count originating in Hyrax view %>
 <%# contribute more from pals update layout to be more visually appealing %>
+<%# render compound metadata cards (Relationships) the engine view adds %>
 
 <% provide :page_title, construct_page_title(@presenter.title) %>
 <% content_for :canonical_url do %>
@@ -106,6 +107,11 @@
       <% end %>
     </div>
   </div>
+
+  <%# OVERRIDE Hyrax 5.2.0: render compound metadata cards (e.g. Relationships)
+      as their own band, after the collection metadata and before the member
+      listing — mirroring upstream collections/show.html.erb placement. %>
+  <%= render_compound_cards(@presenter) %>
 
   <!-- Search results label -->
   <% if @members_count > 0 || @presenter.subcollection_count > 0 %>

--- a/app/views/hyrax/dashboard/collections/_form.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form.html.erb
@@ -1,4 +1,7 @@
-<%# OVERRIDE Hyrax v5.2.0 to make it say 'Default thumbnail' in the thumbnail select box instead of 'undefined' %>
+<%# OVERRIDE Hyrax v5.2.0
+      - make the thumbnail select box say 'Default thumbnail' instead of 'undefined'
+      - add a thumbnail upload control
+%>
 <%= render "shared/nav_safety_modal" %>
 <div class="tabs mt-4" id="collection-edit-controls">
   <ul class="nav nav-tabs" id="dashboard-collection-tab" role="tablist">
@@ -48,6 +51,13 @@
             <div id="base-terms">
               <% f.object.primary_terms.each do |term| %>
                 <%= render_edit_field_partial(term, f: f) %>
+              <% end %>
+
+              <%# OVERRIDE: mirror upstream Hyrax to render compound metadata fields with their add/remove buttons and JS hooks %>
+              <% if f.object.respond_to?(:compound_terms) %>
+                <% f.object.compound_terms.each do |term| %>
+                  <%= render_compound_field(f, term) %>
+                <% end %>
               <% end %>
 
               <% # TODO: Remove check for PcdmCollection when Issue #5286 is resolved. %>

--- a/app/views/hyrax/etds/_attribute_rows.html.erb
+++ b/app/views/hyrax/etds/_attribute_rows.html.erb
@@ -3,6 +3,9 @@
 <%# hyrax-doi doesn't work post hyrax v3.0.0 %>
 <% if Hyrax.config.flexible? %>
   <% view_options_for(presenter).each do |field, options| %>
+    <%# Card compounds (view: display: card) render in their own card via
+        render_compound_cards, so skip them in the inline metadata list. %>
+    <% next if compound_card_field?(presenter, field) %>
     <% view_options = conform_options(field, options) %>
     <% if field == :admin_note %>
       <%= presenter.attribute_to_html(conform_field(field, options), view_options) if presenter.editor? %>

--- a/app/views/hyrax/oers/_attribute_rows.html.erb
+++ b/app/views/hyrax/oers/_attribute_rows.html.erb
@@ -3,6 +3,9 @@
 <%# hyrax-doi doesn't work post hyrax v3.0.0 %>
 <% if Hyrax.config.flexible? %>
   <% view_options_for(presenter).each do |field, options| %>
+    <%# Card compounds (view: display: card) render in their own card via
+        render_compound_cards, so skip them in the inline metadata list. %>
+    <% next if compound_card_field?(presenter, field) %>
     <% view_options = conform_options(field, options) %>
     <% if field == :admin_note %>
       <%= presenter.attribute_to_html(conform_field(field, options), view_options) if presenter.editor? %>

--- a/app/views/hyrax/oers/show.html.erb
+++ b/app/views/hyrax/oers/show.html.erb
@@ -58,6 +58,8 @@
           </div>
 
           <div class="col-sm-12">
+            <%# OVERRIDE: render schema-driven compound cards (view: display: card) %>
+            <%= render_compound_cards(@presenter) %>
             <%= render 'relationships', presenter: @presenter %>
             <% if @presenter.class == Hyrax::OerPresenter %>
               <%= render 'hyrax/oers/related_items', presenter: @presenter %>

--- a/app/views/themes/community_show/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/themes/community_show/hyrax/base/_attribute_rows.html.erb
@@ -11,6 +11,14 @@
     field_visible?(conform_options(field, options), presenter)
   end
 
+  # Only keep fields that actually have a value to render, so the two columns
+  # split by visible rows. Empty fields (including unfilled compounds) would
+  # otherwise pad the count and skew everything into one column.
+  fields_array.select! do |field, options|
+    render_field = conform_field(field, options)
+    presenter.respond_to?(render_field) && presenter.public_send(render_field).present?
+  end
+
   half = (fields_array.count / 2.0).ceil
   left_fields = fields_array[0...half]
   right_fields = fields_array[half..-1] || []

--- a/app/views/themes/cultural_show/hyrax/base/show.html.erb
+++ b/app/views/themes/cultural_show/hyrax/base/show.html.erb
@@ -37,6 +37,8 @@
             <%= render 'metadata', presenter: @presenter %>
           </div>
           <div class="col-12 relationships-container">
+            <%# OVERRIDE: render schema-driven compound cards (view: display: card) %>
+            <%= render_compound_cards(@presenter) %>
             <div class='relationships-box'>
               <%= render 'relationships', presenter: @presenter %>
             </div>

--- a/app/views/themes/cultural_show/hyrax/oers/show.html.erb
+++ b/app/views/themes/cultural_show/hyrax/oers/show.html.erb
@@ -42,6 +42,8 @@
             <%= render 'metadata', presenter: @presenter %>
           </div>
           <div class="<%= @presenter.iiif_viewer? ? 'col-sm-4' : 'col-sm-12' %>  relationships-container">
+            <%# OVERRIDE: render schema-driven compound cards (view: display: card) %>
+            <%= render_compound_cards(@presenter) %>
             <div class='relationships-box'>
               <%= render 'relationships', presenter: @presenter %>
               </div>

--- a/app/views/themes/image_show/hyrax/base/show.html.erb
+++ b/app/views/themes/image_show/hyrax/base/show.html.erb
@@ -56,6 +56,8 @@
           </div>
 
           <div class="col-sm-12">
+            <%# OVERRIDE: render schema-driven compound cards (view: display: card) %>
+            <%= render_compound_cards(@presenter) %>
             <%= render 'relationships', presenter: @presenter %>
             <% if @presenter.class == Hyrax::OerPresenter %>
               <%= render 'hyrax/oers/related_items', presenter: @presenter %>

--- a/app/views/themes/scholarly_show/hyrax/base/show.html.erb
+++ b/app/views/themes/scholarly_show/hyrax/base/show.html.erb
@@ -66,6 +66,8 @@
         <div class="row">
           <div class="col-12 work-show-items">
             <%= render 'relationships', presenter: @presenter %>
+            <%# OVERRIDE: render schema-driven compound cards (view: display: card) %>
+            <%= render_compound_cards(@presenter) %>
             <% if @presenter.class == Hyrax::OerPresenter %>
               <%= render 'hyrax/oers/related_items', presenter: @presenter %>
             <% end %>

--- a/app/views/themes/scholarly_show/hyrax/oers/show.html.erb
+++ b/app/views/themes/scholarly_show/hyrax/oers/show.html.erb
@@ -56,6 +56,8 @@
           </div>
 
           <div class="col-sm-12">
+            <%# OVERRIDE: render schema-driven compound cards (view: display: card) %>
+            <%= render_compound_cards(@presenter) %>
             <%= render 'relationships', presenter: @presenter %>
             <% if @presenter.class == Hyrax::OerPresenter %>
               <%= render 'hyrax/oers/related_items', presenter: @presenter %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,7 +9,7 @@ require 'i18n/debug' if ENV['I18N_DEBUG']
 groups = Rails.groups
 Bundler.require(*groups)
 
-module Hyku
+module Hyku # rubocop:disable Metrics/ModuleLength
   # Providing a common method to ensure consistent UTF-8 encoding.  Also removing the tricksy Byte
   # Order Marker character which is an invisible 0 space character.
   #
@@ -105,11 +105,24 @@ module Hyku
       'related_item' => { from: ['related_item'], split: '\|' },
       'relative_path' => { from: ['relative_path'], split: '\|', generated: true },
       'related_url' => { from: ['related_url', 'relation'], split: /\s* [|]\s*/ },
-      # Redirects persist as Array<Hash> with string keys ('path', 'is_display_url').
-      # `nested_attributes: true` routes the imported data through `redirects_attributes`
-      # so the form populator (which strips the bare `redirects` key) receives it correctly.
+      # Compound fields: each CSV column maps into an entry on its `object:`. Use
+      # numbered columns (participant_name_1, participant_name_2, …) for multiple
+      # entries. `name:` sets the key inside the entry when the column name can't
+      # be reused as-is (e.g. two compounds both need a `title` or `type`).
+      #   Redirects: alternate URLs for a work.
       'path' => { from: ['redirect_path'], object: 'redirects', nested_attributes: true },
       'is_display_url' => { from: ['redirect_is_display_url'], object: 'redirects', nested_attributes: true },
+      #   Participants: people/organizations with a name, role, and title.
+      'name' => { from: ['participant_name'], object: 'participants', nested_attributes: true },
+      'role' => { from: ['participant_role'], object: 'participants', nested_attributes: true },
+      'participant_title' => { from: ['participant_title'], object: 'participants', nested_attributes: true, name: 'title' },
+      #   Identifiers: a value plus its type (e.g. a DOI).
+      'value' => { from: ['identifier_value'], object: 'identifiers', nested_attributes: true },
+      'identifier_type' => { from: ['identifier_type'], object: 'identifiers', nested_attributes: true, name: 'type' },
+      #   Relationships: links to related works or URLs, with a type and title.
+      'item' => { from: ['relationship_item'], object: 'relationships', nested_attributes: true },
+      'relationship_type' => { from: ['relationship_type'], object: 'relationships', nested_attributes: true, name: 'type' },
+      'relationship_title' => { from: ['relationship_title'], object: 'relationships', nested_attributes: true, name: 'title' },
       'remote_files' => { from: ['remote_files'], split: /\s*[|]\s*/ },
       'rendering_ids' => { from: ['rendering_ids'], split: '\|', generated: true },
       'resource_type' => { from: ['resource_type'], split: true },
@@ -358,3 +371,4 @@ module Hyku
   end
   # rubocop:enable Metrics/ClassLength
 end
+# rubocop:enable Metrics/ModuleLength

--- a/config/metadata/compound_metadata.yaml
+++ b/config/metadata/compound_metadata.yaml
@@ -1,0 +1,117 @@
+# OVERRIDE: Overrides Hyrax's sample compound_metadata schema (used under
+# HYRAX_FLEXIBLE=false). Mirrors the compounds defined in the m3 profile
+# (config/metadata_profiles/m3_profile.yaml) so both flex modes expose the same
+# fields: participants, identifiers, and relationships — each a primary, optional
+# compound. Hyrax's `compound_rights` sample is intentionally not carried over.
+attributes:
+  # Participants associated with the work: a name, a controlled role, and a
+  # display title (the reused `shared_title` below).
+  participants:
+    type: hash
+    multiple: true
+    predicate: http://id.loc.gov/vocabulary/relators/asn
+    form:
+      primary: true
+    groups:
+      identity:
+        label: Identity
+    view:
+      render_as: compound
+      html_dl: true
+  participant_name:
+    type: string
+    name: name
+    available_on:
+      properties:
+        - participants
+    group: identity
+    required: true
+    form:
+      cols: 4
+  participant_role:
+    type: controlled
+    name: role
+    available_on:
+      properties:
+        - participants
+    group: identity
+    required: true
+    values: [Author, Editor, Contributor, Creator, Data Collector, Funder, Publisher, Other]
+    form:
+      cols: 4
+
+  # A typed identifier: an open-entry value plus a controlled identifier type.
+  # Named `identifiers` (plural) to avoid colliding with the scalar `identifier`.
+  identifiers:
+    type: hash
+    multiple: true
+    predicate: http://purl.org/dc/terms/identifier
+    form:
+      primary: true
+    view:
+      render_as: compound
+      html_dl: true
+  identifier_value:
+    type: string
+    name: value
+    available_on:
+      properties:
+        - identifiers
+    required: true
+    form:
+      cols: 6
+  identifier_type:
+    type: controlled
+    name: type
+    available_on:
+      properties:
+        - identifiers
+    required: true
+    values: [DOI, Handle, ISBN, ISSN, URL, URN, ARK, Other]
+    form:
+      cols: 6
+
+  # A related-item grouping using the `work_or_url` sub-property: the user
+  # searches for an internal work (typeahead) or types an external URL.
+  relationships:
+    type: hash
+    multiple: true
+    predicate: http://purl.org/dc/terms/relation
+    form:
+      primary: true
+    view:
+      render_as: compound
+      html_dl: true
+      display: card
+  relationship_item:
+    type: work_or_url
+    name: item
+    available_on:
+      properties:
+        - relationships
+    required: true
+    form:
+      cols: 6
+  relationship_type:
+    type: controlled
+    name: type
+    available_on:
+      properties:
+        - relationships
+    required: true
+    values: [References, Is Referenced By, Is Part Of, Has Part, Is Version Of, Replaces, Requires, Other]
+    form:
+      cols: 6
+
+  # A single subproperty reused by both compounds: `name: title` sets the row
+  # key, `available_on.properties` lists both parents. Solr fields derive per
+  # parent (participants_title_*, relationships_title_*), so no collision.
+  shared_title:
+    type: string
+    name: title
+    available_on:
+      properties:
+        - participants
+        - relationships
+    form:
+      cols: 12

--- a/config/metadata_profiles/m3_profile.yaml
+++ b/config/metadata_profiles/m3_profile.yaml
@@ -1963,12 +1963,12 @@ properties:
   agents:
     available_on:
       class:
-        - Hyrax::Work
         - CollectionResource
+        - GenericWorkResource
     data_type: array
     type: hash
     cardinality:
-      minimum: 1
+      minimum: 0
     range: http://www.w3.org/2001/XMLSchema#string
     display_label:
       default: Agents
@@ -1996,10 +1996,12 @@ properties:
   identifiers:
     available_on:
       class:
-        - Hyrax::Work
         - CollectionResource
+        - GenericWorkResource
     data_type: array
     type: hash
+    cardinality:
+      minimum: 0
     range: http://www.w3.org/2001/XMLSchema#string
     display_label:
       default: Identifiers
@@ -2022,10 +2024,12 @@ properties:
   compound_rights:
     available_on:
       class:
-        - Hyrax::Work
         - CollectionResource
+        - GenericWorkResource
     data_type: array
     type: hash
+    cardinality:
+      minimum: 0
     range: http://www.w3.org/2001/XMLSchema#string
     display_label:
       default: Rights
@@ -2050,10 +2054,12 @@ properties:
   relationships:
     available_on:
       class:
-        - Hyrax::Work
         - CollectionResource
+        - GenericWorkResource
     data_type: array
     type: hash
+    cardinality:
+      minimum: 0
     range: http://www.w3.org/2001/XMLSchema#string
     display_label:
       default: Relationships

--- a/config/metadata_profiles/m3_profile.yaml
+++ b/config/metadata_profiles/m3_profile.yaml
@@ -1956,10 +1956,12 @@ properties:
       primary: false
     property_uri: http://vocabulary.samvera.org/ns#transcriptIds
     range: http://www.w3.org/2001/XMLSchema#string
-  # Sample compound (hierarchical) metadata shipped with Hyrax. Each is a
-  # `type: hash, multiple: true` property whose entries are hashes of the
-  # `subfields:` keys, rendered/populated/indexed generically by the compound
-  # foundation. See Hyrax's documentation/forms/compound_fields.md.
+  # Sample compound (hierarchical) metadata shipped with Hyrax. A compound is a
+  # `type: hash, multiple: true` parent property; its members are declared as
+  # separate properties pointing back with `subproperty_of: <parent>`, each
+  # carrying its own indexing and form placement. Sibling order follows document
+  # order. `subproperty_of` entries are not standalone resource attributes.
+  # See Hyrax's documentation/compound_fields.md.
   participants:
     available_on:
       class:
@@ -1973,26 +1975,42 @@ properties:
     display_label:
       default: Participants
     form:
-      primary: false
+      primary: true
     property_uri: http://id.loc.gov/vocabulary/relators/asn
-    subfields:
-      # Indexing per sub-field via `indexing:` (literal Solr field names), the
-      # same mechanism scalar properties use. No `indexing:` => display-only.
-      title: { type: string }
-      participant_name:
-        type: string
-        required: true
-        indexing: [participant_name_sim, participant_name_tesim]
-      participant_role:
-        type: controlled
-        required: true
-        values: [Author, Editor, Contributor, Creator, Data Collector, Funder, Publisher, Other]
-        indexing: [participant_role_sim, participant_role_tesim]
+    # Group metadata (label) for subproperties declaring `group: <key>`.
     groups:
-      - { label: ~, cols: 4, fields: [title, participant_name, participant_role] }
+      identity:
+        label: Identity
     view:
       render_as: compound
       html_dl: true
+  # Subproperties omit `available_on`/`range`/`display_label`: they inherit the
+  # parent compound's class scope and are folded into it by the schema loader.
+  # Indexing per sub-property via `indexing:` (literal Solr field names), the
+  # same mechanism scalar properties use. No `indexing:` => display-only.
+  participant_title:
+    type: string
+    subproperty_of: participants
+    group: identity
+    form:
+      cols: 4
+  participant_name:
+    type: string
+    subproperty_of: participants
+    group: identity
+    required: true
+    indexing: [participant_name_sim, participant_name_tesim]
+    form:
+      cols: 4
+  participant_role:
+    type: controlled
+    subproperty_of: participants
+    group: identity
+    required: true
+    values: [Author, Editor, Contributor, Creator, Data Collector, Funder, Publisher, Other]
+    indexing: [participant_role_sim, participant_role_tesim]
+    form:
+      cols: 4
   identifiers:
     available_on:
       class:
@@ -2008,19 +2026,24 @@ properties:
     form:
       primary: false
     property_uri: http://purl.org/dc/terms/identifier
-    subfields:
-      identifier:
-        type: string
-        required: true
-        indexing: [identifier_value_sim, identifier_value_tesim]
-      identifier_type:
-        type: controlled
-        required: true
-        values: [DOI, Handle, ISBN, ISSN, URL, URN, ARK, Other]
-        indexing: [identifier_type_sim]
     view:
       render_as: compound
       html_dl: true
+  identifier_value:
+    type: string
+    subproperty_of: identifiers
+    required: true
+    indexing: [identifier_value_sim, identifier_value_tesim]
+    form:
+      cols: 6
+  identifier_type:
+    type: controlled
+    subproperty_of: identifiers
+    required: true
+    values: [DOI, Handle, ISBN, ISSN, URL, URN, ARK, Other]
+    indexing: [identifier_type_sim]
+    form:
+      cols: 6
   compound_rights:
     available_on:
       class:
@@ -2036,21 +2059,29 @@ properties:
     form:
       primary: false
     property_uri: http://purl.org/dc/terms/rights
-    subfields:
-      rights_statement:
-        type: controlled
-        authority: rights_statements
-        indexing: [compound_rights_statement_sim, compound_rights_statement_tesim]
-      license:
-        type: controlled
-        authority: licenses
-        indexing: [compound_rights_license_sim, compound_rights_license_tesim]
-      rights_notes:
-        type: string
-        indexing: [compound_rights_notes_tesim]
     view:
       render_as: compound
       html_dl: true
+  compound_rights_statement:
+    type: controlled
+    subproperty_of: compound_rights
+    authority: rights_statements
+    indexing: [compound_rights_statement_sim, compound_rights_statement_tesim]
+    form:
+      cols: 6
+  compound_rights_license:
+    type: controlled
+    subproperty_of: compound_rights
+    authority: licenses
+    indexing: [compound_rights_license_sim, compound_rights_license_tesim]
+    form:
+      cols: 6
+  compound_rights_notes:
+    type: string
+    subproperty_of: compound_rights
+    indexing: [compound_rights_notes_tesim]
+    form:
+      cols: 12
   relationships:
     available_on:
       class:
@@ -2064,19 +2095,24 @@ properties:
     display_label:
       default: Relationships
     form:
-      primary: false
+      primary: true
     property_uri: http://purl.org/dc/terms/relation
-    subfields:
-      related_item:
-        type: work_or_url
-        required: true
-        indexing: [relationships_item_ssim]
-      relationship_type:
-        type: controlled
-        required: true
-        values: [References, Is Referenced By, Is Part Of, Has Part, Is Version Of, Replaces, Requires, Other]
-        indexing: [relationships_type_sim]
     view:
       render_as: compound
       html_dl: true
       display: card
+  relationship_item:
+    type: work_or_url
+    subproperty_of: relationships
+    required: true
+    indexing: [relationships_item_ssim]
+    form:
+      cols: 6
+  relationship_type:
+    type: controlled
+    subproperty_of: relationships
+    required: true
+    values: [References, Is Referenced By, Is Part Of, Has Part, Is Version Of, Replaces, Requires, Other]
+    indexing: [relationships_type_sim]
+    form:
+      cols: 6

--- a/config/metadata_profiles/m3_profile.yaml
+++ b/config/metadata_profiles/m3_profile.yaml
@@ -1956,12 +1956,13 @@ properties:
       primary: false
     property_uri: http://vocabulary.samvera.org/ns#transcriptIds
     range: http://www.w3.org/2001/XMLSchema#string
-  # Sample compound (hierarchical) metadata shipped with Hyrax. A compound is a
-  # `type: hash, multiple: true` parent property; its members are declared as
-  # separate properties pointing back with `subproperty_of: <parent>`, each
-  # carrying its own indexing and form placement. Sibling order follows document
-  # order. `subproperty_of` entries are not standalone resource attributes.
-  # See Hyrax's documentation/compound_fields.md.
+  # Sample compound (hierarchical) metadata, demonstrating the Hyrax compound
+  # foundation in flexible mode. A compound is a `type: hash, multiple: true`
+  # parent; its members are declared as separate properties naming it via
+  # `available_on: { properties: [<parent>] }`, each carrying its own indexing
+  # and form placement. A member may name more than one parent, and `name:` sets
+  # its key inside the compound. Such members are not standalone resource
+  # attributes. See in hyrax at documentation/compound_fields.md.
   participants:
     available_on:
       class:
@@ -1984,31 +1985,31 @@ properties:
     view:
       render_as: compound
       html_dl: true
-  # Subproperties omit `available_on`/`range`/`display_label`: they inherit the
-  # parent compound's class scope and are folded into it by the schema loader.
-  # Indexing per sub-property via `indexing:` (literal Solr field names), the
-  # same mechanism scalar properties use. No `indexing:` => display-only.
-  participant_title:
-    type: string
-    subproperty_of: participants
-    group: identity
-    form:
-      cols: 4
+  # Subproperties declare `available_on: { properties: [<parent>] }` (no
+  # `class:`/`range`/`display_label`): they inherit their parent compound's class
+  # scope and are folded into it by the schema loader. Solr fields are derived
+  # per sub-property (`<parent>_<name>_<suffix>`) unless an explicit `indexing:`
+  # overrides or `indexing: false` opts out. (`participants` gets its `title`
+  # from the reused `shared_title` below.)
   participant_name:
     type: string
-    subproperty_of: participants
+    name: name
+    available_on:
+      properties:
+        - participants
     group: identity
     required: true
-    indexing: [participant_name_sim, participant_name_tesim]
     form:
       cols: 4
   participant_role:
     type: controlled
-    subproperty_of: participants
+    name: role
+    available_on:
+      properties:
+        - participants
     group: identity
     required: true
     values: [Author, Editor, Contributor, Creator, Data Collector, Funder, Publisher, Other]
-    indexing: [participant_role_sim, participant_role_tesim]
     form:
       cols: 4
   identifiers:
@@ -2024,64 +2025,30 @@ properties:
     display_label:
       default: Identifiers
     form:
-      primary: false
+      primary: true
     property_uri: http://purl.org/dc/terms/identifier
     view:
       render_as: compound
       html_dl: true
   identifier_value:
     type: string
-    subproperty_of: identifiers
+    name: value
+    available_on:
+      properties:
+        - identifiers
     required: true
-    indexing: [identifier_value_sim, identifier_value_tesim]
     form:
       cols: 6
   identifier_type:
     type: controlled
-    subproperty_of: identifiers
+    name: type
+    available_on:
+      properties:
+        - identifiers
     required: true
     values: [DOI, Handle, ISBN, ISSN, URL, URN, ARK, Other]
-    indexing: [identifier_type_sim]
     form:
       cols: 6
-  compound_rights:
-    available_on:
-      class:
-        - CollectionResource
-        - GenericWorkResource
-    data_type: array
-    type: hash
-    cardinality:
-      minimum: 0
-    range: http://www.w3.org/2001/XMLSchema#string
-    display_label:
-      default: Rights
-    form:
-      primary: false
-    property_uri: http://purl.org/dc/terms/rights
-    view:
-      render_as: compound
-      html_dl: true
-  compound_rights_statement:
-    type: controlled
-    subproperty_of: compound_rights
-    authority: rights_statements
-    indexing: [compound_rights_statement_sim, compound_rights_statement_tesim]
-    form:
-      cols: 6
-  compound_rights_license:
-    type: controlled
-    subproperty_of: compound_rights
-    authority: licenses
-    indexing: [compound_rights_license_sim, compound_rights_license_tesim]
-    form:
-      cols: 6
-  compound_rights_notes:
-    type: string
-    subproperty_of: compound_rights
-    indexing: [compound_rights_notes_tesim]
-    form:
-      cols: 12
   relationships:
     available_on:
       class:
@@ -2103,16 +2070,36 @@ properties:
       display: card
   relationship_item:
     type: work_or_url
-    subproperty_of: relationships
+    name: item
+    available_on:
+      properties:
+        - relationships
     required: true
-    indexing: [relationships_item_ssim]
     form:
       cols: 6
   relationship_type:
     type: controlled
-    subproperty_of: relationships
+    name: type
+    available_on:
+      properties:
+        - relationships
     required: true
     values: [References, Is Referenced By, Is Part Of, Has Part, Is Version Of, Replaces, Requires, Other]
-    indexing: [relationships_type_sim]
     form:
       cols: 6
+  # A single subproperty definition reused by two compounds. The top-level key
+  # (`shared_title`) is globally unique, while `name: title` sets the cleaner key
+  # inside each compound row (so both `participants` and `relationships` rows
+  # carry a `title`), and `available_on.properties` lists both parents. Its Solr
+  # fields are derived per parent (`participants_title_sim`/`_tesim` and
+  # `relationships_title_sim`/`_tesim`), so the reused field is searchable in
+  # each compound with no collision and no hand-written `indexing:`.
+  shared_title:
+    type: string
+    name: title
+    available_on:
+      properties:
+        - participants
+        - relationships
+    form:
+      cols: 12

--- a/config/metadata_profiles/m3_profile.yaml
+++ b/config/metadata_profiles/m3_profile.yaml
@@ -1956,3 +1956,121 @@ properties:
       primary: false
     property_uri: http://vocabulary.samvera.org/ns#transcriptIds
     range: http://www.w3.org/2001/XMLSchema#string
+  # Sample compound (hierarchical) metadata shipped with Hyrax. Each is a
+  # `type: hash, multiple: true` property whose entries are hashes of the
+  # `subfields:` keys, rendered/populated/indexed generically by the compound
+  # foundation. See Hyrax's documentation/forms/compound_fields.md.
+  agents:
+    available_on:
+      class:
+        - Hyrax::Work
+        - CollectionResource
+    data_type: array
+    type: hash
+    cardinality:
+      minimum: 1
+    range: http://www.w3.org/2001/XMLSchema#string
+    display_label:
+      default: Agents
+    form:
+      primary: false
+    property_uri: http://id.loc.gov/vocabulary/relators/asn
+    subfields:
+      # Indexing per sub-field via `indexing:` (literal Solr field names), the
+      # same mechanism scalar properties use. No `indexing:` => display-only.
+      title: { type: string }
+      agent_name:
+        type: string
+        required: true
+        indexing: [agent_name_sim, agent_name_tesim]
+      agent_role:
+        type: controlled
+        required: true
+        values: [Author, Editor, Contributor, Creator, Data Collector, Funder, Publisher, Other]
+        indexing: [agent_role_sim, agent_role_tesim]
+    groups:
+      - { label: ~, cols: 4, fields: [title, agent_name, agent_role] }
+    view:
+      render_as: compound
+      html_dl: true
+  identifiers:
+    available_on:
+      class:
+        - Hyrax::Work
+        - CollectionResource
+    data_type: array
+    type: hash
+    range: http://www.w3.org/2001/XMLSchema#string
+    display_label:
+      default: Identifiers
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/terms/identifier
+    subfields:
+      identifier:
+        type: string
+        required: true
+        indexing: [identifier_value_sim, identifier_value_tesim]
+      identifier_type:
+        type: controlled
+        required: true
+        values: [DOI, Handle, ISBN, ISSN, URL, URN, ARK, Other]
+        indexing: [identifier_type_sim]
+    view:
+      render_as: compound
+      html_dl: true
+  compound_rights:
+    available_on:
+      class:
+        - Hyrax::Work
+        - CollectionResource
+    data_type: array
+    type: hash
+    range: http://www.w3.org/2001/XMLSchema#string
+    display_label:
+      default: Rights
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/terms/rights
+    subfields:
+      rights_statement:
+        type: controlled
+        authority: rights_statements
+        indexing: [compound_rights_statement_sim, compound_rights_statement_tesim]
+      license:
+        type: controlled
+        authority: licenses
+        indexing: [compound_rights_license_sim, compound_rights_license_tesim]
+      rights_notes:
+        type: string
+        indexing: [compound_rights_notes_tesim]
+    view:
+      render_as: compound
+      html_dl: true
+  relationships:
+    available_on:
+      class:
+        - Hyrax::Work
+        - CollectionResource
+    data_type: array
+    type: hash
+    range: http://www.w3.org/2001/XMLSchema#string
+    display_label:
+      default: Relationships
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/terms/relation
+    subfields:
+      related_item:
+        type: work_or_url
+        required: true
+        indexing: [relationships_item_ssim]
+      relationship_type:
+        type: controlled
+        required: true
+        values: [References, Is Referenced By, Is Part Of, Has Part, Is Version Of, Replaces, Requires, Other]
+        indexing: [relationships_type_sim]
+    view:
+      render_as: compound
+      html_dl: true
+      display: card

--- a/config/metadata_profiles/m3_profile.yaml
+++ b/config/metadata_profiles/m3_profile.yaml
@@ -1960,7 +1960,7 @@ properties:
   # `type: hash, multiple: true` property whose entries are hashes of the
   # `subfields:` keys, rendered/populated/indexed generically by the compound
   # foundation. See Hyrax's documentation/forms/compound_fields.md.
-  agents:
+  participants:
     available_on:
       class:
         - CollectionResource
@@ -1971,7 +1971,7 @@ properties:
       minimum: 0
     range: http://www.w3.org/2001/XMLSchema#string
     display_label:
-      default: Agents
+      default: Participants
     form:
       primary: false
     property_uri: http://id.loc.gov/vocabulary/relators/asn
@@ -1979,17 +1979,17 @@ properties:
       # Indexing per sub-field via `indexing:` (literal Solr field names), the
       # same mechanism scalar properties use. No `indexing:` => display-only.
       title: { type: string }
-      agent_name:
+      participant_name:
         type: string
         required: true
-        indexing: [agent_name_sim, agent_name_tesim]
-      agent_role:
+        indexing: [participant_name_sim, participant_name_tesim]
+      participant_role:
         type: controlled
         required: true
         values: [Author, Editor, Contributor, Creator, Data Collector, Funder, Publisher, Other]
-        indexing: [agent_role_sim, agent_role_tesim]
+        indexing: [participant_role_sim, participant_role_tesim]
     groups:
-      - { label: ~, cols: 4, fields: [title, agent_name, agent_role] }
+      - { label: ~, cols: 4, fields: [title, participant_name, participant_role] }
     view:
       render_as: compound
       html_dl: true


### PR DESCRIPTION
## Summary
- Enable Hyrax's compound metadata in Hyku, with participants, identifiers, and relationships as worked examples that render on work and collection pages and import via Bulkrax.

## Details
- Defines three compounds in both flex modes: static `config/metadata/compound_metadata.yaml` (non-flexible) and the m3 profile (flexible) — participants (name/role/title), identifiers (value/type), relationships (item/type/title).
- Includes the static `:compound_metadata` schema on each work + collection model only when not in flexible mode; the m3 profile drives it when flexible.
- Renders `display: card` compounds (such as the example `relationships` property) as their own card above Relationships/Items; inline compounds render in the attribute rows. Card vs. inline handled consistently across the default and themed (cultural/scholarly/community/image) show pages, with theme SCSS to match each theme's section styling.
- Adds the compound add/remove field controls to the collection edit form.
- Maps the compound sub-fields for Bulkrax CSV import (numbered columns for multiple entries; `name:` aliasing where column names collide), and updates bulkrax to v9.5.1 to support importing these. 
- Guards the collection presenter's `#[]` so a declared-but-empty compound term returns nil instead of raising.
- Bumps the hyrax pin to pick up the compound metadata work


