### PR TITLE
Deposit wizard extras phase

### DIFF
--- a/app/assets/javascripts/hyrax/deposit_wizard.js
+++ b/app/assets/javascripts/hyrax/deposit_wizard.js
@@ -1,6 +1,19 @@
 // Progressive enhancement for the guided deposit wizard. Attaches behavior to
 // wizard steps by class when present; a no-op on other pages.
 (function () {
+  // Debounced so rapid edits (typing a redirect path) coalesce into one save.
+  var extrasSaveTimer = null;
+  function autosaveExtras() {
+    var form = document.querySelector('.deposit-wizard__commit-form');
+    if (!form) return;
+    var url = form.getAttribute('data-extras-url');
+    if (!url) return;
+    clearTimeout(extrasSaveTimer);
+    extrasSaveTimer = setTimeout(function () {
+      $.ajax({ url: url, method: 'POST', data: $(form).serialize() });
+    }, 400);
+  }
+
   function initFileUploader() {
     var uploader = $('.fileupload-deposit-wizard');
     if (!uploader.length || typeof $.fn.hyraxUploader !== 'function') return;
@@ -151,6 +164,12 @@
     }
     var index = 0;
 
+    // Delegated so server-rendered chips (restored on refresh) are removable too.
+    chips.on('click', '.deposit-wizard__chip-remove', function () {
+      $(this).closest('.deposit-wizard__extra-chip').remove();
+      autosaveExtras();
+    });
+
     section.find('[data-behavior="collection-add"]').on('click', function () {
       var id = select.val();
       if (!id) return;
@@ -162,9 +181,9 @@
       var chip = $('<li class="deposit-wizard__extra-chip" data-collection-id="' + id + '"></li>');
       chip.append($('<span></span>').text(label));
       chip.append($('<input type="hidden">').attr('name', field).val(id));
-      chip.append($('<button type="button" class="deposit-wizard__chip-remove" aria-label="remove">×</button>')
-        .on('click', function () { chip.remove(); }));
+      chip.append($('<button type="button" class="deposit-wizard__chip-remove" aria-label="remove">×</button>'));
       chips.append(chip);
+      autosaveExtras();
 
       if (typeof select.val === 'function') { select.val('').trigger('change'); }
     });
@@ -175,6 +194,12 @@
     if (!section.length) return;
     var chips = section.find('[data-behavior="share-chips"]');
     var index = 0;
+
+    // Delegated so server-rendered chips (restored on refresh) are removable too.
+    chips.on('click', '.deposit-wizard__chip-remove', function () {
+      $(this).closest('.deposit-wizard__extra-chip').remove();
+      autosaveExtras();
+    });
 
     var paramKey = section.data('param-key');
     function addGrant(type, name, accessVal, accessLabel) {
@@ -187,9 +212,9 @@
       chip.append($('<input type="hidden">').attr('name', prefix + '[type]').val(type));
       chip.append($('<input type="hidden">').attr('name', prefix + '[name]').val(name));
       chip.append($('<input type="hidden">').attr('name', prefix + '[access]').val(accessVal));
-      chip.append($('<button type="button" class="deposit-wizard__chip-remove" aria-label="remove">×</button>')
-        .on('click', function () { chip.remove(); }));
+      chip.append($('<button type="button" class="deposit-wizard__chip-remove" aria-label="remove">×</button>'));
       chips.append(chip);
+      autosaveExtras();
     }
 
     section.find('[data-behavior="share-person-add"]').on('click', function () {
@@ -206,21 +231,6 @@
     });
   }
 
-  function initRedirectsConnect() {
-    var section = $('[data-behavior="extra-redirects"]');
-    if (!section.length) return;
-    var rows = section.find('[data-behavior="redirect-rows"]');
-    var template = section.find('[data-behavior="redirect-row-template"]');
-    if (!template.length) return;
-    var index = 1; // row 0 is rendered server-side
-
-    section.find('[data-behavior="redirect-add"]').on('click', function () {
-      var html = template.html().replace(/__index__/g, index);
-      index += 1;
-      rows.append($(html));
-    });
-  }
-
   // Select2 v3 (the version Hyrax bundles) binds an ajax typeahead to a HIDDEN
   // INPUT, not a <select>. That input is the parent_id field posted with the
   // deposit, so its value is the chosen work id — no separate hidden field.
@@ -234,11 +244,11 @@
       placeholder: input.data('placeholder'),
       allowClear: true,
       minimumInputLength: 2,
-      // A hidden input has no option text for a pre-seeded value; supply one so
-      // the id round-trips as its own label until the user picks a fresh result.
+      // A hidden input has no option text for a pre-seeded value; show the work's
+      // title (passed as data-initial-label) rather than the bare id.
       initSelection: function (element, callback) {
         var val = element.val();
-        if (val) callback({ id: val, text: val });
+        if (val) callback({ id: val, text: input.data('initial-label') || val });
       },
       ajax: {
         url: section.data('options-url'),
@@ -248,6 +258,31 @@
           return { results: data.map(function (row) { return { id: row.id, text: row.label }; }) };
         }
       }
+    });
+
+    input.on('change', autosaveExtras);
+  }
+
+  // The redirects rows are the stock partial's (hyrax/redirects.js owns them), so
+  // autosave via delegation to catch dynamically-added rows.
+  function initRedirectsAutosave() {
+    var section = document.querySelector('[data-behavior="extra-redirects"]');
+    if (!section) return;
+    section.addEventListener('input', autosaveExtras);
+    section.addEventListener('change', autosaveExtras);
+    section.addEventListener('click', function (event) {
+      if (event.target.closest('[data-redirects-remove-row]')) autosaveExtras();
+    });
+  }
+
+  function initExtrasToggle() {
+    $('[data-behavior="extra-toggle"]').on('click', function () {
+      var toggle = $(this);
+      var body = toggle.siblings('[data-behavior="extra-body"]');
+      var open = body.prop('hidden');
+      body.prop('hidden', !open);
+      toggle.attr('aria-expanded', open ? 'true' : 'false');
+      toggle.closest('.deposit-wizard__extra').toggleClass('is-open', open);
     });
   }
 
@@ -271,8 +306,9 @@
     initDepositAgreement();
     initCollectionConnect();
     initSharingConnect();
-    initRedirectsConnect();
     initParentConnect();
+    initRedirectsAutosave();
+    initExtrasToggle();
   }
 
   $(document).on('turbolinks:load ready', initDepositWizard);

--- a/app/assets/javascripts/hyrax/deposit_wizard.js
+++ b/app/assets/javascripts/hyrax/deposit_wizard.js
@@ -140,6 +140,117 @@
     refresh();
   }
 
+  function initCollectionConnect() {
+    var section = $('[data-behavior="extra-collection"]');
+    if (!section.length) return;
+    var paramKey = section.data('param-key');
+    var select = section.find('[data-behavior="collection-select"]');
+    var chips = section.find('[data-behavior="collection-chips"]');
+    if (typeof select.select2 === 'function') {
+      select.select2({ placeholder: select.data('placeholder'), allowClear: true, width: '20rem' });
+    }
+    var index = 0;
+
+    section.find('[data-behavior="collection-add"]').on('click', function () {
+      var id = select.val();
+      if (!id) return;
+      if (chips.find('[data-collection-id="' + id + '"]').length) return;
+      var label = select.find('option:selected').text();
+      var field = paramKey + '[member_of_collections_attributes][' + index + '][id]';
+      index += 1;
+
+      var chip = $('<li class="deposit-wizard__extra-chip" data-collection-id="' + id + '"></li>');
+      chip.append($('<span></span>').text(label));
+      chip.append($('<input type="hidden">').attr('name', field).val(id));
+      chip.append($('<button type="button" class="deposit-wizard__chip-remove" aria-label="remove">×</button>')
+        .on('click', function () { chip.remove(); }));
+      chips.append(chip);
+
+      if (typeof select.val === 'function') { select.val('').trigger('change'); }
+    });
+  }
+
+  function initSharingConnect() {
+    var section = $('[data-behavior="extra-sharing"]');
+    if (!section.length) return;
+    var chips = section.find('[data-behavior="share-chips"]');
+    var index = 0;
+
+    var paramKey = section.data('param-key');
+    function addGrant(type, name, accessVal, accessLabel) {
+      if (!name || !accessVal || accessVal === 'none') return;
+      var prefix = paramKey + '[permissions_attributes][' + index + ']';
+      index += 1;
+
+      var chip = $('<li class="deposit-wizard__extra-chip"></li>');
+      chip.append($('<span></span>').text(name + ' — ' + accessLabel));
+      chip.append($('<input type="hidden">').attr('name', prefix + '[type]').val(type));
+      chip.append($('<input type="hidden">').attr('name', prefix + '[name]').val(name));
+      chip.append($('<input type="hidden">').attr('name', prefix + '[access]').val(accessVal));
+      chip.append($('<button type="button" class="deposit-wizard__chip-remove" aria-label="remove">×</button>')
+        .on('click', function () { chip.remove(); }));
+      chips.append(chip);
+    }
+
+    section.find('[data-behavior="share-person-add"]').on('click', function () {
+      var access = section.find('[data-behavior="share-person-access"]');
+      addGrant('person', $.trim(section.find('[data-behavior="share-person-name"]').val()),
+        access.val(), access.find('option:selected').text());
+      section.find('[data-behavior="share-person-name"]').val('');
+    });
+
+    section.find('[data-behavior="share-group-add"]').on('click', function () {
+      var name = section.find('[data-behavior="share-group-name"]');
+      var access = section.find('[data-behavior="share-group-access"]');
+      addGrant('group', name.val(), access.val(), access.find('option:selected').text());
+    });
+  }
+
+  function initRedirectsConnect() {
+    var section = $('[data-behavior="extra-redirects"]');
+    if (!section.length) return;
+    var rows = section.find('[data-behavior="redirect-rows"]');
+    var template = section.find('[data-behavior="redirect-row-template"]');
+    if (!template.length) return;
+    var index = 1; // row 0 is rendered server-side
+
+    section.find('[data-behavior="redirect-add"]').on('click', function () {
+      var html = template.html().replace(/__index__/g, index);
+      index += 1;
+      rows.append($(html));
+    });
+  }
+
+  // Select2 v3 (the version Hyrax bundles) binds an ajax typeahead to a HIDDEN
+  // INPUT, not a <select>. That input is the parent_id field posted with the
+  // deposit, so its value is the chosen work id — no separate hidden field.
+  function initParentConnect() {
+    var section = $('[data-behavior="extra-parent"]');
+    if (!section.length) return;
+    var input = section.find('[data-behavior="parent-select"]');
+    if (!input.length || typeof input.select2 !== 'function') return;
+
+    input.select2({
+      placeholder: input.data('placeholder'),
+      allowClear: true,
+      minimumInputLength: 2,
+      // A hidden input has no option text for a pre-seeded value; supply one so
+      // the id round-trips as its own label until the user picks a fresh result.
+      initSelection: function (element, callback) {
+        var val = element.val();
+        if (val) callback({ id: val, text: val });
+      },
+      ajax: {
+        url: section.data('options-url'),
+        dataType: 'json',
+        data: function (term) { return { q: term }; },
+        results: function (data) {
+          return { results: data.map(function (row) { return { id: row.id, text: row.label }; }) };
+        }
+      }
+    });
+  }
+
   function initDepositWizard() {
     // Idempotency guard: this handler is bound to both `turbolinks:load` and
     // `ready`, which can both fire on a full page load. Running the inits twice
@@ -158,6 +269,10 @@
     initFileMeta();
     initStepValidity();
     initDepositAgreement();
+    initCollectionConnect();
+    initSharingConnect();
+    initRedirectsConnect();
+    initParentConnect();
   }
 
   $(document).on('turbolinks:load ready', initDepositWizard);

