### PR TITLE
Keep scroll position when toggling features

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -37,6 +37,7 @@
 //= require hyku/admin/appearance/default_images
 //= require hyku/admin/appearance/fonts
 //= require hyku/admin/appearance/themes
+//= require hyku/admin/features_scroll
 //= require hyku/groups/per_page
 //= require hyku/groups/add_member
 //= require hyku/google_analytics_settings

--- a/app/assets/javascripts/hyku/admin/features_scroll.js
+++ b/app/assets/javascripts/hyku/admin/features_scroll.js
@@ -1,0 +1,20 @@
+// Preserve scroll position on the admin Features page across a feature-toggle
+// submit. Each toggle is its own form that POSTs and reloads the page, which
+// otherwise jumps the admin back to the top. Scoped to the features page: the
+// early return makes this a no-op everywhere else (it is in the global bundle).
+$(document).on('turbolinks:load', function () {
+  var page = document.querySelector('.flip.row form[action*="feature"]');
+  if (!page) return;
+
+  var KEY = 'adminFeaturesScroll';
+
+  document.addEventListener('submit', function () {
+    sessionStorage.setItem(KEY, window.scrollY);
+  });
+
+  var y = sessionStorage.getItem(KEY);
+  if (y !== null) {
+    window.scrollTo(0, parseInt(y, 10));
+    sessionStorage.removeItem(KEY);
+  }
+});


### PR DESCRIPTION
## Summary

The admin Features page now stays where you were after flipping a feature, instead of jumping back to the top on every toggle.
