### PR TITLE
Add index to increase speed of MeSH autocomplete lookups

### DIFF
--- a/db/migrate/20260701170000_add_trigram_index_to_qa_local_authority_entries.rb
+++ b/db/migrate/20260701170000_add_trigram_index_to_qa_local_authority_entries.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# Qa::Authorities::Mesh (app/authorities/qa/authorities/mesh.rb) searches
+# qa_local_authority_entries with `LOWER(label) LIKE '%term%'`, a leading-wildcard
+# match that a normal b-tree index can't accelerate. On a tenant's full MeSH
+# vocabulary (~31k rows) this is a sequential scan on every autocomplete
+# keystroke. A GIN trigram index lets Postgres use it for this query without any
+# change to the query itself.
+class AddTrigramIndexToQaLocalAuthorityEntries < ActiveRecord::Migration[7.2]
+  INDEX_NAME = 'index_qa_local_authority_entries_on_lower_label_trgm'
+
+  def up
+    unless pg_trgm_available?
+      say 'pg_trgm extension is not available on this Postgres server — skipping the ' \
+          'trigram index on qa_local_authority_entries. Local authority search (e.g. ' \
+          'MeSH autocomplete) will still work, just without this index optimization.'
+      return
+    end
+
+    execute 'CREATE EXTENSION IF NOT EXISTS pg_trgm SCHEMA shared_extensions;'
+
+    # Schema-qualify the opclass explicitly rather than relying on search_path
+    # to include shared_extensions. Apartment::Tenant.create (used by
+    # CreateAccount#create_tenant to provision brand-new tenants — a different
+    # path from db:migrate's per-existing-tenant loop) clones the schema
+    # without shared_extensions on the search_path during the DDL replay, so
+    # an unqualified gin_trgm_ops fails to resolve there even though the
+    # extension itself is correctly installed.
+    execute <<-SQL.squish
+      CREATE INDEX IF NOT EXISTS #{INDEX_NAME}
+      ON qa_local_authority_entries
+      USING gin (lower(label) shared_extensions.gin_trgm_ops)
+    SQL
+  end
+
+  def down
+    remove_index :qa_local_authority_entries, name: INDEX_NAME, if_exists: true
+  end
+
+  private
+
+  # Checking pg_available_extensions up front lets us skip cleanly on Postgres
+  # installs that don't have the contrib module, instead of a mid-deploy
+  # migration failure that's hard for downstream institutions to diagnose.
+  def pg_trgm_available?
+    select_value("SELECT 1 FROM pg_available_extensions WHERE name = 'pg_trgm'").present?
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_21_230524) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_01_170000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
+  enable_extension "pg_trgm"
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
@@ -699,6 +700,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_21_230524) do
     t.string "uri"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.index "lower((label)::text) gin_trgm_ops", name: "index_qa_local_authority_entries_on_lower_label_trgm", using: :gin
     t.index ["local_authority_id"], name: "index_qa_local_authority_entries_on_local_authority_id"
     t.index ["uri"], name: "index_qa_local_authority_entries_on_uri", unique: true
   end

--- a/lib/tasks/db_enhancements.rake
+++ b/lib/tasks/db_enhancements.rake
@@ -10,6 +10,8 @@ namespace :db do
     # Enable UUID-OSSP
     ActiveRecord::Base.connection.execute 'CREATE EXTENSION IF NOT EXISTS "uuid-ossp" SCHEMA shared_extensions;'
     ActiveRecord::Base.connection.execute 'CREATE EXTENSION IF NOT EXISTS "pgcrypto" SCHEMA shared_extensions;'
+    # Enable pg_trgm (used for trigram-indexed local authority search, e.g. MeSH)
+    ActiveRecord::Base.connection.execute 'CREATE EXTENSION IF NOT EXISTS "pg_trgm" SCHEMA shared_extensions;'
     # Grant usage to public
     ActiveRecord::Base.connection.execute 'GRANT usage ON SCHEMA shared_extensions to public;'
   end

--- a/spec/db/migrate/add_trigram_index_to_qa_local_authority_entries_spec.rb
+++ b/spec/db/migrate/add_trigram_index_to_qa_local_authority_entries_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Regression test for https://github.com/samvera/hyku/actions/runs/28541351737
+#
+# CreateAccount#create_tenant (app/services/create_account.rb) provisions a new
+# tenant with `Apartment::Tenant.create(account.tenant)`, which clones the
+# already-migrated schema into a fresh Postgres schema. That's a different code
+# path from `db:migrate`'s per-existing-tenant loop, and it does not appear to
+# resolve `gin_trgm_ops` the same way `Apartment::Tenant.switch!` does, even
+# though the pg_trgm extension itself lives in shared_extensions.
+RSpec.describe 'AddTrigramIndexToQaLocalAuthorityEntries', :multitenant do
+  let(:tenant) { "trgm_regression_test_#{SecureRandom.hex(4)}" }
+
+  after do
+    Apartment::Tenant.drop(tenant)
+  rescue Apartment::TenantNotFound
+    nil
+  end
+
+  it 'provisions a new tenant without raising on the trigram index' do
+    expect { Apartment::Tenant.create(tenant) }.not_to raise_error
+  end
+
+  it 'creates a usable trigram index in the new tenant' do
+    Apartment::Tenant.create(tenant)
+
+    Apartment::Tenant.switch(tenant) do
+      indexes = ActiveRecord::Base.connection.indexes('qa_local_authority_entries')
+      expect(indexes.map(&:name)).to include('index_qa_local_authority_entries_on_lower_label_trgm')
+    end
+  end
+end


### PR DESCRIPTION
Enables a trusted postgres extension (if it's not already enabled & is available), and adds a trigram index

Fixes timeouts when working on entering many MeSH vocabulary items.

Significantly increases the speed of postgres search for MeSH autocomplete


Changes proposed in this pull request:
* Add migration to use trigram index for MeSH subject headings

@samvera/hyku-code-reviewers