--- a/app/assets/stylesheets/deposit_wizard.scss
+++ b/app/assets/stylesheets/deposit_wizard.scss
@@ -10,4 +10,5 @@
 @import 'deposit_wizard/visibility';
 @import 'deposit_wizard/file_meta';
 @import 'deposit_wizard/review';
+@import 'deposit_wizard/extras';
 @import 'deposit_wizard/subtext';

--- a/app/assets/stylesheets/deposit_wizard/_base.scss
+++ b/app/assets/stylesheets/deposit_wizard/_base.scss
@@ -6,7 +6,7 @@
   --dw-accent: #2b6da5;
   --dw-accent-tint: #e7f3ff;        // selected card background
   --dw-success: #5cb85c;            // completed step
-  --dw-danger: #bb5b4b;             // remove/delete accent
+  --dw-danger: #a04436;             // remove/delete accent
   --dw-surface: #fff;
   --dw-surface-sunk: #f8f9fa;
   --dw-ink: #232a32;

--- a/app/assets/stylesheets/deposit_wizard/_extras.scss
+++ b/app/assets/stylesheets/deposit_wizard/_extras.scss
@@ -1,0 +1,430 @@
+// Optional connect/share/redirect sections on the review step. Each is gated by
+// its own feature, so any number may appear. Each is a collapsible card showing
+// a title + subtitle; its body of controls expands on click.
+.deposit-wizard {
+  &__extra {
+    margin-top: 0.75rem;
+    border: 1px solid var(--dw-border);
+    border-radius: var(--dw-radius-sm);
+    background: var(--dw-surface);
+    overflow: hidden;
+
+    &.is-open {
+      border-color: var(--dw-border-strong);
+      box-shadow: var(--dw-shadow-sm);
+    }
+  }
+
+  &__extra-toggle {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    width: 100%;
+    padding: 1rem 1.25rem;
+    border: 0;
+    background: none;
+    text-align: left;
+    cursor: pointer;
+    transition: background-color 0.15s ease;
+
+    &:hover,
+    &:focus {
+      background: var(--dw-surface-sunk);
+      outline: none;
+    }
+  }
+
+  &__extra-titles {
+    flex: 1 1 auto;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+  }
+
+  &__extra-title {
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--dw-ink);
+  }
+
+  &__extra-subtitle {
+    font-size: 0.85rem;
+    line-height: 1.4;
+    color: var(--dw-ink-muted);
+  }
+
+  &__extra-chevron {
+    flex: none;
+    width: 0.6rem;
+    height: 0.6rem;
+    border-right: 2px solid var(--dw-ink-subtle);
+    border-bottom: 2px solid var(--dw-ink-subtle);
+    transform: rotate(-45deg); // points right when collapsed
+    transition: transform 0.2s ease;
+
+    .deposit-wizard__extra.is-open & {
+      transform: rotate(45deg); // points down when open
+    }
+  }
+
+  &__extra-body {
+    padding: 0.75rem 1.25rem 1.25rem;
+
+    &[hidden] {
+      display: none;
+    }
+
+    .form-inline {
+      align-items: flex-end;
+      gap: 0.5rem;
+
+      .form-control {
+        width: auto;
+        min-width: 12rem;
+      }
+    }
+  }
+
+  // Sharing: align the person and group rows into shared columns so the two
+  // rows' labels, name field, access select, and Add button line up vertically.
+  // Both rows use the same grid template, so the columns match across rows.
+  &__extra[data-behavior="extra-sharing"] {
+    .form-inline {
+      display: grid;
+      grid-template-columns: 7rem minmax(12rem, 1fr) 10rem auto;
+      align-items: center;
+      gap: 0.5rem 0.75rem;
+
+      .deposit-wizard__field-label {
+        margin: 0;
+        text-align: right;
+      }
+
+      .form-control {
+        width: 100%;
+        min-width: 0;
+      }
+    }
+  }
+
+  // ---- Added-item chips (collections, share grants) --------------------
+  &__extra-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin: 0.85rem 0 0;
+
+    &:empty {
+      display: none;
+    }
+  }
+
+  // Match the shape of a selected visibility pill (see _visibility.scss):
+  // rounded rectangle, accent-tint fill, accent border — not a full pill.
+  &__extra-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.4rem 0.4rem 0.4rem 0.85rem;
+    border: 1px solid var(--dw-accent);
+    border-radius: var(--dw-radius-sm);
+    background: var(--dw-accent-tint);
+    color: var(--dw-accent);
+    font-size: 0.9rem;
+    font-weight: 600;
+  }
+
+  // Remove control matches the wizard's file-remove idiom: red at rest, darker
+  // red on hover (see _files.scss __file-remove).
+  &__chip-remove {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.35rem;
+    height: 1.35rem;
+    padding: 0;
+    border: 0;
+    border-radius: 50%;
+    background: none;
+    color: var(--dw-danger);
+    font-size: 1.05rem;
+    font-weight: 700;
+    line-height: 1;
+    cursor: pointer;
+    transition: background-color 0.15s ease, color 0.15s ease;
+
+    &:hover {
+      background: rgba(160, 68, 54, 0.14);
+      color: #82372b;
+    }
+  }
+
+  // ---- Redirects tab (stock Hyrax partial restyled into the card) ------
+  // The vanity-URL section renders hyrax/base/_form_redirects — a Bootstrap
+  // table — into the card body. We keep its markup and behavior (none-radio,
+  // per-row remove, disable-until-path, marker, monotonic index via
+  // hyrax/redirects.js) but restyle it, scoped here, to read like the other
+  // wizard cards: sunk-surface rows, token borders, quiet accent buttons. The
+  // stock elements are targeted by their stable data hooks and Bootstrap
+  // classes, so Hyrax's own redirects tab elsewhere is untouched.
+  &__extra-body {
+    // The partial's own <h2> duplicates the card header's title, so hide it.
+    // Keep the two help paragraphs — they explain aliases and the display-URL
+    // radio, giving the expanded card the context the screenshot was missing.
+    h2.h3 {
+      display: none;
+    }
+
+    h2.h3 + p {
+      margin-top: 0;
+    }
+
+    // Keep a light table structure (header underline, ruled rows) so the layout
+    // reads as a grid. Rows are flex; every row shares one column geometry so the
+    // Display-URL radio and remove × line up under the "Display URL" header. The
+    // two columns: a flexible Path column, then a fixed right-aligned control
+    // column holding the radio + ×.
+    $dw-redirect-controls: 7rem; // width of the radio + × group on the right
+
+    [data-redirects-table] {
+      margin: 0.85rem 0 0;
+      border: 1px solid var(--dw-border);
+      border-radius: var(--dw-radius-sm);
+      overflow: hidden;
+
+      thead tr {
+        display: flex;
+        align-items: baseline;
+        padding: 0.5rem 0.75rem;
+        background: var(--dw-surface-sunk);
+        border-bottom: 1px solid var(--dw-border);
+      }
+
+      thead th {
+        border: 0;
+        padding: 0;
+        font-size: 0.75rem;
+        font-weight: 700;
+        letter-spacing: 0.03em;
+        text-transform: uppercase;
+        color: var(--dw-ink-subtle);
+
+        &:first-child {
+          flex: 1 1 auto;
+        }
+
+        &:last-child {
+          flex: none;
+          width: $dw-redirect-controls;
+          text-align: right;
+        }
+      }
+
+      tbody {
+        display: block;
+      }
+
+      td {
+        border: 0;
+        padding: 0;
+      }
+    }
+
+    // Rows: ruled blocks. The None row and each path row share the same padding
+    // so their left edges line up. Both are laid out as a grid whose columns are
+    // shared, so the Display-URL radio and remove × align across rows and under
+    // the right-aligned "Display URL" header, regardless of path-field width.
+    // (The selector is scoped through [data-redirects-table] so it out-specifies
+    // the generic tbody-tr reset and the grid actually applies to the <tr>.)
+    [data-redirects-table] tbody tr {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) calc(#{$dw-redirect-controls} - 2rem) 2rem;
+      align-items: center;
+      padding: 0.6rem 0.75rem;
+
+      & + tr {
+        border-top: 1px solid var(--dw-divider);
+      }
+    }
+
+    [data-redirects-table] tbody td {
+      display: flex;
+      align-items: center;
+      min-width: 0; // let the path track shrink instead of overflowing
+      width: auto !important; // beat the stock inline width on the × cell
+    }
+
+    [data-redirects-row] td:nth-child(2),
+    [data-redirects-row] td:last-child {
+      justify-content: flex-end;
+    }
+
+    // The <site.org> prefix + path input. Both share the field font so the
+    // prefix and the typed path read as one control.
+    [data-redirects-table] .input-group {
+      flex-wrap: nowrap;
+      width: 100%;
+    }
+
+    [data-redirects-table] .input-group-text,
+    [data-redirects-path-input] {
+      font-size: 0.9rem;
+      line-height: 1.5;
+    }
+
+    [data-redirects-table] .input-group-text {
+      border: 1px solid var(--dw-border-strong);
+      border-right: 0;
+      border-radius: var(--dw-radius-sm) 0 0 var(--dw-radius-sm);
+      background: var(--dw-surface);
+      color: var(--dw-ink-subtle);
+    }
+
+    [data-redirects-path-input] {
+      flex: 1 1 auto; // fill the input-group so the field spans the Path column
+      min-width: 0;
+      border-radius: 0 var(--dw-radius-sm) var(--dw-radius-sm) 0;
+    }
+
+    // The stock partial wraps the add button in the <p> right after the table;
+    // right-align it so the action sits on the right like the wizard's other
+    // action buttons.
+    [data-redirects-table] + p {
+      margin-bottom: 0;
+      text-align: right;
+    }
+
+    // Add-a-row button: solid accent, matching the other cards' Add buttons
+    // (which use btn-primary). The stock markup gives it btn-secondary, so set
+    // the primary look here.
+    [data-redirects-add-row] {
+      border-color: var(--dw-accent);
+      background: var(--dw-accent);
+      color: #fff;
+      font-weight: 600;
+
+      &:hover,
+      &:focus {
+        border-color: var(--dw-accent);
+        background: #245e8f;
+        color: #fff;
+      }
+    }
+
+    // Per-row remove: the red × used by the chips / file-remove.
+    [data-redirects-remove-row] {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 1.35rem;
+      height: 1.35rem;
+      padding: 0;
+      border: 0;
+      border-radius: 50%;
+      background: none;
+      color: var(--dw-danger);
+      font-size: 1.05rem; // match the chip × (Bootstrap .close is larger)
+      font-weight: 700;
+      line-height: 1;
+      opacity: 1;
+      text-shadow: none;
+      transition: background-color 0.15s ease, color 0.15s ease;
+
+      &:hover {
+        background: rgba(160, 68, 54, 0.14);
+        color: #82372b;
+      }
+    }
+  }
+
+  // ---- Select2 v3 (parent + collection typeaheads) ---------------------
+  // Hyrax bundles Select2 v3. Its widget is a .select2-container wrapping a
+  // .select2-choice box with a bordered .select2-arrow segment. When the source
+  // field carries .form-control, both the container and the inner choice get a
+  // border, so the control reads as a box-inside-a-box. Collapse it to a single
+  // field: strip the container's own border/padding and style only the inner
+  // choice with the wizard's field tokens; flatten the arrow into the box.
+  &__extra-body {
+    .select2-container {
+      display: block;
+      width: 100% !important;
+      max-width: 24rem;
+      height: auto;
+      padding: 0;
+      border: 0;
+      background: none;
+      box-shadow: none;
+    }
+
+    .select2-container .select2-choice {
+      display: flex;
+      align-items: center;
+      height: auto;
+      min-height: calc(1.5em + 0.75rem + 2px); // match .form-control height
+      padding: 0.375rem 0.75rem;
+      border: 1px solid var(--dw-border-strong);
+      border-radius: var(--dw-radius-sm);
+      background: var(--dw-surface);
+      background-image: none;
+      color: var(--dw-ink);
+      line-height: 1.5;
+    }
+
+    .select2-container.select2-container-active .select2-choice,
+    .select2-container.select2-dropdown-open .select2-choice {
+      border-color: var(--dw-accent);
+      box-shadow: 0 0 0 0.15rem rgba(43, 109, 165, 0.15);
+    }
+
+    .select2-choice > .select2-chosen {
+      flex: 1 1 auto;
+      margin-right: 0.5rem;
+    }
+
+    .select2-choice .select2-chosen.select2-default {
+      color: var(--dw-ink-subtle);
+    }
+
+    // Flatten Select2's separately-bordered arrow segment into the box.
+    .select2-choice .select2-arrow {
+      position: static;
+      flex: none;
+      width: auto;
+      border: 0;
+      border-radius: 0;
+      background: none;
+    }
+
+    // The clear (×) shown when a value is chosen. Select2 v3 renders it as an
+    // <abbr> that the browser draws small, gray, and underlined, absolutely
+    // positioned top-right. Replace the glyph with a bold × matching the red
+    // remove idiom used elsewhere, centered as a normal flex child.
+    .select2-choice .select2-search-choice-close,
+    .select2-choice abbr.select2-search-choice-close {
+      position: static;
+      flex: none;
+      align-self: center;
+      order: 1; // sit after the caret, at the right edge
+      width: 1rem;
+      height: 1rem;
+      margin: 0 0 0 0.35rem;
+      top: auto;
+      right: auto;
+      background: none; // drop Select2's sprite ×
+      text-decoration: none;
+      color: var(--dw-danger);
+      font-size: 1rem;
+      font-weight: 700;
+      line-height: 1;
+
+      &::before {
+        content: "\00d7"; // ×
+      }
+
+      &:hover {
+        color: #82372b;
+      }
+    }
+  }
+}

