### PR TITLE
Deposit wizard integration modes

### DIFF
--- a/app/controllers/hyrax/deposit_wizard_controller.rb
+++ b/app/controllers/hyrax/deposit_wizard_controller.rb
@@ -29,6 +29,7 @@ module Hyrax
     def start
       reset_state
       seed_launch_context
+      assign_admin_sets_for_standard_chooser
       render :start
     end
 
@@ -57,7 +58,7 @@ module Hyrax
     end
 
     def parent_options
-      return head(:forbidden) unless wizard_config.capabilities.parent_connect?
+      return head(:forbidden) unless wizard_config.parent_connect?
 
       # FindWorksSearchBuilder excludes a "current" work by params[:id]; the wizard
       # has no current work, so a blank id excludes nothing.
@@ -139,7 +140,7 @@ module Hyrax
     # Mirror Hyrax's batch-upload guard: redirect to the dashboard rather than
     # exposing the wizard routes when the feature is off.
     def ensure_enabled
-      return if Flipflop.deposit_wizard?
+      return if wizard_config.enabled?
 
       redirect_to hyrax.my_works_path, alert: t('hyku.deposit_wizard.disabled')
     end
@@ -191,12 +192,27 @@ module Hyrax
       }
     end
 
+    # The "switch to the standard deposit form" link reuses Hyrax's
+    # select_work_type_modal, whose admin-set dropdown reads this ivar (mirroring
+    # My::WorksController). Only needed when that link is shown.
+    def assign_admin_sets_for_standard_chooser
+      return unless wizard_config.standard_link?
+
+      @admin_sets_for_select = helpers.available_admin_sets_for_creating_works(ability: current_ability)
+    end
+
     # Seed wizard state from the same context params other entry points pass
     # allowing a potential connection point with other deposit flows.
+    #
+    # A present +parent_id+ / +add_works_to_collection+ is a directed handoff
+    # ("attach a child to THIS work" / "deposit into THIS collection") and always
+    # seeds; it is independent of the +parent_connect+ / +collection_connect+
+    # capabilities, which only govern the optional start/review pickers a depositor
+    # uses to choose a parent or collections themselves.
     def seed_launch_context
-      wizard_state.parent_id = params[:parent_id] if wizard_config.capabilities.parent_connect? && params[:parent_id].present?
+      wizard_state.parent_id = params[:parent_id] if params[:parent_id].present?
 
-      return unless wizard_config.capabilities.collection_connect? && params[:add_works_to_collection].present?
+      return if params[:add_works_to_collection].blank?
 
       wizard_state.attributes = wizard_state.attributes.merge(
         'member_of_collections_attributes' => { '0' => { 'id' => params[:add_works_to_collection] } }

--- a/app/helpers/hyrax/deposit_wizard_helper.rb
+++ b/app/helpers/hyrax/deposit_wizard_helper.rb
@@ -3,6 +3,49 @@
 module Hyrax
   # View helpers for the guided deposit wizard.
   module DepositWizardHelper
+    # These read the deposit-mode config. They are view helpers (not presenter
+    # methods) because the legacy entry points — the works-page buttons, a
+    # collection's add-items button, the themed homepage share buttons — render
+    # outside DepositWizardController and so have no wizard presenter in scope. See
+    # the deposit modes in docs/deposit-wizard.md.
+    def deposit_wizard_config
+      Hyku::DepositWizard.config
+    end
+
+    # True when guided deposit is enabled: the standard "Add new work" entry points
+    # open the guided wizard instead of the standard form.
+    delegate :guided_replaces_standard?, to: :deposit_wizard_config
+
+    # Whether to show the standard-deposit button on the works page (independent of
+    # guided; each enable flag adds its own button).
+    def show_standard_deposit_button?
+      deposit_wizard_config.standard_deposit_button?
+    end
+
+    # Whether to show the guided-deposit button on the works page.
+    def show_guided_deposit_button?
+      deposit_wizard_config.enabled?
+    end
+
+    # A deposit entry point's +[href, data]+ — routes into the guided wizard when
+    # guided has taken over, otherwise the standard target. Used by the non-works-page
+    # entry points (collection add-items, themed homepage share buttons), which flip
+    # to guided when it is enabled. Takes primitives (not a presenter) because those
+    # views expose +many+ / +first_type+ under different presenter method names.
+    def deposit_new_work_target(many:, first_type:)
+      return [main_app.deposit_wizard_path, {}] if guided_replaces_standard?
+
+      standard_deposit_target(many: many, first_type: first_type)
+    end
+
+    # The standard-deposit +[href, data]+, never routed to guided: the select-work
+    # modal when several types are creatable, else a direct link to the only type.
+    def standard_deposit_target(many:, first_type:)
+      return ['#', { behavior: 'select-work', toggle: 'modal', target: '#worktypes-to-create', 'create-type' => 'single' }] if many
+
+      [new_polymorphic_path([main_app, first_type]), {}]
+    end
+
     # Render a human-readable visibility summary for the review step. For open and
     # restricted, this is just the visibility badge. For embargo and lease, the
     # base "visibility" is the transitional state (e.g. "embargo"), so a badge

--- a/app/models/hyku/deposit_wizard/config.rb
+++ b/app/models/hyku/deposit_wizard/config.rb
@@ -6,30 +6,42 @@ module Hyku
     # docs/deposit-wizard.md for the full option reference and insertion points.
     # Downstream apps replace the shared instance via +Hyku::DepositWizard.config+.
     class Config
-      # The parent/collection/sharing capabilities are per-tenant Flipflop
-      # features, deliberately kept separate from static config: a flag must switch
-      # and take effect immediately, so these are read live from Flipflop on every
-      # call — never stored on the config, never overridable in memory. (Static
-      # deployment settings live on Config itself.)
+      # Capabilities read live from Flipflop on every call — never stored on the
+      # config — so toggling a flag takes effect immediately. (Static deployment
+      # settings, including parent/collection connect, live on Config itself.)
       module Capabilities
         module_function
 
-        def parent_connect?
-          Flipflop.deposit_wizard_parent_connect?
+        # The guided wizard is on exactly when enable_guided_deposit is on: this
+        # gates its routes/start page and the dependent pickers. When on, guided also
+        # takes over every non-works-page deposit entry link (see
+        # guided_replaces_standard?).
+        def enabled?
+          Flipflop.enable_guided_deposit?
         end
 
-        def collection_connect?
-          Flipflop.deposit_wizard_collection_connect?
+        # Guided overrides the standard deposit entry links whenever it is enabled;
+        # the entry-point views ask this to decide where their links point.
+        def guided_replaces_standard?
+          enabled?
         end
 
-        def sharing?
-          Flipflop.deposit_wizard_sharing?
+        # The standard-deposit button on the works page — independent of guided.
+        def standard_deposit_button?
+          Flipflop.enable_standard_deposit?
+        end
+
+        # The "switch to the standard deposit form" link on the guided start screen:
+        # offered when both deposit paths are enabled, so a guided depositor can opt
+        # into the standard form the tenant also offers.
+        def standard_link?
+          enabled? && standard_deposit_button?
         end
       end
 
       attr_accessor :container_type, :item_types, :suggestions,
                     :post_commit, :parent_types, :parent_connect_placement
-      attr_writer :flow
+      attr_writer :flow, :parent_connect, :collection_connect, :depositor_sharing
 
       # Only takes effect when parent-connect is enabled.
       # Where the parent-connect capability offers to attach a parent:
@@ -43,6 +55,12 @@ module Hyku
         Capabilities
       end
 
+      # Consumers talk to +config+ as the single surface for every deposit-mode
+      # question, whether it resolves to a live Flipflop capability (delegated here)
+      # or a static setting (parent_connect? / collection_connect? / sharing? below).
+      delegate :enabled?, :guided_replaces_standard?, :standard_deposit_button?, :standard_link?,
+               to: :capabilities
+
       def initialize
         @container_type = nil
         @item_types = nil
@@ -50,11 +68,31 @@ module Hyku
         @post_commit = nil
         @parent_types = nil
         @parent_connect_placement = :review
+        @parent_connect = true
+        @collection_connect = true
+        @depositor_sharing = true
         yield self if block_given?
       end
 
       def container?
         container_type.present?
+      end
+
+      # Whether the wizard offers a parent picker / a collection picker. Static
+      # deployment settings (default on), not Flipflop capabilities — an app opts
+      # out in its initializer.
+      def parent_connect?
+        @parent_connect
+      end
+
+      def collection_connect?
+        @collection_connect
+      end
+
+      # Whether the wizard offers the sharing (per-user/group access) section on the
+      # review step. A static setting (default on), gated by the wizard being enabled.
+      def sharing?
+        enabled? && @depositor_sharing
       end
 
       # The ordered wizard step sequence (a Flow). Downstream apps reshape the
@@ -72,13 +110,13 @@ module Hyku
       # The up-front "add to an existing work" path is offered when parent-connect
       # is on and its placement includes the start edge.
       def parent_connect_on_start?
-        capabilities.parent_connect? && %i[both start].include?(parent_connect_placement)
+        parent_connect? && %i[both start].include?(parent_connect_placement)
       end
 
       # The review-step parent section is offered when parent-connect is on and its
       # placement includes the review edge.
       def parent_connect_on_review?
-        capabilities.parent_connect? && %i[both review].include?(parent_connect_placement)
+        parent_connect? && %i[both review].include?(parent_connect_placement)
       end
 
       def redirects_available?(form = nil)

--- a/app/presenters/hyku/deposit_wizard/presenter.rb
+++ b/app/presenters/hyku/deposit_wizard/presenter.rb
@@ -33,6 +33,13 @@ module Hyku
         authorized.select { |model| allowed.include?(model.to_s) }
       end
 
+      # Hyrax's own work-type chooser presenter, backing the shared
+      # select_work_type_modal for the wizard-primary "switch to the classic deposit
+      # form" escape link exactly as the classic works page does.
+      def create_work_presenter
+        @create_work_presenter ||= Hyrax::SelectTypeListPresenter.new(current_user)
+      end
+
       # The stepper rail rows ({n:, label:, icon:}) for the current state, built
       # from the flow's rail (one entry per distinct visible rail_key).
       def item_stepper_steps
@@ -539,8 +546,19 @@ module Hyku
                                                 messages: form_error_messages(work_form))
         end
 
