### PR TITLE
Add masonry as a selectable search results page theme

### DIFF
--- a/app/controllers/hyrax/admin/appearances_controller_decorator.rb
+++ b/app/controllers/hyrax/admin/appearances_controller_decorator.rb
@@ -80,9 +80,16 @@ module Hyrax
       end
 
       def load_search_themes
+        # Slideshow is a working Blacklight view too, but adding it here alone
+        # is not enough to make it a good default: out of the box the results
+        # page is a grid of thumbnails and the actual slideshow only opens in a
+        # pop-up after clicking one. Offering it as a default needs more work
+        # first (a real image source and a clearer launch UX), so it is left
+        # out for now and stays available as a per-user view toggle.
         {
           'List view' => 'list_view',
-          'Gallery view' => 'gallery_view'
+          'Gallery view' => 'gallery_view',
+          'Masonry view' => 'masonry_view'
         }
       end
 

--- a/spec/features/appearance_theme_spec.rb
+++ b/spec/features/appearance_theme_spec.rb
@@ -88,6 +88,25 @@ RSpec.describe 'Admin can select home page theme', type: :feature, js: true, cle
       expect(page).to have_css('a.view-type-gallery.active')
     end
 
+    it 'supports masonry as a default search results view' do
+      login_as admin
+      visit '/admin/appearance'
+      click_link('Themes')
+      select('Masonry view', from: 'Search Results Page Theme')
+      find('body').click
+      click_on('Save')
+      site = Site.last
+      account.sites << site
+      allow_any_instance_of(ApplicationController).to receive(:current_account).and_return(account)
+      expect(page).to have_content('The appearance was successfully updated')
+      expect(site.search_theme).to eq('masonry_view')
+      visit '/'
+      expect(page).to have_css('body.masonry_view')
+      fill_in "search-field-header", with: "llama"
+      click_button "search-submit-header"
+      expect(page).to have_css('a.view-type-masonry.active')
+    end
+
     # Temporarily commenting out these specs because they consistently fail in the CI pipeline
     # after the Bulkrax version update. The issue seems related to form submission failing
     # in the CI environment but not locally. This needs further investigation to resolve.


### PR DESCRIPTION
## Summary

Issue: 
- https://github.com/research-technologies/enact_knapsack/issues/128
- 
Adds **Masonry view** as a selectable option in **Appearance > Search Results Page Theme**, so admins can set masonry as the tenant-wide default search results view.

Everything masonry needs already ships in Hyku - it's a registered Blacklight view (`CatalogController`), its SCSS (`blacklight_gallery/masonry`) and layout JS are imported, and the picker wireframe `masonry_view.jpg` already exists in the repo. The only missing piece was the dropdown entry itself, so `masonry_view.jpg` has effectively been an orphaned asset since the theming feature landed. This wires it up.

The selected value (`masonry_view`) is split on `_` and its first token is used as the Blacklight view key (`:masonry`), exactly like the existing `list_view`/`gallery_view` entries, so no other plumbing is required.

## Screenshots

<img width="1141" height="623" alt="image" src="https://github.com/user-attachments/assets/0f06f04b-3816-4eb6-a25d-fb06ca2947b2" />

<img width="1333" height="715" alt="image" src="https://github.com/user-attachments/assets/18094361-790c-4d5a-b52a-3c699f4b1009" />


## Why not slideshow?

This will be handled in a separate PR
- https://github.com/research-technologies/enact_knapsack/issues/128

## Changes

- `app/controllers/hyrax/admin/appearances_controller_decorator.rb` - add `'Masonry view' => 'masonry_view'` to `load_search_themes`.
- `spec/features/appearance_theme_spec.rb` - feature spec verifying masonry can be set as the default (asserts the `body.masonry_view` class and the active `view-type-masonry` toggle on a search).

## Testing / QA

- Verified in a running Hyku that selecting Masonry saves the theme, applies the `masonry_view` body class, and activates the masonry view toggle.
- Confirmed the masonry layout JS runs (results container gets `position: relative` + a computed height; tiles are absolutely positioned).
- Note: with works that have no thumbnails/IIIF derivatives, every tile renders the default work icon, so masonry (like gallery) looks grid-like until real, variably-sized images are present. This is existing thumbnail behavior, not affected by this change.

## Testing Instructions

1. Go to **Appearance > Search Results Page Theme** and select **Masonry view**; save.
2. Run a catalog search and confirm results render in the masonry view by default and the masonry view toggle is active.
3. Confirm List and Gallery remain available and selectable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
