### PR TITLE
ci: treat dependencies label as release patch

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -12,6 +12,7 @@ changelog:
     - title: Bug Fixes 🐞
       labels:
         - patch-ver
+        - dependencies
     - title: Database Changes
       labels:
         - database-changes

--- a/.github/workflows/verify_labels.yml
+++ b/.github/workflows/verify_labels.yml
@@ -21,5 +21,5 @@ jobs:
       - name: Check PR for Release Notes labels
         uses: docker://agilepathway/pull-request-label-checker:latest
         with:
-          one_of: patch-ver,minor-ver,major-ver,ignore-for-release
+          one_of: patch-ver,minor-ver,major-ver,ignore-for-release,dependencies
           repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Allows the `dependencies` label to satisfy the release-label verification workflow
- Groups `dependencies` PRs under the patch/bug-fix release notes category

## Test Plan
- [x] `git diff --check`