### PR TITLE
ci: allow manifest push from dependabot

### DIFF
--- a/.github/workflows/build-test-lint.yaml
+++ b/.github/workflows/build-test-lint.yaml
@@ -90,6 +90,7 @@ jobs:
   push:
     needs: build
     runs-on: ubuntu-latest
+    permissions: write-all
     steps:
       - name: Determine git sha to checkout
         uses: haya14busa/action-cond@v1


### PR DESCRIPTION
## Summary
- Adds `permissions: write-all` to the `push` job in `build-test-lint`
- Allows Dependabot-triggered PR runs to push GHCR multiarch manifests so downstream lint/test jobs can run

## Notes
Dependabot-triggered workflows get a restricted token by default; the build matrix already had `write-all`, but the manifest `push` job did not.

## Test Plan
- [x] `git diff --check`