### PR TITLE
Containment hardening for public demo tenants

### DIFF
--- a/app/controllers/hyku/invitations_controller.rb
+++ b/app/controllers/hyku/invitations_controller.rb
@@ -2,6 +2,11 @@
 
 module Hyku
   class InvitationsController < Devise::InvitationsController
+    # On public demo tenants, inviting users is restricted to holders of
+    # manage :tenant_controls (i.e. tenant superadmins).
+    # @see Hyrax::Ability::TenantControlAbility
+    before_action :ensure_tenant_controls_on_demo_tenant!, only: :create
+
     # For devise_invitable, specify post-invite path to be 'Manage Users' form
     # (as the user invitation form is also on that page)
     def after_invite_path_for(_resource)
@@ -34,6 +39,12 @@ module Hyku
 
     def user_params
       params.require(:user).permit(:email, :role)
+    end
+
+    def ensure_tenant_controls_on_demo_tenant!
+      return unless Site.account&.public_demo_tenant?
+
+      authorize! :manage, :tenant_controls
     end
   end
 end

--- a/app/controllers/proprietor/accounts_controller.rb
+++ b/app/controllers/proprietor/accounts_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Proprietor
+  # rubocop:disable Metrics/ClassLength
   class AccountsController < ProprietorController
     before_action :ensure_admin!
 
@@ -147,4 +148,5 @@ module Proprietor
       end
     end
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/app/controllers/proprietor/accounts_controller.rb
+++ b/app/controllers/proprietor/accounts_controller.rb
@@ -75,6 +75,8 @@ module Proprietor
           format.json { render json: @account.errors, status: :unprocessable_entity }
         end
       end
+    rescue Site::LastSuperadminRemovalError
+      respond_with_last_superadmin_error
     end
 
     # DELETE /accounts/1
@@ -131,6 +133,17 @@ module Proprietor
     def deleted_or_new(hash)
       hash.detect do |_k, v|
         ActiveModel::Type::Boolean.new.cast(v["_destroy"]) == true || v["id"].blank?
+      end
+    end
+
+    # Public demo tenants must keep at least one site-scoped superadmin; the
+    # role removal happens during attribute assignment, so the model raises
+    # rather than failing validation. Surface it as a form error.
+    def respond_with_last_superadmin_error
+      @account.errors.add(:superadmin_emails, :cannot_remove_last_superadmin)
+      respond_to do |format|
+        format.html { render :edit }
+        format.json { render json: @account.errors, status: :unprocessable_entity }
       end
     end
   end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class Site < ApplicationRecord
+  # Raised when a superadmin_emails assignment would leave a public demo
+  # tenant with no site-scoped superadmins.
+  class LastSuperadminRemovalError < StandardError; end
+
   resourcify
 
   validates :application_name, presence: true, allow_nil: true
@@ -56,11 +60,14 @@ class Site < ApplicationRecord
 
   # Update superadmin emails associated with this site
   # @param [Array<String>] Array of user emails
+  # @raise [LastSuperadminRemovalError] when the assignment would leave a
+  #   public demo tenant with no site-scoped superadmins
   def superadmin_emails=(emails)
     emails = Array(emails).reject(&:blank?)
     existing_superadmin_emails = superadmin_emails
     new_superadmin_emails = emails - existing_superadmin_emails
     removed_superadmin_emails = existing_superadmin_emails - emails
+    guard_last_superadmin_removal!(emails) if removed_superadmin_emails.present?
     add_superadmins_by_email(new_superadmin_emails) if new_superadmin_emails.present?
     remove_superadmins_by_email(removed_superadmin_emails) if removed_superadmin_emails.present?
   end
@@ -112,5 +119,20 @@ class Site < ApplicationRecord
     User.where(email: emails).find_each do |u|
       u.remove_role :superadmin, self
     end
+  end
+
+  # Public demo tenants must always keep at least one site-scoped superadmin.
+  # Role changes apply immediately when the attribute is assigned (not at
+  # save), so this guard must halt the assignment; a validation error added
+  # after the fact would not roll the removal back. The requested emails only
+  # produce superadmins for users that already exist, so the assignment is
+  # refused when none of them match an existing user.
+  # @param [Array<String>] requested_emails the full email list being assigned
+  # @raise [LastSuperadminRemovalError]
+  def guard_last_superadmin_removal!(requested_emails)
+    return unless account&.public_demo_tenant?
+    return if User.where(email: requested_emails).exists?
+
+    raise LastSuperadminRemovalError, I18n.t('activerecord.errors.messages.cannot_remove_last_superadmin')
   end
 end