--- a/app/controllers/concerns/hyrax/deposit_wizard/context.rb
+++ b/app/controllers/concerns/hyrax/deposit_wizard/context.rb
@@ -170,6 +170,28 @@ module Hyrax
         Hyrax::AdminSetService.new(self).search_results(:deposit)
       end
 
+      def eligible_parent_documents(query)
+        search = Hyrax::SearchService.new(config: blacklight_config, user_params: { q: query.to_s },
+                                          search_builder_class: Hyrax::My::FindWorksSearchBuilder,
+                                          scope: self, current_ability: current_ability)
+        _, docs = search.search_results do |builder|
+          builder.with(q: query.to_s).with_access(:read).rows(20)
+          types = eligible_parent_types
+          builder.merge(fq: type_filter_query(types)) if types.present?
+          builder
+        end
+        docs
+      end
+
+      def eligible_parent_types
+        wizard_config.parent_types.presence || available_work_types.map(&:to_s)
+      end
+
+      def type_filter_query(type_names)
+        clauses = Array(type_names).map { |name| "has_model_ssim:\"#{name}\"" }
+        "(#{clauses.join(' OR ')})"
+      end
+
       def last_deposited
         session.delete(:deposit_wizard_last)
       end

--- a/app/controllers/concerns/hyrax/deposit_wizard/context.rb
+++ b/app/controllers/concerns/hyrax/deposit_wizard/context.rb
@@ -13,7 +13,8 @@ module Hyrax
                       :available_admin_sets, :selected_admin_set_id, :selected_admin_set_name,
                       :uploaded_files, :file_meta_forms, :file_inherits_visibility?,
                       :file_visibility_summaries, :work_visibility_attributes,
-                      :file_display_title
+                      :file_display_title, :selected_member_collections, :saved_permission_grants,
+                      :extra_prefilled?, :selected_parent_title, :collection_display_title
       end
 
       # The seam downstream apps replace to add container types, suggestions, etc.
@@ -168,6 +169,58 @@ module Hyrax
 
       def admin_sets_for_deposit
         Hyrax::AdminSetService.new(self).search_results(:deposit)
+      end
+
+      # A since-deleted collection id is dropped individually rather than failing
+      # the whole review render.
+      def selected_member_collections
+        rows = wizard_state.attributes['member_of_collections_attributes']
+        ids = Array.wrap(rows.is_a?(Hash) ? rows.values : rows)
+                   .reject { |h| h.is_a?(Hash) && h['_destroy'].to_s == 'true' }
+                   .map { |h| h.is_a?(Hash) ? h['id'] : h }.compact.uniq
+
+        ids.filter_map do |id|
+          Hyrax.query_service.find_by(id: id)
+        rescue Valkyrie::Persistence::ObjectNotFoundError
+          nil
+        end
+      end
+
+      def saved_permission_grants
+        rows = wizard_state.attributes['permissions_attributes']
+        Array.wrap(rows.is_a?(Hash) ? rows.values : rows)
+             .select { |h| h.is_a?(Hash) && h['name'].present? && h['access'].present? }
+      end
+
+      def saved_redirect_paths
+        rows = wizard_state.attributes['redirects_attributes']
+        Array.wrap(rows.is_a?(Hash) ? rows.values : rows)
+             .select { |h| h.is_a?(Hash) && h['path'].present? }
+      end
+
+      # Read the title, not #to_s: a CollectionResource's #to_s is class+id, and
+      # available_collections and find_by return different object types here.
+      def collection_display_title(collection)
+        Array(collection.title).first
+      end
+
+      def selected_parent_title
+        return if wizard_state.parent_id.blank?
+
+        Array(Hyrax.query_service.find_by(id: wizard_state.parent_id).title).first
+      rescue Valkyrie::Persistence::ObjectNotFoundError
+        nil
+      end
+
+      # Drives whether the capability's review card renders expanded on load.
+      def extra_prefilled?(kind)
+        case kind
+        when :parent     then wizard_state.parent_id.present?
+        when :collection then selected_member_collections.any?
+        when :sharing    then saved_permission_grants.any?
+        when :redirects  then saved_redirect_paths.any?
+        else false
+        end
       end
 
       def eligible_parent_documents(query)

--- a/app/controllers/concerns/hyrax/deposit_wizard/navigation.rb
+++ b/app/controllers/concerns/hyrax/deposit_wizard/navigation.rb
@@ -69,6 +69,29 @@ module Hyrax
         wizard_state.file_metadata = submitted.slice(*allowed)
         redirect_to main_app.deposit_wizard_step_path(step: 'review')
       end
+
+      # Capture the enabled connect/share/redirect capabilities posted with the
+      # deposit form into wizard state before commit.
+      def capture_review_extras
+        keys = enabled_extra_attribute_keys
+        if keys.any?
+          submitted = params.fetch(work_form.model_name.param_key, {}).permit!.to_h.slice(*keys)
+          wizard_state.attributes = wizard_state.attributes.merge(submitted) if submitted.present?
+        end
+
+        # Guard on params.key? so an absent parent_id doesn't clobber one seeded at
+        # launch (the handoff).
+        return unless wizard_config.enable_parent_connect && params.key?(:parent_id)
+        wizard_state.parent_id = params[:parent_id]
+      end
+
+      def enabled_extra_attribute_keys
+        keys = []
+        keys << 'member_of_collections_attributes' if wizard_config.enable_collection_connect
+        keys << 'permissions_attributes' if wizard_config.enable_sharing
+        keys.push('redirects_attributes', 'redirects_display_url_index') if wizard_config.redirects_available?
+        keys
+      end
     end
   end
 end

--- a/app/controllers/concerns/hyrax/deposit_wizard/navigation.rb
+++ b/app/controllers/concerns/hyrax/deposit_wizard/navigation.rb
@@ -75,8 +75,12 @@ module Hyrax
       def capture_review_extras
         keys = enabled_extra_attribute_keys
         if keys.any?
-          submitted = params.fetch(work_form.model_name.param_key, {}).permit!.to_h.slice(*keys)
-          wizard_state.attributes = wizard_state.attributes.merge(submitted) if submitted.present?
+          posted = params.fetch(work_form.model_name.param_key, {}).permit!.to_h
+          attributes = wizard_state.attributes
+          # Delete-when-absent (not merge) so removing all of a capability's
+          # entries clears it rather than leaving the prior value to reappear.
+          keys.each { |key| posted.key?(key) ? attributes[key] = posted[key] : attributes.delete(key) }
+          wizard_state.attributes = attributes
         end
 
         # Guard on params.key? so an absent parent_id doesn't clobber one seeded at

--- a/app/controllers/concerns/hyrax/deposit_wizard/persistence.rb
+++ b/app/controllers/concerns/hyrax/deposit_wizard/persistence.rb
@@ -47,10 +47,13 @@ module Hyrax
       def commit_params
         attributes = wizard_state.attributes.merge('admin_set_id' => selected_admin_set_id).compact
         attributes['file_set'] = file_set_params if file_set_params.any?
-        ActionController::Parameters.new(
+        params = {
           work_form.model_name.param_key => attributes,
           'uploaded_files' => wizard_state.uploaded_file_ids
-        )
+        }
+        # parent_id is top-level (not under the work key); add_to_parent reads it there.
+        params['parent_id'] = wizard_state.parent_id if wizard_state.parent_id.present?
+        ActionController::Parameters.new(params)
       end
 
       # Per-file metadata for CreateValkyrieWork's add_file_sets step: one hash

--- a/app/controllers/hyrax/deposit_wizard_controller.rb
+++ b/app/controllers/hyrax/deposit_wizard_controller.rb
@@ -29,6 +29,7 @@ module Hyrax
 
     def start
       reset_state
+      seed_launch_context
       render :start
     end
 
@@ -69,6 +70,8 @@ module Hyrax
         return render(:review)
       end
 
+      capture_review_extras
+      build_work_form
       work = create_work
       return render(:review) unless work
 
@@ -97,6 +100,18 @@ module Hyrax
 
     def reset_state
       session[:deposit_wizard] = {}
+    end
+
+    # Seed wizard state from the same context params other entry points pass
+    # allowing a potential connection point with other deposit flows.
+    def seed_launch_context
+      wizard_state.parent_id = params[:parent_id] if wizard_config.enable_parent_connect && params[:parent_id].present?
+
+      return unless wizard_config.enable_collection_connect && params[:add_works_to_collection].present?
+
+      wizard_state.attributes = wizard_state.attributes.merge(
+        'member_of_collections_attributes' => { '0' => { 'id' => params[:add_works_to_collection] } }
+      )
     end
   end
 end

--- a/app/controllers/hyrax/deposit_wizard_controller.rb
+++ b/app/controllers/hyrax/deposit_wizard_controller.rb
@@ -15,6 +15,7 @@ module Hyrax
 
     before_action :ensure_enabled
     before_action :authenticate_user!
+    before_action :assign_current_ability
     before_action :build_breadcrumbs
 
     STEPS = %w[start item_start known_type files details file_meta review done].freeze
@@ -59,6 +60,15 @@ module Hyrax
       end
     end
 
+    def parent_options
+      return head(:forbidden) unless wizard_config.enable_parent_connect
+
+      # FindWorksSearchBuilder excludes a "current" work by params[:id]; the wizard
+      # has no current work, so a blank id excludes nothing.
+      params[:id] ||= ''
+      render json: eligible_parent_documents(params[:q]).map { |doc| { id: doc.id, label: doc.title.first } }
+    end
+
     # Persist the work from the collected state, then run the configured
     # post-commit hook (e.g. Enact nesting) and land on the done screen.
     def commit
