### PR TITLE
🎁 Support PDF content with IIIF

### DIFF
--- a/app/presenters/hyrax/iiif_manifest_presenter_decorator.rb
+++ b/app/presenters/hyrax/iiif_manifest_presenter_decorator.rb
@@ -51,9 +51,9 @@ module Hyrax
 
     module DisplayImagePresenterDecorator
       # override Hyrax to keep pdfs from gumming up the v3 manifest
-      # in app/presenters/hyrax/iiif_manifest_presenter.rb
+      # in app/presenters/hyrax/iiif_manifest_presenter.rb if Flipflop.iiif_pdf? is false
       def file_set?
-        super && (image? || audio? || video?)
+        super && (image? || audio? || video? || (Flipflop.iiif_pdf? && pdf?))
       end
     end
   end

--- a/spec/presenters/hyrax/iiif_manifest_presenter/display_image_presenter_spec.rb
+++ b/spec/presenters/hyrax/iiif_manifest_presenter/display_image_presenter_spec.rb
@@ -9,4 +9,24 @@ RSpec.describe Hyrax::IiifManifestPresenter::DisplayImagePresenter do
   it "includes Hyrax::DisplaysContent" do
     expect(described_class.include?(Hyrax::DisplaysContent)).to be true
   end
+
+  describe "#file_set?" do
+    before do
+      # stubbing this so super returns true
+      allow(work).to receive(:file_set?).and_return(true)
+      allow(work).to receive_messages(image?: false, audio?: false, video?: false, pdf?: true)
+    end
+
+    context "when Flipflop.iiif_pdf? is enabled" do
+      before { allow(Flipflop).to receive(:iiif_pdf?).and_return(true) }
+
+      it { expect(presenter.file_set?).to be true }
+    end
+
+    context "when Flipflop.iiif_pdf? is disabled" do
+      before { allow(Flipflop).to receive(:iiif_pdf?).and_return(false) }
+
+      it { expect(presenter.file_set?).to be false }
+    end
+  end
 end


### PR DESCRIPTION
Now that Hyrax has IIIF support for PDFs, we can enable it with this change.  The idea is that if we do turn on IIIF for PDFs (via Flipflop), then manifests should include the PDF content.

```json
  "items": [
    {
      "type": "Canvas",
      "id": "https://dev-hyku.localhost.direct/concern/generic_works/ac69b524-dc8d-4280-9cfe-1d8f6634d1f2/manifest/canvas/1e15bb48-b32d-468b-9817-6ccacf532d59",
      "items": [
        {
          "type": "AnnotationPage",
          "items": [
            {
              "type": "Annotation",
              "motivation": "painting",
              "body": {
                "id": "http://dev-hyku.localhost.direct/downloads/1e15bb48-b32d-468b-9817-6ccacf532d59?file=pdf",
                "type": "Text",
                "format": "application/pdf",
                "label": {
                  "none": [
                    "pdf"
                  ]
                }
              },
              "id": "https://dev-hyku.localhost.direct/concern/generic_works/ac69b524-dc8d-4280-9cfe-1d8f6634d1f2/manifest/canvas/1e15bb48-b32d-468b-9817-6ccacf532d59/annotation_page/ecaebe5e-1999-4921-953c-0110df583ab1/annotation/82e34b00-a312-4eae-961d-7185a5b2ee07",
              "target": "https://dev-hyku.localhost.direct/concern/generic_works/ac69b524-dc8d-4280-9cfe-1d8f6634d1f2/manifest/canvas/1e15bb48-b32d-468b-9817-6ccacf532d59"
            }
          ],
          "id": "https://dev-hyku.localhost.direct/concern/generic_works/ac69b524-dc8d-4280-9cfe-1d8f6634d1f2/manifest/canvas/1e15bb48-b32d-468b-9817-6ccacf532d59/annotation_page/ecaebe5e-1999-4921-953c-0110df583ab1"
        }
      ],
      "label": {
        "none": [
          "cat_scan.pdf"
        ]
      },
      "thumbnail": [
        {
          "id": "http://dev-hyku.localhost.direct/downloads/1e15bb48-b32d-468b-9817-6ccacf532d59?file=thumbnail",
          "type": "Image",
          "format": "image/jpeg"
        }
      ]
    }
  ]
```