### PR TITLE
Render compound metadata in the community_show theme

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ gem 'good_job', '~> 4.10' # Updated for Rails 7.2 compatibility
 gem 'googleauth', '~> 1.9.0'
 gem 'google-protobuf'
 gem 'grpc'
-gem 'hyrax', github: 'samvera/hyrax', branch: 'file-set-show-compounds'
+gem 'hyrax', github: 'samvera/hyrax', branch: 'main'
 gem 'hyrax-doi', github: 'samvera-labs/hyrax-doi', branch: 'rails_hyrax_upgrade'
 gem 'i18n-debug', require: false, group: %i[development test]
 gem 'i18n-tasks', group: %i[development test]

--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ gem 'good_job', '~> 4.10' # Updated for Rails 7.2 compatibility
 gem 'googleauth', '~> 1.9.0'
 gem 'google-protobuf'
 gem 'grpc'
-gem 'hyrax', github: 'samvera/hyrax', branch: 'main'
+gem 'hyrax', github: 'samvera/hyrax', branch: 'file-set-show-compounds'
 gem 'hyrax-doi', github: 'samvera-labs/hyrax-doi', branch: 'rails_hyrax_upgrade'
 gem 'i18n-debug', require: false, group: %i[development test]
 gem 'i18n-tasks', group: %i[development test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,8 +29,8 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: 5b5a4704696d24f188c7314458f48b5f8c548373
-  branch: main
+  revision: 3cecdda584b8421a02c464df1a1ce243528f7131
+  branch: file-set-show-compounds
   specs:
     hyrax (5.2.0)
       active-fedora (~> 15.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,8 +29,8 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: 3cecdda584b8421a02c464df1a1ce243528f7131
-  branch: file-set-show-compounds
+  revision: ab3f45b03d54e88581c24d8ce8ddd8759d32e00f
+  branch: main
   specs:
     hyrax (5.2.0)
       active-fedora (~> 15.0)

--- a/app/views/themes/community_show/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/themes/community_show/hyrax/base/_attribute_rows.html.erb
@@ -6,6 +6,11 @@
   # Convert to array for splitting
   fields_array = all_fields.to_a
 
+  # Card compounds (view: { display: card }) render as their own cards via
+  # render_compound_cards on the show page, so skip them here or they render
+  # twice. Matches Hyrax's base/_attribute_rows.
+  fields_array.reject! { |field, _options| compound_card_field?(presenter, field) }
+
   # Filter out admin-only and editor-only fields per Hyrax's view-visibility rules
   fields_array.select! do |field, options|
     field_visible?(conform_options(field, options), presenter)

--- a/app/views/themes/community_show/hyrax/base/show.html.erb
+++ b/app/views/themes/community_show/hyrax/base/show.html.erb
@@ -81,6 +81,13 @@
             <%= render 'citations', presenter: @presenter %>
           </div>
         </div>
+        <%# Card compounds (view: { display: card }) render as their own cards,
+            above the relationships and items cards - matching Hyrax's base show. %>
+        <div class="row">
+          <div class="col-12">
+            <%= render_compound_cards(@presenter) %>
+          </div>
+        </div>
         <div class="row">
           <div class="col-12 work-show-items">
             <%= render 'relationships', presenter: @presenter %>


### PR DESCRIPTION
## Summary

Hyrax renders compound metadata (cards + inline) on work, collection, and FileSet show pages. The `community_show` theme overrides `base/_attribute_rows` and `base/show.html.erb` wholesale, so it never inherited that compound rendering: card compounds rendered inline as plain rows (no card styling) and never as cards.

This adds the two compound hooks the theme override was missing, matching Hyrax's base show:

- **`base/_attribute_rows.html.erb`** - skip card compounds (`compound_card_field?`) in the inline two-column list, so they don't double-render. Inline compounds already render through `attribute_to_html`.
- **`base/show.html.erb`** - call `render_compound_cards(@presenter)` above the relationships/items cards.

This is the only Hyku theme with both gaps; the other show themes (`cultural_show`, `scholarly_show`, `image_show`) already call `render_compound_cards` and inherit the base `_attribute_rows` card-skip.

## Verification

- **Compound rendering** is covered upstream in Hyrax (view/indexer/presenter specs); this change is a thin theme-parity fix whose behavior matches the base theme.
- **Manual, flexible (`HYRAX_FLEXIBLE=true`):** verified live on a Hyku tenant using the `community_show` show theme, on a `GenericWorkResource` carrying the profile's sample compounds. The screenshot below shows all three shapes rendering correctly:
  - **`participants`** and **`identifiers`** as **inline** compounds (each with multiple rows: name/role/title, value/type) in the two-column metadata list;
  - **`relationships`** as its own **card** (Item/Type/Title), which is exactly the rendering this PR restores - previously it would have rendered inline as plain rows.

## ⚠️ Draft - dependency + temporary Hrax pin

This depends on FileSet compound work that is still in flight upstream:

- samvera/hyrax #7510 (FileSet edit-form compounds) - merged
- samvera/hyrax #7513 (FileSet show-page + indexer compounds) - open

The second commit temporarily points the `hyrax` gem at the `file-set-show-compounds` branch so this can be exercised end to end before #7513 merges. **Before merge, that commit should be dropped / the pin flipped back to `branch: 'main'`** once #7513 has landed on Hyrax main. Keeping as draft until then.

## Demo with community theme

<img width="1352" height="1618" alt="hyku-community-show-compounds-flexible" src="https://github.com/user-attachments/assets/c3b7b32e-e6f8-4cd0-8a5e-18b4df71d5a4" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)