@@ -90,6 +100,14 @@ module Hyrax
       return if Flipflop.deposit_wizard?
 
       redirect_to hyrax.my_works_path, alert: t('hyku.deposit_wizard.disabled')
+    end
+
+    # Hyrax's collection/search helpers (e.g. available_collections) read the
+    # @current_ability instance variable, which stock works controllers set via
+    # WorksControllerBehavior. This lean controller must set it itself, or those
+    # helpers bail with an empty list.
+    def assign_current_ability
+      @current_ability = current_ability
     end
 
     def build_breadcrumbs

--- a/app/controllers/hyrax/deposit_wizard_controller.rb
+++ b/app/controllers/hyrax/deposit_wizard_controller.rb
@@ -69,6 +69,15 @@ module Hyrax
       render json: eligible_parent_documents(params[:q]).map { |doc| { id: doc.id, label: doc.title.first } }
     end
 
+    # Autosave endpoint for the review-step extras, so they survive a refresh.
+    def save_extras
+      return head(:bad_request) if wizard_state.work_type.blank?
+
+      build_work_form
+      capture_review_extras
+      head :no_content
+    end
+
     # Persist the work from the collected state, then run the configured
     # post-commit hook (e.g. Enact nesting) and land on the done screen.
     def commit

--- a/app/services/hyku/deposit_wizard/config.rb
+++ b/app/services/hyku/deposit_wizard/config.rb
@@ -83,10 +83,11 @@ module Hyku
         container_type.present?
       end
 
-      # Redirects are governed entirely by Hyrax's own per-tenant gate
-      # (+redirects_enabled?+ boot flag && +Flipflop.redirects?+).
-      def redirects_available?
-        Hyrax.config.redirects_active?
+      def redirects_available?(form = nil)
+        return false unless Hyrax.config.redirects_active?
+
+        target = form.respond_to?(:model) ? form.model : form
+        target.nil? || target.respond_to?(:redirects)
       end
     end
   end

--- a/app/services/hyku/deposit_wizard/config.rb
+++ b/app/services/hyku/deposit_wizard/config.rb
@@ -45,6 +45,27 @@ module Hyku
       # Callable run after commit, receiving the persisted work and wizard state.
       attr_accessor :post_commit
 
+      # The parent/collection/sharing capabilities are per-tenant Flipflop features
+      # (grouped with :deposit_wizard). A writer stays for an explicit in-memory
+      # override (used by specs and any app that sets it directly). Redirects are
+      # not here — they use their own Flipflop gate (see #redirects_available?).
+      attr_writer :enable_parent_connect, :enable_collection_connect, :enable_sharing
+
+      # Work types eligible as parents; +nil+ falls back to the tenant's available
+      # work types.
+      attr_accessor :parent_types
+
+      # Each reader returns the in-memory override when one was set, otherwise the
+      # tenant's Flipflop feature value.
+      %i[parent_connect collection_connect sharing].each do |capability|
+        define_method("enable_#{capability}") do
+          override = instance_variable_get("@enable_#{capability}")
+          return override unless override.nil?
+
+          Flipflop.public_send("deposit_wizard_#{capability}?")
+        end
+      end
+
       def initialize
         @single_admin_set = true
         @enable_batch = false
@@ -54,11 +75,18 @@ module Hyku
         @item_types = nil
         @suggestions = {}
         @post_commit = nil
+        @parent_types = nil
         yield self if block_given?
       end
 
       def container?
         container_type.present?
+      end
+
+      # Redirects are governed entirely by Hyrax's own per-tenant gate
+      # (+redirects_enabled?+ boot flag && +Flipflop.redirects?+).
+      def redirects_available?
+        Hyrax.config.redirects_active?
       end
     end
   end

--- a/app/services/hyku/deposit_wizard/state.rb
+++ b/app/services/hyku/deposit_wizard/state.rb
@@ -36,6 +36,14 @@ module Hyku
         @store['admin_set_id'] = value.presence
       end
 
+      def parent_id
+        @store['parent_id']
+      end
+
+      def parent_id=(value)
+        @store['parent_id'] = value.presence
+      end
+
       # Ids of the Hyrax::UploadedFiles attached on the files step. Stored as
       # strings (the form round-trips them as strings); the commit phase attaches
       # them by id.

--- a/app/views/hyrax/deposit_wizard/_extras_collection.html.erb
+++ b/app/views/hyrax/deposit_wizard/_extras_collection.html.erb
@@ -1,0 +1,30 @@
+<%# Posts member_of_collections_attributes[N][id]; the ResourceForm's
+    in_collections_populator persists membership in the deposit transaction. %>
+<% param_key = work_form.model_name.param_key %>
+<% collections = available_collections(work: work_form) %>
+<section class="deposit-wizard__extra" data-behavior="extra-collection" data-param-key="<%= param_key %>">
+  <h3 class="deposit-wizard__section-heading"><%= t('hyku.deposit_wizard.extras.collection.heading') %></h3>
+  <p class="deposit-wizard__step-hint"><%= t('hyku.deposit_wizard.extras.collection.hint') %></p>
+
+  <% if collections.any? %>
+    <div class="deposit-wizard__field form-inline">
+      <%= label_tag "#{param_key}_collection_select", t('hyku.deposit_wizard.extras.collection.label'),
+                    class: 'deposit-wizard__field-label sr-only' %>
+      <select id="<%= param_key %>_collection_select" class="form-control"
+              data-behavior="collection-select"
+              data-placeholder="<%= t('hyku.deposit_wizard.extras.collection.placeholder') %>">
+        <option value=""></option>
+        <% collections.each do |collection| %>
+          <option value="<%= collection.id %>"><%= collection.to_s %></option>
+        <% end %>
+      </select>
+      <button type="button" class="btn btn-secondary" data-behavior="collection-add">
+        <%= t('hyku.deposit_wizard.extras.add') %>
+      </button>
+    </div>
+
+    <ul class="deposit-wizard__extra-chips list-unstyled" data-behavior="collection-chips"></ul>
+  <% else %>
+    <p class="deposit-wizard__empty"><%= t('hyku.deposit_wizard.extras.collection.none') %></p>
+  <% end %>
+</section>

--- a/app/views/hyrax/deposit_wizard/_extras_collection.html.erb
+++ b/app/views/hyrax/deposit_wizard/_extras_collection.html.erb
@@ -2,29 +2,49 @@
     in_collections_populator persists membership in the deposit transaction. %>
 <% param_key = work_form.model_name.param_key %>
 <% collections = available_collections(work: work_form) %>
-<section class="deposit-wizard__extra" data-behavior="extra-collection" data-param-key="<%= param_key %>">
-  <h3 class="deposit-wizard__section-heading"><%= t('hyku.deposit_wizard.extras.collection.heading') %></h3>
-  <p class="deposit-wizard__step-hint"><%= t('hyku.deposit_wizard.extras.collection.hint') %></p>
+<% selected_collections = selected_member_collections %>
+<% open = extra_prefilled?(:collection) %>
+<section class="deposit-wizard__extra <%= 'is-open' if open %>" data-behavior="extra-collection" data-param-key="<%= param_key %>">
+  <button type="button" class="deposit-wizard__extra-toggle" data-behavior="extra-toggle"
+          aria-expanded="<%= open %>">
+    <span class="deposit-wizard__extra-titles">
+      <span class="deposit-wizard__extra-title"><%= t('hyku.deposit_wizard.extras.collection.heading') %></span>
+      <span class="deposit-wizard__extra-subtitle"><%= t('hyku.deposit_wizard.extras.collection.hint') %></span>
+    </span>
+    <span class="deposit-wizard__extra-chevron" aria-hidden="true"></span>
+  </button>
 
-  <% if collections.any? %>
-    <div class="deposit-wizard__field form-inline">
-      <%= label_tag "#{param_key}_collection_select", t('hyku.deposit_wizard.extras.collection.label'),
-                    class: 'deposit-wizard__field-label sr-only' %>
-      <select id="<%= param_key %>_collection_select" class="form-control"
-              data-behavior="collection-select"
-              data-placeholder="<%= t('hyku.deposit_wizard.extras.collection.placeholder') %>">
-        <option value=""></option>
-        <% collections.each do |collection| %>
-          <option value="<%= collection.id %>"><%= collection.to_s %></option>
-        <% end %>
-      </select>
-      <button type="button" class="btn btn-secondary" data-behavior="collection-add">
-        <%= t('hyku.deposit_wizard.extras.add') %>
-      </button>
-    </div>
+  <div class="deposit-wizard__extra-body" data-behavior="extra-body" <%= 'hidden' unless open %>>
+    <% if collections.any? %>
+      <div class="deposit-wizard__field form-inline">
+        <%= label_tag "#{param_key}_collection_select", t('hyku.deposit_wizard.extras.collection.label'),
+                      class: 'deposit-wizard__field-label sr-only' %>
+        <select id="<%= param_key %>_collection_select" class="form-control"
+                data-behavior="collection-select"
+                data-placeholder="<%= t('hyku.deposit_wizard.extras.collection.placeholder') %>">
+          <option value=""></option>
+          <% collections.each do |collection| %>
+            <option value="<%= collection.id %>"><%= collection_display_title(collection) %></option>
+          <% end %>
+        </select>
+        <button type="button" class="btn btn-primary" data-behavior="collection-add">
+          <%= t('hyku.deposit_wizard.extras.add') %>
+        </button>
+      </div>
+    <% elsif selected_collections.empty? %>
+      <p class="deposit-wizard__empty"><%= t('hyku.deposit_wizard.extras.collection.none') %></p>
+    <% end %>
 
-    <ul class="deposit-wizard__extra-chips list-unstyled" data-behavior="collection-chips"></ul>
-  <% else %>
-    <p class="deposit-wizard__empty"><%= t('hyku.deposit_wizard.extras.collection.none') %></p>
-  <% end %>
+    <%# Chosen collections always render (even when none remain available to add),
+        so restored chips survive a refresh. %>
+    <ul class="deposit-wizard__extra-chips list-unstyled" data-behavior="collection-chips">
+      <% selected_collections.each_with_index do |collection, i| %>
+        <li class="deposit-wizard__extra-chip" data-collection-id="<%= collection.id %>">
+          <span><%= collection_display_title(collection) %></span>
+          <%= hidden_field_tag "#{param_key}[member_of_collections_attributes][pre#{i}][id]", collection.id %>
+          <button type="button" class="deposit-wizard__chip-remove" aria-label="remove">×</button>
+        </li>
+      <% end %>
+    </ul>
+  </div>
 </section>

--- a/app/views/hyrax/deposit_wizard/_extras_parent.html.erb
+++ b/app/views/hyrax/deposit_wizard/_extras_parent.html.erb
@@ -1,19 +1,31 @@
 <%# Sets the top-level parent_id (not under the work key); add_to_parent
     consumes it in the deposit transaction to nest this work under the chosen one. %>
-<section class="deposit-wizard__extra" data-behavior="extra-parent"
+<% open = extra_prefilled?(:parent) %>
+<section class="deposit-wizard__extra <%= 'is-open' if open %>" data-behavior="extra-parent"
          data-options-url="<%= main_app.deposit_wizard_parent_options_path %>">
-  <h3 class="deposit-wizard__section-heading"><%= t('hyku.deposit_wizard.extras.parent.heading') %></h3>
-  <p class="deposit-wizard__step-hint"><%= t('hyku.deposit_wizard.extras.parent.hint') %></p>
+  <button type="button" class="deposit-wizard__extra-toggle" data-behavior="extra-toggle"
+          aria-expanded="<%= open %>">
+    <span class="deposit-wizard__extra-titles">
+      <span class="deposit-wizard__extra-title"><%= t('hyku.deposit_wizard.extras.parent.heading') %></span>
+      <span class="deposit-wizard__extra-subtitle"><%= t('hyku.deposit_wizard.extras.parent.hint') %></span>
+    </span>
+    <span class="deposit-wizard__extra-chevron" aria-hidden="true"></span>
+  </button>
 
