### PR TITLE
Site instance memoization

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem 'cocoon'
 gem 'codemirror-rails'
 gem 'coffee-rails', '~> 4.2' # Use CoffeeScript for .coffee assets and views
 gem 'database_cleaner', group: %i[test]
+gem 'db-query-matchers', '~> 0.15', group: %i[test]
 gem 'derivative-rodeo', '~>0.5', '>= 0.5.3'
 gem 'devise'
 gem 'devise-guests', '~> 0.3'

--- a/Gemfile
+++ b/Gemfile
@@ -90,6 +90,7 @@ gem 'redcarpet' # for Markdown constant
 gem 'redis-actionpack'
 gem 'redis-namespace', '~> 1.10' # Hyrax v5 relies on 1.5; but we'd like to have the #clear method so we need 1.10 or greater.
 gem 'redlock', '>= 0.1.2', '< 2.0' # lock redlock per https://github.com/samvera/hyrax/pull/5961
+gem 'request_store', '~> 1.7'
 gem 'riiif', git: 'https://github.com/sul-dlss/riiif.git', ref: '9a375'
 gem 'rolify'
 gem 'ros-apartment', require: 'apartment' # Rails 7.2 compatible apartment fork - drop-in replacement

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1732,6 +1732,7 @@ DEPENDENCIES
   redis-actionpack
   redis-namespace (~> 1.10)
   redlock (>= 0.1.2, < 2.0)
+  request_store (~> 1.7)
   riiif!
   rolify
   ros-apartment

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -455,6 +455,9 @@ GEM
       database_cleaner-core (~> 2.0)
     database_cleaner-core (2.0.1)
     date (3.5.1)
+    db-query-matchers (0.15.0)
+      activesupport (>= 4.0)
+      rspec (>= 3.0)
     declarative (0.0.20)
     denormalize_fields (1.3.0)
       activerecord (>= 4.1.14, < 8.0.0)
@@ -1674,6 +1677,7 @@ DEPENDENCIES
   codemirror-rails
   coffee-rails (~> 4.2)
   database_cleaner
+  db-query-matchers (~> 0.15)
   derivative-rodeo (~> 0.5, >= 0.5.3)
   devise
   devise-guests (~> 0.3)

--- a/app/controllers/admin/work_types_controller.rb
+++ b/app/controllers/admin/work_types_controller.rb
@@ -32,7 +32,7 @@ module Admin
     private
 
     def site
-      @site ||= Site.first
+      @site ||= Site.instance
     end
 
     def setup_profile_work_types

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -35,6 +35,11 @@ class Site < ApplicationRecord
         end
       end
     end
+
+    # Clears the memoized Site so the next call to .instance re-fetches it.
+    def reset!
+      RequestStore.delete(:site_instance)
+    end
   end
 
   # Get all administrator emails associated with this site

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -27,9 +27,12 @@ class Site < ApplicationRecord
              to: :instance
 
     def instance
-      return NilSite.instance if Account.global_tenant?
-      first_or_create do |site|
-        site.available_works = Hyrax.config.registered_curation_concern_types
+      RequestStore.fetch(:site_instance) do
+        return NilSite.instance if Account.global_tenant?
+
+        first_or_create do |site|
+          site.available_works = Hyrax.config.registered_curation_concern_types
+        end
       end
     end
   end

