### PR TITLE
Stash the deposited work's id and parent id for the done screen

### DIFF
--- a/app/controllers/hyrax/deposit_wizard_controller.rb
+++ b/app/controllers/hyrax/deposit_wizard_controller.rb
@@ -90,8 +90,10 @@ module Hyrax
         return render(:review)
       end
 
-      reset_state
+      # Stash before resetting, so reading the session-scoped parent doesn't rely
+      # on the memoized State still pointing at the hash reset_state replaced.
       stash_deposited(work)
+      reset_state
       redirect_to main_app.deposit_wizard_step_path(step: 'done')
     end
 
@@ -184,9 +186,13 @@ module Hyrax
     end
 
     # Survive the redirect to the done screen, which reads it once. The show path
-    # is built here where the work object is available.
+    # is built here where the work object is available. The ids let a done-screen
+    # override render something about the deposit in context (e.g. the parent's
+    # membership) without re-deriving them from state the redirect has dropped.
     def stash_deposited(work)
       session[:deposit_wizard_last] = {
+        'id' => work.id.to_s,
+        'parent_id' => wizard_state.parent_id.presence,
         'title' => Array(work.title).first,
         'path' => main_app.polymorphic_path([main_app, work])
       }

--- a/spec/requests/deposit_wizard_spec.rb
+++ b/spec/requests/deposit_wizard_spec.rb
@@ -826,6 +826,9 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
 
         expect(response).to redirect_to(deposit_wizard_step_path(step: 'done'))
         expect(session[:deposit_wizard]).to eq({})
+
+        work = Hyrax.query_service.find_all_of_model(model: resource_class).to_a.last
+        expect(session[:deposit_wizard_last]).to include('id' => work.id.to_s, 'parent_id' => nil)
       end
 
       it 'applies a per-file embargo that differs from the work embargo' do
@@ -1078,6 +1081,8 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
             child = Hyrax.query_service.find_all_of_model(model: resource_class).to_a
                          .reject { |w| w.id.to_s == parent.id.to_s }.last
             expect(reloaded_parent.member_ids.map(&:to_s)).to include(child.id.to_s)
+            expect(session[:deposit_wizard_last])
+              .to include('id' => child.id.to_s, 'parent_id' => parent.id.to_s)
           end
 
           it 'nests using a parent seeded at launch (handoff), without re-posting it' do

--- a/spec/requests/deposit_wizard_spec.rb
+++ b/spec/requests/deposit_wizard_spec.rb
@@ -827,8 +827,13 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
         expect(response).to redirect_to(deposit_wizard_step_path(step: 'done'))
         expect(session[:deposit_wizard]).to eq({})
 
-        work = Hyrax.query_service.find_all_of_model(model: resource_class).to_a.last
-        expect(session[:deposit_wizard_last]).to include('id' => work.id.to_s, 'parent_id' => nil)
+        stashed = session[:deposit_wizard_last]
+        expect(stashed['parent_id']).to be_nil
+        # Resolve the work from the stashed id rather than the newest record, so the
+        # assertion doesn't depend on query-service ordering.
+        work = Hyrax.query_service.find_by(id: Valkyrie::ID.new(stashed['id']))
+        expect(work).to be_a(resource_class)
+        expect(Array(work.title).first).to eq(stashed['title'])
       end
 
       it 'applies a per-file embargo that differs from the work embargo' do
@@ -1081,8 +1086,11 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
             child = Hyrax.query_service.find_all_of_model(model: resource_class).to_a
                          .reject { |w| w.id.to_s == parent.id.to_s }.last
             expect(reloaded_parent.member_ids.map(&:to_s)).to include(child.id.to_s)
-            expect(session[:deposit_wizard_last])
-              .to include('id' => child.id.to_s, 'parent_id' => parent.id.to_s)
+            # The stashed ids identify the nesting the done screen renders: the parent
+            # chosen this session, and a child that really is one of its members.
+            stashed = session[:deposit_wizard_last]
+            expect(stashed['parent_id']).to eq(parent.id.to_s)
+            expect(reloaded_parent.member_ids.map(&:to_s)).to include(stashed['id'])
           end
 
           it 'nests using a parent seeded at launch (handoff), without re-posting it' do


### PR DESCRIPTION
Stash the deposited work's id and parent id for the done screen

The deposit wizard's done screen reads a single-use session summary of the
deposit (`session[:deposit_wizard_last]`, via `Presenter#last_deposited`), which
carried only a title and a show path.

That is enough to render the stock done screen, but not enough for a downstream
app to render anything about the deposit *in context* - for example the parent
work's membership after nesting a child, or a "what's next" prompt scoped to the
parent. The ids it would need are gone by then: the wizard redirects to `done`,
and `reset_state` has already swapped out the session-scoped wizard state.

So downstream apps end up overriding the controller purely to add two keys to
that hash. This adds them upstream instead. Discovered in
[research-technologies/enact_knapsack#133](https://github.com/research-technologies/enact_knapsack/pull/133),
where the only content of the override was exactly this.

`stash_deposited` also moves ahead of `reset_state`. Reading
`wizard_state.parent_id` after the reset happens to work today, but only because
`reset_state` assigns a *new* hash to `session[:deposit_wizard]` while the
memoized `State` still holds a reference to the old, populated one. Stashing
first means the read doesn't depend on that. The two touch different session
keys, so the order is otherwise immaterial.

No behavior change to the stock done screen: it reads `title` and `path` and
ignores the rest.

Changes proposed in this pull request:
* Add `id` and `parent_id` to the `session[:deposit_wizard_last]` summary that `Hyrax::DepositWizardController#stash_deposited` writes.
* Call `stash_deposited` before `reset_state`, so reading the session-scoped parent doesn't rely on the memoized `State` still pointing at the replaced hash.
* Assert the stashed ids in the two existing request specs that already cover the stash: a plain commit (no parent) and the parent-connect nesting case.

@samvera/hyku-code-reviewers
