### PR TITLE
Send noindex directives on all public demo tenant pages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,12 +21,14 @@ class ApplicationController < ActionController::Base
   include DeviseGuestControllersHelpersDecorator
 
   helper_method :current_account, :admin_host?, :home_page_theme, :show_page_theme, :search_results_theme
+  helper_method :public_demo_tenant?
   before_action :authenticate_if_needed
   before_action :require_active_account!, if: :multitenant?
   before_action :set_account_specific_connections!
   before_action :elevate_single_tenant!, if: :singletenant?
 
   after_action :clear_session_cookie
+  after_action :add_noindex_header, if: :public_demo_tenant?
 
   rescue_from Apartment::TenantNotFound do
     raise ActionController::RoutingError, 'Not Found'
@@ -48,6 +50,19 @@ class ApplicationController < ActionController::Base
 
   def hidden?
     current_account.persisted? && !current_account.is_public?
+  end
+
+  # Search engines must not index public demo tenants: work show pages emit
+  # Google Scholar citation meta tags, so an indexable demo tenant can pollute
+  # Google Scholar and compete with production repositories in search results.
+  # robots.txt intentionally stays permissive; crawlers have to be able to
+  # fetch a page in order to see this directive.
+  def add_noindex_header
+    response.headers['X-Robots-Tag'] = 'noindex, nofollow'
+  end
+
+  def public_demo_tenant?
+    current_account&.persisted? && current_account.public_demo_tenant?
   end
 
   def api_or_pdf?

--- a/app/views/_head_tag_extras.html.erb
+++ b/app/views/_head_tag_extras.html.erb
@@ -23,3 +23,7 @@
 
 <!— Windows 8.1 + IE11 and above —>
 <meta name="msapplication-config" content="/browserconfig.xml" />
+
+<% if public_demo_tenant? %>
+  <meta name="robots" content="noindex, nofollow">
+<% end %>

--- a/spec/requests/demo_tenant_noindex_spec.rb
+++ b/spec/requests/demo_tenant_noindex_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Public demo tenant noindex directives', type: :request, clean: true, multitenant: true do
+  before do
+    WebMock.disable!
+    Apartment::Tenant.create(account.tenant)
+    Apartment::Tenant.switch(account.tenant) do
+      Site.update(account:)
+    end
+  end
+
+  after do
+    WebMock.enable!
+    Apartment::Tenant.drop(account.tenant)
+  end
+
+  context 'with a public demo tenant' do
+    let(:account) { create(:demo_account) }
+
+    it 'sends the X-Robots-Tag header and robots meta tag on the home page' do
+      get "http://#{account.cname}/"
+      expect(response).to have_http_status(:ok)
+      expect(response.headers['X-Robots-Tag']).to eq('noindex, nofollow')
+      expect(response.body).to include('<meta name="robots" content="noindex, nofollow">')
+    end
+
+    it 'sends the X-Robots-Tag header and robots meta tag on the sign in page' do
+      get "http://#{account.cname}/users/sign_in"
+      expect(response).to have_http_status(:ok)
+      expect(response.headers['X-Robots-Tag']).to eq('noindex, nofollow')
+      expect(response.body).to include('<meta name="robots" content="noindex, nofollow">')
+    end
+  end
+
+  context 'with a regular tenant' do
+    let(:account) { create(:account) }
+
+    it 'sends neither the X-Robots-Tag header nor the robots meta tag' do
+      get "http://#{account.cname}/"
+      expect(response).to have_http_status(:ok)
+      expect(response.headers['X-Robots-Tag']).to be_nil
+      expect(response.body).not_to include('name="robots"')
+    end
+  end
+end


### PR DESCRIPTION

## Summary

Tenants flagged as `public_demo_tenant` now send an `X-Robots-Tag: noindex, nofollow` response header on every page served through the application's controllers, and render a matching `<meta name="robots" content="noindex, nofollow">` tag in the document head. Tenants without the flag are completely unaffected: no header is added and no meta tag is rendered. This change came out of work to make public Hyku demo environments safe to operate.

## Motivation

Hyku work show pages emit Google Scholar citation meta tags (`citation_title`, `citation_pdf_url`, and related tags from Hyrax's `shared/_citations` partial, plus Hyku's `shared/_additional_citations`). If a public demo tenant is indexable, sample records can surface in Google Scholar as though they were real scholarship, and the demo host itself competes with production repositories in ordinary search results. A demo tenant should stay reachable by anyone who has the link while staying out of search indexes.

