### PR TITLE
Stop loading every child work to find a parent's file sets

### DIFF
--- a/app/indexers/concerns/hyku_indexing.rb
+++ b/app/indexers/concerns/hyku_indexing.rb
@@ -57,10 +57,53 @@ module HykuIndexing
 
   # The parent's own child file sets, fetched once per object. Both
   # `extract_text_from_plain_text_files` and the `extract_text_from_pdf_directly`
-  # fallback need them, and `find_child_file_sets` loads the member resources, so
+  # fallback need them, and loading member resources is the expensive part, so
   # memoize to avoid running that load twice in the same indexing pass.
   def child_file_sets(object)
-    (@child_file_sets ||= {})[object.id] ||= Hyrax.custom_queries.find_child_file_sets(resource: object).to_a
+    (@child_file_sets ||= {})[object.id] ||= file_set_members(object)
+  end
+
+  # Loads only the members that are file sets. `find_child_file_sets` is
+  # `find_members(resource:).select(&:file_set?)`, so it instantiates every member
+  # before discarding the non-file-sets: a 100-child work spent ~1.7s per reindex
+  # loading child works it never uses, and the parent is reindexed several times
+  # per save (#3175, the other half of #3105).
+  #
+  # `find_members(model:)` can't do the filtering: Goddess maps a Valkyrie model
+  # to its Wings counterpart, so asking for `Hyrax::FileSet` queries
+  # `internal_resource = 'FileSet'` and matches nothing.
+  def file_set_members(object)
+    ids = file_set_member_ids(object)
+    return [] if ids.empty?
+
+    # find_many_by_ids does not preserve the order of the ids it is given.
+    by_id = Hyrax.query_service.find_many_by_ids(ids: ids).index_by { |member| member.id.to_s }
+    ids.filter_map { |id| by_id[id.to_s] }
+  end
+
+  # Which members are file sets, in member order. Same batched-Solr shape as
+  # `child_work_full_texts`, and the same eventual consistency: a file set not yet
+  # indexed contributes on the next reindex.
+  def file_set_member_ids(object)
+    member_ids = Array(object.member_ids).map(&:to_s).reject(&:blank?)
+    return [] if member_ids.empty?
+
+    found = Hyrax::SolrService.query(
+      "{!terms f=id}#{member_ids.join(',')}",
+      fq: file_set_model_filter,
+      fl: 'id',
+      rows: member_ids.length,
+      method: :post
+    ).map { |doc| doc['id'].to_s }.to_set
+
+    member_ids.select { |id| found.include?(id) }.map { |id| Valkyrie::ID.new(id) }
+  end
+
+  # File sets are indexed with `has_model_ssim` but no `generic_type_sim`, so the
+  # model names are the only way to select them.
+  def file_set_model_filter
+    names = Hyrax::ModelRegistry.file_set_class_names.map { |name| name.delete_prefix('::') }.uniq
+    "has_model_ssim:(#{names.map { |name| %("#{name}") }.join(' OR ')})"
   end
 
   # Aggregate each child work's already-indexed full text from Solr rather than

--- a/spec/indexers/concerns/hyku_indexing_spec.rb
+++ b/spec/indexers/concerns/hyku_indexing_spec.rb
@@ -56,4 +56,52 @@ RSpec.describe HykuIndexing do
       expect(all_text).not_to include('text from file set')
     end
   end
+
+  # Finding the parent's own file sets used to go through `find_child_file_sets`
+  # (`find_members(resource:).select(&:file_set?)`), which instantiated every
+  # member before discarding the non-file-sets. On an aggregating work that is
+  # O(child works) of wasted loading per reindex, several times per save.
+  describe 'resolving the parent\'s own file sets', :clean_repo do
+    let(:indexer) { Hyrax::Indexers::ResourceIndexer.for(resource: work) }
+
+    context 'when the members are child works' do
+      let(:child_work_id) { 'work-member-not-loaded' }
+      let(:work) { valkyrie_create(:generic_work_resource, member_ids: [Valkyrie::ID.new(child_work_id)]) }
+
+      before do
+        Hyrax::SolrService.add({ 'id' => child_work_id, 'generic_type_sim' => ['Work'] }, commit: true)
+      end
+
+      it 'treats them as no file sets at all' do
+        expect(indexer.send(:child_file_sets, work)).to be_empty
+      end
+    end
+
+    context 'when a member really is a file set' do
+      let(:file_set) { valkyrie_create(:hyrax_file_set) }
+      let(:work) { valkyrie_create(:generic_work_resource, member_ids: [file_set.id]) }
+
+      it 'still finds it' do
+        expect(indexer.send(:child_file_sets, work).map(&:id)).to eq([file_set.id])
+      end
+    end
+
+    context 'with both a child work and a file set, in member order' do
+      let(:file_set) { valkyrie_create(:hyrax_file_set) }
+      let(:other_file_set) { valkyrie_create(:hyrax_file_set) }
+      let(:child_work_id) { 'interleaved-work-member' }
+      let(:work) do
+        valkyrie_create(:generic_work_resource,
+                        member_ids: [other_file_set.id, Valkyrie::ID.new(child_work_id), file_set.id])
+      end
+
+      before do
+        Hyrax::SolrService.add({ 'id' => child_work_id, 'generic_type_sim' => ['Work'] }, commit: true)
+      end
+
+      it 'returns only the file sets, in member order' do
+        expect(indexer.send(:child_file_sets, work).map(&:id)).to eq([other_file_set.id, file_set.id])
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #3175 ; refs #3105

