### PR TITLE
Adds concurrency group and cancel-in-progress

### DIFF
--- a/.github/workflows/build-test-lint.yaml
+++ b/.github/workflows/build-test-lint.yaml
@@ -20,6 +20,10 @@ on:
           - test
           - lint
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: samvera/hyku

--- a/.github/workflows/build-test-lint.yaml
+++ b/.github/workflows/build-test-lint.yaml
@@ -20,7 +20,7 @@ on:
           - test
           - lint
 
-# Cancel in-progress runs for the same ref when a newer push arrives.
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/build-test-lint.yaml
+++ b/.github/workflows/build-test-lint.yaml
@@ -20,6 +20,7 @@ on:
           - test
           - lint
 
+# Cancel in-progress runs for the same ref when a newer push arrives.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary

Adds concurrency group and cancel-in-progress to the CI workflow. The intent is if a PR or branch is updated with new commits then any specs running will be cancelled.