robots.txt intentionally stays permissive. A `Disallow` rule would stop crawlers from fetching pages, and a page that cannot be fetched can never present its noindex directive, so previously indexed URLs would linger in the index. Allowing the crawl and answering with a noindex directive is the mechanism search engines document for keeping a host out of their indexes.

## What changed

- `app/controllers/application_controller.rb`: a new `after_action :add_noindex_header, if: :public_demo_tenant?` sets `X-Robots-Tag: noindex, nofollow` on the response. `ApplicationController` is the base class for Hyku's own controllers and for the Hyrax, Blacklight, and Devise controllers, so the header covers the homepage, catalog, work show pages, sign-in pages, and the rest of the tenant-facing surface. The new `public_demo_tenant?` predicate guards on `current_account&.persisted? && current_account.public_demo_tenant?`, mirroring the existing `hidden?` guard, so the admin host, unknown hosts, and installations that never set the flag see no behavior change. The predicate is also exposed as a helper method for use in views.
- `app/views/_head_tag_extras.html.erb`: conditionally renders `<meta name="robots" content="noindex, nofollow">` for flagged tenants. This partial is rendered as the final line of Hyrax's `layouts/_head_tag_content`, which every tenant-facing layout family reaches (the `hyrax` layout, the three theme layouts, the homepage and proprietor layouts, and the dashboard layout), so the meta tag appears in the head of all tenant pages.

## Placement rationale

This belongs in samvera/hyku core rather than in a downstream knapsack. The `public_demo_tenant` flag itself lives in core (the `Account` model, the proprietor UI, and the factories), and this change is the enforcement half of what that flag promises. The indexing hazard also applies to every Hyku installation equally, because the citation meta tags come from Hyrax itself; any adopter who runs a public demo or sandbox tenant has the same exposure. Finally, a knapsack implementation would be fragile: knapsacks routinely override views, and an override of `_head_tag_extras` would silently drop a meta tag defined there, while a core `after_action` on `ApplicationController` stays in force underneath overlays. The behavior is inert unless an operator explicitly sets the flag, which defaults to false and is `attr_readonly`, so shipping it in core carries no risk for existing tenants.

## Specs

`spec/requests/demo_tenant_noindex_spec.rb` adds three request examples, following the existing real-tenant exemplars (`Apartment::Tenant.create`/`switch`/`drop` with WebMock toggled off, requests issued against the tenant cname). As far as I can tell these are the first response header assertions in the request suite.

1. A flagged tenant's home page returns 200 with `X-Robots-Tag: noindex, nofollow` and the robots meta tag in the body.
2. A flagged tenant's sign-in page carries the same header and meta tag, demonstrating that Devise pages are covered and the behavior is not specific to catalog routes.
3. A regular tenant's home page returns 200 with no `X-Robots-Tag` header and no robots meta tag.

## Notes for reviewers

- Responses from mounted engines that do not inherit the host `ApplicationController` (Riiif, Questioning Authority, BrowseEverything, the Sidekiq and GoodJob dashboards) and files served straight from `public/` do not receive the header. The pages crawlers actually discover and rank flow through `ApplicationController`, so this covers the stated goal; a Rack middleware could widen coverage later and is listed under follow-ups.
- JSON and API responses on flagged tenants (for example the SUSHI endpoints) also inherit `ApplicationController` and will carry the header. That is harmless to API clients, which ignore robots directives.
- `public_demo_tenant` is `attr_readonly`, so a tenant cannot flip the flag after creation. Edge-cached responses on `/concern` and `/catalog` therefore cannot end up serving a stale header value for a tenant whose status changed.
- No user-facing strings are introduced; the header value and meta tag content are protocol tokens, so nothing new goes through i18n.

## Follow-ups

- If coverage should extend to static files, error pages, and engines that bypass `ApplicationController`, add a Rack middleware modeled on `lib/middleware/no_cache_middleware.rb` and insert it ahead of `ActionDispatch::Static`.
- Demo tenants still publish a dynamic sitemap through BlacklightDynamicSitemap, and that engine does not inherit the host `ApplicationController`. Suppressing or noindexing sitemap responses for flagged tenants would be a reasonable next increment.