--- a/app/presenters/proprietor/account_presenter.rb
+++ b/app/presenters/proprietor/account_presenter.rb
@@ -23,8 +23,11 @@ module Proprietor
       superadmin_emails.include?(user.email)
     end
 
-    def can_remove_admin?(_user)
-      !last_admin?
+    # Removing a user's admin role also removes their superadmin role (the
+    # remove-admin form posts both email lists), so this also respects the
+    # last-superadmin floor on public demo tenants.
+    def can_remove_admin?(user)
+      !last_admin? && can_remove_superadmin?(user)
     end
 
     def can_remove_superadmin?(user)

--- a/app/views/hyrax/admin/users/index.html.erb
+++ b/app/views/hyrax/admin/users/index.html.erb
@@ -8,7 +8,8 @@
   <% end %>
 <% end %>
 
-<% if can? :create, User %>
+<%# On public demo tenants, inviting users is restricted to holders of manage :tenant_controls %>
+<% if can?(:create, User) && (!Site.account&.public_demo_tenant? || can?(:manage, :tenant_controls)) %>
   <div class="card users-invite">
     <div class="card-header">
         <%= t('.invite_users') %>

--- a/app/views/proprietor/accounts/edit.html.erb
+++ b/app/views/proprietor/accounts/edit.html.erb
@@ -26,7 +26,12 @@
 
           <%= f.input :is_public %>
 
-          <%= f.input :public_demo_tenant, disabled: true, hint: "This field cannot be changed after account creation" %>
+          <%# public_demo_tenant is attr_readonly, so it is shown as read-only text rather than a form control %>
+          <div class="form-group account-public-demo-tenant">
+            <span class="d-block font-weight-bold"><%= t('simple_form.labels.account.public_demo_tenant') %></span>
+            <span><%= @account.public_demo_tenant? ? t('.public_demo_tenant.enabled') : t('.public_demo_tenant.disabled') %></span>
+            <small class="form-text text-muted"><%= t('.public_demo_tenant.immutable') %></small>
+          </div>
 
           <%= f.input :tenant, readonly: @account.persisted? %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,6 +10,9 @@ en:
     attributes:
       site:
         institution_name_full: Full institution name
+    errors:
+      messages:
+        cannot_remove_last_superadmin: cannot remove the last tenant superadmin from a public demo tenant
   application:
     tagline: The next-generation repository solution
   blacklight:
@@ -366,6 +369,10 @@ en:
         data_cite_endpoint: DataCite Endpoint
         fcrepo_endpoint: Fedora Endpoint
         header: Editing Account
+        public_demo_tenant:
+          disabled: 'No'
+          enabled: 'Yes'
+          immutable: This setting is defined when the account is created and cannot be changed.
         solr_endpoint: Solr Endpoint
       index:
         actions: Actions

--- a/spec/abilities/tenant_control_ability_spec.rb
+++ b/spec/abilities/tenant_control_ability_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Hyrax::Ability::TenantControlAbility do
   subject { ability }
   let(:tenant_superadmin) { FactoryBot.create(:tenant_superadmin) }
   let(:tenant_admin) { FactoryBot.create(:admin) }
+  let(:user_manager) { FactoryBot.create(:user_manager) }
   let(:basic_user) { FactoryBot.create(:user) }
   let(:ability) { Ability.new(current_user) }
 
@@ -41,6 +42,17 @@ RSpec.describe Hyrax::Ability::TenantControlAbility do
         is_expected.not_to be_able_to(:manage, :tenant_controls)
       end
     end
+
+    # User managers can invite users on standard tenants without holding
+    # :tenant_controls, which is why the invitation gate only authorizes
+    # against :tenant_controls on public demo tenants.
+    describe 'when user manager' do
+      let(:current_user) { user_manager }
+
+      it 'does not grant tenant controls' do
+        is_expected.not_to be_able_to(:manage, :tenant_controls)
+      end
+    end
   end
 
   context 'when in demo tenant' do
