### PR TITLE
Aggregate child-work full text from Solr instead of re-deriving from disk

### DIFF
--- a/app/indexers/concerns/hyku_indexing.rb
+++ b/app/indexers/concerns/hyku_indexing.rb
@@ -47,12 +47,20 @@ module HykuIndexing
   end
 
   def extract_text_from_plain_text_files(object)
-    members = Hyrax.custom_queries.find_child_file_sets(resource: object).to_a
+    members = child_file_sets(object)
 
     return [] if members.empty?
 
     text_file_sets = members.select { |fs| fs.file_set? && fs.original_file&.mime_type == 'text/plain' }
     text_file_sets.map { |fs| scrub_text(fs.original_file&.content) }
+  end
+
+  # The parent's own child file sets, fetched once per object. Both
+  # `extract_text_from_plain_text_files` and the `extract_text_from_pdf_directly`
+  # fallback need them, and `find_child_file_sets` loads the member resources, so
+  # memoize to avoid running that load twice in the same indexing pass.
+  def child_file_sets(object)
+    (@child_file_sets ||= {})[object.id] ||= Hyrax.custom_queries.find_child_file_sets(resource: object).to_a
   end
 
   # Aggregate each child work's already-indexed full text from Solr rather than
@@ -98,7 +106,7 @@ module HykuIndexing
   end
 
   def extract_text_from_pdf_directly(object)
-    file_set = Hyrax.custom_queries.find_child_file_sets(resource: object).first
+    file_set = child_file_sets(object).first
     file_set_id = file_set&.id&.to_s
     return if file_set_id.blank?
 

--- a/app/indexers/concerns/hyku_indexing.rb
+++ b/app/indexers/concerns/hyku_indexing.rb
@@ -84,13 +84,16 @@ module HykuIndexing
 
   # The members' already-indexed full text, in one query. `fq` on generic_type
   # keeps file-set members out; the parent's own file sets are handled by
-  # `extract_text_from_plain_text_files`.
+  # `extract_text_from_plain_text_files`. Forced to POST so the `{!terms}` id
+  # list (one parent can have thousands of members) is sent in the request body
+  # rather than the URL, avoiding URL-length limits on a GET.
   def child_work_full_texts(member_ids)
     Hyrax::SolrService.query(
       "{!terms f=id}#{member_ids.join(',')}",
       fq: 'generic_type_sim:Work',
       fl: 'all_text_tsimv',
-      rows: member_ids.length
+      rows: member_ids.length,
+      method: :post
     ).flat_map { |doc| Array(doc['all_text_tsimv']) }.select(&:present?)
   end
 

--- a/app/indexers/concerns/hyku_indexing.rb
+++ b/app/indexers/concerns/hyku_indexing.rb
@@ -55,16 +55,43 @@ module HykuIndexing
     text_file_sets.map { |fs| scrub_text(fs.original_file&.content) }
   end
 
+  # Aggregate each child work's already-indexed full text from Solr rather than
+  # re-deriving every child work's file-set text from disk on each reindex.
+  #
+  # A parent work is reindexed several times per save (the WorkUpdate
+  # transaction publishes `object.metadata.updated` and
+  # `object.membership.updated`, plus the ACL reindex), and the old path walked
+  # Postgres for each child work, queried each child's file sets, and read each
+  # derivative from disk every time. That is O(child works x file sets) per
+  # reindex and made saving a "hub" work with many children time out (a
+  # ~95-child work took 60-70s, past common ingress timeouts).
+  #
+  # Every child work is indexed by this same concern, so its `all_text_tsimv`
+  # already holds its (and its descendants') text. One batched Solr read keyed
+  # on `member_ids` recovers the same content in a single round trip regardless
+  # of child/file-set count. A child not yet indexed contributes on the next
+  # reindex (eventual consistency), which matches how derived text already
+  # propagates.
   def extract_text_from_child_works(object)
-    child_works = Hyrax.custom_queries.find_child_works(resource: object)
+    member_ids = Array(object.member_ids).map(&:to_s).reject(&:blank?)
+    return extract_text_from_pdf_directly(object) if member_ids.empty?
 
-    return extract_text_from_pdf_directly(object) if child_works.none?
+    texts = child_work_full_texts(member_ids)
+    return extract_text_from_pdf_directly(object) if texts.blank?
 
-    file_set_texts = child_works_file_sets(child_works).map { |fs| all_text(fs) }.select(&:present?)
+    texts.join("\n---------------------------\n")
+  end
 
-    return extract_text_from_pdf_directly(object) if file_set_texts.join.blank?
-
-    file_set_texts.join("\n---------------------------\n")
+  # The members' already-indexed full text, in one query. `fq` on generic_type
+  # keeps file-set members out; the parent's own file sets are handled by
+  # `extract_text_from_plain_text_files`.
+  def child_work_full_texts(member_ids)
+    Hyrax::SolrService.query(
+      "{!terms f=id}#{member_ids.join(',')}",
+      fq: 'generic_type_sim:Work',
+      fl: 'all_text_tsimv',
+      rows: member_ids.length
+    ).flat_map { |doc| Array(doc['all_text_tsimv']) }.select(&:present?)
   end
 
   def extract_text_from_pdf_directly(object)
@@ -76,17 +103,6 @@ module HykuIndexing
   rescue Blacklight::Exceptions::RecordNotFound
     file_set_doc = Hyrax::Indexers::ResourceIndexer.for(resource: file_set).to_solr
     return file_set_doc&.[]('all_text_tsimv')
