### PR TITLE
Pin SolrCloud node identity with SOLR_HOST in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,6 +78,13 @@ services:
       - SOLR_ENABLE_CLOUD_MODE=yes
       - SOLR_ENABLE_AUTHENTICATION=yes
       - ZK_HOST=zoo:2181
+      # Pin the SolrCloud node identity to the compose service DNS name so it
+      # survives container restarts. Without this, Solr registers node_name as
+      # <container-IP>:8983_solr; when the container's IP changes on restart the
+      # tenant collections' replicas are orphaned at the dead IP (queries proxy
+      # to a dead node and cores can be lost on cleanup). `solr` is the network
+      # alias every other service already uses to reach Solr.
+      - SOLR_HOST=solr
       - VIRTUAL_PORT=8983
       - VIRTUAL_HOST=solr.hyku.test
     labels:


### PR DESCRIPTION
## Problem

The `solr` service in `docker-compose.yml` enables SolrCloud (`SOLR_ENABLE_CLOUD_MODE=yes`, `ZK_HOST=zoo:2181`) but does not set `SOLR_HOST`. As a result the Solr node registers itself in Zookeeper by IP: `node_name = <container-IP>:8983_solr`.

`node_name` is the coordinate SolrCloud uses to locate each collection's replicas. When the Solr container's IP changes across a restart — routine for `docker compose`, since Compose reassigns container IPs — every tenant collection's replica is left registered at the now-dead IP. The live node then proxies queries to that dead address and they time out, and SolrCloud can unload the orphaned core during recovery. Downstream this surfaces as `Blacklight::Exceptions::RepositoryTimeout` and a hard 500 on every page, even though Postgres/Fedora (the source of truth) are untouched.

## Fix

Add `SOLR_HOST=solr` to the `solr` service environment. `solr` is the compose-network DNS alias every other service already uses to reach Solr (it is the value `.env` and `config/solr.yml` already use on the client side). Stock `solr:8.11.2` `bin/solr` maps `SOLR_HOST` → `-Dhost=solr`, which pins `node_name` to `solr:8983_solr` — independent of the container IP and therefore stable across restarts.

The variable is already present in the repo for the **client** side (`.env`, `config/solr.yml`, the `solrcloud-*` scripts); it was simply never placed on the `solr` **service** block, so the Solr node process never received it. This PR closes that gap.

## Verification

Reproduced and fixed on a downstream Hyku knapsack instance:

- **Before:** restarting the `solr` container orphaned the tenant collection's replica at the old IP; every page returned a 500 (`RepositoryTimeout`).
- **After** setting `SOLR_HOST=solr` and recreating the container: the node registers as `solr:8983_solr`, and force-recreating the container (new container, the exact break scenario) brings the collection back `active`/`leader` with all pages 200 and **zero manual intervention**.

## Scope / blast radius

- Dev/CI `docker-compose` only. The value equals the existing service name and the existing client-side `.env` value, so there is no behavior change beyond stabilizing node identity.
- Production/k8s is unaffected: the `ops/*-deploy` templates point the Rails client at an external Solr subchart whose node identity is owned by that chart's StatefulSet (stable pod DNS), a different topology.

## Caveat

This fixes node identity **going forward**. A collection already orphaned under an old IP-based `node_name` on a persistent Solr volume still needs a one-time collection recreate (or `DELETEREPLICA`/`ADDREPLICA`) to re-register under the stable name; existing local volumes won't self-heal on the first boot after this change if they already carry an orphaned replica.

---

Opening as a **draft** for review. Happy to add a note to the docs (`docs/configuration.md`) if that's wanted alongside the compose change.