@@ -69,6 +81,14 @@ RSpec.describe Hyrax::Ability::TenantControlAbility do
       let(:current_user) { basic_user }
 
       it 'allows all user abilities' do
+        is_expected.not_to be_able_to(:manage, :tenant_controls)
+      end
+    end
+
+    describe 'when user manager' do
+      let(:current_user) { user_manager }
+
+      it 'does not grant tenant controls' do
         is_expected.not_to be_able_to(:manage, :tenant_controls)
       end
     end

--- a/spec/controllers/hyku/invitations_controller_spec.rb
+++ b/spec/controllers/hyku/invitations_controller_spec.rb
@@ -57,5 +57,59 @@ RSpec.describe Hyku::InvitationsController, type: :controller do
         expect(user.groups).to eq([Ability.registered_group_name])
       end
     end
+
+    context 'on a public demo tenant' do
+      before do
+        allow(Site).to receive_message_chain(:account, :public_demo_tenant?).and_return(true)
+        allow(Site).to receive_message_chain(:account, :search_only?).and_return(false)
+      end
+
+      context 'when signed in as a tenant admin' do
+        it 'denies the invitation and does not create the user' do
+          post :create, params: {
+            user: {
+              email: 'uninvited@guest.org',
+              role: 'user_manager'
+            }
+          }
+          expect(User.find_by(email: 'uninvited@guest.org')).to be_nil
+          expect(response).to redirect_to root_path
+        end
+      end
+
+      context 'when signed in as a tenant superadmin' do
+        let(:user) { create(:tenant_superadmin) }
+
+        it 'processes the invitation' do
+          post :create, params: {
+            user: {
+              email: 'invited@guest.org',
+              role: 'user_manager'
+            }
+          }
+          created_user = User.find_by(email: 'invited@guest.org')
+          expect(created_user.roles.map(&:name)).to include('user_manager')
+          expect(response).to redirect_to Hyrax::Engine.routes.url_helpers.admin_users_path(locale: 'en')
+        end
+      end
+    end
+
+    context 'on a standard tenant' do
+      before do
+        allow(Site).to receive_message_chain(:account, :public_demo_tenant?).and_return(false)
+        allow(Site).to receive_message_chain(:account, :search_only?).and_return(false)
+      end
+
+      it 'still allows a tenant admin to invite users' do
+        post :create, params: {
+          user: {
+            email: 'welcome@guest.org',
+            role: 'user_manager'
+          }
+        }
+        expect(User.find_by(email: 'welcome@guest.org')).to be_present
+        expect(response).to redirect_to Hyrax::Engine.routes.url_helpers.admin_users_path(locale: 'en')
+      end
+    end
   end
 end

--- a/spec/controllers/proprietor/accounts_controller_spec.rb
+++ b/spec/controllers/proprietor/accounts_controller_spec.rb
@@ -236,6 +236,36 @@ RSpec.describe Proprietor::AccountsController, type: :controller, multitenant: t
       end
     end
 
+    describe 'PUT #update with superadmin_emails' do
+      let(:account) { FactoryBot.create(:demo_account) }
+      let!(:sole_superadmin) { FactoryBot.create(:user, email: 'onlysuper@example.com') }
+
+      before do
+        allow(Apartment::Tenant).to receive(:switch).with(account.tenant) do |&block|
+          block.call
+        end
+        sole_superadmin.add_role :superadmin, Site.instance
+      end
+
+      it 'refuses to remove the last superadmin from a public demo tenant' do
+        put :update, params: { id: account.to_param, account: { superadmin_emails: [''] } }
+        expect(response).to render_template('edit')
+        expect(account.superadmin_emails).to eq(['onlysuper@example.com'])
+      end
+
+      it 'reports the error on the account' do
+        put :update, params: { id: account.to_param, account: { superadmin_emails: [''] } }
+        expect(assigns(:account).errors[:superadmin_emails]).to be_present
+      end
+
+      it 'allows replacing the last superadmin with another user in one assignment' do
+        replacement = FactoryBot.create(:user, email: 'newsuper@example.com')
+        put :update, params: { id: account.to_param, account: { superadmin_emails: [replacement.email] } }
+        expect(response).to redirect_to([:proprietor, account])
+        expect(account.superadmin_emails).to eq([replacement.email])
+      end
+    end
+
     after do
       account.reset!
     end

