### PR TITLE
Fix/batch edit descriptions 2990

### DIFF
--- a/app/assets/stylesheets/hyrax.scss
+++ b/app/assets/stylesheets/hyrax.scss
@@ -51,21 +51,24 @@ a {
 }
 
 // Fix: Batch Edit Descriptions labels render vertically (one char per line)
-// Regression in Hyku 7 — labels inside accordion toggles need explicit
-// white-space and display overrides to match Add/Edit Work formatting.
+// Regression in Hyku 7 — accordion toggle links have overflow-wrap: anywhere
+// which breaks text character-by-character in narrow columns.
+// Solution: Set overflow-wrap: normal on the link itself + white-space: nowrap on label
 // Ref: #2990, original fix #2527
 .descriptions_display,
 #descriptions_display {
-  .accordion-toggle label,
-  .accordion-toggle > label {
-    display: inline !important;
-    white-space: nowrap !important;
-    letter-spacing: normal !important;
+  // Fix the parent link's overflow-wrap behavior
+  .accordion-toggle {
+    display: block;
+    line-height: normal;
+    overflow-wrap: normal;
   }
 
-  // Ensure the accordion toggle link itself doesn't force vertical layout
-  .accordion-toggle {
-    display: block !important;
-    line-height: normal !important;
+  // Fix the label display and wrapping
+  .accordion-toggle label,
+  .accordion-toggle > label {
+    display: inline;
+    white-space: nowrap;
+    letter-spacing: normal;
   }
 }

--- a/app/assets/stylesheets/hyrax.scss
+++ b/app/assets/stylesheets/hyrax.scss
@@ -49,3 +49,23 @@
 a {
   overflow-wrap: anywhere;
 }
+
+// Fix: Batch Edit Descriptions labels render vertically (one char per line)
+// Regression in Hyku 7 — labels inside accordion toggles need explicit
+// white-space and display overrides to match Add/Edit Work formatting.
+// Ref: #2990, original fix #2527
+.descriptions_display,
+#descriptions_display {
+  .accordion-toggle label,
+  .accordion-toggle > label {
+    display: inline !important;
+    white-space: nowrap !important;
+    letter-spacing: normal !important;
+  }
+
+  // Ensure the accordion toggle link itself doesn't force vertical layout
+  .accordion-toggle {
+    display: block !important;
+    line-height: normal !important;
+  }
+}


### PR DESCRIPTION
<img width="1628" height="944" alt="Screenshot 2026-06-24 at 4 24 13 PM" src="https://github.com/user-attachments/assets/7b21ca08-2c27-493e-a9ec-2d52f9120cd4" />

Fixes #2990 ; refs #2527 #7071 notch8/palni_palci_knapsack#386

Fix batch edit descriptions label wrapping

## Description

This PR restores horizontal label rendering on the Batch Edit Descriptions tab, which was broken in Hyku 7. Previously, metadata field labels (Creator, Contributor, Description, Keyword, etc.) were rendering vertically with each character on its own line, making the page difficult to use and failing accessibility standards.

### Root Cause

The batch edit description template renders labels inside narrow `col-sm-4` Bootstrap columns. The parent `<a class="accordion-toggle">` link had `overflow-wrap: anywhere` set globally, which caused the browser to break text at character boundaries when the container width narrowed—placing each letter on its own line.

### Solution

Target the root cause property instead of fighting CSS cascade:
- Set `overflow-wrap: normal` on the `.accordion-toggle` parent link (prevents character-level breaking)
- Set `white-space: nowrap` on the `.accordion-toggle label` elements (prevents any wrapping)
- Set `display: inline` on labels (ensures horizontal flow)

This approach achieves the desired layout without `!important` flags by addressing the actual CSS property causing the wrapping behavior, meeting team standards for clean CSS.

### Testing

- Visual verification: Labels render horizontally on batch edit descriptions tab (testing-hyku.localhost.direct)
- Confirmed layout matches expected behavior from prior implementation
- Asset precompilation: No errors

## Changes proposed in this pull request:

* Added CSS override targeting `.descriptions_display` and `#descriptions_display` selectors
* Set `overflow-wrap: normal` on `.accordion-toggle` to prevent character-level breaking
* Set `white-space: nowrap` on `.accordion-toggle label` to maintain horizontal layout
* Set `display: inline` to ensure labels flow horizontally
* Set `line-height: normal` on toggle to prevent vertical spacing issues
* Removed `!important` flags—solution addresses root CSS property instead of fighting specificity

@samvera/hyku-code-reviewers