-  <div class="deposit-wizard__field">
-    <%= label_tag 'dw_parent_search', t('hyku.deposit_wizard.extras.parent.label'),
-                  class: 'deposit-wizard__field-label' %>
-    <%# Select2 3.x ajax binds to a hidden input (not a <select>); this input both
-        drives the typeahead and carries the chosen work's id as the top-level
-        parent_id, which add_to_parent consumes in the transaction. %>
-    <%= hidden_field_tag 'parent_id', nil, id: 'dw_parent_search',
-                         class: 'form-control', style: 'width: 24rem;',
-                         data: { behavior: 'parent-select',
-                                 placeholder: t('hyku.deposit_wizard.extras.parent.placeholder') } %>
+  <div class="deposit-wizard__extra-body" data-behavior="extra-body" <%= 'hidden' unless open %>>
+    <div class="deposit-wizard__field">
+      <%# Label duplicates the placeholder ("Search for a work…"), so keep it for
+          screen readers only. %>
+      <%= label_tag 'dw_parent_search', t('hyku.deposit_wizard.extras.parent.label'),
+                    class: 'deposit-wizard__field-label sr-only' %>
+      <%# Select2 3.x ajax binds to a hidden input (not a <select>); this input both
+          drives the typeahead and carries the chosen work's id as the top-level
+          parent_id, which add_to_parent consumes in the transaction. %>
+      <%= hidden_field_tag 'parent_id', wizard_state.parent_id, id: 'dw_parent_search',
+                           class: 'form-control', style: 'width: 24rem;',
+                           data: { behavior: 'parent-select',
+                                   'initial-label': selected_parent_title,
+                                   placeholder: t('hyku.deposit_wizard.extras.parent.placeholder') } %>
+    </div>
   </div>
 </section>

--- a/app/views/hyrax/deposit_wizard/_extras_parent.html.erb
+++ b/app/views/hyrax/deposit_wizard/_extras_parent.html.erb
@@ -1,0 +1,19 @@
+<%# Sets the top-level parent_id (not under the work key); add_to_parent
+    consumes it in the deposit transaction to nest this work under the chosen one. %>
+<section class="deposit-wizard__extra" data-behavior="extra-parent"
+         data-options-url="<%= main_app.deposit_wizard_parent_options_path %>">
+  <h3 class="deposit-wizard__section-heading"><%= t('hyku.deposit_wizard.extras.parent.heading') %></h3>
+  <p class="deposit-wizard__step-hint"><%= t('hyku.deposit_wizard.extras.parent.hint') %></p>
+
+  <div class="deposit-wizard__field">
+    <%= label_tag 'dw_parent_search', t('hyku.deposit_wizard.extras.parent.label'),
+                  class: 'deposit-wizard__field-label' %>
+    <%# Select2 3.x ajax binds to a hidden input (not a <select>); this input both
+        drives the typeahead and carries the chosen work's id as the top-level
+        parent_id, which add_to_parent consumes in the transaction. %>
+    <%= hidden_field_tag 'parent_id', nil, id: 'dw_parent_search',
+                         class: 'form-control', style: 'width: 24rem;',
+                         data: { behavior: 'parent-select',
+                                 placeholder: t('hyku.deposit_wizard.extras.parent.placeholder') } %>
+  </div>
+</section>

--- a/app/views/hyrax/deposit_wizard/_extras_redirects.html.erb
+++ b/app/views/hyrax/deposit_wizard/_extras_redirects.html.erb
@@ -1,35 +1,23 @@
-<%# Posts redirects_attributes[i][path] and redirects_display_url_index; the
-    redirects populator + sync_redirect_paths persist them in the deposit
-    transaction. %>
-<% param_key = work_form.model_name.param_key %>
-<section class="deposit-wizard__extra" data-behavior="extra-redirects" data-param-key="<%= param_key %>">
-  <h3 class="deposit-wizard__section-heading"><%= t('hyku.deposit_wizard.extras.redirects.heading') %></h3>
-  <p class="deposit-wizard__step-hint"><%= t('hyku.deposit_wizard.extras.redirects.hint', base_url: request.base_url) %></p>
-
-  <ul class="deposit-wizard__extra-rows list-unstyled" data-behavior="redirect-rows">
-    <li class="deposit-wizard__extra-row">
-      <%= text_field_tag "#{param_key}[redirects_attributes][0][path]", nil, class: 'form-control',
-                         placeholder: t('hyku.deposit_wizard.extras.redirects.placeholder') %>
-      <label class="deposit-wizard__redirect-primary">
-        <%= radio_button_tag "#{param_key}[redirects_display_url_index]", '0' %>
-        <%= t('hyku.deposit_wizard.extras.redirects.primary') %>
-      </label>
-    </li>
-  </ul>
-
-  <button type="button" class="btn btn-secondary" data-behavior="redirect-add">
-    <%= t('hyku.deposit_wizard.extras.redirects.add') %>
+<%# Vanity-URL section. Renders Hyrax's stock redirects tab (hyrax/base/
+    _form_redirects) inside the wizard card so it inherits the full behavior —
+    none-radio, per-row remove, disable-until-path, the always-submitted marker,
+    and the monotonic row index — driven by hyrax/redirects.js. The posted
+    redirects_attributes ride the deposit form; the populator + sync_redirect_paths
+    persist them in the transaction. %>
+<% open = extra_prefilled?(:redirects) %>
+<section class="deposit-wizard__extra <%= 'is-open' if open %>" data-behavior="extra-redirects">
+  <button type="button" class="deposit-wizard__extra-toggle" data-behavior="extra-toggle"
+          aria-expanded="<%= open %>">
+    <span class="deposit-wizard__extra-titles">
+      <span class="deposit-wizard__extra-title"><%= t('hyku.deposit_wizard.extras.redirects.heading') %></span>
+      <span class="deposit-wizard__extra-subtitle"><%= t('hyku.deposit_wizard.extras.redirects.hint', base_url: request.base_url) %></span>
+    </span>
+    <span class="deposit-wizard__extra-chevron" aria-hidden="true"></span>
   </button>
 
-  <%# Row template cloned by the wizard JS for each additional path (index filled in). %>
-  <template data-behavior="redirect-row-template">
-    <li class="deposit-wizard__extra-row">
-      <input type="text" name="<%= param_key %>[redirects_attributes][__index__][path]" class="form-control"
-             placeholder="<%= t('hyku.deposit_wizard.extras.redirects.placeholder') %>">
-      <label class="deposit-wizard__redirect-primary">
-        <input type="radio" name="<%= param_key %>[redirects_display_url_index]" value="__index__">
-        <%= t('hyku.deposit_wizard.extras.redirects.primary') %>
-      </label>
-    </li>
-  </template>
+  <div class="deposit-wizard__extra-body" data-behavior="extra-body" <%= 'hidden' unless open %>>
+    <%= fields_for work_form.model_name.param_key, work_form do |f| %>
+      <%= render 'hyrax/base/form_redirects', f: f %>
+    <% end %>
+  </div>
 </section>

--- a/app/views/hyrax/deposit_wizard/_extras_redirects.html.erb
+++ b/app/views/hyrax/deposit_wizard/_extras_redirects.html.erb
@@ -1,0 +1,35 @@
+<%# Posts redirects_attributes[i][path] and redirects_display_url_index; the
+    redirects populator + sync_redirect_paths persist them in the deposit
+    transaction. %>
+<% param_key = work_form.model_name.param_key %>
+<section class="deposit-wizard__extra" data-behavior="extra-redirects" data-param-key="<%= param_key %>">
+  <h3 class="deposit-wizard__section-heading"><%= t('hyku.deposit_wizard.extras.redirects.heading') %></h3>
+  <p class="deposit-wizard__step-hint"><%= t('hyku.deposit_wizard.extras.redirects.hint', base_url: request.base_url) %></p>
+
+  <ul class="deposit-wizard__extra-rows list-unstyled" data-behavior="redirect-rows">
+    <li class="deposit-wizard__extra-row">
+      <%= text_field_tag "#{param_key}[redirects_attributes][0][path]", nil, class: 'form-control',
+                         placeholder: t('hyku.deposit_wizard.extras.redirects.placeholder') %>
+      <label class="deposit-wizard__redirect-primary">
+        <%= radio_button_tag "#{param_key}[redirects_display_url_index]", '0' %>
+        <%= t('hyku.deposit_wizard.extras.redirects.primary') %>
+      </label>
+    </li>
+  </ul>
+
+  <button type="button" class="btn btn-secondary" data-behavior="redirect-add">
+    <%= t('hyku.deposit_wizard.extras.redirects.add') %>
+  </button>
+
+  <%# Row template cloned by the wizard JS for each additional path (index filled in). %>
+  <template data-behavior="redirect-row-template">
+    <li class="deposit-wizard__extra-row">
+      <input type="text" name="<%= param_key %>[redirects_attributes][__index__][path]" class="form-control"
+             placeholder="<%= t('hyku.deposit_wizard.extras.redirects.placeholder') %>">
+      <label class="deposit-wizard__redirect-primary">
+        <input type="radio" name="<%= param_key %>[redirects_display_url_index]" value="__index__">
+        <%= t('hyku.deposit_wizard.extras.redirects.primary') %>
+      </label>
+    </li>
+  </template>
+</section>

--- a/app/views/hyrax/deposit_wizard/_extras_sharing.html.erb
+++ b/app/views/hyrax/deposit_wizard/_extras_sharing.html.erb
@@ -1,35 +1,56 @@
 <%# Posts permissions_attributes[i][type|name|access]; save_acl persists the
     grants in the deposit transaction. %>
-<section class="deposit-wizard__extra" data-behavior="extra-sharing" data-param-key="<%= work_form.model_name.param_key %>">
-  <h3 class="deposit-wizard__section-heading"><%= t('hyku.deposit_wizard.extras.sharing.heading') %></h3>
-  <p class="deposit-wizard__step-hint"><%= t('hyku.deposit_wizard.extras.sharing.hint') %></p>
+<% open = extra_prefilled?(:sharing) %>
+<section class="deposit-wizard__extra <%= 'is-open' if open %>" data-behavior="extra-sharing" data-param-key="<%= work_form.model_name.param_key %>">
+  <button type="button" class="deposit-wizard__extra-toggle" data-behavior="extra-toggle"
+          aria-expanded="<%= open %>">
+    <span class="deposit-wizard__extra-titles">
+      <span class="deposit-wizard__extra-title"><%= t('hyku.deposit_wizard.extras.sharing.heading') %></span>
+      <span class="deposit-wizard__extra-subtitle"><%= t('hyku.deposit_wizard.extras.sharing.hint') %></span>
+    </span>
+    <span class="deposit-wizard__extra-chevron" aria-hidden="true"></span>
+  </button>
 
