### PR TITLE
Develop on multiple hykus

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-APP_NAME=hyku
+# APP_NAME is intentionally left unset here so docker-compose works across checkouts
 CH12N_TOOL=fits_servlet
 CHROME_HOSTNAME=chrome
 COMPOSE_DOCKER_CLI_BUILD=1

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -91,5 +91,6 @@ Rails.application.configure do # rubocop:disable Metrics/BlockLength
 
   config.active_job.queue_adapter = ENV.fetch('HYRAX_ACTIVE_JOB_QUEUE', 'sidekiq')
   # adding `.` wildcard to allow for subdomains
-  config.hosts << "." + ENV['HYKU_ROOT_HOST']
+  # adding regex to allow for COMPOSE_PROJECT_NAME-created hostnames
+  config.hosts << /\A(?:[a-z0-9_-]+\.)?#{Regexp.escape(ENV['HYKU_ROOT_HOST'])}(:\d+)?\z/i
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,13 +57,9 @@ networks:
   default:
   # `proxy` is the one network every concurrently-running Hyku/knapsack
   # checkout shares, so a single Traefik (`sc proxy up`) can route
-  # *.localhost.direct to whichever stack is currently running. It must
-  # already exist (`sc proxy up` creates it) - only services that Traefik
-  # actually routes to (see traefik.enable labels below) join it, in
-  # addition to `default`.
+  # *.localhost.direct to whichever stack is currently running.
   proxy:
     name: stackcar
-    external: true
 
 services:
   zoo:
@@ -111,6 +107,7 @@ services:
       - VIRTUAL_HOST=solr.hyku.test
     labels:
       - "traefik.enable=true"
+      - "traefik.docker.network=stackcar"
       - "traefik.http.routers.solr-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.tls=true"
       - "traefik.http.routers.solr-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.entrypoints=websecure"
       - "traefik.http.routers.solr-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.rule=Host(`solr-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.localhost.direct`)"
@@ -141,6 +138,7 @@ services:
       - 8080
     labels:
       - "traefik.enable=true"
+      - "traefik.docker.network=stackcar"
       - "traefik.http.routers.fits-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.tls=true"
       - "traefik.http.routers.fits-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.entrypoints=websecure"
       - "traefik.http.routers.fits-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.rule=Host(`fits-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.localhost.direct`)"
@@ -161,6 +159,7 @@ services:
       - 8080
     labels:
       - "traefik.enable=true"
+      - "traefik.docker.network=stackcar"
       - "traefik.http.routers.fcrepo-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.tls=true"
       - "traefik.http.routers.fcrepo-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.entrypoints=websecure"
       - "traefik.http.routers.fcrepo-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.rule=Host(`fcrepo-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.localhost.direct`)"
@@ -189,6 +188,7 @@ services:
       - VIRTUAL_HOST=admin.hyku.test
     labels:
       - "traefik.enable=true"
+      - "traefik.docker.network=stackcar"
       - "traefik.http.routers.adminer-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.tls=true"
       - "traefik.http.routers.adminer-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.entrypoints=websecure"
       - "traefik.http.routers.adminer-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.rule=Host(`adminer-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.localhost.direct`)"
@@ -205,6 +205,7 @@ services:
       VIRTUAL_HOST: .hyku.test
     labels:
       - "traefik.enable=true"
+      - "traefik.docker.network=stackcar"
       - "traefik.http.routers.web-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.tls=true"
       - "traefik.http.routers.web-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.entrypoints=websecure"
       - "traefik.http.routers.web-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.priority=10"
@@ -330,6 +331,7 @@ services:
       - VIRTUAL_HOST=chrome.hyku.test
     labels:
       - "traefik.enable=true"
+      - "traefik.docker.network=stackcar"
       - "traefik.http.routers.chrome-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.tls=true"
       - "traefik.http.routers.chrome-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.entrypoints=websecure"
       - "traefik.http.routers.chrome-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.rule=Host(`chrome-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.localhost.direct`)"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,8 @@
 # through verbatim, so the container would literally get `${HYKU_ROOT_HOST:-...}`.
 # Keep `.env` values as plain literals and express overridable defaults here.
 x-app-env: &app-env