-        state.attributes = work_params.to_unsafe_h
+        # The details form owns the work fields, but not the launch-seeded extras
+        # (a collection carried in by the "deposit into THIS collection" handoff).
+        # Replacing wholesale would drop those before commit, so re-apply any that
+        # the form did not submit.
+        submitted = work_params.to_unsafe_h
+        state.attributes = preserved_launch_extras.merge(submitted)
         Transition.advance(next_step('details'))
+      end
+
+      # Launch-seeded attributes the details form does not manage (today: collection
+      # membership from the handoff).
+      def preserved_launch_extras
+        state.attributes.slice('member_of_collections_attributes')
       end
 
       def advance_from_file_meta
@@ -552,8 +570,8 @@ module Hyku
 
       def enabled_extra_attribute_keys
         keys = []
-        keys << 'member_of_collections_attributes' if config.capabilities.collection_connect?
-        keys << 'permissions_attributes' if config.capabilities.sharing?
+        keys << 'member_of_collections_attributes' if config.collection_connect?
+        keys << 'permissions_attributes' if config.sharing?
         keys.push('redirects_attributes', 'redirects_display_url_index') if config.redirects_available?
         keys
       end

--- a/app/views/hyrax/base/_attach_child_control.html.erb
+++ b/app/views/hyrax/base/_attach_child_control.html.erb
@@ -1,0 +1,22 @@
+<%# The work show page's "Attach a child work" control, shared by the base and
+    themed _show_actions partials. In wizard mode it is a single link, not the
+    per-concern dropdown: the wizard picks the child type in its own type step, so a
+    type dropdown here would only be ignored. %>
+<% if guided_replaces_standard? %>
+  <%= link_to t('hyrax.base.show_actions.attach_child'),
+              main_app.deposit_wizard_path(parent_id: presenter.id),
+              class: 'btn btn-secondary' %>
+<% else %>
+  <div class="btn-group">
+    <button type="button" class="btn btn-secondary dropdown-toggle" id="dropdown-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      <%= t('hyrax.base.show_actions.attach_child') %>
+    </button>
+    <div class="dropdown-menu">
+      <% presenter.valid_child_concerns.each do |concern| %>
+        <%= link_to "Attach #{concern.human_readable_type}",
+                    polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular.to_sym], parent_id: presenter.id),
+                    class: 'dropdown-item' %>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -32,16 +32,7 @@
           <%= link_to t("hyrax.file_manager.link_text"), polymorphic_path([main_app, :file_manager, presenter]), class: 'btn btn-secondary' %>
       <% end %>
       <% if presenter.valid_child_concerns.length > 0 %>
-        <div class="btn-group">
-          <button type="button" class="btn btn-secondary dropdown-toggle" type="button" id="dropdown-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <%= t('.attach_child') %>
-          </button>
-          <div class="dropdown-menu">
-            <% presenter.valid_child_concerns.each do |concern| %>
-              <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular.to_sym], parent_id: presenter.id), class: "dropdown-item" %>
-            <% end %>
-          </div>
-        </div>
+        <%= render 'hyrax/base/attach_child_control', presenter: presenter %>
       <% end %>
       <%# OVERRIDE to validate delete permission %>
       <% if current_ability.can?(:delete, presenter.solr_document) %>

--- a/app/views/hyrax/dashboard/collections/_show_add_items_actions.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_add_items_actions.html.erb
@@ -4,7 +4,12 @@
   <%# OVERRIDE: add check for :manage_items_in_collection permission %>
   <% if can?(:deposit, presenter.solr_document) || can?(:manage_items_in_collection, presenter.solr_document) %>
     <div>
-      <% if @presenter.create_many_work_types? %>
+      <% if guided_replaces_standard? %>
+        <%= link_to t('hyrax.collection.actions.add_new_work.label'),
+                    main_app.deposit_wizard_path(add_works_to_collection: presenter.id),
+                    title: t('hyrax.collection.actions.add_new_work.desc'),
+                    class: 'btn btn-primary deposit-new-work-through-collection' %>
+      <% elsif @presenter.create_many_work_types? %>
         <%= link_to t('hyrax.collection.actions.add_new_work.label'),
                     '#',
                     title: t('hyrax.collection.actions.add_new_work.desc'),

--- a/app/views/hyrax/deposit_wizard/_standard_deposit_link.html.erb
+++ b/app/views/hyrax/deposit_wizard/_standard_deposit_link.html.erb
@@ -1,0 +1,22 @@
+<%# Opt-out link from the guided start screen to the standard single-page deposit.
+    Rendered by start.html.erb only when +config.standard_link?+ (both guided and
+    standard deposit enabled). To remove the feature entirely, delete: this file, its
+    render line in start.html.erb,
+    DepositWizardController#assign_admin_sets_for_standard_chooser (and its call),
+    Presenter#create_work_presenter, Capabilities#standard_link?, and the
+    start.standard_link locale keys.
+
+    Reproduces the standard deposit type-selection UX: several creatable types open
+    Hyrax's select_work_type_modal; a single type links straight to its new-work
+    form. %>
+<% create_work_presenter = deposit_wizard.create_work_presenter %>
+<p class="deposit-wizard__standard-link">
+  <% if create_work_presenter.many? %>
+    <%= link_to t('hyku.deposit_wizard.start.standard_link'), '#',
+                data: { behavior: 'select-work', toggle: 'modal', target: '#worktypes-to-create', 'create-type' => 'single' } %>
+  <% elsif (standard_type = create_work_presenter.first_model) %>
+    <%= link_to t('hyku.deposit_wizard.start.standard_link'),
+                new_polymorphic_path([main_app, standard_type]) %>
+  <% end %>
+</p>
+<%= render '/shared/select_work_type_modal', create_work_presenter: create_work_presenter if create_work_presenter.many? %>

--- a/app/views/hyrax/deposit_wizard/review.html.erb
+++ b/app/views/hyrax/deposit_wizard/review.html.erb
@@ -9,8 +9,8 @@
   <%= form_tag main_app.deposit_wizard_commit_path, method: :post, class: 'deposit-wizard__commit-form',
                data: { 'extras-url': main_app.deposit_wizard_extras_path } do %>
     <%= render 'extras_parent' if deposit_wizard.config.parent_connect_on_review? %>
-    <%= render 'extras_collection' if deposit_wizard.config.capabilities.collection_connect? %>
-    <%= render 'extras_sharing' if deposit_wizard.config.capabilities.sharing? %>
+    <%= render 'extras_collection' if deposit_wizard.config.collection_connect? %>
+    <%= render 'extras_sharing' if deposit_wizard.config.sharing? %>
     <%= render 'extras_redirects' if deposit_wizard.config.redirects_available?(deposit_wizard.work_form) %>
 
     <%= render 'review_agreement' %>

--- a/app/views/hyrax/deposit_wizard/start.html.erb
+++ b/app/views/hyrax/deposit_wizard/start.html.erb
@@ -36,4 +36,6 @@
       </div>
     <% end %>
   <% end %>
+
+  <%= render 'standard_deposit_link' if deposit_wizard.config.standard_link? %>
 </div>

--- a/app/views/hyrax/homepage/index.html.erb
+++ b/app/views/hyrax/homepage/index.html.erb
@@ -1,0 +1,31 @@
+<%# OVERRIDE Hyrax v5.2.0 route the signed-in "share your work" button into the
+    guided deposit wizard when it replaces the legacy deposit (deposit_new_work_target).
+    TODO: upstream, extract the share-your-work button into its own partial so we can
+    override just that partial instead of the whole index — the rest of this file is
+    mirrored from upstream only to reach the one button and will drift on a gem bump. %>
+<% provide :page_title, application_name %>
+
+<% if @presenter.display_share_button? && !Flipflop.read_only? %>
+<div class="home-share-work text-center">
+  <% if signed_in? %>
+    <%# OVERRIDE: single share button whose target the deposit mode resolves. %>
+    <% href, data = deposit_new_work_target(many: @presenter.create_many_work_types?,
+                                            first_type: @presenter.first_work_type) %>
+    <%= link_to href, class: "btn btn-primary btn-lg", data: data do %>
+      <i class="fa fa-upload" aria-hidden="true"></i> <%= t('hyrax.share_button') %>
+    <% end %>
+  <% else %>
+    <%= link_to hyrax.my_works_path,
+      class: "btn btn-primary btn-lg" do %>
+      <i class="fa fa-upload" aria-hidden="true"></i> <%= t('hyrax.share_button') %>
+    <% end %>
+  <% end %>
+  <p class="terms-of-use"><%= link_to t(:'hyrax.pages.tabs.terms_page'), hyrax.terms_path %></p>
+</div>
+<% end %>
+
+<div class="row home-content">
+  <%= render 'home_content' %>
+</div>
+
+<%= render '/shared/select_work_type_modal', create_work_presenter: @presenter.create_work_presenter if @presenter.draw_select_work_modal? %>

--- a/app/views/hyrax/my/works/_deposit_actions.html.erb
+++ b/app/views/hyrax/my/works/_deposit_actions.html.erb
@@ -1,43 +1,38 @@
-<%# Works-page deposit buttons: the stock "Add new work"/batch buttons (mirrored
-    from Hyrax's my/works/index) plus the guided deposit wizard when enabled. %>
+<%# Works-page deposit buttons. Guided and standard are independent: each enable
+    flag adds its own button (guided when enable_guided_deposit, standard when
+    enable_standard_deposit). The standard "Add new work" button always targets the
+    standard form; the batch upload path is a separate bulk workflow, unaffected. %>
 <% if current_ability.can_create_any_work? %>
   <div class="float-right">
