### PR TITLE
Backport #3159: Route demo/staging mail through SendGrid instead of maildev (7.1-stable)

### DIFF
--- a/ops/demo-deploy.tmpl.yaml
+++ b/ops/demo-deploy.tmpl.yaml
@@ -134,7 +134,7 @@ extraEnvVars: &envVars
   - name: HYKU_BULKRAX_ENABLED
     value: "true"
   - name: HYKU_CONTACT_EMAIL
-    value: support@notch8.com
+    value: no-reply@hykudemo.org
   - name: HYKU_FILE_ACL
     value: "false"
   - name: HYRAX_ANALYTICS
@@ -172,19 +172,19 @@ extraEnvVars: &envVars
   - name: NEGATIVE_CAPTCHA_SECRET
     value: $NEGATIVE_CAPTCHA_SECRET
   - name: SMTP_ADDRESS
-    value: "maildev-smtp.maildev.svc.cluster.local"
+    value: "smtp.sendgrid.net"
   - name: SMTP_DOMAIN
-    value: "maildev-smtp.maildev.svc.cluster.local"
+    value: "hykudemo.org"
   - name: SMTP_ENABLED
     value: "true"
   - name: SMTP_PORT
-    value: "1025"
+    value: "587"
   - name: SMTP_TYPE
     value: "plain"
   - name: SMTP_USER_NAME
-    value: "admin"
+    value: "apikey"
   - name: SMTP_STARTTLS
-    value: "false"
+    value: "true"
   - name: SMTP_PASSWORD
     value: $SMTP_PASSWORD
   - name: SOLR_ADMIN_USER

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -132,7 +132,7 @@ extraEnvVars: &envVars
   - name: HYKU_BULKRAX_ENABLED
     value: "true"
   - name: HYKU_CONTACT_EMAIL
-    value: support@notch8.com
+    value: no-reply@hykustaging.org
   - name: HYKU_FILE_ACL
     value: "false"
   - name: HYRAX_FITS_PATH
@@ -164,19 +164,19 @@ extraEnvVars: &envVars
   - name: NEGATIVE_CAPTCHA_SECRET
     value: $NEGATIVE_CAPTCHA_SECRET
   - name: SMTP_ADDRESS
-    value: "maildev-smtp.maildev.svc.cluster.local"
+    value: "smtp.sendgrid.net"
   - name: SMTP_DOMAIN
-    value: "maildev-smtp.maildev.svc.cluster.local"
+    value: "hykustaging.org"
   - name: SMTP_ENABLED
     value: "true"
   - name: SMTP_PORT
-    value: "1025"
+    value: "587"
   - name: SMTP_TYPE
     value: "plain"
   - name: SMTP_USER_NAME
-    value: "admin"
+    value: "apikey"
   - name: SMTP_STARTTLS
-    value: "false"
+    value: "true"
   - name: SMTP_PASSWORD
     value: $SMTP_PASSWORD
   - name: SOLR_ADMIN_USER


### PR DESCRIPTION
Backport of #3159 to `7.1-stable`.

## Why
hyku-demo and hyku-staging send outbound mail to an internal maildev catch-all, so password-reset emails never leave the cluster. This blocks self-serve password resets for users recovered after the r2-friends DB loss (dev-ops #1422). This points both environments at a SendGrid account dedicated to non-production mail, matching the SMTP settings pattern already used in production.

The `HYKU_CONTACT_EMAIL` (mailer From address) is also updated per environment to a SendGrid-authenticated domain (`no-reply@hykudemo.org` / `no-reply@hykustaging.org`), since SendGrid silently drops mail from unverified senders (`notch8.com` is not domain-authenticated). It's only used as the mailer From address, not shown in the UI.

## What changed
- `ops/demo-deploy.tmpl.yaml` - SMTP settings + `HYKU_CONTACT_EMAIL`
- `ops/staging-deploy.tmpl.yaml` - SMTP settings + `HYKU_CONTACT_EMAIL`

## Difference from #3159
The `.github/workflows/deploy.yaml` `workflow_dispatch` change from #3159 is **not included** here because `7.1-stable` already lists `demo` as a deploy option (it was never commented out on this branch, and stable has no `test` option). Only the ops template changes are applicable.

## After deploy
Users should be able to reset their passwords and receive emails from the demo/staging environments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)