### PR TITLE
🐛 Fix Download PDF button

### DIFF
--- a/app/helpers/pdf_js_helper.rb
+++ b/app/helpers/pdf_js_helper.rb
@@ -5,9 +5,11 @@ module PdfJsHelper
     "/pdf.js/viewer.html?file=#{path}##{query_param}"
   end
 
-  def pdf_file_set_presenter(presenter)
-    # currently only supports one pdf per work, falls back to the first pdf file set in ordered members
-    representative_presenter(presenter) || presenter.file_set_presenters.find(&:pdf?)
+  def pdf_file_set_presenter(presenter, downloadable: false)
+    pdfs = presenter.file_set_presenters.select { |file_set_presenter| file_set_presenter.try(:pdf?) }
+    pdfs = pdfs.select { |file_set_presenter| can?(:download, file_set_presenter.id) } if downloadable
+
+    pdfs.find { |file_set_presenter| file_set_presenter.id == presenter.representative_id } || pdfs.first
   end
 
   def representative_presenter(presenter)

--- a/app/views/hyrax/base/_download_pdf.html.erb
+++ b/app/views/hyrax/base/_download_pdf.html.erb
@@ -1,14 +1,13 @@
-<% if can?(:download, file_set_id) %>
+<% pdf = pdf_file_set_presenter(presenter, downloadable: true) %>
+<% if pdf.present? %>
   <div class="download-pdf-controls">
-    <% if @presenter.representative_presenter.present? && presenter.file_set_presenters.any?(&:pdf?) %>
-      <%= button_tag type: 'button',
-                     id: "file_download",
-                     data: { label: @presenter.representative_presenter.id,
-                             path: hyrax.download_path(presenter.representative_presenter) },
-                     class: "btn btn-success btn-block file_download center-block",
-                     onclick: "window.open(this.dataset.path, '_blank');" do %>
-        Download PDF
-      <% end %>
+    <%= button_tag type: 'button',
+                   id: "file_download",
+                   data: { label: pdf.id,
+                           path: hyrax.download_path(pdf) },
+                   class: "btn btn-success btn-block file_download center-block",
+                   onclick: "window.open(this.dataset.path, '_blank', 'noopener,noreferrer');" do %>
+      <%= t('hyrax.base.download_pdf') %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/themes/community_show/hyrax/base/_download_pdf.html.erb
+++ b/app/views/themes/community_show/hyrax/base/_download_pdf.html.erb
@@ -10,17 +10,16 @@
   - Custom CSS in community_show_buttons.scss applies min-width: 350px, max-width: 500px for proper sizing
 %>
 
-<% if can?(:download, file_set_id) %>
+<% pdf = pdf_file_set_presenter(presenter, downloadable: true) %>
+<% if pdf.present? %>
   <div class="download-pdf-controls text-center">
-    <% if @presenter.representative_presenter.present? && presenter.file_set_presenters.any?(&:pdf?) %>
-      <%= link_to 'Download PDF',
-                  hyrax.download_path(presenter.representative_presenter),
-                  id: 'file_download',
-                  class: 'btn btn-primary file_download mx-auto d-block',
-                  target: '_blank',
-                  rel: 'noopener noreferrer',
-                  role: 'button',
-                  data: { label: @presenter.representative_presenter.id } %>
-    <% end %>
+    <%= link_to t('hyrax.base.download_pdf'),
+                hyrax.download_path(pdf),
+                id: 'file_download',
+                class: 'btn btn-primary file_download mx-auto d-block',
+                target: '_blank',
+                rel: 'noopener noreferrer',
+                role: 'button',
+                data: { label: pdf.id } %>
   </div>
 <% end %>

--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -301,6 +301,7 @@ de:
     base:
       citations:
         header: Zitate
+      download_pdf: PDF herunterladen
       form_child_work_relationships:
         actions:
           remove: Aus dieser Arbeit entfernen

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -301,6 +301,7 @@ en:
     base:
       citations:
         header: Citation
+      download_pdf: Download PDF
       form_child_work_relationships:
         actions:
           remove: Remove from this work

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -302,6 +302,7 @@ es:
     base:
       citations:
         header: Citación
+      download_pdf: Descargar PDF
       form_child_work_relationships:
         actions:
           remove: Eliminar de este trabajo

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -300,6 +300,7 @@ fr:
     base:
       citations:
         header: Citation
+      download_pdf: Télécharger le PDF
       form_child_work_relationships:
         actions:
           remove: Supprimer de ce travail

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -302,6 +302,7 @@ it:
     base:
       citations:
         header: Citazioni
+      download_pdf: Scarica il PDF
       form_child_work_relationships:
         actions:
           remove: Rimuovi da questo lavoro

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -302,6 +302,7 @@ pt-BR:
     base:
       citations:
         header: 'Citaçõ:'
+      download_pdf: Baixar PDF
       form_child_work_relationships:
         actions:
           remove: Remover deste trabalho

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -302,6 +302,7 @@ zh:
     base:
       citations:
         header: 引文
+      download_pdf: 下载 PDF
       form_child_work_relationships:
         actions:
           remove: 从这项工作中删除