-    <% if Flipflop.deposit_wizard? %>
+    <% if show_guided_deposit_button? %>
       <%= link_to t('hyku.deposit_wizard.button'),
                   main_app.deposit_wizard_path,
                   id: 'guided-deposit-button',
                   class: 'btn btn-primary' %>
     <% end %>
-    <% if @create_work_presenter.many? %>
-      <% if Flipflop.batch_upload? %>
+
+    <% if Flipflop.batch_upload? %>
+      <% if @create_work_presenter.many? %>
         <%= link_to(
               t(:'helpers.action.batch.new'),
               '#',
               data: { behavior: "select-work", toggle: 'modal', target: "#worktypes-to-create", 'create-type' => 'batch' },
               class: 'btn btn-primary'
             ) %>
-      <% end %>
-      <%= link_to(
-            t(:'helpers.action.work.new'),
-            '#',
-            data: { behavior: "select-work", toggle: 'modal', target: "#worktypes-to-create", 'create-type' => 'single' },
-            id: 'add-new-work-button',
-            class: 'btn btn-primary'
-          ) %>
-    <% else # simple link to the first work type %>
-      <% if Flipflop.batch_upload? %>
+      <% else %>
         <%= link_to(
-            t(:'helpers.action.batch.new'),
-            hyrax.new_batch_upload_path(payload_concern: @create_work_presenter.first_model),
-            class: 'btn btn-primary'
+              t(:'helpers.action.batch.new'),
+              hyrax.new_batch_upload_path(payload_concern: @create_work_presenter.first_model),
+              class: 'btn btn-primary'
             ) %>
       <% end %>
-      <%= link_to(
-            t(:'helpers.action.work.new'),
-            new_polymorphic_path([main_app, @create_work_presenter.first_model]),
-            id: 'add-new-work-button',
-            class: 'btn btn-primary'
-          ) %>
+    <% end %>
+
+    <% if show_standard_deposit_button? %>
+      <% href, data = standard_deposit_target(many: @create_work_presenter.many?,
+                                              first_type: @create_work_presenter.first_model) %>
+      <%= link_to t(:'helpers.action.work.new'), href,
+                  id: 'add-new-work-button', class: 'btn btn-primary', data: data %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/themes/community_show/hyrax/base/_show_actions.html.erb
+++ b/app/views/themes/community_show/hyrax/base/_show_actions.html.erb
@@ -12,16 +12,7 @@
           <%= link_to t('hyrax.file_manager.link_text'), polymorphic_path([main_app, :file_manager, presenter]), class: 'btn btn-secondary' %>
       <% end %>
       <% if presenter.valid_child_concerns.length > 0 %>
-        <div class="btn-group">
-          <button type="button" class="btn btn-secondary dropdown-toggle" id="dropdown-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <%= t('.attach_child') %>
-          </button>
-          <div class="dropdown-menu">
-            <% presenter.valid_child_concerns.each do |concern| %>
-              <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular.to_sym], parent_id: presenter.id), class: 'dropdown-item' %>
-            <% end %>
-          </div>
-        </div>
+        <%= render 'hyrax/base/attach_child_control', presenter: presenter %>
       <% end %>
       <%# OVERRIDE to validate delete permission %>
       <% if current_ability.can?(:delete, presenter.solr_document) %>

--- a/app/views/themes/cultural_repository/layouts/_share_your_work_row.html.erb
+++ b/app/views/themes/cultural_repository/layouts/_share_your_work_row.html.erb
@@ -2,23 +2,13 @@
 <div class="home_share_work row">
   <div class="col-sm-12 text-center">
     <% if signed_in? %>
-      <% if @presenter.create_many_work_types? %>
-        <%= link_to '#',
-          class: "btn btn-secondary btn-sm mt-2",
-          data: { behavior: 'select-work', target: '#worktypes-to-create', 'create-type' => 'single' } do %>
-          <i class="fa fa-upload" aria-hidden="true"></i> <%= t('hyrax.share_button') %>
-        <% end %>
-      <% else # simple link to the first work type %>
-        <%= link_to new_polymorphic_path([main_app, @presenter.first_work_type]),
-              class: "btn btn-secondary btn-sm mt-2" do %>
-          <i class="fa fa-upload" aria-hidden="true"></i> <%= t('hyrax.share_button') %>
-        <% end %>
-      <% end %>
+      <% href, data = deposit_new_work_target(many: @presenter.create_many_work_types?,
+                                              first_type: @presenter.first_work_type) %>
     <% else %>
-      <%= link_to hyrax.my_works_path,
-        class: "btn btn-secondary btn-sm mt-2" do %>
-        <i class="fa fa-upload" aria-hidden="true"></i> <%= t('hyrax.share_button') %>
-      <% end %>
+      <% href, data = hyrax.my_works_path, {} %>
+    <% end %>
+    <%= link_to href, class: "btn btn-secondary btn-sm mt-2", data: data do %>
+      <i class="fa fa-upload" aria-hidden="true"></i> <%= t('hyrax.share_button') %>
     <% end %>
     <p><%= link_to t(:'hyrax.pages.tabs.terms_page'), hyrax.terms_path, class: 'cr_terms'  %></p>
   </div>

--- a/app/views/themes/cultural_show/hyrax/base/_show_actions.html.erb
+++ b/app/views/themes/cultural_show/hyrax/base/_show_actions.html.erb
@@ -12,16 +12,7 @@
           <%= link_to t("hyrax.file_manager.link_text"), polymorphic_path([main_app, :file_manager, presenter]), class: 'btn btn-secondary' %>
       <% end %>
       <% if presenter.valid_child_concerns.length > 0 %>
-        <div class="btn-group">
-          <button type="button" class="btn btn-secondary dropdown-toggle" type="button" id="dropdown-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <%= t('.attach_child') %>
-          </button>
-          <div class="dropdown-menu">
-            <% presenter.valid_child_concerns.each do |concern| %>
-              <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular.to_sym], parent_id: presenter.id), class: "dropdown-item" %>
-            <% end %>
-          </div>
-        </div>
+        <%= render 'hyrax/base/attach_child_control', presenter: presenter %>
       <% end %>
       <%# OVERRIDE to validate delete permission %>
       <% if current_ability.can?(:delete, presenter.solr_document) %>

--- a/app/views/themes/institutional_repository/layouts/homepage.html.erb
+++ b/app/views/themes/institutional_repository/layouts/homepage.html.erb
@@ -14,23 +14,13 @@
             <div class="institutional-repository home_share_work row">
               <div class="col-12 text-center">
                 <% if signed_in? %>
-                  <% if @presenter.create_many_work_types? %>
-                    <%= link_to '#',
-                      class: "btn btn-primary btn-lg",
-                      data: { behavior: 'select-work', target: '#worktypes-to-create', 'create-type' => 'single' } do %>
-                      <i class="fa fa-upload" aria-hidden="true"></i> <%= t('hyrax.share_button') %>
-                    <% end %>
-                  <% else # simple link to the first work type %>
-                    <%= link_to new_polymorphic_path([main_app, @presenter.first_work_type]),
-                          class: 'btn btn-primary' do %>
-                      <i class="fa fa-upload" aria-hidden="true"></i> <%= t('hyrax.share_button') %>
-                    <% end %>
-                  <% end %>
+                  <% href, data = deposit_new_work_target(many: @presenter.create_many_work_types?,
+                                                          first_type: @presenter.first_work_type) %>
                 <% else %>
-                  <%= link_to hyrax.my_works_path,
-                    class: "btn btn-primary btn-lg" do %>
-                    <i class="fa fa-upload" aria-hidden="true"></i> <%= t('hyrax.share_button') %>
-                  <% end %>
+                  <% href, data = hyrax.my_works_path, {} %>
+                <% end %>
+                <%= link_to href, class: "btn btn-primary btn-lg", data: data do %>
+                  <i class="fa fa-upload" aria-hidden="true"></i> <%= t('hyrax.share_button') %>
                 <% end %>
                 <p><%= link_to t(:'hyrax.pages.tabs.terms_page'), hyrax.terms_path %></p>
               </div>

--- a/app/views/themes/neutral_repository/layouts/_share_your_work_row.html.erb
+++ b/app/views/themes/neutral_repository/layouts/_share_your_work_row.html.erb
@@ -2,23 +2,13 @@
 <div class="home_share_work row">
   <div class="col-sm-12 text-center">
     <% if signed_in? %>
-      <% if @presenter.create_many_work_types? %>
-        <%= link_to '#',
-          class: "btn btn-secondary btn-sm mt-20",
-          data: { behavior: 'select-work', target: '#worktypes-to-create', 'create-type' => 'single' } do %>
-          <i class="fa fa-upload" aria-hidden="true"></i> <%= t('hyrax.share_button') %>
-        <% end %>
-      <% else # simple link to the first work type %>
-        <%= link_to new_polymorphic_path([main_app, @presenter.first_work_type]),
-              class: "btn btn-secondary btn-sm mt-20" do %>
-          <i class="fa fa-upload" aria-hidden="true"></i> <%= t('hyrax.share_button') %>
-        <% end %>
-      <% end %>
+      <% href, data = deposit_new_work_target(many: @presenter.create_many_work_types?,
+                                              first_type: @presenter.first_work_type) %>
     <% else %>
-      <%= link_to hyrax.my_works_path,
-        class: "btn btn-secondary btn-sm mt-20" do %>
-        <i class="fa fa-upload" aria-hidden="true"></i> <%= t('hyrax.share_button') %>
-      <% end %>
+      <% href, data = hyrax.my_works_path, {} %>
+    <% end %>
+    <%= link_to href, class: "btn btn-secondary btn-sm mt-20", data: data do %>
+      <i class="fa fa-upload" aria-hidden="true"></i> <%= t('hyrax.share_button') %>
     <% end %>
     <p><%= link_to t(:'hyrax.pages.tabs.terms_page'), hyrax.terms_path, class: 'cr_terms'  %></p>
   </div>