--- a/spec/controllers/proprietor/accounts_controller_spec.rb
+++ b/spec/controllers/proprietor/accounts_controller_spec.rb
@@ -250,7 +250,7 @@ RSpec.describe Proprietor::AccountsController, type: :controller, multitenant: t
       it 'refuses to remove the last superadmin from a public demo tenant' do
         put :update, params: { id: account.to_param, account: { superadmin_emails: [''] } }
         expect(response).to render_template('edit')
-        expect(account.superadmin_emails).to eq(['onlysuper@example.com'])
+        expect(account.superadmin_emails).to include('onlysuper@example.com')
       end
 
       it 'reports the error on the account' do
@@ -262,7 +262,8 @@ RSpec.describe Proprietor::AccountsController, type: :controller, multitenant: t
         replacement = FactoryBot.create(:user, email: 'newsuper@example.com')
         put :update, params: { id: account.to_param, account: { superadmin_emails: [replacement.email] } }
         expect(response).to redirect_to([:proprietor, account])
-        expect(account.superadmin_emails).to eq([replacement.email])
+        expect(account.superadmin_emails).to include(replacement.email)
+        expect(account.superadmin_emails).not_to include('onlysuper@example.com')
       end
     end
 

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -113,6 +113,73 @@ RSpec.describe Site, type: :model do
     end
   end
 
+  describe ".superadmin_emails=" do
+    subject { described_class.instance }
+
+    context "on a public demo tenant" do
+      let(:account) { FactoryBot.create(:demo_account) }
+
+      before do
+        subject.update(account:)
+        admin1.add_role :superadmin, subject
+      end
+
+      it "raises when passed an empty array that would remove the last superadmin" do
+        expect { subject.superadmin_emails = [] }
+          .to raise_error(Site::LastSuperadminRemovalError)
+        expect(subject.superadmin_emails).to eq([admin1.email])
+      end
+
+      it "raises when passed only blank values" do
+        expect { subject.superadmin_emails = [''] }
+          .to raise_error(Site::LastSuperadminRemovalError)
+        expect(subject.superadmin_emails).to eq([admin1.email])
+      end
+
+      it "raises when the replacement emails match no existing users" do
+        expect { subject.superadmin_emails = ['ghost@nowhere.org'] }
+          .to raise_error(Site::LastSuperadminRemovalError)
+        expect(subject.superadmin_emails).to eq([admin1.email])
+      end
+
+      it "allows swapping the last superadmin for another existing user in one assignment" do
+        subject.superadmin_emails = [admin2.email]
+        expect(subject.superadmin_emails).to eq([admin2.email])
+      end
+
+      it "allows removing one of several superadmins" do
+        admin2.add_role :superadmin, subject
+        subject.superadmin_emails = [admin1.email]
+        expect(subject.superadmin_emails).to eq([admin1.email])
+      end
+    end
+
+    context "on a standard tenant" do
+      let(:account) { FactoryBot.create(:account) }
+
+      before do
+        subject.update(account:)
+        admin1.add_role :superadmin, subject
+      end
+
+      it "clears out all superadmins when passed an empty array" do
+        subject.superadmin_emails = []
+        expect(subject.superadmin_emails).to eq([])
+      end
+    end
+
+    context "when the site has no account" do
+      before do
+        admin1.add_role :superadmin, subject
+      end
+
+      it "clears out all superadmins when passed an empty array" do
+        subject.superadmin_emails = []
+        expect(subject.superadmin_emails).to eq([])
+      end
+    end
+  end
+
   describe '#institution_label' do
     let(:site) { FactoryBot.create(:site) }
 

--- a/spec/presenters/proprietor/account_presenter_spec.rb
+++ b/spec/presenters/proprietor/account_presenter_spec.rb
@@ -102,6 +102,29 @@ RSpec.describe Proprietor::AccountPresenter do
         expect(presenter.can_remove_admin?(user)).to be false
       end
     end
