### PR TITLE
Update iiif_print gem version to 3.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,7 @@ gem 'hyrax', github: 'samvera/hyrax', branch: 'main'
 gem 'hyrax-doi', github: 'samvera-labs/hyrax-doi', branch: 'rails_hyrax_upgrade'
 gem 'i18n-debug', require: false, group: %i[development test]
 gem 'i18n-tasks', group: %i[development test]
-gem 'iiif_print', '~> 3.0.12'
+gem 'iiif_print', '~> 3.1'
 gem 'jbuilder', '~> 2.5'
 gem 'jquery-rails' # Use jquery as the JavaScript library
 gem 'json', '~> 2.0' # avoid v3 breaking changes downstream

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -781,7 +781,7 @@ GEM
       json
     iiif_manifest (1.6.0)
       activesupport (>= 4)
-    iiif_print (3.0.12)
+    iiif_print (3.1.0)
       blacklight_iiif_search (>= 1.0, < 3.0)
       derivative-rodeo (~> 0.5)
       hyrax (>= 2.5, < 6)
@@ -1685,7 +1685,7 @@ DEPENDENCIES
   hyrax-doi!
   i18n-debug
   i18n-tasks
-  iiif_print (~> 3.0.12)
+  iiif_print (~> 3.1)
   jbuilder (~> 2.5)
   jquery-rails
   json (~> 2.0)


### PR DESCRIPTION
This gem update allows Valkyrie resources using and external iiif provider to create correct iiif manifests without erroring

Connected to https://github.com/notch8/iiif_print/issues/325

@samvera/hyku-code-reviewers