--- a/config/initializers/apartment.rb
+++ b/config/initializers/apartment.rb
@@ -78,6 +78,9 @@ unless ActiveModel::Type::Boolean.new.cast(ENV.fetch('APARTMENT_DISABLE_INIT', '
       # switch (e.g. from AccountElevator#parse_tenant_name) don't poison the
       # cache with values from the wrong tenant schema.
       Flipflop::FeatureCache.current.clear!
+      # Same reasoning as above: a memoized Site.instance is only valid for
+      # the tenant it was fetched under.
+      Site.reset!
       account = Account.find_by(tenant: current)
       account&.switch!
     }

--- a/config/initializers/apartment_activejob.rb
+++ b/config/initializers/apartment_activejob.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 require 'active_job'
 require 'active_job_tenant'
+require 'active_job_request_store_reset'
 
 class ActiveJob::Base
   include ActiveJobTenant
+  include ActiveJobRequestStoreReset
 end

--- a/lib/active_job_request_store_reset.rb
+++ b/lib/active_job_request_store_reset.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# request_store's own Rack middleware clears RequestStore at the end of every
+# HTTP request (see request_store/railtie.rb), but that doesn't cover
+# background jobs: GoodJob and Sidekiq both reuse threads across job
+# executions, so anything stashed in RequestStore during one job (e.g.
+# Site.instance, Draper's current view context, Lograge's captured redirect
+# location) could otherwise leak into the next job run on that thread. This
+# mirrors the ensure-based clear in request_store-sidekiq's server
+# middleware (https://github.com/madebylotus/request_store-sidekiq), but via
+# ActiveJob's own around_perform callback so it applies regardless of queue
+# adapter.
+module ActiveJobRequestStoreReset
+  extend ActiveSupport::Concern
+
+  included do
+    around_perform do |_job, block|
+      block.call
+    ensure
+      RequestStore.clear!
+    end
+  end
+end

--- a/spec/controllers/sites_controller_spec.rb
+++ b/spec/controllers/sites_controller_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe SitesController, type: :controller, singletenant: true do
 
     context "site with existing directory image" do
       before do
-        expect(Hyku::AvatarUploader).to receive(:storage).and_return(CarrierWave::Storage::File).at_least(3).times
+        allow(Hyku::AvatarUploader).to receive(:storage).and_return(CarrierWave::Storage::File)
         f = fixture_file_upload('/images/nypl-hydra-of-lerna.jpg', 'image/jpg')
         Site.instance.update(directory_image: f)
         ContentBlock.find_or_create_by(name: 'directory_image_text').update!(value: 'Sample text')

--- a/spec/features/site_instance_memoization_spec.rb
+++ b/spec/features/site_instance_memoization_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Site.instance memoization on a real page render', type: :feature, clean: true, js: false do
+  it 'issues at most one sites-table query to render the catalog search page' do
+    expect { visit '/catalog' }
+      .to make_database_queries(matching: /FROM "sites"/, count: 0..1)
+
+    expect(page).to have_content('Search Results')
+  end
+end

--- a/spec/lib/active_job_request_store_reset_spec.rb
+++ b/spec/lib/active_job_request_store_reset_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# Real ActiveJob subclasses (not test doubles) used to exercise the actual
+# perform_now -> run_callbacks(:perform) -> around_perform path, so these
+# specs prove the real behavior rather than a mocked approximation of it.
+class RequestStoreWritingJob < ApplicationJob
+  def perform
+    RequestStore.store[:probe] = 'set during job'
+  end
+end
+
+class RequestStoreWritingThenRaisingJob < ApplicationJob
+  def perform
+    RequestStore.store[:probe] = 'set before raising'
+    raise StandardError, 'boom'
+  end
+end
+
+RSpec.describe ActiveJobRequestStoreReset do
+  around do |example|
+    RequestStore.clear!
+    example.run
+    RequestStore.clear!
+  end
+
+  it 'clears RequestStore after a job performs successfully' do
+    RequestStoreWritingJob.perform_now
+
+    expect(RequestStore.store).to be_empty
+  end
+
+  it 'clears RequestStore even when the job raises (ApplicationJob#retry_on rescues and re-enqueues it)' do
+    expect { RequestStoreWritingThenRaisingJob.perform_now }.not_to raise_error
+
+    expect(RequestStore.store).to be_empty
+  end
+
+  it 'does not leak state from one job execution into the next job on the same thread' do
+    RequestStoreWritingJob.perform_now
+
+    probe_reading_job = Class.new(ApplicationJob) do
+      def perform
+        RequestStore.store[:probe]
+      end
+    end
+
+    expect(probe_reading_job.perform_now).to be_nil
+  end
+end

--- a/spec/models/concerns/account_settings_spec.rb
+++ b/spec/models/concerns/account_settings_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe AccountSettings do
                                                                                 cache_api
                                                                                 contact_email
                                                                                 contact_email_to
+                                                                                demo_acceptable_use_url
                                                                                 depositor_email_notifications
                                                                                 discogs_user_token
                                                                                 doi_reader

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -47,6 +47,31 @@ RSpec.describe Site, type: :model do
         described_class.instance
       end
     end
+    describe '.instance across an in-process tenant switch' do
+      after { Apartment::Tenant.switch!(Apartment.default_tenant) }
+
+      let(:old_account) { FactoryBot.build(:sign_up_account) }
+      let(:new_account) { FactoryBot.build(:sign_up_account) }
+
+      before do
+        CreateAccount.new(old_account).save
+        CreateAccount.new(new_account).save
+
+        Apartment::Tenant.switch!(old_account.tenant)
+        Site.instance.update!(application_name: 'old site')
+
+        Apartment::Tenant.switch!(new_account.tenant)
+        Site.instance.update!(application_name: 'new site')
+      end
+
+      it 'does not return a stale Site after switching tenants within the same thread' do
+        Apartment::Tenant.switch!(old_account.tenant)
+        expect(described_class.instance.application_name).to eq('old site')
+
+        Apartment::Tenant.switch!(new_account.tenant)
+        expect(described_class.instance.application_name).to eq('new site')
+      end
+    end
   end
 
   describe ".superadmin_emails" do

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -1,5 +1,14 @@
 # frozen_string_literal: true
 
+# Test-only job used to exercise the real ActiveJobTenant#perform_now wrapper
+# (config/initializers/apartment_activejob.rb includes it into ActiveJob::Base,
+# so every real job gets this same tenant-switching behavior for free).
+class SiteNameCapturingJob < ApplicationJob
+  def perform
+    Site.instance.application_name
+  end
+end
+
 RSpec.describe Site, type: :model do
   let(:admin1) { FactoryBot.create(:user, email: 'bob@was_here.net') }
   let(:admin2) { FactoryBot.create(:user, email: 'jane@was_here.net') }
@@ -70,6 +79,44 @@ RSpec.describe Site, type: :model do
 
         Apartment::Tenant.switch!(new_account.tenant)
         expect(described_class.instance.application_name).to eq('new site')
+      end
+
+      # RequestStore.store is Thread.current[:request_store] (pure thread-local), so
+      # this test needs real accounts visible to a *different* DB connection than the
+      # one holding the example's own open transaction - truncation instead of the
+      # suite's default transactional strategy for model specs.
+      it 'does not leak a memoized Site across concurrent threads for different tenants', truncation: true do
+        seen_names = Queue.new
+        [[old_account, 'old site'], [new_account, 'new site']].map do |account, expected_name|
+          Thread.new do
+            Apartment::Tenant.switch!(account.tenant)
+            names = Array.new(20) { Site.instance.application_name }
+            seen_names << { expected: expected_name, actual: names.uniq }
+          ensure
+            Apartment::Tenant.switch!(Apartment.default_tenant)
+          end
+        end.each(&:join)
+
+        2.times do
+          result = seen_names.pop
+          expect(result[:actual]).to eq([result[:expected]])
+        end
+      end
+
+      # Every job includes ActiveJobTenant (config/initializers/apartment_activejob.rb),
+      # whose perform_now wraps execution in Apartment::Tenant.switch(tenant) { super } -
+      # which calls switch! (firing the :switch callback, i.e. Site.reset!) on entry AND
+      # exit. This proves that mechanism actually protects sequential job execution on a
+      # reused thread (the GoodJob/Sidekiq thread-pool-reuse scenario), using the real
+      # job execution path rather than calling Apartment::Tenant.switch! directly.
+      it 'does not leak a memoized Site across sequential job executions on the same thread' do
+        old_job = SiteNameCapturingJob.new
+        old_job.tenant = old_account.tenant
+        new_job = SiteNameCapturingJob.new
+        new_job.tenant = new_account.tenant
+
+        expect(old_job.perform_now).to eq('old site')
+        expect(new_job.perform_now).to eq('new site')
       end
     end
   end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -6,19 +6,45 @@ RSpec.describe Site, type: :model do
   let(:admin3) { FactoryBot.create(:user, email: 'i@was_here.net') }
 
   describe ".instance" do
+    let(:request_store_mock) { {} }
+    before do
+      allow(RequestStore).to receive(:store).and_return(request_store_mock)
+    end
     context "on global tenant" do
       before do
         allow(Account).to receive(:global_tenant?).and_return true
       end
 
       it "is a NilSite" do
-        expect(described_class.instance).to eq(NilSite.instance)
+        expect(described_class.instance).to be_an_instance_of(NilSite)
       end
     end
 
     context "on a specific tenant" do
       it "is a singleton site" do
         expect(described_class.instance).to eq(described_class.instance)
+      end
+      it 'only queries the database once across multiple calls in the same request' do
+        expect(described_class).to receive(:first_or_create).once.and_call_original
+
+        3.times { described_class.instance }
+      end
+
+      it 'returns the same object across multiple calls' do
+        first = described_class.instance
+        second = described_class.instance
+
+        expect(first).to equal(second)
+      end
+
+      it 'queries again after RequestStore is cleared (simulating a new request)' do
+        local_request_store_mock = {}
+        allow(RequestStore).to receive(:store).and_return(local_request_store_mock)
+        described_class.instance
+        expect(local_request_store_mock.keys).to eq([:site_instance])
+        local_request_store_mock.delete(:site_instance)
+        expect(Site).to receive(:first_or_create).once.and_call_original
+        described_class.instance
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -178,6 +178,7 @@ RSpec.configure do |config|
                     end
     ActiveFedora::Fedora.reset! unless disable_wings
     SolrEndpoint.reset!
+    RequestStore.clear!
     if example.metadata[:clean] || example.metadata[:clean_repo] || example.metadata[:type] == :feature
       if disable_wings
         Hyrax::SolrService.wipe!

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -187,8 +187,10 @@ RSpec.configure do |config|
       end
     end
 
-    # Only use truncation for JS-enabled feature specs
-    if example.metadata[:js] && example.metadata[:type] == :feature
+    # Only use truncation for JS-enabled feature specs, or specs that explicitly opt in
+    # (e.g. real Thread.new-based tests, where a spawned thread's own DB connection can't
+    # see data created inside the main thread's still-open transaction).
+    if (example.metadata[:js] && example.metadata[:type] == :feature) || example.metadata[:truncation]
       DatabaseCleaner.strategy = :truncation
     else
       DatabaseCleaner.strategy = :transaction

--- a/spec/support/db_query_matchers.rb
+++ b/spec/support/db_query_matchers.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'db_query_matchers'
+
+DBQueryMatchers.configure do |config|
+  config.schemaless = true
+end


### PR DESCRIPTION
Significantly reduces db calls

In the views Site.instance was being called many times per view, creating a new database call each time. We can memoize the Site.instance per-request in the RequestStore, avoiding cross-site, cross-tenant, and cross-user contamination.

The Admin::WorkTypesController had its own implementation of Site which had to be brought in alignment with Site.instance.