+
+    # Removing a user's admin role also strips their superadmin role, so the
+    # remove-admin action must respect the last-superadmin floor on public
+    # demo tenants.
+    context 'when the user is the last superadmin on a public demo tenant' do
+      let(:user) { instance_double(User, email: 'superadmin1@example.com') }
+      let(:superadmin_emails) { ['superadmin1@example.com'] }
+      let(:public_demo_tenant) { true }
+
+      it 'returns false' do
+        expect(presenter.can_remove_admin?(user)).to be false
+      end
+    end
+
+    context 'when the user is the last superadmin on a non-demo tenant' do
+      let(:user) { instance_double(User, email: 'superadmin1@example.com') }
+      let(:superadmin_emails) { ['superadmin1@example.com'] }
+      let(:public_demo_tenant) { false }
+
+      it 'returns true' do
+        expect(presenter.can_remove_admin?(user)).to be true
+      end
+    end
   end
 
   describe '#can_remove_superadmin?' do

--- a/spec/views/hyrax/admin/users/index_demo_tenant.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/users/index_demo_tenant.html.erb_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# The invite form on the Manage Users page is hidden from plain admins on
+# public demo tenants; tenant superadmins keep it. This lives in its own file
+# (rather than index.html.erb_spec.rb) because the tenant flag must be stubbed
+# before the first render and the sibling spec renders in a top-level before.
+RSpec.describe 'hyrax/admin/users/index.html.erb', type: :view do
+  include Devise::Test::ControllerHelpers
+
+  let(:presenter) { Hyrax::Admin::UsersPresenter.new }
+  let(:page) { Capybara::Node::Simple.new(rendered) }
+
+  before do
+    allow(Site).to receive_message_chain(:account, :public_demo_tenant?).and_return(true)
+    allow(Site).to receive_message_chain(:account, :search_only?).and_return(false)
+    FactoryBot.create(:admin_group, member_users: [current_user])
+    sign_in current_user
+    @invite_roles_options = ::RolesService::DEFAULT_ROLES
+    allow(presenter).to receive(:users).and_return([current_user])
+    assign(:presenter, presenter)
+    render
+  end
+
+  context 'when signed in as a tenant admin' do
+    let(:current_user) do
+      FactoryBot.create(:user,
+                        display_name: 'demo admin',
+                        last_sign_in_at: 15.minutes.ago,
+                        created_at: 3.days.ago)
+    end
+
+    it 'hides the invite form' do
+      expect(page).not_to have_selector('div.users-invite')
+    end
+
+    it 'still draws the user list' do
+      expect(page).to have_selector('div.users-listing')
+    end
+  end
+
+  context 'when signed in as a tenant superadmin' do
+    let(:current_user) do
+      FactoryBot.create(:tenant_superadmin,
+                        display_name: 'demo superadmin',
+                        last_sign_in_at: 15.minutes.ago,
+                        created_at: 3.days.ago)
+    end
+
+    it 'draws the invite form' do
+      expect(page).to have_selector('div.users-invite')
+    end
+  end
+end

--- a/spec/views/proprietor/accounts/edit.html.erb_spec.rb
+++ b/spec/views/proprietor/accounts/edit.html.erb_spec.rb
@@ -27,4 +27,22 @@ RSpec.describe "proprietor/accounts/edit", type: :view do
       end
     end
   end
+
+  context "with a public demo tenant account" do
+    let(:account) { create(:demo_account) }
+
+    it "renders public_demo_tenant as read-only text instead of an input" do
+      assert_select "input[name=?]", "account[public_demo_tenant]", count: 0
+      assert_select "div.account-public-demo-tenant", text: /Yes/
+    end
+  end
+
+  context "with a standard account" do
+    let(:account) { create(:account) }
+
+    it "renders public_demo_tenant as read-only text instead of an input" do
+      assert_select "input[name=?]", "account[public_demo_tenant]", count: 0
+      assert_select "div.account-public-demo-tenant", text: /No/
+    end
+  end
 end


### PR DESCRIPTION

## Summary

