### PR TITLE
Adds environment vars to override name/cname during account creation

### DIFF
--- a/.env
+++ b/.env
@@ -52,6 +52,11 @@ HYKU_USER_DEFAULT_PASSWORD=password
 # HYKU_ROOT_HOST=hyku.test
 # HYKU_MULTITENANT=false
 
+# Comment out to override the default name and cname used during single tenant creation
+# HYKU_SINGLE_TENANT_NAME=hyku-single
+# HYKU_SINGLE_TENANT_CNAME=hyku-single.example.com
+
+
 # Uncomment this line to disable Bulkrax
 # HYKU_BULKRAX_ENABLED=false
 

--- a/.github/workflows/build-test-lint.yaml
+++ b/.github/workflows/build-test-lint.yaml
@@ -202,7 +202,7 @@ jobs:
             -e SOLR_COLLECTION_NAME=hydra-development \
             web bundle exec rails runner "
               core = ENV.fetch('SOLR_COLLECTION', 'hydra-development')
-              account = Account.find_by(cname: 'single.tenant.default')
+              account = Account.find_by(cname: ENV.fetch('HYKU_SINGLE_TENANT_CNAME', 'single.tenant.default'))
               raise 'No single-tenant account found' unless account
               raise 'Account has no SolrEndpoint' if account.solr_endpoint.is_a?(NilSolrEndpoint)
               raise \"SolrEndpoint URL does not include core name '#{core}'\" unless account.solr_endpoint.url.include?(core)

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -84,7 +84,7 @@ class Account < ApplicationRecord
 
   # @return [Account] a placeholder account using the default connections configured by the application
   def self.single_tenant_default
-    @single_tenant_default ||= Account.from_cname('single.tenant.default')
+    @single_tenant_default ||= Account.from_cname(ENV.fetch('HYKU_SINGLE_TENANT_CNAME', 'single.tenant.default'))
     @single_tenant_default ||= Account.new do |a|
       a.build_solr_endpoint
       a.build_fcrepo_endpoint unless Hyrax.config.disable_wings

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,9 +7,9 @@
 
 unless ActiveModel::Type::Boolean.new.cast(ENV.fetch('HYKU_MULTITENANT', false))
   puts "\n== Creating single tenant resources"
-  single_tenant_default = Account.find_by(cname: 'single.tenant.default')
+  single_tenant_default = Account.find_by(cname: ENV.fetch('HYKU_SINGLE_TENANT_CNAME', 'single.tenant.default'))
   if single_tenant_default.blank?
-    single_tenant_default = Account.new(name: 'Single Tenant', cname: 'single.tenant.default', tenant: SecureRandom.uuid, is_public: true)
+    single_tenant_default = Account.new(name: ENV.fetch('HYKU_SINGLE_TENANT_NAME', 'Single Tenant'), cname: ENV.fetch('HYKU_SINGLE_TENANT_CNAME', 'single.tenant.default'), tenant: SecureRandom.uuid, is_public: true)
     CreateAccount.new(single_tenant_default).save
     raise "Account creation failed for #{single_tenant_default.errors.full_messages}" unless single_tenant_default.valid?
     single_tenant_default = single_tenant_default.reload
@@ -49,7 +49,7 @@ if ENV['INITIAL_ADMIN_EMAIL'] && ENV['INITIAL_ADMIN_PASSWORD']
     u.password = ENV['INITIAL_ADMIN_PASSWORD']
     u.add_role(:superadmin)
   end
-  account = Account.find_by(cname: 'single.tenant.default')
+  account = Account.find_by(cname: ENV.fetch('HYKU_SINGLE_TENANT_CNAME', 'single.tenant.default'))
   if account
     Apartment::Tenant.switch!(account.tenant)
     u.add_role(:admin, Site.instance)

--- a/spec/jobs/cleanup_account_job_spec.rb
+++ b/spec/jobs/cleanup_account_job_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe CleanupAccountJob do
   it 'removes the various end points and database records' do
-    account = Account.new(name: 'Single Tenant', cname: 'single.tenant.default', tenant: SecureRandom.uuid, is_public: true)
+    account = Account.new(name: ENV.fetch('HYKU_SINGLE_TENANT_NAME', 'Single Tenant'), cname: ENV.fetch('HYKU_SINGLE_TENANT_CNAME', 'single.tenant.default'), tenant: SecureRandom.uuid, is_public: true)
     # Perform all the tenant creation stuff.
     CreateAccount.new(account, []).save
     account.reload


### PR DESCRIPTION
References PR #3097 

Adds the HYKU_SINGLE_TENANT_NAME and HYKU_SINGLE_TENANT_CNAME env vars to allow single tenant Hyku users to override the default name and cname of their tenant.

@samvera/hyku-code-reviewers