-  APP_NAME: ${APP_NAME:-hyku}
+  # Falls back to COMPOSE_PROJECT_NAME (the checkout directory name)
+  APP_NAME: ${APP_NAME:-${COMPOSE_PROJECT_NAME}}
   HYRAX_FLEXIBLE: ${HYRAX_FLEXIBLE:-false}
   FCREPO_HOST: ${FCREPO_HOST:-fcrepo}
   HYKU_ROOT_HOST: ${HYKU_ROOT_HOST:-localhost.direct}
@@ -14,8 +15,8 @@ x-app-env: &app-env
   # Derived from APP_NAME. Computed here (not in .env) so the ${APP_NAME}
   # reference resolves on every Compose version; via env_file it would only
   # interpolate on Compose >= ~2.24 and breaks entirely if APP_NAME is unset.
-  HYKU_ADMIN_HOST: admin-${APP_NAME:-hyku}.${HYKU_ROOT_HOST:-localhost.direct}
-  HYKU_DEFAULT_HOST: "%{tenant}-${APP_NAME:-hyku}.${HYKU_ROOT_HOST:-localhost.direct}"
+  HYKU_ADMIN_HOST: admin-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.${HYKU_ROOT_HOST:-localhost.direct}
+  HYKU_DEFAULT_HOST: "%{tenant}-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.${HYKU_ROOT_HOST:-localhost.direct}"
 
 x-app: &app
   build:
@@ -51,8 +52,18 @@ volumes:
   zoo:
 
 networks:
+  # `default` is left unnamed so Compose auto-namespaces it per checkout
+  # (<project>_default).
   default:
+  # `proxy` is the one network every concurrently-running Hyku/knapsack
+  # checkout shares, so a single Traefik (`sc proxy up`) can route
+  # *.localhost.direct to whichever stack is currently running. It must
+  # already exist (`sc proxy up` creates it) - only services that Traefik
+  # actually routes to (see traefik.enable labels below) join it, in
+  # addition to `default`.
+  proxy:
     name: stackcar
+    external: true
 
 services:
   zoo:
@@ -92,17 +103,19 @@ services:
       - SOLR_ENABLE_AUTHENTICATION=yes
       - ZK_HOST=zoo:2181
       # Register SolrCloud replicas by this stable hostname instead of the
-      # container IP, so ZooKeeper's node_name stays valid across IP churn on the
-      # shared stackcar network (switching between the Hyku and a knapsack stack).
+      # container IP, so ZooKeeper's node_name stays valid across IP churn.
+      # zoo is private-only (default network), so this alias is always
+      # project-scoped and can't collide with another checkout's solr/zoo.
       - SOLR_HOST=solr
       - VIRTUAL_PORT=8983
       - VIRTUAL_HOST=solr.hyku.test
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.solr-${APP_NAME}.tls=true"
-      - "traefik.http.routers.solr-${APP_NAME}.entrypoints=websecure"
-      - "traefik.http.routers.solr-${APP_NAME}.rule=Host(`solr-${APP_NAME}.localhost.direct`)"
-      - "traefik.http.services.solr-${APP_NAME}.loadbalancer.server.port=8983"
+      - "traefik.http.routers.solr-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.tls=true"
+      - "traefik.http.routers.solr-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.entrypoints=websecure"
+      - "traefik.http.routers.solr-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.rule=Host(`solr-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.localhost.direct`)"
+      - "traefik.http.services.solr-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.loadbalancer.server.port=8983"
+    networks: [default, proxy]
     user: root
     command: bash -c "
       chown -R 8983:8983 /var/solr
@@ -128,10 +141,11 @@ services:
       - 8080
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.fits-${APP_NAME}.tls=true"
-      - "traefik.http.routers.fits-${APP_NAME}.entrypoints=websecure"
-      - "traefik.http.routers.fits-${APP_NAME}.rule=Host(`fits-${APP_NAME}.localhost.direct`)"
-      - "traefik.http.services.fits-${APP_NAME}.loadbalancer.server.port=8080"
+      - "traefik.http.routers.fits-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.tls=true"
+      - "traefik.http.routers.fits-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.entrypoints=websecure"
+      - "traefik.http.routers.fits-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.rule=Host(`fits-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.localhost.direct`)"
+      - "traefik.http.services.fits-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.loadbalancer.server.port=8080"
+    networks: [default, proxy]
 
   fcrepo:
     image: ghcr.io/samvera/fcrepo4:4.7.5