Stop loading every child work to find a parent's file sets

`HykuIndexing#child_file_sets` resolved the parent's own file sets through
`Hyrax.custom_queries.find_child_file_sets`, which is:

```ruby
def find_child_file_sets(resource:)
  query_service.find_members(resource: resource).select(&:file_set?)
end
```

It instantiates **every** member and then discards the non-file-sets. On an
aggregating work whose members are child works, that is O(child works) of wasted
loading per reindex, and the parent is reindexed several times per save (the
`WorkUpdate` transaction publishes `object.metadata.updated` and
`object.membership.updated`, plus the ACL reindex).

This is the other half of the N+1 that #3105 addressed. #3105 replaced the
per-child **full text** walk with one batched Solr read; the **file-set
discovery** call in the same method still loaded every member.

### Fix

Resolve which member ids are file sets from Solr, then load only those. Same
batched-Solr shape `child_work_full_texts` already uses, and the same eventual
consistency (a file set not yet indexed contributes on the next reindex, which is
already true of the `extract_text_from_pdf_directly` fallback, since it reads the
file set's text from `SolrDocument.find`).

Member order is preserved: `find_many_by_ids` does not return ids in the order it
was given, and `extract_text_from_pdf_directly` takes `.first`.

### Measurements

Against a real 100-child `Portfolio` in a dev tenant (Valkyrie/Postgres, flexible
metadata), A/B'd in one process with only `child_file_sets` swapped:

| | before | after |
|---|---|---|
| 100-child parent, `to_solr` | 1,906.8 ms / 222 pg queries | **29.5 ms / 19 pg queries** |
| 5-child parent, `to_solr` | 108.4 ms / 30 pg queries | 19.3 ms / 19 pg queries |

The resulting Solr document is byte-identical in both cases, so this is purely a
load-path change, not an output change.

End to end, one deposit into that 100-child parent went from
`Completed 302 Found in 21016ms (3107 queries)`. The hierarchy of that page was
never the cost; this indexing path was.

Correctness spot-check across the 8 works in that tenant that actually hold file
sets: all 8 return the same file sets in the same order as before.

### Why not `find_members(model:)`

That would be the obvious fix, and it is what I tried first. It silently returns
nothing. `Goddess::Query::MethodMissingMachinations#setup_model` rewrites
`opts[:model]`:

```ruby
def model_class_for(model)
  internal_resource = model.respond_to?(:internal_resource) ? model.internal_resource : nil
  internal_resource&.safe_constantize || Wings::ModelRegistry.lookup(model)
end
```

A Valkyrie resource **class** does not respond to `internal_resource` (it is an
instance attribute), so this falls through to `Wings::ModelRegistry.lookup`, which
maps `Hyrax::FileSet` to the ActiveFedora `FileSet`. The Postgres query then
filters `internal_resource = 'FileSet'` while the rows are stored as
`'Hyrax::FileSet'`, so it matches nothing:

```
setup_model(Hyrax::FileSet) -> FileSet
  postgres service, model=FileSet        -> 0
  postgres service, model=Hyrax::FileSet -> 1   # unmapped, correct
```

That looks like a genuine bug worth its own issue, since any caller passing a
Valkyrie model to a `find_*` query gets empty results rather than an error. Happy
to file it separately; I did not want to widen the blast radius of this fix.

Two related notes for reviewers, both empirical in this app:
- File sets are indexed with `has_model_ssim` but **no** `generic_type_sim`, so
  the `generic_type_sim:Work` trick used for child works cannot be inverted here.
- `Hyrax::ModelRegistry.file_set_rdf_representations` returns only `["FileSet"]`,
  which misses the `Hyrax::FileSet` rows, so the filter is built from
  `file_set_class_names` instead.

### Testing

- Added three examples to `spec/indexers/concerns/hyku_indexing_spec.rb`: child-work
  members yield no file sets, a real file-set member is still found, and a mixed
  member list returns only the file sets in member order.
- The measurements and correctness spot-check above were run against real data in a
  dev tenant.
- I have **not** run the RSpec suite locally (my local bundle will not resolve);
  relying on CI for that.

@samvera/hyku-code-reviewers
