### PR TITLE
Add a Work Type facet to the catalog and dashboard works page

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -125,6 +125,7 @@ class CatalogController < ApplicationController
     #   The ordering of the field names is the order of the display
     config.add_facet_field 'generic_type_sim', label: "Type", limit: 5
     config.add_facet_field 'resource_type_sim', label: "Resource Type", limit: 5
+    config.add_facet_field 'has_model_ssim', label: "Work Type", helper_method: :work_type_facet_label, limit: 5
     config.add_facet_field 'creator_sim', limit: 5
     config.add_facet_field 'contributor_sim', label: "Contributor", limit: 5
     config.add_facet_field 'keyword_sim', limit: 5

--- a/app/controllers/hyrax/my/works_controller_decorator.rb
+++ b/app/controllers/hyrax/my/works_controller_decorator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-# OVERRIDE Hyrax 5.2.0 to add custom sort fields while in the dashboard for works
+# OVERRIDE Hyrax 5.2.0 to add custom sort fields and a Work Type facet while
+# in the dashboard for works
 
 module Hyrax
   module My
@@ -19,6 +20,14 @@ module Hyrax
           config.add_sort_field "depositor_ssi desc, title_ssi desc", label: "depositor (Z-A)"
           config.add_sort_field "creator_ssi asc, title_ssi asc", label: "creator (A-Z)"
           config.add_sort_field "creator_ssi desc, title_ssi desc", label: "creator (Z-A)"
+
+          # A "Work Type" dropdown in the dashboard filter row (the row renders
+          # every configured facet). Guarded in case this config already copied
+          # the facet from the CatalogController.
+          unless config.facet_fields.key?('has_model_ssim')
+            config.add_facet_field 'has_model_ssim', label: "Work Type",
+                                                     helper_method: :work_type_facet_label, limit: 10
+          end
         end
       end
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,6 +14,21 @@ module ApplicationHelper
     @group_navigation_presenter ||= Hyku::Admin::Group::NavigationPresenter.new(params:)
   end
 
+  # Facet label for a has_model_ssim value (the "Work Type" facet): the human
+  # model name from the app's locales (activerecord.models.*), so a value like
+  # "GenericWorkResource" can render as whatever the installation calls it.
+  # Blacklight passes a facet item (not a bare string), so unwrap it first.
+  # The locale entries may be pluralized (one:/other:), which model_name.human
+  # does not resolve, so look them up with an explicit count. Falls back to
+  # titleizing unknown values so the facet never breaks on stale index data.
+  def work_type_facet_label(value)
+    name = (value.respond_to?(:value) ? value.value : value).to_s
+    klass = name.safe_constantize
+    return name.titleize unless klass.respond_to?(:model_name)
+
+    I18n.t("activerecord.models.#{klass.model_name.i18n_key}", count: 1, default: name.titleize)
+  end
+
   # Return collection thumbnail formatted for display:
   #  - use collection's branding thumbnail if it exists
   #  - use site's default collection image if one exists

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -76,4 +76,22 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
   end
+
+  describe '#work_type_facet_label' do
+    it 'returns the human model name from the locales' do
+      allow(I18n).to receive(:t).and_call_original
+      allow(I18n).to receive(:t).with('activerecord.models.generic_work_resource', count: 1, default: 'Generic Work Resource')
+                                .and_return('Generic Work')
+      expect(helper.work_type_facet_label('GenericWorkResource')).to eq('Generic Work')
+    end
+
+    it 'unwraps a Blacklight facet item' do
+      item = double(value: 'GenericWorkResource')
+      expect(helper.work_type_facet_label(item)).to be_a(String)
+    end
+
+    it 'titleizes values that are not model classes (stale index data)' do
+      expect(helper.work_type_facet_label('NoSuchModel')).to eq('No Such Model')
+    end
+  end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -79,8 +79,12 @@ RSpec.describe ApplicationHelper, type: :helper do
 
   describe '#work_type_facet_label' do
     it 'returns the human model name from the locales' do
+      # Hyrax overrides model_name on resource classes, so the i18n key is
+      # :generic_work, not :generic_work_resource - derive it instead of
+      # hardcoding it.
+      key = "activerecord.models.#{GenericWorkResource.model_name.i18n_key}"
       allow(I18n).to receive(:t).and_call_original
-      allow(I18n).to receive(:t).with('activerecord.models.generic_work_resource', count: 1, default: 'Generic Work Resource')
+      allow(I18n).to receive(:t).with(key, count: 1, default: 'Generic Work Resource')
                                 .and_return('Generic Work')
       expect(helper.work_type_facet_label('GenericWorkResource')).to eq('Generic Work')
     end


### PR DESCRIPTION
## What

Adds a **Work Type** facet so you can narrow to a single work type:
- on the **catalog search page** (a sidebar facet section), and
- on the **dashboard Works page** (a dropdown in the filter row next to Visibility / Status / Admin Set).

The existing "Type" facet only distinguishes Work vs Collection vs Image, and "Resource Type" is depositor-entered metadata - neither answers "show me just the GenericWorks." Installations with several work types feel this immediately; this came out of the Enact build (five work types), where we shipped it as a knapsack override first and are contributing it back.

## How

- A `has_model_ssim` facet on `CatalogController` and in the dashboard works decorator's `configure_facets` (the dashboard filter row renders every configured facet as a dropdown, so declaring it is all it takes).
- A `work_type_facet_label` helper translates class names through each installation's `activerecord.models` locale entries, so the facet reads "Generic Work" rather than "GenericWorkResource". Two details baked in from debugging the knapsack version:
  - pluralized locale entries (`one:/other:`) are not resolved by `model_name.human`, so the lookup passes an explicit count;
  - unknown values fall back to titleized class names, so stale index data never breaks the page.
- The dashboard addition is guarded in case the facet was already copied from the catalog config.

## Testing

Helper specs included. Verified functionally in a running Hyku app (the Enact instance) with the equivalent knapsack code: facet appears in both places with counts, filtering narrows results, and the constraint chip shows the human name.


<img width="1349" height="805" alt="image" src="https://github.com/user-attachments/assets/db8a0865-fa2b-4227-9355-b5ba5361ebaa" />

<img width="2704" height="1454" alt="image" src="https://github.com/user-attachments/assets/f26a70c0-7cca-44bb-b8e2-87fd57696356" />

<img width="2704" height="1454" alt="image" src="https://github.com/user-attachments/assets/acfe676b-3ea9-4004-ae78-2abb53852414" />

<img width="2704" height="1454" alt="image" src="https://github.com/user-attachments/assets/dfe4a290-e215-48a9-8203-deceb3dec777" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)