--- a/app/views/themes/scholarly_show/hyrax/base/_show_actions.html.erb
+++ b/app/views/themes/scholarly_show/hyrax/base/_show_actions.html.erb
@@ -12,16 +12,7 @@
           <%= link_to t("hyrax.file_manager.link_text"), polymorphic_path([main_app, :file_manager, presenter]), class: 'btn btn-secondary' %>
       <% end %>
       <% if presenter.valid_child_concerns.length > 0 %>
-        <div class="btn-group">
-          <button type="button" class="btn btn-secondary dropdown-toggle" type="button" id="dropdown-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <%= t('.attach_child') %>
-          </button>
-          <div class="dropdown-menu">
-            <% presenter.valid_child_concerns.each do |concern| %>
-              <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular.to_sym], parent_id: presenter.id), class: "dropdown-item" %>
-            <% end %>
-          </div>
-        </div>
+        <%= render 'hyrax/base/attach_child_control', presenter: presenter %>
       <% end %>
       <%# OVERRIDE to validate delete permission %>
       <% if current_ability.can?(:delete, presenter.solr_document) %>

--- a/config/features.rb
+++ b/config/features.rb
@@ -17,10 +17,6 @@ Flipflop.configure do
           default: true,
           description: "Shows the Featured Researcher tab on the homepage."
 
-  feature :show_share_button,
-          default: true,
-          description: "Shows the 'Share Your Work' button on the homepage."
-
   feature :show_featured_works,
           default: true,
           description: "Shows the Featured Works tab on the homepage."
@@ -56,23 +52,18 @@ Flipflop.configure do
             description: "Enable the guided import workflow."
   end
 
-  group :deposit_wizard do
-    feature :deposit_wizard,
-            default: false,
-            description: "Enable the guided deposit wizard for creating works. Additional features are " \
-                         "available to connect works to parent works, collections, and sharing. If the " \
-                         "redirects feature is enabled, it will also be active for the deposit wizard."
+  group :deposit_features do
+    feature :show_share_button,
+          default: true,
+          description: "Shows the 'Share Your Work' button on the homepage for users who can deposit."
 
-    feature :deposit_wizard_parent_connect,
+    feature :enable_guided_deposit,
             default: false,
-            description: "In the deposit wizard, let depositors add the work to a parent work. Requires the deposit wizard."
+            description: "Enables a button on the dashboard works page for guided deposit, and uses guided deposit for all deposit entry points."
 
-    feature :deposit_wizard_collection_connect,
-            default: false,
-            description: "In the deposit wizard, let depositors add the work to a collection. Requires the deposit wizard."
-
-    feature :deposit_wizard_sharing,
-            default: false,
-            description: "In the deposit wizard, let depositors share the work with specific users and groups. Requires the deposit wizard."
+    feature :enable_standard_deposit,
+            default: true,
+            description: "Enables the standard 'Add new work' button on the dashboard works page. When guided " \
+                         "deposit is also enabled, the guided start page offers a 'switch to the standard deposit form' link."
   end
 end

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -297,6 +297,7 @@ de:
         label: Werke suchen
       start:
         heading: Was möchten Sie einreichen?
+        standard_link: Zum Standard-Einreichungsformular wechseln
         subtext: Dieser geführte Ablauf begleitet Sie Schritt für Schritt bei der Einreichung Ihres Werks.
         paths:
           add:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -158,6 +158,7 @@ en:
         label: Search works
       start:
         heading: What would you like to deposit?
+        standard_link: Switch to the standard deposit form
         subtext: This guided flow walks you through depositing your work step by step.
         paths:
           add:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -298,6 +298,7 @@ es:
         label: Buscar obras
       start:
         heading: ¿Qué te gustaría depositar?
+        standard_link: Cambiar al formulario de depósito estándar
         subtext: Este flujo guiado te acompaña paso a paso en el depósito de tu obra.
         paths:
           add:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -298,6 +298,7 @@ fr:
         label: Rechercher des œuvres
       start:
         heading: Que souhaitez-vous déposer ?
+        standard_link: Passer au formulaire de dépôt standard
         subtext: Ce flux guidé vous accompagne étape par étape dans le dépôt de votre œuvre.
         paths:
           add:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -298,6 +298,7 @@ it:
         label: Cerca opere
       start:
         heading: Cosa vorresti depositare?
+        standard_link: Passa al modulo di deposito standard
         subtext: Questo flusso guidato ti accompagna passo dopo passo nel deposito della tua opera.
         paths:
           add:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -180,6 +180,7 @@ pt-BR:
         label: Pesquisar obras
       start:
         heading: O que você gostaria de depositar?
+        standard_link: Mudar para o formulário de depósito padrão
         subtext: Este fluxo guiado acompanha você passo a passo no depósito da sua obra.
         paths:
           add:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -298,6 +298,7 @@ zh:
         label: 搜索作品
       start:
         heading: 您想存缴什么？
+        standard_link: 切换到标准存缴表单
         subtext: 此引导流程将逐步带您完成作品的存缴。
         paths:
           add:

--- a/docs/deposit-wizard.md
+++ b/docs/deposit-wizard.md
@@ -6,14 +6,15 @@ upload, metadata, per-file metadata, and review, then commits through the same
 public Hyrax create transaction — so a work created by the wizard is
 indistinguishable from one created by the stock form.
 
