### PR TITLE
build: switch to Soldevelo container images (Bitnami access now paid)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -87,7 +87,7 @@ test:
       alias: fcrepo
     - name: redis:5-alpine
       alias: redis
-    - name: bitnami/zookeeper:3
+    - name: soldevelo/zookeeper:3.9
       alias: zk
     - name: bitnami/solr:8
       alias: solr


### PR DESCRIPTION
## Switch container base images to SolDevelo

Bitnami images now require a VMware Tanzu subscription (change effective **August 28, 2025**). This causes pipeline failures and added cost for teams that relied on the public registry.

[SolDevelo](https://hub.docker.com/u/soldevelo) provides drop-in replacements - same Debian-based images, same startup scripts, same environment-variable API - built openly from [SolDevelo/containers](https://github.com/SolDevelo/containers) and tagged to match Bitnami upstream.

## Image substitutions

- `bitnami/zookeeper:3` → [`soldevelo/zookeeper:3.9`](https://hub.docker.com/r/soldevelo/zookeeper)