### PR TITLE
Route demo/staging mail through SendGrid instead of maildev

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -9,7 +9,7 @@ on:
         default: "staging"
         type: choice
         options:
-          # - demo - pausing for accessibility testing
+          - demo
           - iiif
           - staging
           - test

--- a/ops/demo-deploy.tmpl.yaml
+++ b/ops/demo-deploy.tmpl.yaml
@@ -136,7 +136,7 @@ extraEnvVars: &envVars
   - name: HYKU_BULKRAX_ENABLED
     value: "true"
   - name: HYKU_CONTACT_EMAIL
-    value: support@notch8.com
+    value: no-reply@hykudemo.org
   - name: HYKU_FILE_ACL
     value: "false"
   - name: HYRAX_ANALYTICS

--- a/ops/demo-deploy.tmpl.yaml
+++ b/ops/demo-deploy.tmpl.yaml
@@ -174,19 +174,19 @@ extraEnvVars: &envVars
   - name: NEGATIVE_CAPTCHA_SECRET
     value: $NEGATIVE_CAPTCHA_SECRET
   - name: SMTP_ADDRESS
-    value: "maildev-smtp.maildev.svc.cluster.local"
+    value: "smtp.sendgrid.net"
   - name: SMTP_DOMAIN
-    value: "maildev-smtp.maildev.svc.cluster.local"
+    value: "hykudemo.org"
   - name: SMTP_ENABLED
     value: "true"
   - name: SMTP_PORT
-    value: "1025"
+    value: "587"
   - name: SMTP_TYPE
     value: "plain"
   - name: SMTP_USER_NAME
-    value: "admin"
+    value: "apikey"
   - name: SMTP_STARTTLS
-    value: "false"
+    value: "true"
   - name: SMTP_PASSWORD
     value: $SMTP_PASSWORD
   - name: SOLR_ADMIN_USER

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -176,19 +176,19 @@ extraEnvVars: &envVars
   - name: NEGATIVE_CAPTCHA_SECRET
     value: $NEGATIVE_CAPTCHA_SECRET
   - name: SMTP_ADDRESS
-    value: "maildev-smtp.maildev.svc.cluster.local"
+    value: "smtp.sendgrid.net"
   - name: SMTP_DOMAIN
-    value: "maildev-smtp.maildev.svc.cluster.local"
+    value: "hykustaging.org"
   - name: SMTP_ENABLED
     value: "true"
   - name: SMTP_PORT
-    value: "1025"
+    value: "587"
   - name: SMTP_TYPE
     value: "plain"
   - name: SMTP_USER_NAME
-    value: "admin"
+    value: "apikey"
   - name: SMTP_STARTTLS
-    value: "false"
+    value: "true"
   - name: SMTP_PASSWORD
     value: $SMTP_PASSWORD
   - name: SOLR_ADMIN_USER

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -136,7 +136,7 @@ extraEnvVars: &envVars
   - name: HYKU_BULKRAX_ENABLED
     value: "true"
   - name: HYKU_CONTACT_EMAIL
-    value: support@notch8.com
+    value: no-reply@hykustaging.org
   - name: HYKU_FILE_ACL
     value: "false"
   - name: HYRAX_ANALYTICS


### PR DESCRIPTION
hyku-demo and hyku-staging currently send outbound mail to an internal maildev catch-all, so password-reset emails never leave the cluster. This is blocking self-serve password resets for users recovered after the r2-friends DB loss (dev-ops #1422). 

Also re-enables `demo` in the deploy workflow_dispatch options, so that we can push this fix to demo - re-deploying the same branch to the demo environment for now.

@samvera/hyku-code-reviewers
