### PR TITLE
🐛 Fix A/V derivative job queues

### DIFF
--- a/app/jobs/valkyrie_create_derivatives_job_decorator.rb
+++ b/app/jobs/valkyrie_create_derivatives_job_decorator.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# OVERRIDE Hyrax v5.2.0
+# @see ValkyrieCreateLargeDerivativesJob
+module ValkyrieCreateDerivativesJobDecorator
+  # OVERRIDE: Divert audio and video derivative
+  # creation to ValkyrieCreateLargeDerivativesJob.
+  def perform(file_set_id, file_id, *args)
+    return super if is_a?(ValkyrieCreateLargeDerivativesJob)
+
+    file_metadata = Hyrax.custom_queries.find_file_metadata_by(id: file_id)
+    return super unless file_metadata.video? || file_metadata.audio?
+
+    ValkyrieCreateLargeDerivativesJob.perform_later(file_set_id, file_id, *args)
+    true
+  end
+end
+
+ValkyrieCreateDerivativesJob.prepend(ValkyrieCreateDerivativesJobDecorator)

--- a/app/jobs/valkyrie_create_large_derivatives_job.rb
+++ b/app/jobs/valkyrie_create_large_derivatives_job.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# The Valkyrie counterpart to CreateLargeDerivativesJob. Valkyrie file sets get
+# their derivatives via ValkyrieCreateDerivativesJob (enqueued by
+# Hyrax::Listeners::FileListener), which inherits the :default queue. AV
+# derivatives shell ffmpeg and belong on the resource-heavy :auxiliary queue.
+#
+# @see ValkyrieCreateDerivativesJobDecorator
+# @see CreateLargeDerivativesJob
+class ValkyrieCreateLargeDerivativesJob < ValkyrieCreateDerivativesJob
+  queue_as :auxiliary
+end

--- a/spec/jobs/valkyrie_create_derivatives_job_decorator_spec.rb
+++ b/spec/jobs/valkyrie_create_derivatives_job_decorator_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+RSpec.describe ValkyrieCreateDerivativesJobDecorator, type: :job do
+  before { ActiveJob::Base.queue_adapter = :test }
+  after  { clear_enqueued_jobs }
+
+  let(:file_set_id)    { 'fs1' }
+  let(:file_id)        { 'file1' }
+  let(:video_metadata) { Hyrax::FileMetadata.new(mime_type: 'video/mp4') }
+  let(:image_metadata) { Hyrax::FileMetadata.new(mime_type: 'image/png') }
+
+  describe 'ValkyrieCreateDerivativesJob#perform' do
+    context 'with an A/V file' do
+      before do
+        allow(Hyrax.custom_queries).to receive(:find_file_metadata_by).with(id: file_id).and_return(video_metadata)
+      end
+
+      it 'reschedules onto the :auxiliary queue' do
+        expect { ValkyrieCreateDerivativesJob.perform_now(file_set_id, file_id) }
+          .to have_enqueued_job(ValkyrieCreateLargeDerivativesJob).on_queue('auxiliary')
+      end
+
+      it 'does not build derivatives on the default queue' do
+        expect(Hyrax::DerivativeService).not_to receive(:for)
+        ValkyrieCreateDerivativesJob.perform_now(file_set_id, file_id)
+      end
+    end
+
+    context 'with a non-AV file' do
+      before do
+        allow(Hyrax.custom_queries).to receive(:find_file_metadata_by).with(id: file_id).and_return(image_metadata)
+        allow(Hyrax.storage_adapter).to receive(:find_by).and_return(double('stored_file', disk_path: '/tmp/image.png'))
+        allow(Hyrax::DerivativeService).to receive(:for).and_return(instance_double(Hyrax::DerivativeService, create_derivatives: true))
+        allow(Hyrax.query_service).to receive(:find_by).and_return(nil)
+      end
+
+      it 'builds derivatives inline without rescheduling' do
+        expect(ValkyrieCreateLargeDerivativesJob).not_to receive(:perform_later)
+        expect(Hyrax::DerivativeService).to receive(:for).with(image_metadata)
+        ValkyrieCreateDerivativesJob.perform_now(file_set_id, file_id)
+      end
+    end
+  end
+
+  describe ValkyrieCreateLargeDerivativesJob do
+    it 'runs in the :auxiliary queue' do
+      expect { described_class.perform_later(file_set_id, file_id) }
+        .to have_enqueued_job(described_class).on_queue('auxiliary')
+    end
+
+    it 'does not reschedule itself' do
+      allow(Hyrax.config).to receive(:enable_ffmpeg).and_return(true)
+      allow(Hyrax.custom_queries).to receive(:find_file_metadata_by).with(id: file_id).and_return(video_metadata)
+      allow(Hyrax.storage_adapter).to receive(:find_by).and_return(double('stored_file', disk_path: '/tmp/video.mp4'))
+      allow(Hyrax::DerivativeService).to receive(:for).and_return(instance_double(Hyrax::DerivativeService, create_derivatives: true))
+      allow(Hyrax.query_service).to receive(:find_by).and_return(nil)
+
+      expect(described_class).not_to receive(:perform_later)
+      described_class.perform_now(file_set_id, file_id)
+    end
+  end
+end


### PR DESCRIPTION
Previously, the A/V create derivatives job were being sent to the default queue when it should be sent to the auxiliary queue because the ValkyrieCreateDerivativesJob wasn't being decorated to do so while the AF version was.

<img width="1706" height="251" alt="image" src="https://github.com/user-attachments/assets/d56dec7a-9ae3-4473-8739-77e0f18f2cc1" />