--- a/spec/helpers/pdf_js_helper_spec.rb
+++ b/spec/helpers/pdf_js_helper_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+RSpec.describe PdfJsHelper, type: :helper do
+  describe '#pdf_file_set_presenter' do
+    let(:file_set_class) { Struct.new(:id, :pdf) { alias_method :pdf?, :pdf } }
+    let(:image) { file_set_class.new('img-1', false) }
+    let(:pdf) { file_set_class.new('pdf-1', true) }
+    let(:other_pdf) { file_set_class.new('pdf-2', true) }
+    let(:presenter) do
+      double('WorkShowPresenter', file_set_presenters: file_set_presenters, representative_id: representative_id)
+    end
+
+    context 'when the representative is not a PDF' do
+      let(:file_set_presenters) { [image, pdf] }
+      let(:representative_id) { image.id }
+
+      it 'returns the first PDF rather than the representative' do
+        expect(helper.pdf_file_set_presenter(presenter)).to eq pdf
+      end
+    end
+
+    context 'when the representative is a PDF' do
+      let(:file_set_presenters) { [pdf, other_pdf] }
+      let(:representative_id) { other_pdf.id }
+
+      it 'returns the representative' do
+        expect(helper.pdf_file_set_presenter(presenter)).to eq other_pdf
+      end
+    end
+
+    context 'when there is no PDF' do
+      let(:file_set_presenters) { [image] }
+      let(:representative_id) { image.id }
+
+      it 'returns nil' do
+        expect(helper.pdf_file_set_presenter(presenter)).to be_nil
+      end
+    end
+
+    context 'with downloadable: true' do
+      let(:file_set_presenters) { [pdf, other_pdf] }
+      let(:representative_id) { pdf.id }
+
+      before do
+        allow(helper).to receive(:can?) { |_action, id| id == other_pdf.id }
+      end
+
+      it 'skips PDFs the user cannot download, including the representative' do
+        expect(helper.pdf_file_set_presenter(presenter, downloadable: true)).to eq other_pdf
+      end
+
+      it 'returns nil when no PDF is downloadable' do
+        allow(helper).to receive(:can?).and_return(false)
+
+        expect(helper.pdf_file_set_presenter(presenter, downloadable: true)).to be_nil
+      end
+    end
+  end
+end

--- a/spec/views/hyrax/base/_download_pdf.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_download_pdf.html.erb_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+RSpec.describe 'hyrax/base/_download_pdf.html.erb', type: :view do
+  # Stands in for a file set presenter: the partial only needs id, pdf? and to_param.
+  let(:file_set_class) do
+    Struct.new(:id, :pdf) do
+      alias_method :pdf?, :pdf
+      def to_param
+        id
+      end
+    end
+  end
+  let(:image) { file_set_class.new('img-1', false) }
+  let(:pdf) { file_set_class.new('pdf-1', true) }
+  let(:file_set_presenters) { [image, pdf] }
+  let(:representative_id) { image.id }
+  let(:presenter) do
+    double('WorkShowPresenter', file_set_presenters: file_set_presenters, representative_id: representative_id)
+  end
+  let(:downloadable_ids) { file_set_presenters.map(&:id) }
+
+  before do
+    allow(view).to receive(:can?) { |_action, id| downloadable_ids.include?(id) }
+  end
+
+  def render_button
+    # file_set_id is what the show pages pass; the partial no longer uses it.
+    render 'hyrax/base/download_pdf', presenter: presenter, file_set_id: image.id
+  end
+
+  context 'when the representative is not the PDF' do
+    it 'points the button at the PDF file set' do
+      render_button
+
+      expect(rendered).to have_selector("#file_download[data-label='pdf-1']", text: I18n.t('hyrax.base.download_pdf'), visible: :all)
+      expect(rendered).to have_selector("#file_download[data-path*='pdf-1']", visible: :all)
+      expect(rendered).not_to have_selector("#file_download[data-path*='img-1']", visible: :all)
+    end
+  end
+
+  context 'when the representative is one of several PDFs' do
+    let(:other_pdf) { file_set_class.new('pdf-2', true) }
+    let(:file_set_presenters) { [pdf, other_pdf] }
+    let(:representative_id) { other_pdf.id }
+
+    it 'points the button at the representative' do
+      render_button
+
+      expect(rendered).to have_selector("#file_download[data-path*='pdf-2']", visible: :all)
+    end
+  end
+
+  context 'when the user can download the representative but not the PDF' do
+    let(:downloadable_ids) { [image.id] }
+
+    it 'renders nothing' do
+      render_button
+
+      expect(rendered).not_to have_selector('#file_download', visible: :all)
+    end
+  end
+
+  context 'when the user can download a later PDF but not the first' do
+    let(:other_pdf) { file_set_class.new('pdf-2', true) }
+    let(:file_set_presenters) { [pdf, other_pdf] }
+    let(:downloadable_ids) { [other_pdf.id] }
+
+    it 'points the button at the readable PDF' do
+      render_button
+
+      expect(rendered).to have_selector("#file_download[data-path*='pdf-2']", visible: :all)
+    end
+  end
+
+  context 'when there is no PDF' do
+    let(:file_set_presenters) { [image] }
+
+    it 'renders nothing' do
+      render_button
+
+      expect(rendered).not_to have_selector('#file_download', visible: :all)
+    end
+  end
+end


### PR DESCRIPTION
Prior, the button showed up if any file set in the work was a PDF, but it linked to the work's representative file set, which is often something else, so a work with an image as its representative served that image under a "Download PDF" label.  The permission check used a third file set again, the file_set_id passed into the partial.

Now the partial picks the first PDF file set the user can download and uses it for all three: whether to show the button, what to authorize, and what to link to.  Only downloadable PDFs are considered, since file_set_presenters includes file sets the user cannot see.  At the moment if your work has more than one PDF, only the first one gets downloaded, so perhaps a todo for the future.

Also moves the hardcoded "Download PDF" label into a locale key (hyrax.base.download_pdf, all seven locales) and adds a view spec.