-  <div class="deposit-wizard__field form-inline">
-    <%= label_tag 'dw_share_person_name', t('hyku.deposit_wizard.extras.sharing.person_label'),
-                  class: 'deposit-wizard__field-label' %>
-    <%= text_field_tag 'dw_share_person_name', nil, class: 'form-control',
-                       data: { behavior: 'share-person-name' },
-                       placeholder: t('hyku.deposit_wizard.extras.sharing.person_placeholder') %>
-    <%= select_tag 'dw_share_person_access', options_for_select(Hyrax.config.permission_options),
-                   class: 'form-control', data: { behavior: 'share-person-access' } %>
-    <button type="button" class="btn btn-secondary" data-behavior="share-person-add">
-      <%= t('hyku.deposit_wizard.extras.add') %>
-    </button>
+  <div class="deposit-wizard__extra-body" data-behavior="extra-body" <%= 'hidden' unless open %>>
+    <div class="deposit-wizard__field form-inline">
+      <%= label_tag 'dw_share_person_name', t('hyku.deposit_wizard.extras.sharing.person_label'),
+                    class: 'deposit-wizard__field-label' %>
+      <%= text_field_tag 'dw_share_person_name', nil, class: 'form-control',
+                         data: { behavior: 'share-person-name' },
+                         placeholder: t('hyku.deposit_wizard.extras.sharing.person_placeholder') %>
+      <%= select_tag 'dw_share_person_access', options_for_select(Hyrax.config.permission_options),
+                     class: 'form-control', data: { behavior: 'share-person-access' } %>
+      <button type="button" class="btn btn-primary" data-behavior="share-person-add">
+        <%= t('hyku.deposit_wizard.extras.add') %>
+      </button>
+    </div>
+
+    <div class="deposit-wizard__field form-inline">
+      <%= label_tag 'dw_share_group_name', t('hyku.deposit_wizard.extras.sharing.group_label'),
+                    class: 'deposit-wizard__field-label' %>
+      <%= select_tag 'dw_share_group_name',
+                     options_for_select(Hyrax::Group.all.map { |g| [g.humanized_name, g.name] }),
+                     prompt: t('hyku.deposit_wizard.extras.sharing.group_placeholder'),
+                     class: 'form-control', data: { behavior: 'share-group-name' } %>
+      <%= select_tag 'dw_share_group_access', options_for_select(Hyrax.config.permission_options),
+                     class: 'form-control', data: { behavior: 'share-group-access' } %>
+      <button type="button" class="btn btn-primary" data-behavior="share-group-add">
+        <%= t('hyku.deposit_wizard.extras.add') %>
+      </button>
+    </div>
+
+    <% param_key = work_form.model_name.param_key %>
+    <ul class="deposit-wizard__extra-chips list-unstyled" data-behavior="share-chips">
+      <% saved_permission_grants.each_with_index do |grant, i| %>
+        <% prefix = "#{param_key}[permissions_attributes][pre#{i}]" %>
+        <li class="deposit-wizard__extra-chip">
+          <span><%= grant['name'] %> &mdash; <%= grant['access'] %></span>
+          <%= hidden_field_tag "#{prefix}[type]", grant['type'] %>
+          <%= hidden_field_tag "#{prefix}[name]", grant['name'] %>
+          <%= hidden_field_tag "#{prefix}[access]", grant['access'] %>
+          <button type="button" class="deposit-wizard__chip-remove" aria-label="remove">×</button>
+        </li>
+      <% end %>
+    </ul>
   </div>
-
-  <div class="deposit-wizard__field form-inline">
-    <%= label_tag 'dw_share_group_name', t('hyku.deposit_wizard.extras.sharing.group_label'),
-                  class: 'deposit-wizard__field-label' %>
-    <%= select_tag 'dw_share_group_name',
-                   options_for_select(Hyrax::Group.all.map { |g| [g.humanized_name, g.name] }),
-                   prompt: t('hyku.deposit_wizard.extras.sharing.group_placeholder'),
-                   class: 'form-control', data: { behavior: 'share-group-name' } %>
-    <%= select_tag 'dw_share_group_access', options_for_select(Hyrax.config.permission_options),
-                   class: 'form-control', data: { behavior: 'share-group-access' } %>
-    <button type="button" class="btn btn-secondary" data-behavior="share-group-add">
-      <%= t('hyku.deposit_wizard.extras.add') %>
-    </button>
-  </div>
-
-  <ul class="deposit-wizard__extra-chips list-unstyled" data-behavior="share-chips"></ul>
 </section>

--- a/app/views/hyrax/deposit_wizard/_extras_sharing.html.erb
+++ b/app/views/hyrax/deposit_wizard/_extras_sharing.html.erb
@@ -1,0 +1,35 @@
+<%# Posts permissions_attributes[i][type|name|access]; save_acl persists the
+    grants in the deposit transaction. %>
+<section class="deposit-wizard__extra" data-behavior="extra-sharing" data-param-key="<%= work_form.model_name.param_key %>">
+  <h3 class="deposit-wizard__section-heading"><%= t('hyku.deposit_wizard.extras.sharing.heading') %></h3>
+  <p class="deposit-wizard__step-hint"><%= t('hyku.deposit_wizard.extras.sharing.hint') %></p>
+
+  <div class="deposit-wizard__field form-inline">
+    <%= label_tag 'dw_share_person_name', t('hyku.deposit_wizard.extras.sharing.person_label'),
+                  class: 'deposit-wizard__field-label' %>
+    <%= text_field_tag 'dw_share_person_name', nil, class: 'form-control',
+                       data: { behavior: 'share-person-name' },
+                       placeholder: t('hyku.deposit_wizard.extras.sharing.person_placeholder') %>
+    <%= select_tag 'dw_share_person_access', options_for_select(Hyrax.config.permission_options),
+                   class: 'form-control', data: { behavior: 'share-person-access' } %>
+    <button type="button" class="btn btn-secondary" data-behavior="share-person-add">
+      <%= t('hyku.deposit_wizard.extras.add') %>
+    </button>
+  </div>
+
+  <div class="deposit-wizard__field form-inline">
+    <%= label_tag 'dw_share_group_name', t('hyku.deposit_wizard.extras.sharing.group_label'),
+                  class: 'deposit-wizard__field-label' %>
+    <%= select_tag 'dw_share_group_name',
+                   options_for_select(Hyrax::Group.all.map { |g| [g.humanized_name, g.name] }),
+                   prompt: t('hyku.deposit_wizard.extras.sharing.group_placeholder'),
+                   class: 'form-control', data: { behavior: 'share-group-name' } %>
+    <%= select_tag 'dw_share_group_access', options_for_select(Hyrax.config.permission_options),
+                   class: 'form-control', data: { behavior: 'share-group-access' } %>
+    <button type="button" class="btn btn-secondary" data-behavior="share-group-add">
+      <%= t('hyku.deposit_wizard.extras.add') %>
+    </button>
+  </div>
+
+  <ul class="deposit-wizard__extra-chips list-unstyled" data-behavior="share-chips"></ul>
+</section>

--- a/app/views/hyrax/deposit_wizard/review.html.erb
+++ b/app/views/hyrax/deposit_wizard/review.html.erb
@@ -61,7 +61,8 @@
     </p>
   <% end %>
 
-  <%= form_tag main_app.deposit_wizard_commit_path, method: :post, class: 'deposit-wizard__commit-form' do %>
+  <%= form_tag main_app.deposit_wizard_commit_path, method: :post, class: 'deposit-wizard__commit-form',
+               data: { 'extras-url': main_app.deposit_wizard_extras_path } do %>
     <% if wizard_config.enable_parent_connect %>
       <%= render 'extras_parent' %>
     <% end %>

--- a/app/views/hyrax/deposit_wizard/review.html.erb
+++ b/app/views/hyrax/deposit_wizard/review.html.erb
@@ -62,6 +62,22 @@
   <% end %>
 
   <%= form_tag main_app.deposit_wizard_commit_path, method: :post, class: 'deposit-wizard__commit-form' do %>
+    <% if wizard_config.enable_parent_connect %>
+      <%= render 'extras_parent' %>
+    <% end %>
+
+    <% if wizard_config.enable_collection_connect %>
+      <%= render 'extras_collection' %>
+    <% end %>
+
+    <% if wizard_config.enable_sharing %>
+      <%= render 'extras_sharing' %>
+    <% end %>
+
+    <% if wizard_config.redirects_available?(work_form) %>
+      <%= render 'extras_redirects' %>
+    <% end %>
+
     <% if Flipflop.show_deposit_agreement? %>
       <div class="deposit-wizard__agreement">
         <% if Flipflop.active_deposit_agreement_acceptance? %>

--- a/config/features.rb
+++ b/config/features.rb
@@ -58,5 +58,17 @@ Flipflop.configure do
     feature :deposit_wizard,
             default: false,
             description: "Enable the guided deposit wizard for creating works."
+
+    feature :deposit_wizard_parent_connect,
+            default: false,
+            description: "In the deposit wizard, let depositors add the work to a parent work. Requires the deposit wizard."
+
+    feature :deposit_wizard_collection_connect,
+            default: false,
+            description: "In the deposit wizard, let depositors add the work to a collection. Requires the deposit wizard."
+
+    feature :deposit_wizard_sharing,
+            default: false,
+            description: "In the deposit wizard, let depositors share the work with specific users and groups. Requires the deposit wizard."
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -97,9 +97,6 @@ en:
         redirects:
           heading: Add a vanity URL
           hint: "Optionally add a short, memorable URL that redirects to this work (under %{base_url})."
-          placeholder: /my-vanity-url
-          primary: Use as primary
-          add: Add another URL
       file_meta:
         description: Description
         file: File

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -74,6 +74,32 @@ en:
       errors:
         agreement_required: Please accept the deposit agreement to continue.
         no_work_type: Please choose a work type to continue.
+      extras:
+        add: Add
+        parent:
+          heading: Add to a parent work
+          hint: Optionally nest this work inside an existing work.
+          label: Search works
+          placeholder: Search for a work…
+        collection:
+          heading: Add to a collection
+          hint: Optionally add this work to one or more collections.
+          label: Search collections
+          placeholder: Search for a collection…
+          none: You don't have any collections available to add this work to.
+        sharing:
+          heading: Share with people or groups
+          hint: Optionally give specific people or groups access to this work.
+          person_label: Person (email)
+          person_placeholder: name@example.com
+          group_label: Group
+          group_placeholder: Select a group…
+        redirects:
+          heading: Add a vanity URL
+          hint: "Optionally add a short, memorable URL that redirects to this work (under %{base_url})."
+          placeholder: /my-vanity-url
+          primary: Use as primary
+          add: Add another URL
       file_meta:
         description: Description
         file: File

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -160,6 +160,8 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   # Guided deposit wizard
   scope :dashboard, module: 'hyrax' do
     get 'deposit_wizard', to: 'deposit_wizard#start', as: :deposit_wizard
+    # Must precede the :step wildcard so it isn't captured as a step.
+    get 'deposit_wizard/parent_options', to: 'deposit_wizard#parent_options', as: :deposit_wizard_parent_options
     get 'deposit_wizard/:step', to: 'deposit_wizard#show', as: :deposit_wizard_step
     patch 'deposit_wizard/:step', to: 'deposit_wizard#update', as: :deposit_wizard_advance
     post 'deposit_wizard/commit', to: 'deposit_wizard#commit', as: :deposit_wizard_commit

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -162,6 +162,8 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
     get 'deposit_wizard', to: 'deposit_wizard#start', as: :deposit_wizard
     # Must precede the :step wildcard so it isn't captured as a step.
     get 'deposit_wizard/parent_options', to: 'deposit_wizard#parent_options', as: :deposit_wizard_parent_options
+    # Must precede the :step wildcard so it isn't captured as a step.
+    post 'deposit_wizard/extras', to: 'deposit_wizard#save_extras', as: :deposit_wizard_extras
     get 'deposit_wizard/:step', to: 'deposit_wizard#show', as: :deposit_wizard_step
     patch 'deposit_wizard/:step', to: 'deposit_wizard#update', as: :deposit_wizard_advance
     post 'deposit_wizard/commit', to: 'deposit_wizard#commit', as: :deposit_wizard_commit

