### PR TITLE
Respect a pre-set HYRAX_FLEXIBLE_CLASSES for custom work types

### DIFF
--- a/config/initializers/1flexible.rb
+++ b/config/initializers/1flexible.rb
@@ -3,7 +3,9 @@
 
 flexible = ActiveModel::Type::Boolean.new.cast(ENV.fetch('HYRAX_FLEXIBLE', 'true'))
 if flexible
-  ENV['HYRAX_FLEXIBLE_CLASSES'] = %w[
+  # Respect a pre-set HYRAX_FLEXIBLE_CLASSES (e.g. a deployment or knapsack
+  # adding custom work types); otherwise default to the stock classes.
+  ENV['HYRAX_FLEXIBLE_CLASSES'] ||= %w[
     AdminSetResource
     CollectionResource
     Hyrax::FileSet

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -147,12 +147,8 @@ Add this to your `.env` file for local development, or set it in your deployment
 
 When flexible metadata is enabled, Hyku applies it to the stock work types
 (GenericWork, Image, Etd, Oer) plus Collections, Admin Sets, and File Sets.
-A class only participates in flexible metadata if it is named in the
-`HYRAX_FLEXIBLE_CLASSES` environment variable; custom work types (for example,
-ones generated in a [Hyku Knapsack](https://github.com/samvera-labs/hyku_knapsack)
-with `rails generate hyku_knapsack:work_resource MyWorkType`) must be added to
-it or their forms, indexing, and Bulkrax-template generation will silently fall
-back to static (non-flexible) metadata.
+A class participates in flexible metadata if it is named in the
+`HYRAX_FLEXIBLE_CLASSES` environment variable or if acts_as_flexible_resource is declaired on the class.
 
 `HYRAX_FLEXIBLE_CLASSES` is the **complete** list, not additions — include the
 stock classes too:
@@ -161,7 +157,7 @@ stock classes too:
 HYRAX_FLEXIBLE_CLASSES=AdminSetResource,CollectionResource,Hyrax::FileSet,GenericWorkResource,ImageResource,EtdResource,OerResource,MyWorkType
 ```
 
-When the variable is unset, Hyku defaults it to the stock classes listed above.
+When the variable is unset, Hyku defaults it to the stock classes listed above plus any class with `acts_as_flexible_resource` set.
 Every class named here must also be declared in the tenant's M3 profile
 (`classes:` section) and have its properties' `available_on` entries reference it.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -143,6 +143,28 @@ HYRAX_FLEXIBLE=true
 
 Add this to your `.env` file for local development, or set it in your deployment environment.
 
+### Flexible Metadata for Custom Work Types
+
+When flexible metadata is enabled, Hyku applies it to the stock work types
+(GenericWork, Image, Etd, Oer) plus Collections, Admin Sets, and File Sets.
+A class only participates in flexible metadata if it is named in the
+`HYRAX_FLEXIBLE_CLASSES` environment variable; custom work types (for example,
+ones generated in a [Hyku Knapsack](https://github.com/samvera-labs/hyku_knapsack)
+with `rails generate hyku_knapsack:work_resource MyWorkType`) must be added to
+it or their forms, indexing, and Bulkrax-template generation will silently fall
+back to static (non-flexible) metadata.
+
+`HYRAX_FLEXIBLE_CLASSES` is the **complete** list, not additions — include the
+stock classes too:
+
+```bash
+HYRAX_FLEXIBLE_CLASSES=AdminSetResource,CollectionResource,Hyrax::FileSet,GenericWorkResource,ImageResource,EtdResource,OerResource,MyWorkType
+```
+
+When the variable is unset, Hyku defaults it to the stock classes listed above.
+Every class named here must also be declared in the tenant's M3 profile
+(`classes:` section) and have its properties' `available_on` entries reference it.
+
 ### Documentation
 
 For comprehensive information about flexible metadata, including:


### PR DESCRIPTION
### What does this PR do?

Changes `config/initializers/1flexible.rb` to use `||=` when defaulting `HYRAX_FLEXIBLE_CLASSES`, so an explicitly configured value survives, and documents the variable (complete-list semantics, knapsack custom work type example) in `docs/configuration.md`, which previously did not mention it.

### Why?

Today the initializer unconditionally resets `HYRAX_FLEXIBLE_CLASSES` to the seven stock classes whenever `HYRAX_FLEXIBLE` is on. `Hyrax::Resource.inherited` only mixes `Hyrax::Flexibility` into classes named in that list, so a custom work type generated in a knapsack (`rails generate hyku_knapsack:work_resource Design`) silently does NOT get flexible metadata: the M3 profile uploads fine, the class registers fine, but its instances never load profile attributes, its deposit form shows only core fields, and the Bulkrax sample-CSV template omits every profile property. There is no error anywhere — the failure surfaces as "my fields aren't showing up" with nothing in the logs.

We hit this building a two-work-type repository (a Design/Board collection model) on Hyku 7.1.x with a from-scratch M3 profile: every layer was correctly configured, and the only missing piece was this initializer clobbering the env var. The fix today requires either patching Hyku prime or shipping a knapsack initializer that re-appends after this one runs — both of which defeat the purpose of flexible metadata being a no-developer-required feature, and neither of which is documented.

From a market standpoint: custom work types are the first thing institutions with non-bibliographic collections (archives, museums, research outputs) need, and flexible metadata is Hyku's headline differentiator vs DSpace/InvenioRDM precisely because schema work doesn't require redeploys. This one-line gate is currently the wall between those two features.

### How to test

1. In a knapsack or app with a custom work type `Design` registered and present in the tenant M3 profile, set `HYRAX_FLEXIBLE=true` and `HYRAX_FLEXIBLE_CLASSES=AdminSetResource,CollectionResource,Hyrax::FileSet,GenericWorkResource,ImageResource,EtdResource,OerResource,Design`.
2. Before this change: `Design.new.respond_to?(:your_profile_field) # => false`.
3. After this change: `Hyrax.config.flexible_classes` includes `Design` and the instance responds to profile attributes.
4. With the variable unset, behavior is unchanged (defaults to the stock classes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)