@@ -147,10 +161,11 @@ services:
       - 8080
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.fcrepo-${APP_NAME}.tls=true"
-      - "traefik.http.routers.fcrepo-${APP_NAME}.entrypoints=websecure"
-      - "traefik.http.routers.fcrepo-${APP_NAME}.rule=Host(`fcrepo-${APP_NAME}.localhost.direct`)"
-      - "traefik.http.services.fcrepo-${APP_NAME}.loadbalancer.server.port=8080"
+      - "traefik.http.routers.fcrepo-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.tls=true"
+      - "traefik.http.routers.fcrepo-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.entrypoints=websecure"
+      - "traefik.http.routers.fcrepo-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.rule=Host(`fcrepo-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.localhost.direct`)"
+      - "traefik.http.services.fcrepo-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.loadbalancer.server.port=8080"
+    networks: [default, proxy]
 
   db:
     image: postgres:11.1
@@ -174,10 +189,11 @@ services:
       - VIRTUAL_HOST=admin.hyku.test
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.adminer-${APP_NAME}.tls=true"
-      - "traefik.http.routers.adminer-${APP_NAME}.entrypoints=websecure"
-      - "traefik.http.routers.adminer-${APP_NAME}.rule=Host(`adminer-${APP_NAME}.localhost.direct`)"
-      - "traefik.http.services.adminer-${APP_NAME}.loadbalancer.server.port=8080"
+      - "traefik.http.routers.adminer-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.tls=true"
+      - "traefik.http.routers.adminer-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.entrypoints=websecure"
+      - "traefik.http.routers.adminer-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.rule=Host(`adminer-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.localhost.direct`)"
+      - "traefik.http.services.adminer-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.loadbalancer.server.port=8080"
+    networks: [default, proxy]
 
   web:
     <<: *app
@@ -189,11 +205,12 @@ services:
       VIRTUAL_HOST: .hyku.test
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.web-${APP_NAME}.tls=true"
-      - "traefik.http.routers.web-${APP_NAME}.entrypoints=websecure"
-      - "traefik.http.routers.web-${APP_NAME}.priority=10"
-      - "traefik.http.routers.web-${APP_NAME}.rule=HostRegexp(`.+-${APP_NAME}.localhost.direct`)"
-      - "traefik.http.services.web-${APP_NAME}.loadbalancer.server.port=3000"
+      - "traefik.http.routers.web-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.tls=true"
+      - "traefik.http.routers.web-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.entrypoints=websecure"
+      - "traefik.http.routers.web-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.priority=10"
+      - "traefik.http.routers.web-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.rule=HostRegexp(`.+-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.localhost.direct`)"
+      - "traefik.http.services.web-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.loadbalancer.server.port=3000"
+    networks: [default, proxy]
     depends_on:
       db:
         condition: service_started
@@ -313,7 +330,8 @@ services:
       - VIRTUAL_HOST=chrome.hyku.test
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.chrome-${APP_NAME}.tls=true"
-      - "traefik.http.routers.chrome-${APP_NAME}.entrypoints=websecure"
-      - "traefik.http.routers.chrome-${APP_NAME}.rule=Host(`chrome-${APP_NAME}.localhost.direct`)"
-      - "traefik.http.services.chrome-${APP_NAME}.loadbalancer.server.port=7900"
+      - "traefik.http.routers.chrome-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.tls=true"
+      - "traefik.http.routers.chrome-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.entrypoints=websecure"
+      - "traefik.http.routers.chrome-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.rule=Host(`chrome-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.localhost.direct`)"
+      - "traefik.http.services.chrome-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.loadbalancer.server.port=7900"
+    networks: [default, proxy]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,12 +52,9 @@ volumes:
   zoo:
 
 networks:
-  # `default` is left unnamed so Compose auto-namespaces it per checkout
-  # (<project>_default).
+  # Unnamed: Compose auto-namespaces this per checkout.
   default:
-  # `proxy` is the one network every concurrently-running Hyku/knapsack
-  # checkout shares, so a single Traefik (`sc proxy up`) can route
-  # *.localhost.direct to whichever stack is currently running.
+  # Shared across checkouts so Traefik (`sc proxy up`) can route them all.
   proxy:
     name: stackcar
 
@@ -98,10 +95,7 @@ services:
       - SOLR_ENABLE_CLOUD_MODE=yes
       - SOLR_ENABLE_AUTHENTICATION=yes
       - ZK_HOST=zoo:2181
-      # Register SolrCloud replicas by this stable hostname instead of the
-      # container IP, so ZooKeeper's node_name stays valid across IP churn.
-      # zoo is private-only (default network), so this alias is always
-      # project-scoped and can't collide with another checkout's solr/zoo.
+      # Stable hostname for ZooKeeper's node_name, not the container IP.
       - SOLR_HOST=solr
       - VIRTUAL_PORT=8983
       - VIRTUAL_HOST=solr.hyku.test

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -32,7 +32,7 @@ Start off by setting up a local development environment where you can experiment
     ```bash
     gem install stack_car
     sc proxy cert # Only need this once per stack_car version, requires passwords
-    sc proxy up
+    sc proxy up # Once per Docker re-boot
     ```
 
 3) **Build the Docker images:**
@@ -59,7 +59,10 @@ Start off by setting up a local development environment where you can experiment
     #### Congratulations!!!
 
    You can access the admin app in your browser at
-   [https://admin-hyku.localhost.direct](https://admin-hyku.localhost.direct).
+   `https://admin-<app-name>.localhost.direct` - see
+   [Application name in URL](#application-name-in-url) below for what
+   `<app-name>` is for your checkout. For a checkout directory named `hyku`,
+   that's [https://admin-hyku.localhost.direct](https://admin-hyku.localhost.direct).
    > :thumbsup: You are now ready to start using Hyku! Please refer to **[Using Hyku](./using-hyku.md)**
    > for instructions on getting your first tenant set up.
 
@@ -92,9 +95,14 @@ see the [Configuration Guide](./configuration.md).
 
 #### Application name in URL
 
-The APP_NAME environment variable defaults to `hyku`, You can set this to another value in your
-local environment - e.g. `export APP_NAME=sandbox` - or via the `.env` file. The application path 
-will be "https://admin-${APP_NAME}.localhost.direct" - e.g. 
+The `APP_NAME` environment variable defaults to your checkout directory's name
+(so `git clone .../hyku` gives `APP_NAME=hyku`, a directory named `sandbox`
+gives `APP_NAME=sandbox`, etc.) - this is what lets more than one Hyku/knapsack
+checkout run at the same time without colliding on the same hostname or
+Traefik router. You can still override it explicitly - e.g. `export
+APP_NAME=sandbox` - or via the `.env` file; an explicit value always wins over
+the directory-derived default. The application path will be
+"https://admin-${APP_NAME}.localhost.direct" - e.g.
 [https://admin-**sandbox**.localhost.direct](https://admin-sandbox.localhost.direct).
 
 #### DNS & Certificates


### PR DESCRIPTION
When running multiple instances of Hyku on a development machine, the support services get tangled up in each other. So if you're running `my_hyku` and `your_hyku` locally, for some commands `my_hyku` might connect to `your_hyku`'s database, solr, fedora, or redis.

This is at least a partial cause of this bug - Refs https://github.com/samvera-labs/hyku_knapsack/issues/59

This is because by explicitly naming our docker network, any hyku apps that come up will use that same network, and there's not a way for traefik to know where to send traffic. 

If we let docker name the default network, and then name stackcar as the proxy, we can keep the services separate while allowing for the proxy work stackcar does.

⚠️ If adding this change to a knapsack application, you must also change the docker-compose.yaml in that application:

```diff
   zoo:

 networks:
+  # Unnamed: Compose auto-namespaces this per checkout.
   default:
+  # Shared across checkouts so Traefik (`sc proxy up`) can route them all.
+  proxy:
     name: stackcar
```

@samvera/hyku-code-reviewers