--- a/spec/requests/deposit_wizard_spec.rb
+++ b/spec/requests/deposit_wizard_spec.rb
@@ -37,6 +37,40 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
         expect(response.body).to include(I18n.t('hyrax.controls.home'))
         expect(response.body).to include(I18n.t('hyku.deposit_wizard.button'))
       end
+
+      describe 'launch with context (handoff from another entry point)' do
+        after { Hyku::DepositWizard.reset_config! }
+
+        it 'seeds a parent work from parent_id when parent connect is enabled' do
+          Hyku::DepositWizard.config.enable_parent_connect = true
+          get deposit_wizard_path(parent_id: 'parent-123')
+
+          expect(session[:deposit_wizard]['parent_id']).to eq('parent-123')
+        end
+
+        it 'ignores parent_id when parent connect is disabled' do
+          Hyku::DepositWizard.config.enable_parent_connect = false
+          get deposit_wizard_path(parent_id: 'parent-123')
+
+          expect(session[:deposit_wizard]['parent_id']).to be_nil
+        end
+
+        it 'seeds collection membership from add_works_to_collection when enabled' do
+          Hyku::DepositWizard.config.enable_collection_connect = true
+          get deposit_wizard_path(add_works_to_collection: 'coll-9')
+
+          membership = session[:deposit_wizard].dig('attributes', 'member_of_collections_attributes')
+          expect(membership).to be_present
+          expect(membership.values.map { |row| row['id'] }).to include('coll-9')
+        end
+
+        it 'ignores add_works_to_collection when collection connect is disabled' do
+          Hyku::DepositWizard.config.enable_collection_connect = false
+          get deposit_wizard_path(add_works_to_collection: 'coll-9')
+
+          expect(session[:deposit_wizard].dig('attributes', 'member_of_collections_attributes')).to be_blank
+        end
+      end
     end
   end
 
@@ -639,6 +673,166 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
         post deposit_wizard_commit_path
 
         expect(response).to redirect_to(deposit_wizard_step_path(step: 'known_type'))
+      end
+
+      describe 'the optional connect capabilities on the deposit (Review) form' do
+        let(:resource_class) do
+          Hyrax::ModelRegistry.work_classes.detect { |k| k < Hyrax::Resource && k.model_name.param_key == param_key }
+        end
+
+        after { Hyku::DepositWizard.reset_config! }
+
+        context 'collection connect' do
+          before { Hyku::DepositWizard.config.enable_collection_connect = true }
+
+          it 'adds the work to the chosen collection' do
+            collection = FactoryBot.create(:hyku_collection, user: admin)
+            fill_in_wizard
+
+            post deposit_wizard_commit_path,
+                 params: { param_key => { member_of_collections_attributes: { '0' => { id: collection.id.to_s } } } }
+
+            expect(response).to redirect_to(deposit_wizard_step_path(step: 'done'))
+            work = Hyrax.query_service.find_all_of_model(model: resource_class).to_a.last
+            expect(work.member_of_collection_ids.map(&:to_s)).to include(collection.id.to_s)
+          end
+        end
+
+        context 'when collection connect is disabled' do
+          before { Hyku::DepositWizard.config.enable_collection_connect = false }
+
+          it 'ignores submitted collection membership' do
+            collection = FactoryBot.create(:hyku_collection, user: admin)
+            fill_in_wizard
+
+            post deposit_wizard_commit_path,
+                 params: { param_key => { member_of_collections_attributes: { '0' => { id: collection.id.to_s } } } }
+
+            work = Hyrax.query_service.find_all_of_model(model: resource_class).to_a.last
+            expect(work.member_of_collection_ids).to be_empty
+          end
+        end
+
+        context 'parent connect' do
+          before { Hyku::DepositWizard.config.enable_parent_connect = true }
+
+          it 'nests the work under the chosen parent work' do
+            parent = FactoryBot.valkyrie_create(:generic_work_resource, title: ['Parent work'], depositor: admin.user_key)
+            fill_in_wizard
+
+            post deposit_wizard_commit_path, params: { parent_id: parent.id.to_s }
+
+            expect(response).to redirect_to(deposit_wizard_step_path(step: 'done'))
+            reloaded_parent = Hyrax.query_service.find_by(id: parent.id)
+            child = Hyrax.query_service.find_all_of_model(model: resource_class).to_a
+                         .reject { |w| w.id.to_s == parent.id.to_s }.last
+            expect(reloaded_parent.member_ids.map(&:to_s)).to include(child.id.to_s)
+          end
+
+          it 'nests using a parent seeded at launch (handoff), without re-posting it' do
+            parent = FactoryBot.valkyrie_create(:generic_work_resource, title: ['Parent work'], depositor: admin.user_key)
+            # Launch the wizard from the parent's "attach child" action.
+            get deposit_wizard_path(parent_id: parent.id.to_s)
+            fill_in_wizard
+
+            post deposit_wizard_commit_path
+
+            reloaded_parent = Hyrax.query_service.find_by(id: parent.id)
+            child = Hyrax.query_service.find_all_of_model(model: resource_class).to_a
+                         .reject { |w| w.id.to_s == parent.id.to_s }.last
+            expect(reloaded_parent.member_ids.map(&:to_s)).to include(child.id.to_s)
+          end
+        end
+
+        context 'when parent connect is disabled' do
+          before { Hyku::DepositWizard.config.enable_parent_connect = false }
+
+          it 'ignores a submitted parent_id' do
+            parent = FactoryBot.valkyrie_create(:generic_work_resource, title: ['Parent work'], depositor: admin.user_key)
+            fill_in_wizard
+
+            post deposit_wizard_commit_path, params: { parent_id: parent.id.to_s }
+
+            reloaded_parent = Hyrax.query_service.find_by(id: parent.id)
+            expect(reloaded_parent.member_ids).to be_empty
+          end
+        end
+
+        context 'sharing' do
+          before { Hyku::DepositWizard.config.enable_sharing = true }
+
+          it 'grants a user the access chosen on the review step' do
+            grantee = FactoryBot.create(:user)
+            fill_in_wizard
+
+            post deposit_wizard_commit_path,
+                 params: { param_key => { permissions_attributes: {
+                   '0' => { type: 'person', name: grantee.user_key, access: 'edit' }
+                 } } }
+
+            expect(response).to redirect_to(deposit_wizard_step_path(step: 'done'))
+            work = Hyrax.query_service.find_all_of_model(model: resource_class).to_a.last
+            expect(work.permission_manager.edit_users.to_a).to include(grantee.user_key)
+          end
+        end
+
+        context 'when sharing is disabled' do
+          before { Hyku::DepositWizard.config.enable_sharing = false }
+
+          it 'ignores submitted permissions' do
+            grantee = FactoryBot.create(:user)
+            fill_in_wizard
+
+            post deposit_wizard_commit_path,
+                 params: { param_key => { permissions_attributes: {
+                   '0' => { type: 'person', name: grantee.user_key, access: 'edit' }
+                 } } }
+
+            work = Hyrax.query_service.find_all_of_model(model: resource_class).to_a.last
+            expect(work.permission_manager.edit_users.to_a).not_to include(grantee.user_key)
+          end
+        end
+
+        # The wizard's job for redirects is to CAPTURE the submitted params into
+        # the work attributes when the capability is available; the actual
+        # persistence is Hyrax's redirects populator + sync_redirect_paths step,
+        # which fire only when the `redirects` attribute is in the active schema
+        # (an env/profile concern, not a wizard concern). These specs assert the
+        # wizard's capture behavior, gated by the capability. reset_state is
+        # stubbed so the captured session is observable after commit.
+        context 'redirects' do
+          before do
+            allow(Hyrax.config).to receive(:redirects_active?).and_return(true)
+            allow_any_instance_of(Hyrax::DepositWizardController).to receive(:reset_state)
+          end
+
+          it 'captures the submitted vanity URL into the work attributes' do
+            fill_in_wizard
+
+            post deposit_wizard_commit_path,
+                 params: { param_key => { redirects_attributes: { '0' => { path: '/my-vanity-url' } } } }
+
+            expect(response).to redirect_to(deposit_wizard_step_path(step: 'done'))
+            captured = session[:deposit_wizard].dig('attributes', 'redirects_attributes')
+            expect(captured&.dig('0', 'path')).to eq('/my-vanity-url')
+          end
+        end
+
+        context 'when redirects are not active' do
+          before do
+            allow(Hyrax.config).to receive(:redirects_active?).and_return(false)
+            allow_any_instance_of(Hyrax::DepositWizardController).to receive(:reset_state)
+          end
+
+          it 'ignores a submitted redirect path' do
+            fill_in_wizard
+
+            post deposit_wizard_commit_path,
+                 params: { param_key => { redirects_attributes: { '0' => { path: '/my-vanity-url' } } } }
+
+            expect(session[:deposit_wizard].dig('attributes', 'redirects_attributes')).to be_blank
+          end
+        end
       end
     end
   end

--- a/spec/requests/deposit_wizard_spec.rb
+++ b/spec/requests/deposit_wizard_spec.rb
@@ -84,6 +84,38 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
     end
   end
 
+  describe 'GET /deposit_wizard/parent_options (parent typeahead)' do
+    let(:admin) { FactoryBot.create(:admin) }
+
+    before do
+      allow(Flipflop).to receive(:deposit_wizard?).and_return(true)
+      Hyku::DepositWizard.config.enable_parent_connect = true
+    end
+
+    after { Hyku::DepositWizard.reset_config! }
+
+    it 'returns matching works as JSON id/label pairs' do
+      parent = FactoryBot.valkyrie_create(:generic_work_resource, title: ['Findable Parent'],
+                                                                  depositor: admin.user_key,
+                                                                  visibility_setting: 'open')
+
+      get deposit_wizard_parent_options_path(q: 'Findable')
+
+      expect(response).to have_http_status(:success)
+      results = JSON.parse(response.body)
+      expect(results).to be_an(Array)
+      expect(results.map { |r| r['id'] }).to include(parent.id.to_s)
+    end
+
+    it 'is forbidden when parent connect is disabled' do
+      Hyku::DepositWizard.config.enable_parent_connect = false
+
+      get deposit_wizard_parent_options_path(q: 'anything')
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
   describe 'navigation and type selection' do
     before do
       allow(Flipflop).to receive(:deposit_wizard?).and_return(true)
@@ -374,6 +406,100 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
         expect(response.body).to include(I18n.t('hyku.deposit_wizard.review.heading'))
         expect(response.body).to include('Repair Study')
         expect(response.body).to include(I18n.t('hyku.deposit_wizard.review.work_visibility'))
