### PR TITLE
Adopt restructured compound metadata profile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: fafb610bfe23ea5c90d74e7c73fce6415ff2c0e4
+  revision: 20b843b3fcfba07c6c57a4f4713375b3d4466566
   branch: nested-compound-metadata-foundation
   specs:
     hyrax (5.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: d82788ad0afd29730871ab8d6603d5686ddcb541
+  revision: fafb610bfe23ea5c90d74e7c73fce6415ff2c0e4
   branch: nested-compound-metadata-foundation
   specs:
     hyrax (5.2.0)

--- a/config/metadata_profiles/m3_profile.yaml
+++ b/config/metadata_profiles/m3_profile.yaml
@@ -1956,10 +1956,12 @@ properties:
       primary: false
     property_uri: http://vocabulary.samvera.org/ns#transcriptIds
     range: http://www.w3.org/2001/XMLSchema#string
-  # Sample compound (hierarchical) metadata shipped with Hyrax. Each is a
-  # `type: hash, multiple: true` property whose entries are hashes of the
-  # `subfields:` keys, rendered/populated/indexed generically by the compound
-  # foundation. See Hyrax's documentation/forms/compound_fields.md.
+  # Sample compound (hierarchical) metadata shipped with Hyrax. A compound is a
+  # `type: hash, multiple: true` parent property; its members are declared as
+  # separate properties pointing back with `subproperty_of: <parent>`, each
+  # carrying its own indexing and form placement. Sibling order follows document
+  # order. `subproperty_of` entries are not standalone resource attributes.
+  # See Hyrax's documentation/compound_fields.md.
   participants:
     available_on:
       class:
@@ -1973,26 +1975,42 @@ properties:
     display_label:
       default: Participants
     form:
-      primary: false
+      primary: true
     property_uri: http://id.loc.gov/vocabulary/relators/asn
-    subfields:
-      # Indexing per sub-field via `indexing:` (literal Solr field names), the
-      # same mechanism scalar properties use. No `indexing:` => display-only.
-      title: { type: string }
-      participant_name:
-        type: string
-        required: true
-        indexing: [participant_name_sim, participant_name_tesim]
-      participant_role:
-        type: controlled
-        required: true
-        values: [Author, Editor, Contributor, Creator, Data Collector, Funder, Publisher, Other]
-        indexing: [participant_role_sim, participant_role_tesim]
+    # Group metadata (label) for subproperties declaring `group: <key>`.
     groups:
-      - { label: ~, cols: 4, fields: [title, participant_name, participant_role] }
+      identity:
+        label: Identity
     view:
       render_as: compound
       html_dl: true
+  # Subproperties omit `available_on`/`range`/`display_label`: they inherit the
+  # parent compound's class scope and are folded into it by the schema loader.
+  # Indexing per sub-property via `indexing:` (literal Solr field names), the
+  # same mechanism scalar properties use. No `indexing:` => display-only.
+  participant_title:
+    type: string
+    subproperty_of: participants
+    group: identity
+    form:
+      cols: 4
+  participant_name:
+    type: string
+    subproperty_of: participants
+    group: identity
+    required: true
+    indexing: [participant_name_sim, participant_name_tesim]
+    form:
+      cols: 4
+  participant_role:
+    type: controlled
+    subproperty_of: participants
+    group: identity
+    required: true
+    values: [Author, Editor, Contributor, Creator, Data Collector, Funder, Publisher, Other]
+    indexing: [participant_role_sim, participant_role_tesim]
+    form:
+      cols: 4
   identifiers:
     available_on:
       class:
@@ -2008,19 +2026,24 @@ properties:
     form:
       primary: false
     property_uri: http://purl.org/dc/terms/identifier
-    subfields:
-      identifier:
-        type: string
-        required: true
-        indexing: [identifier_value_sim, identifier_value_tesim]
-      identifier_type:
-        type: controlled
-        required: true
-        values: [DOI, Handle, ISBN, ISSN, URL, URN, ARK, Other]
-        indexing: [identifier_type_sim]
     view:
       render_as: compound
       html_dl: true
+  identifier_value:
+    type: string
+    subproperty_of: identifiers
+    required: true
+    indexing: [identifier_value_sim, identifier_value_tesim]
+    form:
+      cols: 6
+  identifier_type:
+    type: controlled
+    subproperty_of: identifiers
+    required: true
+    values: [DOI, Handle, ISBN, ISSN, URL, URN, ARK, Other]
+    indexing: [identifier_type_sim]
+    form:
+      cols: 6
   compound_rights:
     available_on:
       class:
@@ -2036,21 +2059,29 @@ properties:
     form:
       primary: false
     property_uri: http://purl.org/dc/terms/rights
-    subfields:
-      rights_statement:
-        type: controlled
-        authority: rights_statements
-        indexing: [compound_rights_statement_sim, compound_rights_statement_tesim]
-      license:
-        type: controlled
-        authority: licenses
-        indexing: [compound_rights_license_sim, compound_rights_license_tesim]
-      rights_notes:
-        type: string
-        indexing: [compound_rights_notes_tesim]
     view:
       render_as: compound
       html_dl: true
+  compound_rights_statement:
+    type: controlled
+    subproperty_of: compound_rights
+    authority: rights_statements
+    indexing: [compound_rights_statement_sim, compound_rights_statement_tesim]
+    form:
+      cols: 6
+  compound_rights_license:
+    type: controlled
+    subproperty_of: compound_rights
+    authority: licenses
+    indexing: [compound_rights_license_sim, compound_rights_license_tesim]
+    form:
+      cols: 6
+  compound_rights_notes:
+    type: string
+    subproperty_of: compound_rights
+    indexing: [compound_rights_notes_tesim]
+    form:
+      cols: 12
   relationships:
     available_on:
       class:
@@ -2064,19 +2095,24 @@ properties:
     display_label:
       default: Relationships
     form:
-      primary: false
+      primary: true
     property_uri: http://purl.org/dc/terms/relation
-    subfields:
-      related_item:
-        type: work_or_url
-        required: true
-        indexing: [relationships_item_ssim]
-      relationship_type:
-        type: controlled
-        required: true
-        values: [References, Is Referenced By, Is Part Of, Has Part, Is Version Of, Replaces, Requires, Other]
-        indexing: [relationships_type_sim]
     view:
       render_as: compound
       html_dl: true
       display: card
+  relationship_item:
+    type: work_or_url
+    subproperty_of: relationships
+    required: true
+    indexing: [relationships_item_ssim]
+    form:
+      cols: 6
+  relationship_type:
+    type: controlled
+    subproperty_of: relationships
+    required: true
+    values: [References, Is Referenced By, Is Part Of, Has Part, Is Version Of, Replaces, Requires, Other]
+    indexing: [relationships_type_sim]
+    form:
+      cols: 6


### PR DESCRIPTION
# Summary

Updates Hyrax to use the new compound metadata yaml structure.

The sample compounds in the flexible metadata profile declare their members as flat `subproperty_of:` properties, matching the restructured Hyrax compound foundation, and the Hyrax dependency advances to that branch.

This will break prior test data as the old nested `subfields:` form no longer loads.
