### PR TITLE
Pin json ~> 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ gem 'i18n-tasks', group: %i[development test]
 gem 'iiif_print', '~> 3.0.12'
 gem 'jbuilder', '~> 2.5'
 gem 'jquery-rails' # Use jquery as the JavaScript library
+gem 'json', '~> 2.0' # avoid v3 breaking changes downstream
 gem 'json-canonicalization', "0.3.1" # The maintainers yanked 0.3.2 version (see https://github.com/dryruby/json-canonicalization/issues/2)
 gem 'json_schemer' # Required for m3 schema validation
 gem 'launchy', group: %i[test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1688,6 +1688,7 @@ DEPENDENCIES
   iiif_print (~> 3.0.12)
   jbuilder (~> 2.5)
   jquery-rails
+  json (~> 2.0)
   json-canonicalization (= 0.3.1)
   json_schemer
   launchy


### PR DESCRIPTION
Knapsacks gitignore Gemfile.lock and re-resolve from scratch in CI, so unpinned gems can drift to incompatible majors (e.g. json 3.x).

Pinning json at the Hyku level keeps every downstream resolving to a compatible version without each one overriding via bundler.d.

ref: https://notch8.slack.com/archives/C08EHRPQ9MY/p1780929216187279

<img width="977" height="107" alt="image" src="https://github.com/user-attachments/assets/e200af0f-e18b-42ac-a635-e02ca90f4536" />

@samvera/hyku-code-reviewers