### PR TITLE
Add parent-nesting path and clearer wizard errors

### DIFF
--- a/app/assets/javascripts/hyrax/deposit_wizard.js
+++ b/app/assets/javascripts/hyrax/deposit_wizard.js
@@ -160,7 +160,7 @@
     var select = section.find('[data-behavior="collection-select"]');
     var chips = section.find('[data-behavior="collection-chips"]');
     if (typeof select.select2 === 'function') {
-      select.select2({ placeholder: select.data('placeholder'), allowClear: true, width: '20rem' });
+      select.select2({ placeholder: select.data('placeholder'), allowClear: true, width: '100%' });
     }
     var index = 0;
 
@@ -244,6 +244,7 @@
       placeholder: input.data('placeholder'),
       allowClear: true,
       minimumInputLength: 2,
+      width: '100%',
       // A hidden input has no option text for a pre-seeded value; show the work's
       // title (passed as data-initial-label) rather than the bare id.
       initSelection: function (element, callback) {
@@ -286,6 +287,25 @@
     });
   }
 
+  function initAdminSetDescription() {
+    var block = document.querySelector('[data-behavior="admin-set"]');
+    if (!block) return;
+    var select = block.querySelector('[data-behavior="admin-set-select"]');
+    var desc = block.querySelector('[data-behavior="admin-set-desc"]');
+    var workflow = block.querySelector('[data-behavior="admin-set-workflow"]');
+    var workflowValue = block.querySelector('[data-behavior="admin-set-workflow-value"]');
+    if (!select) return;
+
+    select.addEventListener('change', function () {
+      var option = select.options[select.selectedIndex];
+      var d = option.getAttribute('data-description') || '';
+      var w = option.getAttribute('data-workflow') || '';
+      if (desc) { desc.textContent = d; desc.hidden = d === ''; }
+      if (workflow) workflow.hidden = w === '';
+      if (workflowValue) workflowValue.textContent = w;
+    });
+  }
+
   function initDepositWizard() {
     // Idempotency guard: this handler is bound to both `turbolinks:load` and
     // `ready`, which can both fire on a full page load. Running the inits twice
@@ -309,10 +329,14 @@
     initParentConnect();
     initRedirectsAutosave();
     initExtrasToggle();
+    initAdminSetDescription();
   }
 
   $(document).on('turbolinks:load ready', initDepositWizard);
-  $(document).on('turbolinks:before-render', function () {
+  // Clear the init flag before the page is cached and before a new page renders,
+  // so a restore visit (Back/Forward) re-initializes rather than reusing the
+  // cached DOM's stale "initialized" marker (which left Next unbound/disabled).
+  $(document).on('turbolinks:before-cache turbolinks:before-render', function () {
     var root = document.querySelector('.deposit-wizard');
     if (root) { delete root.dataset.dwInitialized; }
   });

--- a/app/assets/stylesheets/deposit_wizard/_choices.scss
+++ b/app/assets/stylesheets/deposit_wizard/_choices.scss
@@ -74,11 +74,77 @@
     margin-bottom: 0.75rem;
   }
 
+  &__admin-set-guidance {
+    margin-top: 0.6rem;
+  }
+
+  &__admin-set-desc {
+    margin: 0 0 0.4rem;
+    font-size: 0.9rem;
+    line-height: 1.5;
+    color: var(--dw-ink-muted);
+
+    &[hidden] {
+      display: none;
+    }
+  }
+
+  &__admin-set-workflow {
+    margin: 0;
+    font-size: 0.85rem;
+    color: var(--dw-ink-muted);
+
+    &[hidden] {
+      display: none;
+    }
+  }
+
+  &__admin-set-workflow-label {
+    font-weight: 600;
+    color: var(--dw-ink);
+    margin-right: 0.3rem;
+  }
+
+  // Parent line above the type chooser: "Adding as a child of <Type>: <Title>".
+  &__adding-to {
+    margin: 0.5rem 0 1.5rem;
+    color: var(--dw-ink-muted);
+  }
+
+  &__adding-to-type {
+    color: var(--dw-ink-muted);
+  }
+
+  &__adding-to-parent {
+    font-weight: 600;
+    font-size: 0.95rem;
+    color: var(--dw-ink);
+  }
+
   // Drop the browser's default dotted underline on abbr[title] so the required
   // mark reads as a plain red asterisk.
   &__section-heading .required {
     margin-left: 0.25rem;
     text-decoration: none;
     cursor: default;
+  }
+}
+
+// On the select-parent step the parent card has no toggle header (it's always
+// open), so its body needs the vertical padding the review card's header would
+// otherwise provide. The typeahead fills the card width here (the review card
+// caps it at 24rem, which would float left in this full-width step).
+.deposit-wizard--select-parent {
+  .deposit-wizard__extra-body {
+    padding: 1.75rem;
+  }
+
+  // Sole element in the body; the body padding provides the spacing below it.
+  .deposit-wizard__field {
+    margin-bottom: 0;
+  }
+
+  .select2-container {
+    max-width: none;
   }
 }