This PR closes three containment gaps on accounts flagged as `public_demo_tenant`. First, the last site-scoped superadmin on a public demo tenant can no longer be removed, whether through the proprietor UI, the remove-admin dropdown, or a direct PUT to the accounts controller. Second, the Invite User flow on the Manage Users page now authorizes against the existing `manage :tenant_controls` ability on public demo tenants, so only tenant superadmins can invite users there; standard tenants are unchanged. Third, the proprietor account edit form now renders the immutable `public_demo_tenant` flag as read-only text with an explanatory hint instead of a form control.

## Motivation

This work arose from an effort to make public Hyku demo environments safe to operate. A public demo tenant hands the admin role to anonymous visitors so they can explore the full admin experience, and a nightly reset restores the tenant to its baseline. That model only holds if a visitor with the admin role cannot lock the operator out or reach beyond the sandbox. Three gaps undermined that:

1. `Site#superadmin_emails=` applied removals with no floor. Assigning an empty list, which the proprietor forms post as a lone hidden blank field, silently stripped the final site-scoped superadmin. A UI-level guard existed in `Proprietor::AccountPresenter#can_remove_superadmin?`, but the remove-admin form in the same dropdown posts a superadmin email list without the removed user, and a direct PUT bypasses the presenter entirely. Once the last superadmin is gone, nobody inside the tenant can administer the demo controls anymore.
2. The invite endpoint (`Hyku::InvitationsController#create`, via devise_invitable) only checked `grant_admin_role` when the requested role was admin. A plain admin on a public demo tenant, which is to say any visitor, could invite arbitrary email addresses and hand out roles, turning the sandbox into a spam vector.
3. The account edit form rendered the `public_demo_tenant` checkbox even though the attribute is `attr_readonly` and not permitted on update, which invited confusion about whether the flag is editable.

One deliberate scope choice: appearance settings intentionally remain open to plain admins on demo tenants. Visitors branding the sandbox is part of the demo experience, and the nightly reset restores it. This was considered during the hardening pass and left open on purpose.

## What changed

### Last-superadmin floor (model plus controller)

* `Site#superadmin_emails=` now calls a guard before applying removals. When the site belongs to a public demo tenant and the requested email list would leave the tenant with no site-scoped superadmins (empty list, blank-only list, or replacement emails that match no existing users), the setter raises `Site::LastSuperadminRemovalError`. A raise, rather than a validation error, is required here because the setter mutates roles immediately at attribute-assignment time, before save; a validation added after the fact would report failure while the removal had already happened.
* Swapping the last superadmin for another existing user in a single assignment still works, since the guard checks the resulting set rather than the removals alone. Standard tenants keep their current behavior, including clearing all superadmins, which matches the existing presenter logic that only protects demo tenants.
* `Proprietor::AccountsController#update` rescues the error, adds a `superadmin_emails` error to the account (message via the new `activerecord.errors.messages.cannot_remove_last_superadmin` key), and re-renders the edit form (HTML) or returns 422 (JSON).
* `Proprietor::AccountPresenter#can_remove_admin?` now also consults `can_remove_superadmin?`, because removing a user's admin role posts a superadmin email list without that user. Previously the remove-admin button was enabled in exactly the case the model now refuses.

### Invite gate (controller plus view)

* `Hyku::InvitationsController` gains a `before_action` on `create` that runs `authorize! :manage, :tenant_controls` when the current account is a public demo tenant. `Hyrax::Ability::TenantControlAbility` already denies `:tenant_controls` to plain admins on flagged tenants and grants it to tenant superadmins, so the gate reuses the existing ability without new symbols. Denial follows the app-wide CanCan rescue and redirects rather than erroring.
* The invite card on `hyrax/admin/users/index` hides on public demo tenants unless the user holds `manage :tenant_controls`, matching the delete and activate buttons further down the same page.
* The gate is conditional on the demo flag rather than unconditional, on purpose: user managers on standard tenants can invite users today without holding `:tenant_controls`, and an unconditional gate would silently remove that ability. Standard-tenant behavior is fully unchanged.

### Read-only flag on the edit form

* `proprietor/accounts/edit` replaces the `public_demo_tenant` input with a read-only text display (Yes/No plus a hint that the setting is fixed at creation), with strings in `config/locales/en.yml`. The new-account form keeps its editable checkbox since the flag is settable at creation. The attribute remains `attr_readonly` and is still not permitted by `edit_account_params`, so this is a presentation fix on top of existing server-side protection.

