### PR TITLE
Fix Solr wedging when switching between stacks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,6 +91,10 @@ services:
       - SOLR_ENABLE_CLOUD_MODE=yes
       - SOLR_ENABLE_AUTHENTICATION=yes
       - ZK_HOST=zoo:2181
+      # Register SolrCloud replicas by this stable hostname instead of the
+      # container IP, so ZooKeeper's node_name stays valid across IP churn on the
+      # shared stackcar network (switching between the Hyku and a knapsack stack).
+      - SOLR_HOST=solr
       - VIRTUAL_PORT=8983
       - VIRTUAL_HOST=solr.hyku.test
     labels:


### PR DESCRIPTION
## Summary
Solr no longer breaks when two stacks that share the `stackcar` Docker network run on the same machine and you switch between them.

## Details
**Symptom:** after switching stacks, Solr requests fail with 500s and `NullPointerException` in `HttpSolrCall.getCoreUrl`; the Collections API can lock up entirely, so even healthy collections stop responding.

**Cause:** the solr service never set a host, so SolrCloud fell back to Docker's default — it auto-detects the container's own network interface, which returns the container's eth0 IP on the Docker network, and advertises that IP to ZooKeeper as its `node_name`.

On the shared `stackcar` network, container IPs are drawn from one pool in start order, so a later start lands Solr on a different IP than ZooKeeper recorded. The stale address survives `docker compose down` because it lives in the persisted ZK volume — so a recreate doesn't clear it.

**Fix:** set `SOLR_HOST=solr` on the solr service, which the official `solr` image passes through as `-Dhost=solr`. Solr then registers by the stable service hostname, which Docker DNS resolves to whatever IP the container currently holds.

**One-time cleanup after merge:** existing ZK state still holds the old IP-based `node_name`, so affected collections must be recreated (or the ZK volume cleared) once per environment; new registrations are then hostname-based.