--- a/app/assets/stylesheets/deposit_wizard/_extras.scss
+++ b/app/assets/stylesheets/deposit_wizard/_extras.scss
@@ -348,7 +348,7 @@
   &__extra-body {
     .select2-container {
       display: block;
-      width: 100% !important;
+      width: 100%;
       max-width: 24rem;
       height: auto;
       padding: 0;

--- a/app/controllers/concerns/hyrax/deposit_wizard/context.rb
+++ b/app/controllers/concerns/hyrax/deposit_wizard/context.rb
@@ -14,7 +14,9 @@ module Hyrax
                       :uploaded_files, :file_meta_forms, :file_inherits_visibility?,
                       :file_visibility_summaries, :work_visibility_attributes,
                       :file_display_title, :selected_member_collections, :saved_permission_grants,
-                      :extra_prefilled?, :selected_parent_title, :collection_display_title
+                      :extra_prefilled?, :selected_parent_title, :selected_parent, :collection_display_title,
+                      :admin_set_options_for_display, :multiple_admin_sets?, :show_relationship_paths?,
+                      :known_type_back_step
       end
 
       # The seam downstream apps replace to add container types, suggestions, etc.
@@ -39,7 +41,8 @@ module Hyrax
       end
 
       def stepper_icon(key)
-        { type: 'fa-list-alt',
+        { parent: 'fa-sitemap',
+          type: 'fa-list-alt',
           upload: 'fa-cloud-upload',
           detail: 'fa-pencil',
           file_detail: 'fa-file-text-o',
@@ -51,7 +54,9 @@ module Hyrax
       end
 
       def stepper_keys
-        keys = %i[type upload detail]
+        keys = []
+        keys << :parent if wizard_state.path == 'add'
+        keys += %i[type upload detail]
         keys << :file_detail if wizard_state.uploaded_file_ids.any?
         keys << :review
         keys
@@ -171,6 +176,48 @@ module Hyrax
         Hyrax::AdminSetService.new(self).search_results(:deposit)
       end
 
+      # Keep the presenter's data-* hash on each option: the visibility component
+      # enforces those visibility/release rules downstream on the details form.
+      def admin_set_options_for_display
+        @admin_set_options_for_display ||= begin
+          docs = admin_sets_for_deposit
+          templates = Hyrax::PermissionTemplate.where(source_id: docs.map { |d| d.id.to_s }).to_a
+          docs.map do |doc|
+            template = templates.find { |t| t.source_id == doc.id.to_s }
+            entry = Hyrax::AdminSetSelectionPresenter::OptionsEntry.new(admin_set: doc, permission_template: template)
+            label, id, data = entry.result
+            { id: id, label: label, data: data,
+              description: Array(doc.try(:description)).first.presence,
+              workflow: template&.active_workflow&.label.presence }
+          end
+        end
+      end
+
+      def multiple_admin_sets?
+        admin_set_options_for_display.size > 1
+      end
+
+      def show_relationship_paths?
+        wizard_config.container? || wizard_config.enable_parent_connect
+      end
+
+      # item_start is only worth showing when it has a sub-flow to choose between
+      # (guided suggestions or batch); otherwise skip straight to the type chooser.
+      def item_flow_entry_step
+        item_start_offers_choice? ? 'item_start' : 'known_type'
+      end
+
+      def item_start_offers_choice?
+        wizard_config.enable_batch || wizard_config.suggestions.present?
+      end
+
+      def known_type_back_step
+        return 'select_parent' if wizard_state.path == 'add'
+        return 'item_start' if item_start_offers_choice?
+
+        nil # start screen
+      end
+
       # A since-deleted collection id is dropped individually rather than failing
       # the whole review render.
       def selected_member_collections
@@ -205,9 +252,18 @@ module Hyrax
       end
 
       def selected_parent_title
+        selected_parent&.dig(:title)
+      end
+
+      # The chosen parent's human model name + title (one query). nil when unset
+      # or since-deleted.
+      def selected_parent
         return if wizard_state.parent_id.blank?
 
-        Array(Hyrax.query_service.find_by(id: wizard_state.parent_id).title).first
+        @selected_parent ||= begin
+          work = Hyrax.query_service.find_by(id: wizard_state.parent_id)
+          { type: work.model_name.human, title: Array(work.title).first }
+        end
       rescue Valkyrie::Persistence::ObjectNotFoundError
         nil
       end

--- a/app/controllers/concerns/hyrax/deposit_wizard/error_reporting.rb
+++ b/app/controllers/concerns/hyrax/deposit_wizard/error_reporting.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module DepositWizard
+    # Turns wizard validation and transaction failures into a user-facing flash,
+    # so a re-rendered step explains why it didn't advance rather than staying
+    # silent. Shared by the details step (Navigation) and commit (Persistence).
+    module ErrorReporting
+      extend ActiveSupport::Concern
+
+      private
+
+      # Set a multi-line alert: a lead-in ending in a colon, then one line per
+      # message. _flash_msg joins an array flash with <br>, so each is its own row.
+      def flash_error(lead_in_key, messages)
+        flash.now[:alert] = ["#{t(lead_in_key)}:", *Array(messages)]
+        nil
+      end
+
+      def flag_commit_failure(messages)
+        flash_error('hyku.deposit_wizard.errors.deposit_failed', messages)
+      end
+
+      # e.g. invalid redirect path or video embed the form validator rejected.
+      def form_error_messages(form)
+        form.errors.full_messages
+      end
+
+      # A transaction Failure's first element is a symbol reason (e.g.
+      # :redirect_path_collision); prefer a translation for it, else its detail.
+      def transaction_failure_messages(failure)
+        reason, *detail = Array(failure)
+        message = I18n.t("hyku.deposit_wizard.errors.commit.#{reason}", default: nil) ||
+                  Array(detail).flatten.map(&:to_s).presence&.to_sentence || reason.to_s.humanize
+        Array(message)
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/hyrax/deposit_wizard/navigation.rb
+++ b/app/controllers/concerns/hyrax/deposit_wizard/navigation.rb
@@ -12,13 +12,28 @@ module Hyrax
 
       def advance_from_start
         wizard_state.admin_set_id = params[:admin_set_id] if params.key?(:admin_set_id)
-        if wizard_config.container?
-          wizard_state.path = params[:path]
-          redirect_to main_app.deposit_wizard_step_path(step: 'item_start')
-        else
+
+        unless params.key?(:path)
           wizard_state.path = 'standalone'
-          select_work_type_and_continue
+          return select_work_type_and_continue
         end
+
+        wizard_state.path = params[:path]
+        if wizard_state.path == 'add'
+          redirect_to main_app.deposit_wizard_step_path(step: 'select_parent')
+        else
+          redirect_to main_app.deposit_wizard_step_path(step: item_flow_entry_step)
+        end
+      end
+
+      def advance_from_select_parent
+        if params[:parent_id].blank?
+          flash.now[:alert] = t('hyku.deposit_wizard.errors.no_parent')
+          return render(:select_parent)
+        end
+
+        wizard_state.parent_id = params[:parent_id]
+        redirect_to main_app.deposit_wizard_step_path(step: item_flow_entry_step)
       end
 
       def advance_from_item_start
@@ -33,7 +48,9 @@ module Hyrax
         type = params[:work_type].to_s
         unless available_work_types.map(&:to_s).include?(type)
           flash.now[:alert] = t('hyku.deposit_wizard.errors.no_work_type')
-          return render(wizard_config.container? ? :known_type : :start)
+          # Re-render whichever step posted the (invalid) type: the flat start
+          # screen chooses the type inline, every other flow uses known_type.
+          return render(params[:step].to_s == 'start' ? :start : :known_type)
         end
 
         wizard_state.work_type = type
@@ -59,6 +76,7 @@ module Hyrax
           next_step = wizard_state.uploaded_file_ids.any? ? 'file_meta' : 'review'
           redirect_to main_app.deposit_wizard_step_path(step: next_step)
         else
+          flash_error('hyku.deposit_wizard.errors.details_invalid', form_error_messages(@form))
           render :details
         end
       end

--- a/app/controllers/concerns/hyrax/deposit_wizard/persistence.rb
+++ b/app/controllers/concerns/hyrax/deposit_wizard/persistence.rb
@@ -18,18 +18,23 @@ module Hyrax
         params.fetch(wizard_state.work_type.constantize.model_name.param_key, {})
       end
 
-      # Run the stock CreateValkyrieWork action (same as the deposit form) to
-      # persist the work and attach the uploaded files. Returns the work, or nil
-      # when validation or the transaction fails.
+      # Run the stock CreateValkyrieWork action (same as the deposit form). Returns
+      # the work, or nil on validation/transaction failure — flashing why, so the
+      # re-rendered review step isn't silent.
       def create_work
         action = Hyrax::Action::CreateValkyrieWork.new(form: work_form,
                                                        transactions: Hyrax::Transactions::Container,
                                                        user: current_user,
                                                        params: commit_params,
                                                        work_attributes_key: work_form.model_name.param_key)
-        return unless action.validate
+        return flag_commit_failure(form_error_messages(action.form)) unless action.validate
 
-        action.perform.value_or(nil)
+        # Failure#or returns the block's value, so branch explicitly rather than
+        # chaining .value_or (which would run on the block's nil result).
+        result = action.perform
+        return result.value! if result.success?
+
+        flag_commit_failure(transaction_failure_messages(result.failure))
       end
 
       # Survive the redirect to the done screen, which reads it once. The show

--- a/app/controllers/hyrax/deposit_wizard_controller.rb
+++ b/app/controllers/hyrax/deposit_wizard_controller.rb
@@ -8,6 +8,7 @@ module Hyrax
   # Flipflop feature (off by default).
   class DepositWizardController < ApplicationController
     include Hyrax::DepositWizard::Context
+    include Hyrax::DepositWizard::ErrorReporting
     include Hyrax::DepositWizard::Navigation
     include Hyrax::DepositWizard::Persistence
 
@@ -18,7 +19,7 @@ module Hyrax
     before_action :assign_current_ability
     before_action :build_breadcrumbs
 
-    STEPS = %w[start item_start known_type files details file_meta review done].freeze
+    STEPS = %w[start select_parent item_start known_type files details file_meta review done].freeze
     STEPS_REQUIRING_WORK_TYPE = %w[files details file_meta review].freeze
 
     # Let the details step reuse Hyrax's work-form partials: the shared
@@ -37,10 +38,9 @@ module Hyrax
     def show
       step = params[:step].to_s
       return redirect_to(main_app.deposit_wizard_path) unless STEPS.include?(step)
-      return redirect_to(main_app.deposit_wizard_step_path(step: 'known_type')) if needs_work_type?(step)
 
-      # file_meta has nothing to show without files; send it on to review.
-      return redirect_to(main_app.deposit_wizard_step_path(step: 'review')) if step == 'file_meta' && wizard_state.uploaded_file_ids.empty?
+      detour = step_detour(step)
+      return redirect_to(detour) if detour
 
       build_work_form if %w[details review].include?(step)
       render step
@@ -50,12 +50,13 @@ module Hyrax
     # wizard is server-rendered: each step is a GET, and choices POST here.
     def update
       case params[:step].to_s
-      when 'start'      then advance_from_start
-      when 'item_start' then advance_from_item_start
-      when 'known_type' then advance_from_known_type
-      when 'files'      then advance_from_files
-      when 'details'    then advance_from_details
-      when 'file_meta'  then advance_from_file_meta
+      when 'start'         then advance_from_start
+      when 'select_parent' then advance_from_select_parent
+      when 'item_start'    then advance_from_item_start
+      when 'known_type'    then advance_from_known_type
+      when 'files'         then advance_from_files
+      when 'details'       then advance_from_details
+      when 'file_meta'     then advance_from_file_meta
       else redirect_to main_app.deposit_wizard_path
       end
     end
@@ -102,6 +103,17 @@ module Hyrax
     end
 
     private
+
+    # Where a requested step should redirect instead of rendering, or nil to
+    # render it — for steps that don't apply given the current wizard state.
+    def step_detour(step)
+      return main_app.deposit_wizard_step_path(step: 'known_type') if needs_work_type?(step)
+      return main_app.deposit_wizard_step_path(step: 'review') if step == 'file_meta' && wizard_state.uploaded_file_ids.empty?
+      return main_app.deposit_wizard_path if step == 'select_parent' && wizard_state.path != 'add'
+      return main_app.deposit_wizard_step_path(step: 'known_type') if step == 'item_start' && !item_start_offers_choice?
+
+      nil
+    end
 
     # Mirror Hyrax's batch-upload guard: redirect to the dashboard rather than
     # exposing the wizard routes when the feature is off.

--- a/app/services/hyku/deposit_wizard/config.rb
+++ b/app/services/hyku/deposit_wizard/config.rb
@@ -2,61 +2,18 @@
 
 module Hyku
   module DepositWizard
-    # Configuration seam for the guided deposit wizard.
-    #
-    # A plain Hyku install gets a usable flat wizard: any enabled work type, no
-    # container path, no file pool. Downstream apps (e.g. the Enact knapsack)
-    # replace the shared instance with their own configuration to add
-    # container-like work types, subtype/suggestion maps, and a post-commit hook.
-    #
-    #   Hyku::DepositWizard.config = Hyku::DepositWizard::Config.new do |c|
-    #     c.container_type = Portfolio
-    #     c.file_pool = true
-    #     c.file_meta = true
-    #     c.post_commit = ->(work, wizard) { ... }
-    #   end
-    #
-    # The wizard reads the shared instance via +Hyku::DepositWizard.config+.
+    # Configuration seam for the guided deposit wizard. See
+    # docs/deposit-wizard.md for the full option reference and insertion points.
+    # Downstream apps replace the shared instance via +Hyku::DepositWizard.config+.
     class Config
-      # Offer only the primary admin set (v5 +singleAdminSet+ prop).
-      attr_accessor :single_admin_set
+      attr_accessor :single_admin_set, :enable_batch, :file_pool, :file_meta,
+                    :container_type, :item_types, :suggestions, :post_commit, :parent_types
 
-      # Offer the "many files, one type" batch sub-flow (v5 +enableBatch+ prop).
-      attr_accessor :enable_batch
-
-      # Offer an upfront shared upload pool at the container level (v5 +filePool+).
-      attr_accessor :file_pool
-
-      # Collect per-file FileSet metadata inline before commit (v5 +file_meta+).
-      attr_accessor :file_meta
-
-      # The container work type (class or class name); +nil+ means a flat wizard
-      # with no container path.
-      attr_accessor :container_type
-
-      # Child/item work types (array of class names); +nil+ falls back to the
-      # tenant's enabled work types at request time.
-      attr_accessor :item_types
-
-      # File-category => ordered subtype-id suggestions for the guided flow
-      # (v5 +SUGGEST+ map).
-      attr_accessor :suggestions
-
-      # Callable run after commit, receiving the persisted work and wizard state.
-      attr_accessor :post_commit
-
-      # The parent/collection/sharing capabilities are per-tenant Flipflop features
-      # (grouped with :deposit_wizard). A writer stays for an explicit in-memory
-      # override (used by specs and any app that sets it directly). Redirects are
-      # not here — they use their own Flipflop gate (see #redirects_available?).
+      # The parent/collection/sharing capabilities are per-tenant Flipflop
+      # features; a writer stays for an explicit in-memory override (specs, or an
+      # app that sets it directly) that the reader below prefers over Flipflop.
       attr_writer :enable_parent_connect, :enable_collection_connect, :enable_sharing
 
-      # Work types eligible as parents; +nil+ falls back to the tenant's available
-      # work types.
-      attr_accessor :parent_types
-
-      # Each reader returns the in-memory override when one was set, otherwise the
-      # tenant's Flipflop feature value.
       %i[parent_connect collection_connect sharing].each do |capability|
         define_method("enable_#{capability}") do
           override = instance_variable_get("@enable_#{capability}")

--- a/app/views/hyrax/deposit_wizard/_admin_set_select.html.erb
+++ b/app/views/hyrax/deposit_wizard/_admin_set_select.html.erb
@@ -1,8 +1,10 @@
-<%# Inline admin-set chooser, submitted with the enclosing form. Shown only when
-    more than one set is available; otherwise the default is used silently. The
-    chosen set drives the work form's fields. %>
-<% if available_admin_sets.size > 1 %>
-  <div class="form-group deposit-wizard__admin-set">
+<%# Inline admin-set chooser, submitted with the enclosing form; hidden when only
+    one set is available. Options keep the presenter's visibility/release data-*
+    so the visibility component still enforces them on the details step. %>
+<% if multiple_admin_sets? %>
+  <% options = admin_set_options_for_display %>
+  <% selected = options.find { |o| o[:id] == selected_admin_set_id } || options.first %>
+  <div class="form-group deposit-wizard__admin-set" data-behavior="admin-set">
     <h2 class="deposit-wizard__section-heading">
       <%= t('hyku.deposit_wizard.admin_set.heading') %>
       <abbr title="<%= t('simple_form.required.text', default: 'required') %>" class="required text-danger">*</abbr>
@@ -11,8 +13,23 @@
       <%= t('hyku.deposit_wizard.admin_set.hint_lead') %>. <%= t('hyku.deposit_wizard.admin_set.hint') %>
     </p>
     <%= label_tag :admin_set_id, t('hyku.deposit_wizard.admin_set.label'), class: 'sr-only' %>
-    <%= select_tag :admin_set_id,
-                   options_for_select(available_admin_sets.map { |label, id, *| [label, id] }, selected_admin_set_id),
-                   class: 'form-control' %>
+    <select id="admin_set_id" name="admin_set_id" class="form-control" data-behavior="admin-set-select">
+      <% options.each do |option| %>
+        <%= content_tag :option, option[:label],
+                        { value: option[:id], selected: option[:id] == selected[:id],
+                          'data-description': option[:description],
+                          'data-workflow': option[:workflow] }.merge(option[:data] || {}) %>
+      <% end %>
+    </select>
+
+    <div class="deposit-wizard__admin-set-guidance" data-behavior="admin-set-guidance">
+      <p class="deposit-wizard__admin-set-desc" data-behavior="admin-set-desc"
+         <%= 'hidden' if selected[:description].blank? %>><%= selected[:description] %></p>
+      <p class="deposit-wizard__admin-set-workflow" data-behavior="admin-set-workflow"
+         <%= 'hidden' if selected[:workflow].blank? %>>
+        <span class="deposit-wizard__admin-set-workflow-label"><%= t('hyku.deposit_wizard.admin_set.workflow') %></span>
+        <span data-behavior="admin-set-workflow-value"><%= selected[:workflow] %></span>
+      </p>
+    </div>
   </div>
 <% end %>

--- a/app/views/hyrax/deposit_wizard/details.html.erb
+++ b/app/views/hyrax/deposit_wizard/details.html.erb
@@ -4,10 +4,15 @@
   <%= render 'stepper', steps: item_stepper_steps, phase: stepper_phase(:detail) %>
   <%= render 'step_title', title: t('hyku.deposit_wizard.details.heading'), hint: t('hyku.deposit_wizard.details.subtext') %>
 
+  <%# data-behavior=work-form lets Hyrax's app.js instantiate its Editor here, so
+      autocomplete fields (based_near, subject, language) bind as on the stock
+      form; the Editor's save/relationship/sharing sub-inits safely no-op without
+      their DOM. %>
   <%= simple_form_for work_form,
                       url: main_app.deposit_wizard_advance_path(step: 'details'),
                       method: :patch,
-                      html: { class: 'deposit-wizard__details-form', data: { 'param-key' => work_form.model_name.param_key } } do |f| %>
+                      html: { class: 'deposit-wizard__details-form',
+                              data: { behavior: 'work-form', 'param-key' => work_form.model_name.param_key } } do |f| %>
     <%= render 'hyrax/base/form_metadata', f: f %>
 
     <%= render 'visibility', f: f %>

--- a/app/views/hyrax/deposit_wizard/known_type.html.erb
+++ b/app/views/hyrax/deposit_wizard/known_type.html.erb
@@ -4,10 +4,19 @@
   <%= render 'stepper', steps: item_stepper_steps, phase: stepper_phase(:type) %>
   <h2 class="deposit-wizard__section-heading"><%= t('hyku.deposit_wizard.known_type.heading') %></h2>
 
+  <% if selected_parent.present? %>
+    <p class="deposit-wizard__adding-to">
+      <%= t('hyku.deposit_wizard.known_type.adding_to') %>
+      <span class="deposit-wizard__adding-to-type"><%= selected_parent[:type] %>:</span>
+      <span class="deposit-wizard__adding-to-parent"><%= selected_parent[:title] %></span>
+    </p>
+  <% end %>
+
   <%= form_tag main_app.deposit_wizard_advance_path(step: 'known_type'), method: :patch, class: 'deposit-wizard__type-form' do %>
     <%= render 'type_cards' %>
 
-    <% back = wizard_config.container? ? main_app.deposit_wizard_step_path(step: 'item_start') : main_app.deposit_wizard_path %>
+    <% back_step = known_type_back_step %>
+    <% back = back_step ? main_app.deposit_wizard_step_path(step: back_step) : main_app.deposit_wizard_path %>
     <%= render 'nav', back_path: back,
                       next_html: { disabled: wizard_state.work_type.blank?, data: { behavior: 'type-next' } } %>
   <% end %>

--- a/app/views/hyrax/deposit_wizard/select_parent.html.erb
+++ b/app/views/hyrax/deposit_wizard/select_parent.html.erb
@@ -1,0 +1,30 @@
+<%= render 'page_header' %>
+
+<div class="deposit-wizard deposit-wizard--select-parent">
+  <%= render 'stepper', steps: item_stepper_steps, phase: stepper_phase(:parent) %>
+  <%= render 'step_title', title: t('hyku.deposit_wizard.select_parent.heading'),
+                           hint: t('hyku.deposit_wizard.select_parent.subtext') %>
+
+  <%= form_tag main_app.deposit_wizard_advance_path(step: 'select_parent'), method: :patch,
+               class: 'deposit-wizard__select-parent-form' do %>
+    <%# Same Select2-ajax typeahead the review-step parent card uses, wrapped in
+        the __extra-body scope so its Select2 styling (single box, no double
+        border) applies here too; always open (no collapse) since it's the step. %>
+    <section class="deposit-wizard__extra is-open" data-behavior="extra-parent"
+             data-options-url="<%= main_app.deposit_wizard_parent_options_path %>">
+      <div class="deposit-wizard__extra-body">
+        <div class="deposit-wizard__field">
+          <%= label_tag 'dw_parent_search', t('hyku.deposit_wizard.select_parent.label'),
+                        class: 'deposit-wizard__field-label sr-only' %>
+          <%= hidden_field_tag 'parent_id', wizard_state.parent_id, id: 'dw_parent_search',
+                               class: 'form-control',
+                               data: { behavior: 'parent-select',
+                                       'initial-label': selected_parent_title,
+                                       placeholder: t('hyku.deposit_wizard.extras.parent.placeholder') } %>
+        </div>
+      </div>
+    </section>
+
+    <%= render 'nav', back_path: main_app.deposit_wizard_path %>
+  <% end %>
+</div>

--- a/app/views/hyrax/deposit_wizard/start.html.erb
+++ b/app/views/hyrax/deposit_wizard/start.html.erb
@@ -8,9 +8,10 @@
   <%= form_tag main_app.deposit_wizard_advance_path(step: 'start'), method: :patch, class: 'deposit-wizard__start-form' do %>
     <%= render 'admin_set_select' %>
 
-    <% if wizard_config.container? %>
+    <% if show_relationship_paths? %>
+      <% paths = wizard_config.container? ? %w[new add standalone] : %w[new add] %>
       <div class="deposit-wizard__paths">
-        <% %w[new add standalone].each do |path| %>
+        <% paths.each do |path| %>
           <%= button_tag type: 'submit', name: 'path', value: path, class: 'deposit-wizard__path-card' do %>
             <span class="deposit-wizard__path-title"><%= t("hyku.deposit_wizard.start.paths.#{path}.title") %></span>
             <span class="deposit-wizard__path-desc"><%= t("hyku.deposit_wizard.start.paths.#{path}.desc") %></span>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,6 +54,7 @@ en:
         hint_lead: Sets the rules for this deposit
         hint: An administrative set decides which metadata fields you'll complete, the visibility options available to your work, and the review workflow it follows after deposit. Most deposits use the default.
         label: Administrative set
+        workflow: 'Workflow:'
       back: Back
       button: Guided Deposit
       continue: Continue
@@ -73,6 +74,11 @@ en:
         view_work: View work
       errors:
         agreement_required: Please accept the deposit agreement to continue.
+        commit:
+          redirect_path_collision: One of the vanity URLs is already in use. Choose a different path.
+        deposit_failed: Your work could not be deposited
+        details_invalid: Some details need fixing before you can continue
+        no_parent: Please choose a work to add this deposit to.
         no_work_type: Please choose a work type to continue.
       extras:
         add: Add
@@ -121,6 +127,7 @@ en:
         known_type: I know what type of work this is
         subtext: Choose how you would like to describe this item.
       known_type:
+        adding_to: Adding as a child of
         heading: What type of work is this?
         subtext: Choose the type that best fits the work you are depositing.
       no_work_types: There are no work types available for you to deposit. Please contact an administrator.
@@ -145,18 +152,22 @@ en:
         visibility_inherited: Same as work
         work_type: Work type
         work_visibility: Work visibility
+      select_parent:
+        heading: Choose the parent work
+        subtext: Search for the work this deposit should be added to.
+        label: Search works
       start:
         heading: What would you like to deposit?
         subtext: This guided flow walks you through depositing your work step by step.
         paths:
           add:
-            desc: Add one or more works to a portfolio you have already created.
-            title: Add to an existing portfolio
+            desc: Nest this deposit inside a work you have already created.
+            title: Add to an existing work
           new:
-            desc: Start a new portfolio, then add works to it.
-            title: Create a new portfolio
+            desc: Deposit a work on its own.
+            title: Deposit a new work
           standalone:
-            desc: Deposit a single work on its own, without a portfolio.
+            desc: Deposit a single work on its own, without a parent.
             title: Deposit a standalone work
       visibility:
         legend: Visibility
@@ -178,6 +189,7 @@ en:
         item:
           detail: Work detail
           file_detail: File detail
+          parent: Parent work
           review: Review
           type: Item type
           upload: Upload files

--- a/docs/deposit-wizard.md
+++ b/docs/deposit-wizard.md
@@ -1,0 +1,187 @@
+# Guided Deposit Wizard
+
+The guided deposit wizard is a multi-step alternative to Hyrax's single-page
+tabbed deposit form. It walks a depositor through work-type selection, file
+upload, metadata, per-file metadata, and review, then commits through the same
+public Hyrax create transaction — so a work created by the wizard is
+indistinguishable from one created by the stock form.
+
+The wizard is additive: the stock deposit form is untouched, and the wizard is
+off by default behind a feature flag. It is designed as a **generic Hyku
+feature** with **seams a downstream app** (e.g. the Enact knapsack) can configure
+and extend without forking.
+
+## Enabling
+
+The wizard and its optional capabilities are per-tenant Flipflop features
+(declared in `config/features.rb`, group `:experimental_features`):
+
+| Feature | Effect |
+| --- | --- |
+| `deposit_wizard` | Master switch. When off, the wizard routes redirect to the dashboard and the "Guided Deposit" button is hidden. |
+| `deposit_wizard_parent_connect` | Lets a depositor nest the work under a parent work — both a start-screen "add to an existing work" path and a review-step section. |
+| `deposit_wizard_collection_connect` | Lets a depositor add the work to one or more collections on the review step. |
+| `deposit_wizard_sharing` | Lets a depositor grant per-user / per-group access on the review step. |
+
+Vanity-URL redirects on the review step are gated separately by Hyrax's own
+`redirects_active?` (its boot flag plus `Flipflop.redirects?`) **and** the work's
+schema carrying a `redirects` attribute — not by a wizard-specific flag.
+
+The dashboard entry point is a "Guided Deposit" button rendered in
+`app/views/hyrax/my/works/_deposit_actions.html.erb`, shown only when
+`Flipflop.deposit_wizard?` is true.
+
+## Architecture
+
+A single controller drives a sequence of server-rendered steps, holding state in
+the session between steps. It wraps — does not replace — Hyrax's create
+machinery.
+
+- **Controller**: `Hyrax::DepositWizardController`
+  (`app/controllers/hyrax/deposit_wizard_controller.rb`). Actions: `start`,
+  `show` (per step), `update` (advance), `commit`, plus the AJAX endpoints
+  `parent_options` (parent typeahead) and `save_extras` (review-step autosave).
+- **Controller concerns** (`app/controllers/concerns/hyrax/deposit_wizard/`):
+  - `Context` — shared view/step/form helpers (form building, the stepper rail,
+    admin-set options, flow predicates).
+  - `Navigation` — `advance_from_<step>` transitions run from `update`.
+  - `Persistence` — assembling commit params and running the create action.
+  - `ErrorReporting` — turning validation/transaction failures into a flash.
+- **Config + state** (`app/services/hyku/deposit_wizard/`):
+  - `Hyku::DepositWizard.config` — the swappable configuration seam (see below).
+  - `Hyku::DepositWizard::State` — a thin wrapper over `session[:deposit_wizard]`.
+- **Views**: `app/views/hyrax/deposit_wizard/` — one template per step plus
+  shared partials (`_stepper`, `_nav`, `_admin_set_select`, the review `_extras_*`
+  sections).
+- **Assets**: `app/assets/javascripts/hyrax/deposit_wizard.js` (progressive
+  enhancement) and `app/assets/stylesheets/deposit_wizard/` (SCSS partials).
+
+Persistence runs through the public
+`Hyrax::Transactions::Container['work_resource.create']` transaction (via
+`Hyrax::Action::CreateValkyrieWork`) and `Hyrax::WorkUploadsHandler`, so
+workflow, indexing, and access controls match stock deposit. The wizard works
+under both `HYRAX_FLEXIBLE=false` and `HYRAX_FLEXIBLE=true`.
+
+## Steps
+
+The step sequence (`DepositWizardController::STEPS`):
+
+```
+start → select_parent → item_start → known_type → files → details → file_meta → review → done
+```
+
+Not every step runs on every deposit — several are conditional:
+
+| Step | Purpose | Shown when |
+| --- | --- | --- |
+| `start` | Path chooser (new / add / standalone) or, in a flat install, the work-type chooser; inline admin-set selection. | Always the entry point. |
+| `select_parent` | Pick the parent work to nest under. | Only on the "add" path (`parent_connect`). |
+| `item_start` | Sub-flow chooser (known type / guided / batch). | Only when a sub-flow is configured (`enable_batch` or `suggestions`); otherwise skipped straight to `known_type`. |
+| `known_type` | Work-type card chooser. | Whenever a type still needs choosing. |
+| `files` | Hyrax uploader. | Requires a chosen work type. |
+| `details` | Work `ResourceForm` (profile-driven fields, visibility, embargo/lease). | Requires a chosen work type. |
+| `file_meta` | Per-file metadata + per-file visibility. | Only when files were uploaded. |
+| `review` | Summary, optional connect/share/redirect sections, deposit agreement. | Requires a chosen work type. |
+| `done` | Confirmation. | After a successful commit. |
+
+`STEPS_REQUIRING_WORK_TYPE` (`files`, `details`, `file_meta`, `review`) redirect
+back to `known_type` if no type has been chosen. The skip/redirect rules live in
+`DepositWizardController#step_detour`; forward targets live in the
+`advance_from_<step>` methods; the stepper-rail keys and Back targets live in
+`Context` (`stepper_keys`, `known_type_back_step`).
+
+### Error handling
+
+Validation and transaction failures surface a multi-line flash rather than
+silently re-rendering (see `ErrorReporting`):
+
+- **Details step** — a field the form validator rejects (for example a
+  `video_embed` that is not a YouTube/Vimeo embed URL) re-renders `details` with
+  the entered values preserved and the specific errors listed.
+- **Review step / commit** — a form-validation failure, or a transaction failure
+  such as a redirect-path collision (only detectable at commit), re-renders
+  `review` with an explanation. Transaction reasons are translated via
+  `hyku.deposit_wizard.errors.commit.<reason>` where a translation exists.
+
+## Configuration
+
+Downstream apps replace the shared config instance (typically in an initializer):
+
+```ruby
+Hyku::DepositWizard.config = Hyku::DepositWizard::Config.new do |c|
+  c.container_type = Portfolio
+  c.item_types     = %w[PortfolioArtefact PortfolioEvent]
+  c.file_pool      = true
+  c.file_meta      = true
+  c.parent_types   = [Portfolio]
+  c.post_commit    = ->(work, wizard_state) { ... }
+end
+```
+
+The wizard reads the shared instance via `Hyku::DepositWizard.config`; specs
+reset it with `Hyku::DepositWizard.reset_config!`.
+
+| Option | Default | Meaning |
+| --- | --- | --- |
+| `single_admin_set` | `true` | Offer only the primary admin set. |
+| `enable_batch` | `false` | Offer the "many files, one type" batch sub-flow (also makes `item_start` appear). |
+| `file_pool` | `false` | Offer an upfront shared upload pool at the container level. |
+| `file_meta` | `false` | Collect per-file FileSet metadata inline before commit. |
+| `container_type` | `nil` | The container work type (class or class name). Presence makes the start screen a new/add/standalone path chooser (`container?`). `nil` is a flat wizard. |
+| `item_types` | `nil` | Child/item work types. `nil` falls back to the tenant's enabled work types. |
+| `suggestions` | `{}` | File-category → ordered subtype suggestions for the guided sub-flow (also makes `item_start` appear). |
+| `parent_types` | `nil` | Work types eligible as parents in the typeahead. `nil` falls back to the tenant's available work types. |
+| `post_commit` | `nil` | Callable run after a successful commit, receiving `(work, wizard_state)` — the hook for downstream nesting/fan-out. |
+
+The parent/collection/sharing capabilities are **not** plain config options — they
+are the per-tenant Flipflop features above. `Config` exposes `enable_parent_connect`
+/ `enable_collection_connect` / `enable_sharing` readers that return an explicit
+in-memory override when set (used by specs and apps that set it directly),
+otherwise the tenant's Flipflop value. `redirects_available?(form)` combines
+Hyrax's redirects gate with a check that the work's schema carries `redirects`.
+
+## Admin-set assistance
+
+When more than one deposit-eligible admin set exists, the start screen shows a
+selector whose description and workflow label update as the choice changes.
+`Context#admin_set_options_for_display` builds each option from Hyrax's
+`AdminSetSelectionPresenter` (keeping its `data-*` visibility/release attributes,
+which the visibility component enforces on the details step) enriched with the
+set's `description` and active-workflow `label`. Admin-set-scoped extra fields
+(FlexibleSchema `contexts`, flex mode) flow automatically: the wizard passes the
+chosen `admin_set_id` into `ResourceForm.for`, which applies the set's contexts.
+
+## Insertion points for a downstream app
+
+Everything a knapsack needs to customize is a seam; no Hyrax or Hyku override is
+required.
+
+- **Configuration** — assign `Hyku::DepositWizard.config` (see above). This is
+  the primary seam: container type, item types, parent types, suggestions,
+  toggles, and the post-commit hook.
+- **Post-commit hook** — `config.post_commit` receives the persisted work and the
+  wizard state; use it for container nesting or batch fan-out.
+- **Parent nesting** — the persistence layer already honors a top-level
+  `parent_id` (seeded by the "add" path or by launch context) through Hyrax's
+  `add_to_parent` step. No extra wiring needed to nest under a parent.
+- **Launch with context** — `GET deposit_wizard?parent_id=<id>` or
+  `?add_works_to_collection=<id>` seeds the matching state slot (each gated by its
+  capability), so other entry points can hand off into the wizard with a target
+  pre-filled.
+- **View overrides** — the knapsack view-path prepend lets an app override any
+  step template or partial in `hyrax/deposit_wizard/` for bespoke labels or
+  styling.
+- **Styling tokens** — the SCSS is scoped under `.deposit-wizard` and driven by
+  `--dw-*` CSS custom properties (defined in
+  `app/assets/stylesheets/deposit_wizard/_base.scss`), so an app can rebrand by
+  overriding the tokens without touching the baseline.
+
+## JavaScript hooks
+
+`deposit_wizard.js` is progressive enhancement keyed off `data-behavior`
+attributes (a no-op on non-wizard pages): the file uploader, visibility pills,
+per-file master-detail panels, step validity, the review-step connect/share/
+redirect controls, the admin-set description, and the parent/collection Select2
+typeaheads. The details step additionally carries `data-behavior="work-form"` so
+Hyrax's own editor JS binds the autocomplete and controlled-vocabulary fields
+exactly as on the stock form.

--- a/spec/requests/deposit_wizard_spec.rb
+++ b/spec/requests/deposit_wizard_spec.rb
@@ -166,9 +166,12 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
       end
     end
 
-    context 'with a container config' do
+    context 'with a container config offering a sub-flow' do
       before do
-        Hyku::DepositWizard.config = Hyku::DepositWizard::Config.new { |c| c.container_type = 'GenericWorkResource' }
+        Hyku::DepositWizard.config = Hyku::DepositWizard::Config.new do |c|
+          c.container_type = 'GenericWorkResource'
+          c.enable_batch = true
+        end
       end
 
       it 'renders the path chooser on the start screen' do
@@ -195,6 +198,96 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
         patch deposit_wizard_advance_path(step: 'known_type'), params: { work_type: work_type }
 
         expect(session[:deposit_wizard]['work_type']).to eq(work_type)
+      end
+    end
+
+    context 'with a container config offering no sub-flow' do
+      before do
+        Hyku::DepositWizard.config = Hyku::DepositWizard::Config.new { |c| c.container_type = 'GenericWorkResource' }
+      end
+
+      it 'skips item_start and goes straight to the type chooser' do
+        patch deposit_wizard_advance_path(step: 'start'), params: { path: 'standalone' }
+
+        expect(response).to redirect_to(deposit_wizard_step_path(step: 'known_type'))
+      end
+
+      it 'redirects a direct item_start visit to the type chooser' do
+        get deposit_wizard_step_path(step: 'item_start')
+
+        expect(response).to redirect_to(deposit_wizard_step_path(step: 'known_type'))
+      end
+    end
+
+    context 'with the relationship-first path (flat config, parent_connect on)' do
+      before { Hyku::DepositWizard.config.enable_parent_connect = true }
+
+      it 'renders the new/add path cards on the start screen' do
+        get deposit_wizard_path
+
+        expect(response.body).to include(I18n.t('hyku.deposit_wizard.start.paths.new.title'))
+        expect(response.body).to include(I18n.t('hyku.deposit_wizard.start.paths.add.title'))
+      end
+
+      it 'sends the add path to the select_parent step' do
+        patch deposit_wizard_advance_path(step: 'start'), params: { path: 'add' }
+
+        expect(response).to redirect_to(deposit_wizard_step_path(step: 'select_parent'))
+        expect(session[:deposit_wizard]['path']).to eq('add')
+      end
+
+      it 'sends the new path to type selection' do
+        patch deposit_wizard_advance_path(step: 'start'), params: { path: 'new' }
+
+        expect(response).to redirect_to(deposit_wizard_step_path(step: 'known_type'))
+      end
+
+      it 'seeds the chosen parent and advances from select_parent' do
+        parent = FactoryBot.valkyrie_create(:generic_work_resource, title: ['Parent'], depositor: admin.user_key)
+        patch deposit_wizard_advance_path(step: 'start'), params: { path: 'add' }
+
+        patch deposit_wizard_advance_path(step: 'select_parent'), params: { parent_id: parent.id.to_s }
+
+        expect(response).to redirect_to(deposit_wizard_step_path(step: 'known_type'))
+        expect(session[:deposit_wizard]['parent_id']).to eq(parent.id.to_s)
+      end
+
+      it 're-renders select_parent with an alert when no parent is chosen' do
+        patch deposit_wizard_advance_path(step: 'start'), params: { path: 'add' }
+
+        patch deposit_wizard_advance_path(step: 'select_parent'), params: { parent_id: '' }
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include(I18n.t('hyku.deposit_wizard.errors.no_parent'))
+        expect(session[:deposit_wizard]['parent_id']).to be_nil
+      end
+
+      it 'redirects select_parent to start when the add path is not active' do
+        get deposit_wizard_step_path(step: 'select_parent')
+
+        expect(response).to redirect_to(deposit_wizard_path)
+      end
+
+      it 'shows the chosen parent and a Back-to-parent link on the type chooser' do
+        parent = FactoryBot.valkyrie_create(:generic_work_resource, title: ['Umbrella'], depositor: admin.user_key)
+        patch deposit_wizard_advance_path(step: 'start'), params: { path: 'add' }
+        patch deposit_wizard_advance_path(step: 'select_parent'), params: { parent_id: parent.id.to_s }
+
+        get deposit_wizard_step_path(step: 'known_type')
+
+        expect(response.body).to include(I18n.t('hyku.deposit_wizard.known_type.adding_to'))
+        expect(response.body).to include('Umbrella')
+        expect(response.body).to include('Generic Work') # the parent's model name
+        expect(response.body).to include(deposit_wizard_step_path(step: 'select_parent'))
+      end
+    end
+
+    context 'with the relationship-first path off' do
+      it 'shows the flat type chooser and no path cards' do
+        get deposit_wizard_path
+
+        expect(response.body).to include(I18n.t('hyku.deposit_wizard.known_type.heading'))
+        expect(response.body).not_to include(I18n.t('hyku.deposit_wizard.start.paths.add.title'))
       end
     end
 
@@ -278,6 +371,21 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
 
           expect(session[:deposit_wizard]['attributes']['title']).to eq(['A guided deposit work'])
           expect(response).to redirect_to(deposit_wizard_step_path(step: 'review'))
+        end
+
+        it 're-renders details with an error when a server-only field fails' do
+          patch deposit_wizard_advance_path(step: 'details'),
+                params: { param_key => { title: ['Bad embed'], creator: ['Ada'],
+                                         video_embed: 'not a url' } }
+
+          expect(response).to have_http_status(:success)
+          expect(response).not_to redirect_to(deposit_wizard_step_path(step: 'review'))
+          expect(response.body).to include(I18n.t('hyku.deposit_wizard.errors.details_invalid'))
+          # The submission is not advanced into wizard state on failure.
+          expect(session[:deposit_wizard]['attributes']).to be_blank
+          # Entered values survive the re-render so the depositor can correct them.
+          expect(response.body).to include('Bad embed')
+          expect(response.body).to include('not a url')
         end
 
         it 're-renders details with an embargo work visibility restored (Back)' do
@@ -632,6 +740,37 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
           post deposit_wizard_commit_path, params: { agreement: '1' }
 
           expect(response).to redirect_to(deposit_wizard_step_path(step: 'done'))
+        end
+      end
+
+      context 'when the deposit fails server-side validation' do
+        it 'stays on review and shows why (form validation, e.g. a bad path)' do
+          allow(Hyrax.config).to receive(:redirects_active?).and_return(true)
+          fill_in_wizard
+
+          # A malformed redirect path is rejected by the form validator.
+          post deposit_wizard_commit_path,
+               params: { param_key => { redirects_attributes: { '0' => { path: '/bad path' } } } }
+
+          expect(response).to have_http_status(:success)
+          expect(response).not_to redirect_to(deposit_wizard_step_path(step: 'done'))
+          expect(response.body).to include(I18n.t('hyku.deposit_wizard.errors.deposit_failed'))
+        end
+
+        it 'shows a friendly message for a commit-only transaction failure' do
+          # A redirect-path collision is only detectable at commit; the create
+          # transaction returns Failure([:redirect_path_collision, ...]).
+          allow_any_instance_of(Hyrax::Action::CreateValkyrieWork)
+            .to receive(:validate).and_return(true)
+          allow_any_instance_of(Hyrax::Action::CreateValkyrieWork)
+            .to receive(:perform).and_return(Dry::Monads::Failure([:redirect_path_collision, 'taken']))
+          fill_in_wizard
+
+          post deposit_wizard_commit_path
+
+          expect(response).to have_http_status(:success)
+          expect(response).not_to redirect_to(deposit_wizard_step_path(step: 'done'))
+          expect(response.body).to include(I18n.t('hyku.deposit_wizard.errors.commit.redirect_path_collision'))
         end
       end
 


### PR DESCRIPTION
Adds a relationship-first start path: when parent-connect is enabled, the start screen offers "new work / add to an existing work", and "add" leads to a parent-picker step that nests the deposited work under the chosen parent. Container installs keep their new/add/standalone cards.

The item-type intro screen is skipped unless a guided or batch sub-flow is configured; the type chooser shows the chosen parent ("Adding as a child of <Type>: <Title>") with Back returning to the picker. The admin-set chooser shows the selected set's description and workflow, updating as the choice changes.

Validation and transaction failures surface a multi-line flash on the details and review steps instead of silently re-rendering, and the details step binds Hyrax's editor JS so location and other autocomplete fields work as on the stock form.

Adds docs/deposit-wizard.md documenting the wizard's architecture, configuration options, feature flags, step flow, and downstream insertion points.