-  end
-
-  def child_works_file_sets(child_works)
-    child_works.to_a.flat_map { |child_work| Hyrax.custom_queries.find_child_file_sets(resource: child_work).to_a }
-  end
-
-  def all_text(fs)
-    text = IiifPrint::Data::WorkDerivatives.data(from: fs, of_type: 'txt') || ''
-    return text if text.empty?
-
-    text.tr("\n", ' ').squeeze(' ')
   end
 
   def add_date(solr_doc)

--- a/spec/indexers/concerns/hyku_indexing_spec.rb
+++ b/spec/indexers/concerns/hyku_indexing_spec.rb
@@ -25,4 +25,35 @@ RSpec.describe HykuIndexing do
       expect(work.to_solr['all_text_tsimv']).to include('needle from child derivative')
     end
   end
+
+  # Under Valkyrie `member_ids` holds both child-work ids and file-set ids. The
+  # aggregation hands the whole list to Solr and relies on `fq:
+  # generic_type_sim:Work` to return only the child works, so a file-set member
+  # must not contribute its text here (the parent's own file sets are handled
+  # separately by `extract_text_from_plain_text_files`). This proves the type
+  # filter excludes file-set members rather than aggregating everything.
+  describe 'mixed member_ids (child work + file set)', :clean_repo do
+    let(:child_work_id) { 'child-work-member' }
+    let(:file_set_id) { 'file-set-member' }
+    let(:work) do
+      valkyrie_create(:generic_work_resource,
+                      member_ids: [Valkyrie::ID.new(child_work_id), Valkyrie::ID.new(file_set_id)])
+    end
+
+    before do
+      Hyrax::SolrService.add({ 'id' => child_work_id,
+                               'all_text_tsimv' => ['text from child work'],
+                               'generic_type_sim' => ['Work'] }, commit: false)
+      Hyrax::SolrService.add({ 'id' => file_set_id,
+                               'all_text_tsimv' => ['text from file set'],
+                               'generic_type_si' => 'FileSet' }, commit: true)
+    end
+
+    it 'aggregates only the child work text, not the file set member' do
+      all_text = work.to_solr['all_text_tsimv']
+
+      expect(all_text).to include('text from child work')
+      expect(all_text).not_to include('text from file set')
+    end
+  end
 end

--- a/spec/indexers/concerns/hyku_indexing_spec.rb
+++ b/spec/indexers/concerns/hyku_indexing_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+RSpec.describe HykuIndexing do
+  # A parent work aggregates its child works' full text into `all_text_tsimv`.
+  # The aggregation reads each child's already-indexed `all_text_tsimv` from
+  # Solr rather than re-deriving every child file set's derivative from disk on
+  # each reindex (which was O(child works x file sets) and timed out saving
+  # works with many children).
+  #
+  # The child here exists ONLY in Solr - never persisted to Postgres and with no
+  # file set/derivative on disk. The old disk/Postgres walk would find nothing
+  # for it; the Solr read picks it up. A passing assertion therefore proves the
+  # aggregation source, not merely that some text was indexed.
+  describe 'child work full-text aggregation', :clean_repo do
+    let(:child_id) { 'child-from-solr-only' }
+    let(:work) { valkyrie_create(:generic_work_resource, member_ids: [Valkyrie::ID.new(child_id)]) }
+
+    before do
+      Hyrax::SolrService.add({ 'id' => child_id,
+                               'all_text_tsimv' => ['needle from child derivative'],
+                               'generic_type_sim' => ['Work'] }, commit: true)
+    end
+
+    it 'indexes child works\' all_text from the Solr index' do
+      expect(work.to_solr['all_text_tsimv']).to include('needle from child derivative')
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Saving a parent work that has many child works can take 60-70s and trip ingress/proxy timeouts, so the save *appears* to hang in the browser even though it actually commits (the server logs `Completed 302 ... in ~70000ms`). Leaf works save in under a second.

The cost is in indexing. `HykuIndexing#extract_text_from_child_works` builds `all_text_tsimv` by:

1. loading every child work from Postgres (`find_child_works`),
2. querying **each** child's file sets (`find_child_file_sets` per child), and
3. reading **each** file set's `txt` derivative from disk (`IiifPrint::Data::WorkDerivatives.data`).

That is `O(child works × file sets)`. And it runs **multiple times per save**: the `WorkUpdate` transaction publishes `object.metadata.updated` (in `Steps::Save`) and `object.membership.updated` (in `Steps::UpdateWorkMembers`), plus the ACL reindex - each reindexes the parent. On a work with ~95 children this was ~3,000 queries + per-file-set disk reads + several seconds of GC, ~60-70s total.

## Fix

Every child work is already indexed by this same concern, so its derived text is sitting in its own `all_text_tsimv` (and a child's `all_text_tsimv` already includes its descendants' text). Aggregate that with a **single batched Solr query** keyed on the parent's `member_ids`, instead of re-walking Postgres + disk per child:

```ruby
Hyrax::SolrService.query(
  "{!terms f=id}#{member_ids.join(',')}",
  fq: 'generic_type_sim:Work',
  fl: 'all_text_tsimv',
  rows: member_ids.length
)
```

Same indexed content, one round trip regardless of child/file-set count. The now-unused `child_works_file_sets`/`all_text` helpers are removed.

### Behavior note

Child text now comes from the index rather than a fresh disk read. A child not yet indexed contributes on the parent's next reindex (eventual consistency) - which already matches how derived text propagates, since derivatives are generated and indexed asynchronously.

## Test

Adds `spec/indexers/concerns/hyku_indexing_spec.rb`. The child in the test exists **only in Solr** (never persisted to Postgres, no derivative on disk): the old disk/Postgres walk would find nothing for it, so a passing assertion proves the aggregation source actually changed.

The equivalent implementation was verified passing locally against a real Samvera stack (Postgres + Solr) before being lifted here; this PR's spec runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)