+      end
+
+      describe 'the parent connect section on review' do
+        after { Hyku::DepositWizard.reset_config! }
+
+        it 'renders the section when parent connect is enabled' do
+          Hyku::DepositWizard.config.enable_parent_connect = true
+          fill_in_wizard
+          get deposit_wizard_step_path(step: 'review')
+
+          expect(response.body).to include('data-behavior="extra-parent"')
+          expect(response.body).to include(I18n.t('hyku.deposit_wizard.extras.parent.heading'))
+        end
+
+        it 'omits the section when parent connect is disabled' do
+          Hyku::DepositWizard.config.enable_parent_connect = false
+          fill_in_wizard
+          get deposit_wizard_step_path(step: 'review')
+
+          expect(response.body).not_to include('data-behavior="extra-parent"')
+        end
+      end
+
+      describe 'the collection connect section on review' do
+        after { Hyku::DepositWizard.reset_config! }
+
+        it 'renders the section when the capability is enabled' do
+          Hyku::DepositWizard.config.enable_collection_connect = true
+          fill_in_wizard
+          get deposit_wizard_step_path(step: 'review')
+
+          expect(response.body).to include('data-behavior="extra-collection"')
+          expect(response.body).to include(I18n.t('hyku.deposit_wizard.extras.collection.heading'))
+        end
+
+        it 'omits the section when the capability is disabled' do
+          Hyku::DepositWizard.config.enable_collection_connect = false
+          fill_in_wizard
+          get deposit_wizard_step_path(step: 'review')
+
+          expect(response.body).not_to include('data-behavior="extra-collection"')
+        end
+      end
+
+      describe 'the sharing section on review' do
+        after { Hyku::DepositWizard.reset_config! }
+
+        it 'renders the section when sharing is enabled' do
+          Hyku::DepositWizard.config.enable_sharing = true
+          fill_in_wizard
+          get deposit_wizard_step_path(step: 'review')
+
+          expect(response.body).to include('data-behavior="extra-sharing"')
+          expect(response.body).to include(I18n.t('hyku.deposit_wizard.extras.sharing.heading'))
+        end
+
+        it 'omits the section when sharing is disabled' do
+          Hyku::DepositWizard.config.enable_sharing = false
+          fill_in_wizard
+          get deposit_wizard_step_path(step: 'review')
+
+          expect(response.body).not_to include('data-behavior="extra-sharing"')
+        end
+      end
+
+      describe 'the redirects section on review' do
+        it 'renders the section when redirects are active and the work carries the attribute' do
+          allow(Hyrax.config).to receive(:redirects_active?).and_return(true)
+          allow_any_instance_of(Hyku::DepositWizard::Config)
+            .to receive(:redirects_available?).and_return(true)
+          fill_in_wizard
+          get deposit_wizard_step_path(step: 'review')
+
+          expect(response.body).to include('data-behavior="extra-redirects"')
+          expect(response.body).to include(I18n.t('hyku.deposit_wizard.extras.redirects.heading'))
+        end
+
+        it 'omits the section when redirects are not active' do
+          allow(Hyrax.config).to receive(:redirects_active?).and_return(false)
+          fill_in_wizard
+          get deposit_wizard_step_path(step: 'review')
+
+          expect(response.body).not_to include('data-behavior="extra-redirects"')
+        end
+
+        it 'omits the section when the work does not carry the redirects attribute' do
+          allow(Hyrax.config).to receive(:redirects_active?).and_return(true)
+          allow_any_instance_of(Hyku::DepositWizard::Config)
+            .to receive(:redirects_available?).and_return(false)
+          fill_in_wizard
+          get deposit_wizard_step_path(step: 'review')
+
+          expect(response.body).not_to include('data-behavior="extra-redirects"')
+        end
       end
 
       it 'review Back goes to file_meta when there are files, else details' do

--- a/spec/requests/deposit_wizard_spec.rb
+++ b/spec/requests/deposit_wizard_spec.rb
@@ -437,6 +437,19 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
           expect(captured&.dig('0', 'id')).to eq(collection.id.to_s)
         end
 
+        it 'clears a capability from state when its entries are removed' do
+          Hyku::DepositWizard.config.enable_collection_connect = true
+          collection = FactoryBot.create(:hyku_collection, user: admin)
+          fill_in_wizard
+
+          post deposit_wizard_extras_path,
+               params: { param_key => { member_of_collections_attributes: { '0' => { id: collection.id.to_s } } } }
+          expect(session[:deposit_wizard].dig('attributes', 'member_of_collections_attributes')).to be_present
+
+          post deposit_wizard_extras_path, params: { param_key => { title: ['x'] } }
+          expect(session[:deposit_wizard].dig('attributes', 'member_of_collections_attributes')).to be_blank
+        end
+
         it 'rejects the save before a work type is chosen' do
           post deposit_wizard_extras_path, params: { parent_id: 'x' }
           expect(response).to have_http_status(:bad_request)

--- a/spec/requests/deposit_wizard_spec.rb
+++ b/spec/requests/deposit_wizard_spec.rb
@@ -408,6 +408,41 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
         expect(response.body).to include(I18n.t('hyku.deposit_wizard.review.work_visibility'))
       end
 
+      describe 'autosaving review extras (survive a refresh)' do
+        after { Hyku::DepositWizard.reset_config! }
+
+        it 'saves a chosen parent into wizard state and re-renders it on review' do
+          Hyku::DepositWizard.config.enable_parent_connect = true
+          parent = FactoryBot.valkyrie_create(:generic_work_resource, title: ['Parent'], depositor: admin.user_key)
+          fill_in_wizard
+
+          post deposit_wizard_extras_path, params: { parent_id: parent.id.to_s }
+          expect(response).to have_http_status(:no_content)
+          expect(session[:deposit_wizard]['parent_id']).to eq(parent.id.to_s)
+
+          get deposit_wizard_step_path(step: 'review')
+          expect(response.body).to include(parent.id.to_s)
+        end
+
+        it 'saves collection membership into wizard state' do
+          Hyku::DepositWizard.config.enable_collection_connect = true
+          collection = FactoryBot.create(:hyku_collection, user: admin)
+          fill_in_wizard
+
+          post deposit_wizard_extras_path,
+               params: { param_key => { member_of_collections_attributes: { '0' => { id: collection.id.to_s } } } }
+
+          expect(response).to have_http_status(:no_content)
+          captured = session[:deposit_wizard].dig('attributes', 'member_of_collections_attributes')
+          expect(captured&.dig('0', 'id')).to eq(collection.id.to_s)
+        end
+
+        it 'rejects the save before a work type is chosen' do
+          post deposit_wizard_extras_path, params: { parent_id: 'x' }
+          expect(response).to have_http_status(:bad_request)
+        end
+      end
+
       describe 'the parent connect section on review' do
         after { Hyku::DepositWizard.reset_config! }
 

--- a/spec/services/hyku/deposit_wizard/config_spec.rb
+++ b/spec/services/hyku/deposit_wizard/config_spec.rb
@@ -58,6 +58,20 @@ RSpec.describe Hyku::DepositWizard::Config do
       allow(Hyrax.config).to receive(:redirects_active?).and_return(true)
       expect(config.redirects_available?).to be(true)
     end
+
+    context 'when the redirects feature is active' do
+      before { allow(Hyrax.config).to receive(:redirects_active?).and_return(true) }
+
+      it 'is hidden when the work does not carry the redirects attribute' do
+        form = double(model: double(:model))
+        expect(config.redirects_available?(form)).to be(false)
+      end
+
+      it 'is shown when the work carries the redirects attribute' do
+        form = double(model: double(:model, redirects: []))
+        expect(config.redirects_available?(form)).to be(true)
+      end
+    end
   end
 
   describe 'block configuration (downstream override)' do

--- a/spec/services/hyku/deposit_wizard/config_spec.rb
+++ b/spec/services/hyku/deposit_wizard/config_spec.rb
@@ -21,26 +21,67 @@ RSpec.describe Hyku::DepositWizard::Config do
       expect(config.suggestions).to eq({})
       expect(config.post_commit).to be_nil
     end
+
+    it 'has no parent_types restriction by default' do
+      expect(config.parent_types).to be_nil
+    end
+  end
+
+  describe 'per-tenant capability flags' do
+    subject(:config) { described_class.new }
+
+    it 'reads each capability from its Flipflop feature when no override is set' do
+      allow(Flipflop).to receive(:deposit_wizard_parent_connect?).and_return(true)
+      allow(Flipflop).to receive(:deposit_wizard_collection_connect?).and_return(false)
+      allow(Flipflop).to receive(:deposit_wizard_sharing?).and_return(true)
+
+      expect(config.enable_parent_connect).to be(true)
+      expect(config.enable_collection_connect).to be(false)
+      expect(config.enable_sharing).to be(true)
+    end
+
+    it 'lets an explicit in-memory override win over the Flipflop feature' do
+      allow(Flipflop).to receive(:deposit_wizard_parent_connect?).and_return(false)
+      config.enable_parent_connect = true
+
+      expect(config.enable_parent_connect).to be(true)
+    end
+  end
+
+  describe '#redirects_available?' do
+    subject(:config) { described_class.new }
+
+    it 'mirrors Hyrax\'s own redirects gate (no separate wizard flag)' do
+      allow(Hyrax.config).to receive(:redirects_active?).and_return(false)
+      expect(config.redirects_available?).to be(false)
+
+      allow(Hyrax.config).to receive(:redirects_active?).and_return(true)
+      expect(config.redirects_available?).to be(true)
+    end
   end
 
   describe 'block configuration (downstream override)' do
     subject(:config) do
       described_class.new do |c|
-        c.container_type = 'Portfolio'
+        c.container_type = 'GenericWorkResource'
         c.file_pool = true
         c.file_meta = true
         c.suggestions = { image: %w[design installation] }
         c.post_commit = ->(_work, _wizard) {}
+        c.enable_parent_connect = true
+        c.parent_types = %w[GenericWorkResource EtdResource OerResource]
       end
     end
 
     it 'applies the assigned values' do
-      expect(config.container_type).to eq('Portfolio')
+      expect(config.container_type).to eq('GenericWorkResource')
       expect(config).to be_container
       expect(config.file_pool).to be(true)
       expect(config.file_meta).to be(true)
       expect(config.suggestions).to eq(image: %w[design installation])
       expect(config.post_commit).to respond_to(:call)
+      expect(config.enable_parent_connect).to be(true)
+      expect(config.parent_types).to eq(%w[GenericWorkResource EtdResource OerResource])
     end
   end
 end

--- a/spec/services/hyku/deposit_wizard/state_spec.rb
+++ b/spec/services/hyku/deposit_wizard/state_spec.rb
@@ -33,6 +33,18 @@ RSpec.describe Hyku::DepositWizard::State do
     end
   end
 
+  describe '#parent_id' do
+    it 'stores a present value' do
+      state.parent_id = 'abc-123'
+      expect(state.parent_id).to eq('abc-123')
+    end
+
+    it 'stores nil for a blank value' do
+      state.parent_id = ''
+      expect(state.parent_id).to be_nil
+    end
+  end
+
   describe '#uploaded_file_ids' do
     it 'defaults to an empty array' do
       expect(state.uploaded_file_ids).to eq([])


### PR DESCRIPTION
## Summary

Builds on prior PR https://github.com/samvera/hyku/pull/3139 to complete the guided deposit UI base functionality. The UI should now fully encompass the existing deposit UI features.

Adds optional, per-tenant "connect" capabilities to the guided deposit wizard's review step — nesting under a parent work, adding to collections, sharing with users/groups, and vanity URLs — each gated by its own feature and off by default.

## Details
- Four review-step capabilities, each an independent Flipflop feature: parent-connect, collection-connect, sharing, and redirects (redirects also respects the tenant's existing redirects gate + the work's schema).
- Each appears as a collapsible card (title + subtitle) that opens automatically when it already holds data.
- The vanity-URL card renders Hyrax's stock aliases form, so it inherits the full behavior (none-option, per-row remove, disable-until-path) rather than a partial reimplementation.
- Extras autosave to the wizard's session as the depositor edits them, so they survive a page refresh — the review step re-renders the chosen parent (by title), collections, share grants, and vanity URLs.
- A launch-with-context seam seeds `parent_id` / `add_works_to_collection` from the URL, so other entry points can later hand off into the wizard with a target pre-filled.
- All capabilities persist through the one existing deposit transaction (no new persistence path); the remove-control color was darkened to meet WCAG AA contrast.

## Screenshot

<details>
<summary>Deposit Review Page with additional features</summary>

<img width="1332" height="1916" alt="screencapture-cat-hyku-localhost-direct-dashboard-deposit-wizard-review-2026-07-11-23_50_16" src="https://github.com/user-attachments/assets/e7416bf9-78cb-4c82-9fc9-fe9cb86630a5" />

</summary>