### PR TITLE
🧹 Drop webm as a video derivative

### DIFF
--- a/app/services/hyrax/file_set_derivatives_service_decorator.rb
+++ b/app/services/hyrax/file_set_derivatives_service_decorator.rb
@@ -69,8 +69,6 @@ module Hyrax
       Hydra::Derivatives::VideoDerivatives.create(filename,
                                                   outputs: [{ label: :thumbnail, format: 'jpg',
                                                               url: derivative_url('thumbnail') },
-                                                            { label: 'webm', format: 'webm',
-                                                              url: derivative_url('webm') },
                                                             { label: 'mp4', format: 'mp4',
                                                               url: derivative_url('mp4') }])
     end


### PR DESCRIPTION
Nothing is using webm and it takes a lot of resources to generate.  This commit will remove webm as a derivative format for video files.
