### PR TITLE
Updates text for file details deposit UI

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -250,8 +250,8 @@ de:
           other: "Dateien · %{count}"
         files_nav: Hochgeladene Dateien
         heading: Beschreiben Sie Ihre Dateien
-        inherit: Wie das Werk
-        subtext: Fügen Sie Details für jede Datei hinzu oder lassen Sie sie vom Werk erben.
+        inherit: Sichtbarkeitseinstellungen des Werks verwenden. Deaktivieren, um eine dateispezifische Sichtbarkeit festzulegen.
+        subtext: Fügen Sie Details und Sichtbarkeit für jede Datei hinzu.
         title: Titel
         visibility: Sichtbarkeit der Datei
       files:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -111,8 +111,8 @@ en:
           other: "Files · %{count}"
         files_nav: Uploaded files
         heading: Describe your files
-        inherit: Same as the work
-        subtext: Add details for each file, or leave them to inherit from the work.
+        inherit: Use the work's visibility settings. Uncheck to set file-specific visibility.
+        subtext: Add details and visibility for each file.
         title: Title
         visibility: File visibility
       files:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -251,8 +251,8 @@ es:
           other: "Archivos · %{count}"
         files_nav: Archivos subidos
         heading: Describe tus archivos
-        inherit: Igual que la obra
-        subtext: Añade detalles para cada archivo o déjalos para que hereden los de la obra.
+        inherit: Usa la configuración de visibilidad de la obra. Desmarca para establecer una visibilidad específica del archivo.
+        subtext: Añade detalles y visibilidad para cada archivo.
         title: Título
         visibility: Visibilidad del archivo
       files:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -251,8 +251,8 @@ fr:
           other: "Fichiers · %{count}"
         files_nav: Fichiers téléversés
         heading: Décrivez vos fichiers
-        inherit: Identique à l'œuvre
-        subtext: Ajoutez des détails pour chaque fichier, ou laissez-les hériter de ceux de l'œuvre.
+        inherit: Utilisez les paramètres de visibilité de l'œuvre. Décochez pour définir une visibilité propre au fichier.
+        subtext: Ajoutez des détails et la visibilité pour chaque fichier.
         title: Titre
         visibility: Visibilité du fichier
       files:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -251,8 +251,8 @@ it:
           other: "File · %{count}"
         files_nav: File caricati
         heading: Descrivi i tuoi file
-        inherit: Come l'opera
-        subtext: Aggiungi dettagli per ogni file oppure lasciali ereditare dall'opera.
+        inherit: Usa le impostazioni di visibilità dell'opera. Deseleziona per impostare una visibilità specifica del file.
+        subtext: Aggiungi dettagli e visibilità per ogni file.
         title: Titolo
         visibility: Visibilità del file
       files:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -133,8 +133,8 @@ pt-BR:
           other: "Arquivos · %{count}"
         files_nav: Arquivos enviados
         heading: Descreva seus arquivos
-        inherit: Igual à obra
-        subtext: Adicione detalhes para cada arquivo ou deixe-os herdar da obra.
+        inherit: Use as configurações de visibilidade da obra. Desmarque para definir uma visibilidade específica do arquivo.
+        subtext: Adicione detalhes e visibilidade para cada arquivo.
         title: Título
         visibility: Visibilidade do arquivo
       files:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -251,8 +251,8 @@ zh:
           other: "文件 · %{count}"
         files_nav: 已上传的文件
         heading: 描述您的文件
-        inherit: 与作品相同
-        subtext: 为每个文件添加详细信息，或让它们继承作品的信息。
+        inherit: 使用作品的可见性设置。取消勾选可为该文件单独设置可见性。
+        subtext: 为每个文件添加详细信息和可见性。
         title: 标题
         visibility: 文件可见性
       files:


### PR DESCRIPTION
## Summary

Adjust text i18n for deposit wizard file details view.
Refs https://github.com/research-technologies/enact_knapsack/issues/136

## Details

The text on the file set details view in the deposit wizard incorrectly implies that the details can be left to carry down from the work. This modifies the helper text under the title as well as the visibility setting text to clarify the actual behavior.