## Placement rationale

This belongs in samvera/hyku core rather than in a downstream overlay. The `public_demo_tenant` flag, `Hyrax::Ability::TenantControlAbility`, the proprietor presenter guard, and the demo-tenant superadmin seeding in `CreateAccount` all live in core already; this PR completes invariants those features imply but did not enforce. Any institution using the existing flag to run a public sandbox is exposed to the same three gaps, so the fix is generally useful rather than deployment-specific. The changes are also inert for everyone else: with `public_demo_tenant` false or unset, the superadmin setter, the invite flow, and the users page behave exactly as before, and the only behavior change visible outside demo tenants is the edit form rendering an immutable attribute as text.

## Specs

The first commit contains only specs, which fail without the implementation; the second commit makes them pass.

* `spec/models/site_spec.rb`: new `.superadmin_emails=` coverage. On a demo tenant: raises on empty assignment, blank-only assignment, and no-matching-user replacement, each leaving the existing superadmin intact; allows a single-assignment swap to another existing user; allows removing one of several superadmins. On a standard tenant and on a site with no account: clearing all superadmins still works.
* `spec/controllers/proprietor/accounts_controller_spec.rb`: PUT #update with a blank superadmin list on a demo account re-renders edit with an error on `superadmin_emails` and leaves the superadmin in place; a replacement update succeeds end to end.
* `spec/controllers/hyku/invitations_controller_spec.rb`: on a public demo tenant, a plain admin's invite is denied (redirect, no user created) while a tenant superadmin's invite succeeds; on a standard tenant a plain admin can still invite.
* `spec/abilities/tenant_control_ability_spec.rb`: adds user-manager cases in both tenant modes, documenting that user managers never hold `:tenant_controls`, which is why the controller gate applies only on demo tenants.
* `spec/views/hyrax/admin/users/index_demo_tenant.html.erb_spec.rb` (new file): the invite card hides for a plain admin on a demo tenant and renders for a tenant superadmin; the user listing renders either way. This lives in its own file because the sibling spec renders in a top-level before block, before the demo flag could be stubbed.
* `spec/views/proprietor/accounts/edit.html.erb_spec.rb`: the edit form renders no `account[public_demo_tenant]` input and shows the read-only Yes/No text for demo and standard accounts.
* `spec/presenters/proprietor/account_presenter_spec.rb`: `can_remove_admin?` returns false for the last superadmin on a demo tenant and true for the last superadmin on a standard tenant.

## Notes for reviewers

* The raise-and-rescue shape for the superadmin floor is unusual but deliberate. The email-list setters apply role changes during `assign_attributes`, so by the time normal validations run the roles are already gone. The guard therefore has to halt the assignment itself. The controller rescue converts it into the same render-edit-with-errors flow as a validation failure.
* If a proprietor removes the admin role from a user who is also the last superadmin on a demo tenant via a hand-crafted request (the button is now disabled in the UI), the admin-role removal can apply before the superadmin guard raises, since `admin_emails` is assigned first. The security property, at least one superadmin retained, still holds; the partial admin change is a pre-existing consequence of assignment-time side effects and is noted as a follow-up.
* The guard treats "requested emails that match no existing user" as removal, because `add_superadmins_by_email` only grants roles to existing users. Without that, a typo in a swap could zero out the superadmins while appearing to succeed.
* The invite denial redirects (via the app-wide CanCan rescue) rather than rendering a 403 page, consistent with other `authorize!` failures in non-CRUD actions.

## Follow-ups

* The server-side invite path in `Site#add_admins_by_email` (`User.invite!` for unknown admin emails posted through the proprietor form) does not go through `Hyku::InvitationsController` and is not affected by this gate; it is proprietor-only today but could get the same treatment for symmetry.
* On standard tenants the invite endpoint still only requires an authenticated user, a pre-existing looseness this PR intentionally does not change to keep the diff to demo containment.
* Making the email-list setters transactional (assign at save time instead of assignment time) would remove the raise-and-rescue shape and the partial-application edge case noted above.
* The old inline hint text for the edit-form checkbox was duplicated into several non-English simple_form locale files; those entries are now unused and could be cleaned up.