-The wizard is additive: the stock deposit form is untouched, and the wizard is
-off by default behind a feature flag. It is designed as a **generic Hyku
-feature** with **seams a downstream application** can configure and extend
-without forking.
+The wizard is off by default (guided deposit disabled, standard deposit enabled);
+a tenant turns it on per the [Enabling](#enabling) flags, and it can run alongside
+or in place of the standard form. It is designed as a **generic Hyku feature** with
+**seams a downstream application** can configure and extend without forking.
 
 ## Contents
 
 - [Enabling](#enabling)
+- [Deposit modes](#deposit-modes)
 - [Architecture](#architecture)
 - [Steps and the Flow](#steps-and-the-flow)
   - [The progress rail](#the-progress-rail)
@@ -33,23 +34,58 @@ without forking.
 
 ## Enabling
 
-The wizard and its optional capabilities are per-tenant Flipflop features
-(declared in `config/features.rb`, group `:deposit_wizard`):
+Two per-tenant Flipflop features turn each deposit path on (declared in
+`config/features.rb`, group `:deposit_features`):
 
-| Feature | Effect |
-| --- | --- |
-| `deposit_wizard` | Master switch. When off, the wizard routes redirect to the dashboard and the "Guided Deposit" button is hidden. |
-| `deposit_wizard_parent_connect` | Lets a depositor nest the work under a parent work. Where the offer appears — the start-screen "add to an existing work" path, the review-step section, or both — is set by `parent_connect_placement` (see Configuration). |
-| `deposit_wizard_collection_connect` | Lets a depositor add the work to one or more collections on the review step. |
-| `deposit_wizard_sharing` | Lets a depositor grant per-user / per-group access on the review step. |
+| Feature | Default | Effect |
+| --- | :---: | --- |
+| `enable_guided_deposit` | off | Adds a Guided Deposit button to the works page, and overrides every other deposit entry point (homepage, show-page "attach child", collection page) to the guided wizard. |
+| `enable_standard_deposit` | on | Adds a Standard Deposit ("Add new work") button to the works page, and routes deposit entry links to the standard form — unless `enable_guided_deposit` is also on, in which case guided takes precedence for the links. When both are enabled, the guided start page also offers a "switch to the standard deposit form" link. |
 
-Vanity-URL redirects on the review step are gated separately by Hyrax's own
-`redirects_active?` (its boot flag plus `Flipflop.redirects?`) **and** the work's
-schema carrying a `redirects` attribute — not by a wizard-specific flag.
+The two enable flags are independent: each adds its own works-page button. The
+wizard's parent and collection pickers and the sharing section are **not** flags —
+they are config settings (`c.parent_connect` / `c.collection_connect` /
+`c.depositor_sharing`, all default on); see [Configuration](#configuration).
+Vanity-URL redirects on the review step are gated by Hyrax's own `redirects_active?`
+**and** the work's schema carrying a `redirects` attribute — not a wizard flag.
 
-The dashboard entry point is a "Guided Deposit" button rendered in
-`app/views/hyrax/my/works/_deposit_actions.html.erb`, shown only when
-`Flipflop.deposit_wizard?` is true.
+## Deposit modes
+
+All deposit questions are answered by `Hyku::DepositWizard.config` (which delegates
+the live-flag capabilities to `config.capabilities`); the entry-point views — which
+render outside `DepositWizardController` — reach it through `Hyrax::DepositWizardHelper`.
+
+**Which works-page buttons show** — each enable flag independently adds its button:
+
+| `enable_guided_deposit` | `enable_standard_deposit` | Works-page buttons | Entry links elsewhere |
+| :---: | :---: | --- | --- |
+| off | on (default) | Standard only | standard |
+| on | off | Guided only | guided |
+| on | on | Guided **and** Standard | guided (guided wins) |
+| off | off | none | standard |
+
+**Entry-link routing** — `config.guided_replaces_standard?` (`== enable_guided_deposit?`,
+read by the `guided_replaces_standard?` helper) decides whether the non-works-page
+entry points route to the guided wizard: a collection's "Add new work" button (carrying
+`add_works_to_collection`), the work show page's "Attach a child work" control
+(carrying `parent_id`; the child type is chosen in the wizard), and the homepage
+"share your work" buttons (default `hyrax/homepage/index` and the three themed
+homepages). The batch-upload path is unaffected, and the standard `new_polymorphic`
+route is never disabled.
+
+**The standard-form link on the guided start screen** —
+`config.standard_link?` (`== enable_guided_deposit? && enable_standard_deposit?`)
+renders the `_standard_deposit_link` partial, a "switch to the standard deposit form"
+link for all users — offered when the tenant enables both deposit paths, so a guided
+depositor can opt into the standard form. It reproduces the standard type-selection
+UX (chooser modal when several types are creatable, a direct link otherwise).
+
+A directed handoff — `add_works_to_collection` from a collection, or `parent_id`
+from the "Attach a child work" control — always seeds that association into the
+wizard, independent of the `collection_connect` / `parent_connect` config settings.
+Those settings govern only the optional review/start pickers a depositor uses to
+choose a collection or parent themselves; a handoff is an explicit directive, so it
+is honored regardless.
 
 ## Architecture
 
@@ -194,22 +230,27 @@ reset it with `Hyku::DepositWizard.reset_config!`.
 | `container_type` | `nil` | The container work type (class or class name). Presence makes the start screen a new/add/standalone path chooser (`container?`). `nil` is a flat wizard. |
 | `item_types` | `nil` | Restricts the work types the type chooser offers, intersected with what the user is authorized to deposit (it narrows, never widens). `nil` offers all authorized types. |
 | `parent_types` | `nil` | Work types eligible as parents in the typeahead. `nil` falls back to the tenant's available work types. |
-| `parent_connect_placement` | `:review` | Where parent-connect offers to attach a parent: `:both`, `:start` (only the up-front path), `:review` (only the review section), or `:none`. Only takes effect when parent-connect is enabled. |
+| `parent_connect` | `true` | Whether the wizard offers a parent picker. |
+| `collection_connect` | `true` | Whether the wizard offers a collection picker on the review step. |
+| `depositor_sharing` | `true` | Whether the wizard offers the per-user/group sharing section on the review step. |
+| `parent_connect_placement` | `:review` | Where parent-connect offers to attach a parent: `:both`, `:start` (only the up-front path), `:review` (only the review section), or `:none`. Only takes effect when `parent_connect` is on. |
 | `suggestions` | `{}` | A guided sub-flow map (uploaded-file kind → offered sub-types) for the `item_start` step. When present (`item_start_offers_choice?`), the `item_start` step is shown; empty skips straight to the work-type chooser. |
 | `flow` | `Flow.default` | The ordered step sequence (a `Hyku::DepositWizard::Flow`). Assign a reshaped flow to add, remove, or reorder steps (see [Step flow](#step-flow)). |
 | `post_commit` | `nil` | Callable run after a successful commit, receiving `(work, wizard_state)` — the hook for downstream nesting/fan-out. |
 
-The parent/collection/sharing capabilities are **not** config options — they are
-the per-tenant Flipflop features above, read **live** on every request through
-`config.capabilities` (`parent_connect?` / `collection_connect?` / `sharing?`), a
-small module nested in `Config`. They are never stored on the config and cannot be
-overridden in memory, so toggling a flag takes effect immediately. Static
-deployment settings (the table above) live on `Config` itself; the capability
-on/off is always the flag. `parent_connect_placement` (static) then decides which
-of the two parent-connect edges appears when the flag is on
-(`parent_connect_on_start?` / `parent_connect_on_review?`).
-`redirects_available?(form)` combines Hyrax's redirects gate with a check that the
-work's schema carries `redirects`.
+Parent connect, collection connect, and depositor sharing are static config settings
+on `Config` (`parent_connect` / `collection_connect` / `depositor_sharing`, default
+on); `parent_connect_placement` then decides which of the two parent-connect edges
+appears when `parent_connect` is on (`parent_connect_on_start?` /
+`parent_connect_on_review?`). `sharing?` combines the `depositor_sharing` setting
+with the wizard being enabled.
+
+The deposit-mode capabilities read **live** from Flipflop on every request through
+`config.capabilities` (a small module nested in `Config`, surfaced on `config` by
+delegation), so toggling a flag takes effect immediately: `enabled?`,
+`guided_replaces_standard?`, `standard_deposit_button?`, and `standard_link?` (see
+[Deposit modes](#deposit-modes)). `redirects_available?(form)` combines Hyrax's
+redirects gate with a check that the work's schema carries `redirects`.
 
 ## Admin-set assistance
 
@@ -233,8 +274,12 @@ which applies the set's contexts.
 
 ## Insertion points for a downstream app
 
-Everything a downstream application needs to customize is a seam; no Hyrax or
-Hyku file is overridden, prepended, or decorated.
+Everything a downstream application needs to customize is a seam: it configures the
+wizard through the swappable `Hyku::DepositWizard.config` singleton and its own
+view-path prepends, without forking or patching Hyku. (Hyku's own integration does
+override a few Hyrax views — e.g. `hyrax/homepage/index` and the themed
+`_show_actions` / share-row partials — to route the deposit entry points; those are
+platform-level overrides, not something a downstream app needs to touch.)
 
 **Where this code goes.** `Hyku::DepositWizard.config` is a swappable
 module-level singleton (`app/models/hyku/deposit_wizard.rb`); the wizard reads
@@ -381,13 +426,17 @@ end
 
 The persistence layer already honors a top-level `parent_id` (seeded by the "add"
 path or by launch context) through Hyrax's `add_to_parent` step, so nesting under
-a parent needs no extra wiring — set `parent_types` and enable the
-`deposit_wizard_parent_connect` feature.
+a parent needs no extra wiring. To offer the depositor a parent *picker* (the "add"
+start path or the review-step section), set `parent_types` and the `parent_connect`
+config setting (default on). A directed `parent_id` handoff (see
+[Launch with context](#launch-with-context)) nests regardless of that setting.
 
 ### Launch with context
 
 Other entry points can hand off into the wizard with a target pre-filled by
-passing a context param; each is gated by its matching capability:
+passing a context param. A handoff always seeds its association, independent of the
+`collection_connect` / `parent_connect` config settings — those gate only the review
+/ start pickers, not a directed handoff (see [Deposit modes](#deposit-modes)):
 
 ```erb
 <%= link_to "Deposit into this collection",

--- a/spec/helpers/hyrax/deposit_wizard_helper_spec.rb
+++ b/spec/helpers/hyrax/deposit_wizard_helper_spec.rb
@@ -1,6 +1,78 @@
 # frozen_string_literal: true
 
 RSpec.describe Hyrax::DepositWizardHelper, type: :helper do
+  describe '#guided_replaces_standard?' do
+    let(:capabilities) { Hyku::DepositWizard.config.capabilities }
+
+    it 'delegates to the config capability' do
+      allow(capabilities).to receive(:guided_replaces_standard?).and_return(true)
+      expect(helper.guided_replaces_standard?).to be(true)
+
+      allow(capabilities).to receive(:guided_replaces_standard?).and_return(false)
+      expect(helper.guided_replaces_standard?).to be(false)
+    end
+  end
+
+  describe '#show_guided_deposit_button? / #show_standard_deposit_button?' do
+    let(:config) { Hyku::DepositWizard.config }
+
+    it 'each reflects its own enable flag independently' do
+      allow(config).to receive(:enabled?).and_return(true)
+      allow(config).to receive(:standard_deposit_button?).and_return(false)
+      expect(helper.show_guided_deposit_button?).to be(true)
+      expect(helper.show_standard_deposit_button?).to be(false)
+
+      allow(config).to receive(:enabled?).and_return(false)
+      allow(config).to receive(:standard_deposit_button?).and_return(true)
+      expect(helper.show_guided_deposit_button?).to be(false)
+      expect(helper.show_standard_deposit_button?).to be(true)
+    end
+  end
+
+  describe '#standard_deposit_target' do
+    it 'targets the select-work modal when several types are creatable' do
+      href, data = helper.standard_deposit_target(many: true, first_type: GenericWorkResource)
+      expect(href).to eq('#')
+      expect(data).to include(behavior: 'select-work', 'create-type' => 'single')
+    end
+
+    it 'links straight to the only creatable type otherwise' do
+      href, data = helper.standard_deposit_target(many: false, first_type: GenericWorkResource)
+      expect(href).to eq(new_polymorphic_path([main_app, GenericWorkResource]))
+      expect(data).to eq({})
+    end
+  end
+
+  describe '#deposit_new_work_target' do
+    let(:capabilities) { Hyku::DepositWizard.config.capabilities }
+
+    context 'when guided replaces the standard path' do
+      before { allow(capabilities).to receive(:guided_replaces_standard?).and_return(true) }
+
+      it 'targets the wizard regardless of work-type count' do
+        href, data = helper.deposit_new_work_target(many: true, first_type: GenericWorkResource)
+        expect(href).to eq(main_app.deposit_wizard_path)
+        expect(data).to eq({})
+      end
+    end
+
+    context 'when guided does not replace the standard path' do
+      before { allow(capabilities).to receive(:guided_replaces_standard?).and_return(false) }
+
+      it 'targets the select-work modal when several types are creatable' do
+        href, data = helper.deposit_new_work_target(many: true, first_type: GenericWorkResource)
+        expect(href).to eq('#')
+        expect(data).to include(behavior: 'select-work', 'create-type' => 'single')
+      end
+
+      it 'links straight to the only creatable type otherwise' do
+        href, data = helper.deposit_new_work_target(many: false, first_type: GenericWorkResource)
+        expect(href).to eq(new_polymorphic_path([main_app, GenericWorkResource]))
+        expect(data).to eq({})
+      end
+    end
+  end
+
   describe '#visibility_summary' do
     it 'renders an embargo as a transitional phrase with badge HTML' do
       html = helper.visibility_summary('visibility' => 'embargo',

--- a/spec/models/hyku/deposit_wizard/config_spec.rb
+++ b/spec/models/hyku/deposit_wizard/config_spec.rb
@@ -18,27 +18,98 @@ RSpec.describe Hyku::DepositWizard::Config do
     it 'has no parent_types restriction by default' do
       expect(config.parent_types).to be_nil
     end
+
+    it 'offers parent and collection connect by default (config settings, on)' do
+      expect(config.parent_connect?).to be(true)
+      expect(config.collection_connect?).to be(true)
+    end
   end
 
-  describe 'capabilities (live per-tenant Flipflop reads)' do
-    subject(:config) { described_class.new }
+  describe 'parent/collection connect (config settings, not flags)' do
+    it 'reflects the assigned config values' do
+      config = described_class.new do |c|
+        c.parent_connect = false
+        c.collection_connect = false
+      end
 
-    it 'reads each capability straight from its Flipflop feature' do
-      allow(Flipflop).to receive(:deposit_wizard_parent_connect?).and_return(true)
-      allow(Flipflop).to receive(:deposit_wizard_collection_connect?).and_return(false)
-      allow(Flipflop).to receive(:deposit_wizard_sharing?).and_return(true)
+      expect(config.parent_connect?).to be(false)
+      expect(config.collection_connect?).to be(false)
+    end
+  end
 
-      expect(config.capabilities.parent_connect?).to be(true)
-      expect(config.capabilities.collection_connect?).to be(false)
-      expect(config.capabilities.sharing?).to be(true)
+  describe 'capabilities (guided/standard enable flags)' do
+    subject(:capabilities) { described_class.new.capabilities }
+
+    def stub_flags(guided: false, standard: false)
+      allow(Flipflop).to receive(:enable_guided_deposit?).and_return(guided)
+      allow(Flipflop).to receive(:enable_standard_deposit?).and_return(standard)
     end
 
-    it 'reflects a flag change immediately (no stored state to shadow it)' do
-      allow(Flipflop).to receive(:deposit_wizard_parent_connect?).and_return(false)
-      expect(config.capabilities.parent_connect?).to be(false)
+    context 'when neither enable flag is set' do
+      before { stub_flags }
 
-      allow(Flipflop).to receive(:deposit_wizard_parent_connect?).and_return(true)
-      expect(config.capabilities.parent_connect?).to be(true)
+      it 'is disabled; guided-dependent capabilities are inert' do
+        expect(capabilities).not_to be_enabled
+        expect(capabilities).not_to be_guided_replaces_standard
+        expect(capabilities).not_to be_standard_deposit_button
+        expect(capabilities).not_to be_standard_link
+      end
+    end
+
+    context 'with enable_standard_deposit only (the default)' do
+      before { stub_flags(standard: true) }
+
+      it 'shows the standard button but does not enable or replace with guided' do
+        expect(capabilities).to be_standard_deposit_button
+        expect(capabilities).not_to be_enabled
+        expect(capabilities).not_to be_guided_replaces_standard
+      end
+    end
+
+    context 'with enable_guided_deposit on (only)' do
+      before { stub_flags(guided: true) }
+
+      it 'enables guided and overrides the standard entry links' do
+        expect(capabilities).to be_enabled
+        expect(capabilities).to be_guided_replaces_standard
+      end
+
+      it 'does not show the standard button, nor the standard-form link' do
+        expect(capabilities).not_to be_standard_deposit_button
+        expect(capabilities).not_to be_standard_link
+      end
+    end
+
+    context 'with both enable flags on' do
+      before { stub_flags(guided: true, standard: true) }
+
+      it 'shows both buttons; guided still overrides the entry links' do
+        expect(capabilities).to be_enabled
+        expect(capabilities).to be_standard_deposit_button
+        expect(capabilities).to be_guided_replaces_standard
+      end
+
+      it 'offers the standard-form link on the guided start screen' do
+        expect(capabilities).to be_standard_link
+      end
+    end
+  end
+
+  describe 'depositor sharing (config setting, gated by guided being enabled)' do
+    it 'is available by default when guided is enabled' do
+      allow(Flipflop).to receive(:enable_guided_deposit?).and_return(true)
+      expect(described_class.new).to be_sharing
+    end
+
+    it 'is off when the config setting is disabled' do
+      allow(Flipflop).to receive(:enable_guided_deposit?).and_return(true)
+      config = described_class.new { |c| c.depositor_sharing = false }
+      expect(config).not_to be_sharing
+    end
+
+    it 'is off when guided is not enabled, regardless of the setting' do
+      allow(Flipflop).to receive(:enable_guided_deposit?).and_return(false)
+      expect(described_class.new).not_to be_sharing
     end
   end
 
@@ -46,8 +117,6 @@ RSpec.describe Hyku::DepositWizard::Config do
     subject(:config) { described_class.new { |c| c.parent_connect_placement = placement } }
 
     let(:placement) { :both }
-
-    before { allow(Flipflop).to receive(:deposit_wizard_parent_connect?).and_return(true) }
 
     context 'with the default (:both)' do
       it 'offers parent selection on both edges' do
@@ -84,8 +153,13 @@ RSpec.describe Hyku::DepositWizard::Config do
       end
     end
 
-    context 'when the parent-connect flag is off' do
-      before { allow(Flipflop).to receive(:deposit_wizard_parent_connect?).and_return(false) }
+    context 'when parent-connect is turned off in config' do
+      subject(:config) do
+        described_class.new do |c|
+          c.parent_connect_placement = placement
+          c.parent_connect = false
+        end
+      end
 
       it 'shows nothing regardless of placement' do
         expect(config).not_to be_parent_connect_on_start

--- a/spec/presenters/hyku/deposit_wizard/presenter_spec.rb
+++ b/spec/presenters/hyku/deposit_wizard/presenter_spec.rb
@@ -83,6 +83,33 @@ RSpec.describe Hyku::DepositWizard::Presenter do
     end
   end
 
+  describe '#advance_from (details step)' do
+    let(:params) do
+      ActionController::Parameters.new(step: 'details',
+                                       'generic_work' => { 'title' => ['A title'] })
+    end
+    let(:work_form) { instance_double(Hyrax::Forms::ResourceForm) }
+
+    before do
+      presenter.state.work_type = 'GenericWorkResource'
+      allow(presenter).to receive(:build_work_form).and_return(work_form)
+      allow(presenter).to receive(:work_form).and_return(work_form)
+      allow(work_form).to receive(:validate).and_return(true)
+      allow(presenter.config.flow).to receive(:next_after).and_return('review')
+    end
+
+    it 'preserves a launch-seeded collection through the details step' do
+      presenter.state.attributes = { 'member_of_collections_attributes' => { '0' => { 'id' => 'coll-7' } } }
+
+      presenter.advance_from('details')
+
+      seeded = presenter.state.attributes['member_of_collections_attributes']
+      expect(seeded).to be_present
+      expect(seeded.values.map { |row| row['id'] }).to include('coll-7')
+      expect(presenter.state.attributes['title']).to eq(['A title'])
+    end
+  end
+
   describe '#build_work_form' do
     let(:params) { ActionController::Parameters.new }
     let(:work_form) { instance_double(Hyrax::Forms::ResourceForm, deserialize: nil) }

--- a/spec/requests/deposit_wizard_modes_spec.rb
+++ b/spec/requests/deposit_wizard_modes_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Deposit wizard modes', type: :request, singletenant: true, clean: true do
+  let(:admin) { FactoryBot.create(:admin) }
+
+  before do
+    FactoryBot.create(:admin_group)
+    FactoryBot.create(:registered_group)
+    login_as admin
+    # Guided must be on for the start screen (and thus the standard-form link) to exist.
+    allow(Flipflop).to receive(:enable_guided_deposit?).and_return(true)
+  end
+
+  # The works-page button rendering is covered as a view spec
+  # (spec/views/hyrax/my/works/_deposit_actions.html.erb_spec.rb). Here we exercise
+  # the standard-form link on the guided start screen, gated by config.standard_link?
+  # (both guided and standard deposit enabled).
+  describe 'the standard-form link on the guided start screen (GET /deposit_wizard)' do
+    context 'when standard deposit is disabled (guided only)' do
+      before { allow(Flipflop).to receive(:enable_standard_deposit?).and_return(false) }
+
+      it 'does not offer a link to the standard form' do
+        get deposit_wizard_path
+
+        expect(response.body).not_to include(I18n.t('hyku.deposit_wizard.start.standard_link'))
+      end
+    end
+
+    context 'when standard deposit is also enabled' do
+      before { allow(Flipflop).to receive(:enable_standard_deposit?).and_return(true) }
+
+      it 'offers a link to the standard form' do
+        get deposit_wizard_path
+
+        expect(response.body).to include(I18n.t('hyku.deposit_wizard.start.standard_link'))
+      end
+
+      context 'with several creatable work types' do
+        before { allow_any_instance_of(Hyrax::SelectTypeListPresenter).to receive(:many?).and_return(true) }
+
+        it 'routes the link through the standard type chooser modal' do
+          get deposit_wizard_path
+
+          expect(response.body).to include('data-behavior="select-work"')
+          expect(response.body).to include('id="worktypes-to-create"')
+        end
+
+        it 'shows the admin-set dropdown in the chooser when assign_admin_set is on' do
+          allow(Flipflop).to receive(:assign_admin_set?).and_return(true)
+          get deposit_wizard_path
+
+          expect(response.body).to include('select-work-admin-set')
+        end
+      end
+
+      context 'with a single creatable work type' do
+        before { allow_any_instance_of(Hyrax::SelectTypeListPresenter).to receive(:many?).and_return(false) }
+
+        it 'links straight to the standard new-work form (no chooser modal)' do
+          get deposit_wizard_path
+
+          expect(response.body).not_to include('id="worktypes-to-create"')
+          expect(response.body).to include(I18n.t('hyku.deposit_wizard.start.standard_link'))
+          expect(response.body).not_to include('data-behavior="select-work"')
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/deposit_wizard_spec.rb
+++ b/spec/requests/deposit_wizard_spec.rb
@@ -11,7 +11,9 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
 
   describe 'GET /deposit_wizard' do
     context 'when the deposit_wizard feature is off' do
-      before { allow(Flipflop).to receive(:deposit_wizard?).and_return(false) }
+      before do
+        allow(Flipflop).to receive(:enable_guided_deposit?).and_return(false)
+      end
 
       it 'redirects to the dashboard with an alert and does not expose the wizard' do
         get deposit_wizard_path
@@ -22,7 +24,7 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
     end
 
     context 'when the deposit_wizard feature is on' do
-      before { allow(Flipflop).to receive(:deposit_wizard?).and_return(true) }
+      before { allow(Flipflop).to receive(:enable_guided_deposit?).and_return(true) }
 
       it 'renders the start screen' do
         get deposit_wizard_path
@@ -41,22 +43,20 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
       describe 'launch with context (handoff from another entry point)' do
         after { Hyku::DepositWizard.reset_config! }
 
-        it 'seeds a parent work from parent_id when parent connect is enabled' do
-          allow(Flipflop).to receive(:deposit_wizard_parent_connect?).and_return(true)
+        it 'seeds a parent work from parent_id when the parent picker is enabled' do
           get deposit_wizard_path(parent_id: 'parent-123')
 
           expect(session[:deposit_wizard]['parent_id']).to eq('parent-123')
         end
 
-        it 'ignores parent_id when parent connect is disabled' do
-          allow(Flipflop).to receive(:deposit_wizard_parent_connect?).and_return(false)
+        it 'seeds a parent work from parent_id even when the picker is disabled' do
+          Hyku::DepositWizard.config.parent_connect = false
           get deposit_wizard_path(parent_id: 'parent-123')
 
-          expect(session[:deposit_wizard]['parent_id']).to be_nil
+          expect(session[:deposit_wizard]['parent_id']).to eq('parent-123')
         end
 
-        it 'seeds collection membership from add_works_to_collection when enabled' do
-          allow(Flipflop).to receive(:deposit_wizard_collection_connect?).and_return(true)
+        it 'seeds collection membership from add_works_to_collection when the picker is enabled' do
           get deposit_wizard_path(add_works_to_collection: 'coll-9')
 
           membership = session[:deposit_wizard].dig('attributes', 'member_of_collections_attributes')
@@ -64,18 +64,20 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
           expect(membership.values.map { |row| row['id'] }).to include('coll-9')
         end
 
-        it 'ignores add_works_to_collection when collection connect is disabled' do
-          allow(Flipflop).to receive(:deposit_wizard_collection_connect?).and_return(false)
+        it 'seeds collection membership from add_works_to_collection even when the picker is disabled' do
+          Hyku::DepositWizard.config.collection_connect = false
           get deposit_wizard_path(add_works_to_collection: 'coll-9')
 
-          expect(session[:deposit_wizard].dig('attributes', 'member_of_collections_attributes')).to be_blank
+          membership = session[:deposit_wizard].dig('attributes', 'member_of_collections_attributes')
+          expect(membership).to be_present
+          expect(membership.values.map { |row| row['id'] }).to include('coll-9')
         end
       end
     end
   end
 
   describe 'GET /deposit_wizard/:step with an unknown step' do
-    before { allow(Flipflop).to receive(:deposit_wizard?).and_return(true) }
+    before { allow(Flipflop).to receive(:enable_guided_deposit?).and_return(true) }
 
     it 'falls back to the start screen' do
       get deposit_wizard_step_path(step: 'does_not_exist')
@@ -88,8 +90,7 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
     let(:admin) { FactoryBot.create(:admin) }
 
     before do
-      allow(Flipflop).to receive(:deposit_wizard?).and_return(true)
-      allow(Flipflop).to receive(:deposit_wizard_parent_connect?).and_return(true)
+      allow(Flipflop).to receive(:enable_guided_deposit?).and_return(true)
     end
 
     after { Hyku::DepositWizard.reset_config! }
@@ -108,7 +109,7 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
     end
 
     it 'is forbidden when parent connect is disabled' do
-      allow(Flipflop).to receive(:deposit_wizard_parent_connect?).and_return(false)
+      Hyku::DepositWizard.config.parent_connect = false
 
       get deposit_wizard_parent_options_path(q: 'anything')
 
@@ -118,7 +119,7 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
 
   describe 'navigation and type selection' do
     before do
-      allow(Flipflop).to receive(:deposit_wizard?).and_return(true)
+      allow(Flipflop).to receive(:enable_guided_deposit?).and_return(true)
       Hyrax::AdminSetCreateService.find_or_create_default_admin_set
     end
 
@@ -221,7 +222,6 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
 
     context 'with the relationship-first path (flat config, parent_connect on)' do
       before do
-        allow(Flipflop).to receive(:deposit_wizard_parent_connect?).and_return(true)
         # These exercise the start-screen path; the default placement is review-only.
         Hyku::DepositWizard.config.parent_connect_placement = :both
       end
@@ -290,7 +290,6 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
 
     context 'with parent-connect placement :review (review edge only)' do
       before do
-        allow(Flipflop).to receive(:deposit_wizard_parent_connect?).and_return(true)
         Hyku::DepositWizard.config.parent_connect_placement = :review
       end
 
@@ -549,7 +548,6 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
         after { Hyku::DepositWizard.reset_config! }
 
         it 'saves a chosen parent into wizard state and re-renders it on review' do
-          allow(Flipflop).to receive(:deposit_wizard_parent_connect?).and_return(true)
           parent = FactoryBot.valkyrie_create(:generic_work_resource, title: ['Parent'], depositor: admin.user_key)
           fill_in_wizard
 
@@ -562,7 +560,6 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
         end
 
         it 'saves collection membership into wizard state' do
-          allow(Flipflop).to receive(:deposit_wizard_collection_connect?).and_return(true)
           collection = FactoryBot.create(:hyku_collection, user: admin)
           fill_in_wizard
 
@@ -575,7 +572,6 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
         end
 
         it 'clears a capability from state when its entries are removed' do
-          allow(Flipflop).to receive(:deposit_wizard_collection_connect?).and_return(true)
           collection = FactoryBot.create(:hyku_collection, user: admin)
           fill_in_wizard
 
@@ -597,7 +593,6 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
         after { Hyku::DepositWizard.reset_config! }
 
         it 'renders the section when parent connect is enabled' do
-          allow(Flipflop).to receive(:deposit_wizard_parent_connect?).and_return(true)
           fill_in_wizard
           get deposit_wizard_step_path(step: 'review')
 
@@ -606,7 +601,7 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
         end
 
         it 'omits the section when parent connect is disabled' do
-          allow(Flipflop).to receive(:deposit_wizard_parent_connect?).and_return(false)
+          Hyku::DepositWizard.config.parent_connect = false
           fill_in_wizard
           get deposit_wizard_step_path(step: 'review')
 
@@ -614,7 +609,6 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
         end
 
         it 'omits the section when placement is :start (front edge only)' do
-          allow(Flipflop).to receive(:deposit_wizard_parent_connect?).and_return(true)
           Hyku::DepositWizard.config.parent_connect_placement = :start
           fill_in_wizard
           get deposit_wizard_step_path(step: 'review')
@@ -623,7 +617,6 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
         end
 
         it 'renders the section when placement is :review' do
-          allow(Flipflop).to receive(:deposit_wizard_parent_connect?).and_return(true)
           Hyku::DepositWizard.config.parent_connect_placement = :review
           fill_in_wizard
           get deposit_wizard_step_path(step: 'review')
@@ -636,7 +629,6 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
         after { Hyku::DepositWizard.reset_config! }
 
         it 'renders the section when the capability is enabled' do
-          allow(Flipflop).to receive(:deposit_wizard_collection_connect?).and_return(true)
           fill_in_wizard
           get deposit_wizard_step_path(step: 'review')
 
@@ -645,7 +637,7 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
         end
 
         it 'omits the section when the capability is disabled' do
-          allow(Flipflop).to receive(:deposit_wizard_collection_connect?).and_return(false)
+          Hyku::DepositWizard.config.collection_connect = false
           fill_in_wizard
           get deposit_wizard_step_path(step: 'review')
 
@@ -657,7 +649,6 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
         after { Hyku::DepositWizard.reset_config! }
 
         it 'renders the section when sharing is enabled' do
-          allow(Flipflop).to receive(:deposit_wizard_sharing?).and_return(true)
           fill_in_wizard
           get deposit_wizard_step_path(step: 'review')
 
@@ -666,7 +657,7 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
         end
 
         it 'omits the section when sharing is disabled' do
-          allow(Flipflop).to receive(:deposit_wizard_sharing?).and_return(false)
+          Hyku::DepositWizard.config.depositor_sharing = false
           fill_in_wizard
           get deposit_wizard_step_path(step: 'review')
 
@@ -1047,8 +1038,6 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
         after { Hyku::DepositWizard.reset_config! }
 
         context 'collection connect' do
-          before { allow(Flipflop).to receive(:deposit_wizard_collection_connect?).and_return(true) }
-
           it 'adds the work to the chosen collection' do
             collection = FactoryBot.create(:hyku_collection, user: admin)
             fill_in_wizard
@@ -1063,7 +1052,7 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
         end
 
         context 'when collection connect is disabled' do
-          before { allow(Flipflop).to receive(:deposit_wizard_collection_connect?).and_return(false) }
+          before { Hyku::DepositWizard.config.collection_connect = false }
 
           it 'ignores submitted collection membership' do
             collection = FactoryBot.create(:hyku_collection, user: admin)
@@ -1078,8 +1067,6 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
         end
 
         context 'parent connect' do
-          before { allow(Flipflop).to receive(:deposit_wizard_parent_connect?).and_return(true) }
-
           it 'nests the work under the chosen parent work' do
             parent = FactoryBot.valkyrie_create(:generic_work_resource, title: ['Parent work'], depositor: admin.user_key)
             fill_in_wizard
@@ -1109,7 +1096,7 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
         end
 
         context 'when parent connect is disabled' do
-          before { allow(Flipflop).to receive(:deposit_wizard_parent_connect?).and_return(false) }
+          before { Hyku::DepositWizard.config.parent_connect = false }
 
           it 'ignores a submitted parent_id' do
             parent = FactoryBot.valkyrie_create(:generic_work_resource, title: ['Parent work'], depositor: admin.user_key)
@@ -1123,8 +1110,6 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
         end
 
         context 'sharing' do
-          before { allow(Flipflop).to receive(:deposit_wizard_sharing?).and_return(true) }
-
           it 'grants a user the access chosen on the review step' do
             grantee = FactoryBot.create(:user)
             fill_in_wizard
@@ -1141,7 +1126,7 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
         end
 
         context 'when sharing is disabled' do
-          before { allow(Flipflop).to receive(:deposit_wizard_sharing?).and_return(false) }
+          before { Hyku::DepositWizard.config.depositor_sharing = false }
 
           it 'ignores submitted permissions' do
             grantee = FactoryBot.create(:user)
@@ -1207,7 +1192,7 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
     before { Hyrax::AdminSetCreateService.find_or_create_default_admin_set }
 
     it 'appears when the feature is on' do
-      allow(Flipflop).to receive(:deposit_wizard?).and_return(true)
+      allow(Flipflop).to receive(:enable_guided_deposit?).and_return(true)
 
       get hyrax.my_works_path
 
@@ -1216,7 +1201,7 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
     end
 
     it 'is absent when the feature is off' do
-      allow(Flipflop).to receive(:deposit_wizard?).and_return(false)
+      allow(Flipflop).to receive(:enable_guided_deposit?).and_return(false)
 
       get hyrax.my_works_path
 

--- a/spec/views/hyrax/base/_attach_child_control.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_attach_child_control.html.erb_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+RSpec.describe 'hyrax/base/_attach_child_control.html.erb', type: :view do
+  let(:concern) { GenericWorkResource }
+  let(:presenter) { double('WorkShowPresenter', id: 'parent-9', valid_child_concerns: [concern]) }
+
+  def render_control
+    render 'hyrax/base/attach_child_control', presenter: presenter
+  end
+
+  context 'when guided replaces the standard deposit' do
+    before { allow(view).to receive(:guided_replaces_standard?).and_return(true) }
+
+    it 'renders a single link into the wizard with the parent seeded' do
+      render_control
+
+      expect(rendered).to have_link(I18n.t('hyrax.base.show_actions.attach_child'),
+                                    href: main_app.deposit_wizard_path(parent_id: 'parent-9'))
+    end
+
+    it 'does not render a work-type dropdown' do
+      render_control
+
+      expect(rendered).not_to have_selector('.dropdown-menu')
+    end
+  end
+
+  context 'when guided does not replace the standard deposit' do
+    before { allow(view).to receive(:guided_replaces_standard?).and_return(false) }
+
+    it 'renders the per-concern dropdown into the stock nested-new form' do
+      render_control
+
+      expect(rendered).to have_selector('.dropdown-menu')
+      expect(rendered).to have_link(
+        "Attach #{concern.human_readable_type}",
+        href: polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular.to_sym],
+                               parent_id: 'parent-9')
+      )
+    end
+
+    it 'does not link to the wizard' do
+      render_control
+
+      expect(rendered).not_to have_link(href: main_app.deposit_wizard_path(parent_id: 'parent-9'))
+    end
+  end
+end

--- a/spec/views/hyrax/homepage/index.html.erb_spec.rb
+++ b/spec/views/hyrax/homepage/index.html.erb_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+RSpec.describe 'hyrax/homepage/index.html.erb', type: :view do
+  let(:presenter) do
+    double('HomepagePresenter', display_share_button?: true,
+                                create_many_work_types?: false, first_work_type: GenericWorkResource,
+                                draw_select_work_modal?: false)
+  end
+
+  before do
+    assign(:presenter, presenter)
+    allow(view).to receive(:signed_in?).and_return(true)
+    allow(Flipflop).to receive(:read_only?).and_return(false)
+    allow(view).to receive(:application_name).and_return('App')
+    # Isolate the share button from the home-content section.
+    allow(view).to receive(:render).and_call_original
+    allow(view).to receive(:render).with('home_content').and_return('')
+  end
+
+  context 'when guided replaces the standard deposit' do
+    before { allow(view).to receive(:guided_replaces_standard?).and_return(true) }
+
+    it 'points the share-your-work button at the wizard' do
+      render template: 'hyrax/homepage/index'
+
+      expect(rendered).to have_link(I18n.t('hyrax.share_button'),
+                                    href: main_app.deposit_wizard_path)
+    end
+  end
+
+  context 'when guided does not replace the standard deposit' do
+    before { allow(view).to receive(:guided_replaces_standard?).and_return(false) }
+
+    it 'points the share-your-work button at the stock new-work form' do
+      render template: 'hyrax/homepage/index'
+
+      expect(rendered).to have_link(I18n.t('hyrax.share_button'),
+                                    href: new_polymorphic_path([main_app, GenericWorkResource]))
+    end
+  end
+end

--- a/spec/views/hyrax/my/works/_deposit_actions.html.erb_spec.rb
+++ b/spec/views/hyrax/my/works/_deposit_actions.html.erb_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+RSpec.describe 'hyrax/my/works/_deposit_actions.html.erb', type: :view do
+  let(:create_work_presenter) { double('SelectTypeListPresenter', many?: false, first_model: GenericWorkResource) }
+
+  before do
+    assign(:create_work_presenter, create_work_presenter)
+    allow(view).to receive(:current_ability).and_return(double(can_create_any_work?: true))
+    allow(view).to receive(:show_guided_deposit_button?).and_return(guided)
+    allow(view).to receive(:show_standard_deposit_button?).and_return(standard)
+    # Isolate the button branching from the unrelated batch-upload path.
+    allow(Flipflop).to receive(:batch_upload?).and_return(false)
+    render
+  end
+
+  context 'standard only (default)' do
+    let(:guided) { false }
+    let(:standard) { true }
+
+    it 'shows the standard "Add new work" button to the standard form, no guided button' do
+      expect(rendered).not_to have_selector('a#guided-deposit-button')
+      expect(rendered).to have_link(I18n.t('helpers.action.work.new'),
+                                    href: new_polymorphic_path([main_app, GenericWorkResource]))
+    end
+  end
+
+  context 'guided only' do
+    let(:guided) { true }
+    let(:standard) { false }
+
+    it 'shows the Guided Deposit button and no standard button' do
+      expect(rendered).to have_link(I18n.t('hyku.deposit_wizard.button'),
+                                    href: main_app.deposit_wizard_path)
+      expect(rendered).not_to have_selector('a#add-new-work-button')
+    end
+  end
+
+  context 'both enabled' do
+    let(:guided) { true }
+    let(:standard) { true }
+
+    it 'shows both buttons; the standard button still targets the standard form' do
+      expect(rendered).to have_link(I18n.t('hyku.deposit_wizard.button'),
+                                    href: main_app.deposit_wizard_path)
+      expect(rendered).to have_selector('a#guided-deposit-button')
+      expect(rendered).to have_link(I18n.t('helpers.action.work.new'),
+                                    href: new_polymorphic_path([main_app, GenericWorkResource]))
+    end
+  end
+
+  context 'neither enabled' do
+    let(:guided) { false }
+    let(:standard) { false }
+
+    it 'shows no deposit buttons' do
+      expect(rendered).not_to have_selector('a#guided-deposit-button')
+      expect(rendered).not_to have_selector('a#add-new-work-button')
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Configures the guided deposit to be used across every deposit entry point in the site, based on per-tenant feature flags.
- Refs research-technologies/enact_knapsack#112

## Details
- Two per-tenant features select the deposit experience: `enable_guided_deposit` (off by default) and `enable_standard_deposit` (on by default).
- When guided deposit is enabled, every deposit entry point — the works page, homepage "share your work", collection "Add new work", and a work's "Attach a child work" — routes into the guided wizard instead of the standard single-page form.
- When only standard deposit is enabled, those entry points use the standard form (current behavior).
- Each enabled feature adds its own button to the dashboard works page; when both are enabled, the guided start screen also offers a "switch to the standard deposit form" link.
- Parent-connect, collection-connect, and depositor-sharing become configuration settings (default on) rather than feature flags.
- A directed handoff — "deposit into this collection" or "attach a child to this work" — carries that association through to deposit regardless of the picker settings.
- Moves the home page "Share your work" flipper into the deposit features section, since it is also a deposit related function.

## Testing
- **Standard only (default):** confirm every deposit entry point uses the standard form and the works page shows the standard "Add new work" button.
- **Guided only:** enable `enable_guided_deposit`, disable `enable_standard_deposit`. Confirm the works page, homepage "share your work", collection "Add new work", and a work's "Attach a child work" all route into the guided wizard.
- **Both enabled:** confirm both buttons appear on the works page, entry points route to guided, and the guided start screen shows a "switch to the standard deposit form" link.
- **Collection handoff:** from a collection's "Add new work" (guided enabled), complete the wizard and confirm the work lands in that collection.
- **Parent handoff:** from a work's "Attach a child work" (guided enabled), complete the wizard and confirm the work nests under the parent.

## Screenshot

<img width="876" height="372" alt="Screenshot 2026-07-22 at 3 24 05 PM" src="https://github.com/user-attachments/assets/0bf74baf-6a2b-4767-93c7-baed53fbdd01" />

## Follow-up work

This "dual-flipper" structure allows both deposit experiences to be selected and active, but it also allows neither to be active (in a situation where all deposits are intended to come via Bulkrax). This PR removes the options only from the dashboard-works page. It does not remove these other deposit entry points for the situation where both flippers are off:
- homepage (this button has its own feature flipper)
- add a child work from a work: work-show view
- deposit a new work within a collection: collection dashboard-show view

Turn off all UI deposit: https://github.com/research-technologies/enact_knapsack/issues/130

Override Cleanup: https://github.com/samvera/hyku/issues/3156

Accessibility Concerns: https://github.com/samvera/hyku/issues/3157