### PR TITLE
Guided Deposit Adjustments

### DIFF
--- a/app/assets/javascripts/hyrax/deposit_wizard.js
+++ b/app/assets/javascripts/hyrax/deposit_wizard.js
@@ -23,6 +23,40 @@
       uploadTemplateId: 'deposit-wizard-template-upload',
       downloadTemplateId: 'deposit-wizard-template-download'
     });
+    guardNextWhileUploading(uploader);
+  }
+
+  // The uploaded_files[] hidden input is written only by the download template,
+  // which the plugin swaps in on completion — so advancing mid-upload posts
+  // without the in-flight ids and silently drops those files.
+  function guardNextWhileUploading(uploader) {
+    var next = $('[data-behavior="files-next"]');
+    if (!next.length) return;
+    var inFlight = 0;
+
+    function sync() {
+      next.prop('disabled', inFlight > 0);
+    }
+
+    // Decrement on 'finished', not 'completed': completed fires only on success,
+    // so a failed upload would leave the count above zero and Next stuck for the
+    // rest of the page's life. 'finished' fires on both the success and failure
+    // paths. (Hyrax's own save_work/uploaded_files.es6 counts 'completed' and has
+    // exactly that leak — don't mirror it.)
+    uploader.on('fileuploadadded', function () {
+      inFlight += 1;
+      sync();
+      // No explicit return: the plugin cancels the upload when an 'added'
+      // handler returns false.
+    });
+    uploader.on('fileuploadfinished', function () {
+      inFlight = Math.max(0, inFlight - 1);
+      sync();
+    });
+
+    uploader.closest('form').on('submit', function (event) {
+      if (inFlight > 0) event.preventDefault();
+    });
   }
 
   // Visibility pills: mark the selected pill, expand its embargo/lease panel (by

--- a/app/assets/javascripts/hyrax/deposit_wizard.js
+++ b/app/assets/javascripts/hyrax/deposit_wizard.js
@@ -32,30 +32,36 @@
   function guardNextWhileUploading(uploader) {
     var next = $('[data-behavior="files-next"]');
     if (!next.length) return;
-    var inFlight = 0;
+    // Tracked per file rather than as a counter so the settle events can overlap
+    // without double-counting: an aborted upload fires both 'fail' and 'finished'.
+    var pending = [];
 
-    function sync() {
-      next.prop('disabled', inFlight > 0);
+    function settle(data) {
+      var files = (data && data.files) || [];
+      for (var i = 0; i < files.length; i += 1) {
+        var at = pending.indexOf(files[i]);
+        if (at !== -1) pending.splice(at, 1);
+      }
+      next.prop('disabled', pending.length > 0);
     }
 
-    // Decrement on 'finished', not 'completed': completed fires only on success,
-    // so a failed upload would leave the count above zero and Next stuck for the
-    // rest of the page's life. 'finished' fires on both the success and failure
-    // paths. (Hyrax's own save_work/uploaded_files.es6 counts 'completed' and has
-    // exactly that leak — don't mirror it.)
-    uploader.on('fileuploadadded', function () {
-      inFlight += 1;
-      sync();
+    uploader.on('fileuploadadded', function (e, data) {
+      pending = pending.concat((data && data.files) || []);
+      next.prop('disabled', pending.length > 0);
       // No explicit return: the plugin cancels the upload when an 'added'
       // handler returns false.
     });
-    uploader.on('fileuploadfinished', function () {
-      inFlight = Math.max(0, inFlight - 1);
-      sync();
+
+    // 'finished' covers success and a mid-flight abort, but a file cancelled before
+    // it is ever sent has no data.abort, so the plugin fires 'fail' alone — without
+    // that second binding Next would stay disabled until a reload. ('completed'
+    // alone, as Hyrax's save_work/uploaded_files.es6 counts, misses both.)
+    uploader.on('fileuploadfinished fileuploadfail', function (e, data) {
+      settle(data);
     });
 
     uploader.closest('form').on('submit', function (event) {
-      if (inFlight > 0) event.preventDefault();
+      if (pending.length > 0) event.preventDefault();
     });
   }
 

--- a/app/assets/stylesheets/deposit_wizard/_choices.scss
+++ b/app/assets/stylesheets/deposit_wizard/_choices.scss
@@ -9,6 +9,12 @@
     margin-bottom: 1.5rem;
   }
 
+  // The container path creates the thing the other paths deposit into, so it
+  // leads the group across the full width rather than sitting beside them.
+  &__path-card--container {
+    grid-column: 1 / -1;
+  }
+
   &__path-card,
   &__type-card {
     display: flex;

--- a/app/assets/stylesheets/deposit_wizard/_review.scss
+++ b/app/assets/stylesheets/deposit_wizard/_review.scss
@@ -66,6 +66,19 @@
     }
   }
 
+  // Deliberately understated: abandoning the deposit is destructive, so it
+  // shouldn't compete with Back/Next for attention.
+  &__discard-link {
+    color: var(--dw-ink-subtle);
+    font-size: 0.9rem;
+    text-decoration: underline;
+
+    &:hover,
+    &:focus {
+      color: var(--dw-danger);
+    }
+  }
+
   &__empty {
     color: var(--dw-ink-subtle);
     font-style: italic;

--- a/app/controllers/concerns/hyku/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyku/works_controller_behavior.rb
@@ -5,6 +5,8 @@
 #           - correct hostname of manifests
 #           - override for bug https://github.com/samvera/hyrax/issues/5904
 #           - use Hyku::WorkShowPresenter rather than Hyrax's presenter
+#           - refuse a parent_id the depositor cannot edit or whose type cannot
+#             contain the work being created
 module Hyku
   # include this module after including Hyrax::WorksControllerBehavior to override
   # Hyrax::WorksControllerBehavior methods with the ones defined here
@@ -14,6 +16,7 @@ module Hyku
     included do
       # add around action to load theme show page views
       around_action :inject_show_theme_views, except: :delete
+      before_action :ensure_parent_accepts_child, only: :create
       self.show_presenter = Hyku::WorkShowPresenter
 
       # These cache wrapper methods need to be in the top level so that they override other modules
@@ -37,6 +40,26 @@ module Hyku
     end
 
     private
+
+    # parent_id reaches Steps::AddToParent straight from params, and that step
+    # validates neither the type pairing nor the user's access to the parent.
+    def ensure_parent_accepts_child
+      parent_id = params[:parent_id]
+      return if parent_id.blank?
+
+      parent = Hyrax.query_service.find_by(id: parent_id)
+      child_types = Hyrax::ChildTypes.for(parent: parent.class).map(&:to_s)
+      return if current_ability.can?(:edit, parent) &&
+                child_types.include?(self.class.curation_concern_type.to_s)
+
+      reject_parent
+    rescue Valkyrie::Persistence::ObjectNotFoundError
+      reject_parent
+    end
+
+    def reject_parent
+      redirect_to main_app.root_path, alert: I18n.t('hyku.works.errors.parent_not_allowed')
+    end
 
     def iiif_manifest_presenter
       Hyrax::IiifManifestPresenter.new(search_result_document(id: params[:id])).tap do |p|

--- a/app/controllers/concerns/hyku/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyku/works_controller_behavior.rb
@@ -48,9 +48,14 @@ module Hyku
       return if parent_id.blank?
 
       parent = Hyrax.query_service.find_by(id: parent_id)
-      child_types = Hyrax::ChildTypes.for(parent: parent.class).map(&:to_s)
-      return if current_ability.can?(:edit, parent) &&
-                child_types.include?(self.class.curation_concern_type.to_s)
+      # Normalize both sides: valid_child_concerns holds the ActiveFedora classes
+      # while curation_concern_type is the Valkyrie resource, so comparing class
+      # names directly never matches and would reject every legitimate create.
+      child_types = Hyrax::ModelRegistry.rdf_representations_from(
+        Hyrax::ChildTypes.for(parent: parent.class).to_a
+      )
+      child_type = Hyrax::ModelRegistry.rdf_representations_from([self.class.curation_concern_type]).first
+      return if current_ability.can?(:edit, parent) && child_types.include?(child_type)
 
       reject_parent
     rescue Valkyrie::Persistence::ObjectNotFoundError

--- a/app/controllers/hyrax/deposit_wizard_controller.rb
+++ b/app/controllers/hyrax/deposit_wizard_controller.rb
@@ -256,17 +256,28 @@ module Hyrax
     def seed_parent_handoff
       wizard_state.parent_id = params[:parent_id]
       wizard_state.path = 'add'
-      inherit_admin_set_from_parent
+      @admin_set_needs_choosing = !inherit_admin_set_from_parent
     end
 
-    # Skipping `start` skips its inline admin-set chooser, so a child work takes
-    # its parent's admin set. selected_admin_set_id falls back to the default when
-    # this leaves it blank (an unreadable or since-deleted parent).
+    # Skipping `start` skips its inline admin-set chooser, so a child work takes its
+    # parent's admin set. Only from a parent the depositor can edit, and only into an
+    # admin set they may deposit into: parent_id arrives in params, and edit on a work
+    # does not imply deposit rights to the admin set it sits in.
+    #
+    # False when the depositor must choose an admin set themselves, so the caller can
+    # keep them on the start screen rather than silently defaulting one.
     def inherit_admin_set_from_parent
       parent = Hyrax.query_service.find_by(id: wizard_state.parent_id)
-      wizard_state.admin_set_id = parent.try(:admin_set_id).presence
+      return true unless current_ability.can?(:edit, parent)
+
+      inherited = parent.try(:admin_set_id).presence
+      return true if inherited.blank?
+      return false unless deposit_wizard.can_deposit_in_admin_set?(inherited)
+
+      wizard_state.admin_set_id = inherited
+      true
     rescue Valkyrie::Persistence::ObjectNotFoundError
-      nil
+      true
     end
 
     # Land a directed handoff on the parent step rather than the path chooser it
@@ -277,11 +288,13 @@ module Hyrax
     # redirecting those installs to an up-front parent step would contradict it.
     def skip_start_for_handoff?
       # The param, so Back from select_parent (which returns here without one)
-      # reaches the chooser instead of being redirected forward in a loop; the
-      # state too, since parent_id= drops a blank and there'd be nothing to show.
+      # reaches the chooser instead of being redirected forward in a loop; the state
+      # too, since parent_id= drops a blank and there'd be nothing to show. And not
+      # when the admin set still needs choosing, since the chooser lives here.
       params[:parent_id].present? &&
         wizard_config.parent_connect_on_start? &&
-        wizard_state.parent_id.present?
+        wizard_state.parent_id.present? &&
+        !@admin_set_needs_choosing # set by seed_parent_handoff
     end
   end
 end

--- a/app/controllers/hyrax/deposit_wizard_controller.rb
+++ b/app/controllers/hyrax/deposit_wizard_controller.rb
@@ -77,7 +77,6 @@ module Hyrax
       head :no_content
     end
 
-    # Abandon an in-progress deposit.
     def discard
       deleted = discard_staged_uploads
       reset_state

--- a/app/controllers/hyrax/deposit_wizard_controller.rb
+++ b/app/controllers/hyrax/deposit_wizard_controller.rb
@@ -216,6 +216,7 @@ module Hyrax
     def stash_deposited(work)
       session[:deposit_wizard_last] = {
         'id' => work.id.to_s,
+        'work_type' => work.class.to_s,
         'parent_id' => wizard_state.parent_id.presence,
         'title' => Array(work.title).first,
         'path' => main_app.polymorphic_path([main_app, work])

--- a/app/controllers/hyrax/deposit_wizard_controller.rb
+++ b/app/controllers/hyrax/deposit_wizard_controller.rb
@@ -29,6 +29,8 @@ module Hyrax
     def start
       reset_state
       seed_launch_context
+      return redirect_to(step_path('select_parent')) if skip_start_for_handoff?
+
       assign_admin_sets_for_standard_chooser
       render :start
     end
@@ -239,13 +241,47 @@ module Hyrax
     # capabilities, which only govern the optional start/review pickers a depositor
     # uses to choose a parent or collections themselves.
     def seed_launch_context
-      wizard_state.parent_id = params[:parent_id] if params[:parent_id].present?
+      seed_parent_handoff if params[:parent_id].present?
 
       return if params[:add_works_to_collection].blank?
 
       wizard_state.attributes = wizard_state.attributes.merge(
         'member_of_collections_attributes' => { '0' => { 'id' => params[:add_works_to_collection] } }
       )
+    end
+
+    # Setting the 'add' path is required, not redundant with parent_id: without it
+    # select_parent is skipped and its on_skip: :entry detour bounces straight back
+    # here.
+    def seed_parent_handoff
+      wizard_state.parent_id = params[:parent_id]
+      wizard_state.path = 'add'
+      inherit_admin_set_from_parent
+    end
+
+    # Skipping `start` skips its inline admin-set chooser, so a child work takes
+    # its parent's admin set. selected_admin_set_id falls back to the default when
+    # this leaves it blank (an unreadable or since-deleted parent).
+    def inherit_admin_set_from_parent
+      parent = Hyrax.query_service.find_by(id: wizard_state.parent_id)
+      wizard_state.admin_set_id = parent.try(:admin_set_id).presence
+    rescue Valkyrie::Persistence::ObjectNotFoundError
+      nil
+    end
+
+    # Land a directed handoff on the parent step rather than the path chooser it
+    # has already answered.
+    #
+    # Only for installs that choose a parent up front. The default placement
+    # (:review) accepts a handed-off parent and proceeds, which is deliberate —
+    # redirecting those installs to an up-front parent step would contradict it.
+    def skip_start_for_handoff?
+      # The param, so Back from select_parent (which returns here without one)
+      # reaches the chooser instead of being redirected forward in a loop; the
+      # state too, since parent_id= drops a blank and there'd be nothing to show.
+      params[:parent_id].present? &&
+        wizard_config.parent_connect_on_start? &&
+        wizard_state.parent_id.present?
     end
   end
 end

--- a/app/controllers/hyrax/deposit_wizard_controller.rb
+++ b/app/controllers/hyrax/deposit_wizard_controller.rb
@@ -80,6 +80,7 @@ module Hyrax
     def discard
       deleted = discard_staged_uploads
       reset_state
+      clear_deposited_stash
       key = deleted.positive? ? 'discarded_with_files' : 'discarded'
       redirect_to hyrax.my_works_path, notice: t("hyku.deposit_wizard.#{key}", count: deleted)
     end
@@ -194,6 +195,13 @@ module Hyrax
       session[:deposit_wizard] = {}
     end
 
+    # The done screen's read is destructive, but only if it renders — so a stash left
+    # by a deposit whose confirmation was never viewed would otherwise resurface as a
+    # stale confirmation. Not part of reset_state: #commit stashes before resetting.
+    def clear_deposited_stash
+      session.delete(:deposit_wizard_last)
+    end
+
     # Staged uploads are only reachable through this session, so abandoning the
     # deposit orphans them: nothing will attach them to a work, and the cleanup
     # sweeper's default retention is measured in years.
@@ -268,7 +276,10 @@ module Hyrax
     # keep them on the start screen rather than silently defaulting one.
     def inherit_admin_set_from_parent
       parent = Hyrax.query_service.find_by(id: wizard_state.parent_id)
-      return true unless current_ability.can?(:edit, parent)
+      # Nothing to inherit from a parent they cannot edit, so don't skip the chooser
+      # on its behalf. Commit refuses that parent anyway; this keeps the depositor on
+      # a screen where they can still act rather than deferring the refusal.
+      return false unless current_ability.can?(:edit, parent)
 
       inherited = parent.try(:admin_set_id).presence
       return true if inherited.blank?

--- a/app/controllers/hyrax/deposit_wizard_controller.rb
+++ b/app/controllers/hyrax/deposit_wizard_controller.rb
@@ -75,6 +75,14 @@ module Hyrax
       head :no_content
     end
 
+    # Abandon an in-progress deposit.
+    def discard
+      deleted = discard_staged_uploads
+      reset_state
+      key = deleted.positive? ? 'discarded_with_files' : 'discarded'
+      redirect_to hyrax.my_works_path, notice: t("hyku.deposit_wizard.#{key}", count: deleted)
+    end
+
     # Deposit the work from the collected state and land on the done screen.
     def commit
       return redirect_to(main_app.deposit_wizard_step_path(step: 'known_type')) if wizard_state.work_type.blank?
@@ -183,6 +191,21 @@ module Hyrax
 
     def reset_state
       session[:deposit_wizard] = {}
+    end
+
+    # Staged uploads are only reachable through this session, so abandoning the
+    # deposit orphans them: nothing will attach them to a work, and the cleanup
+    # sweeper's default retention is measured in years.
+    #
+    # Scoped by user (matching the `can :destroy, UploadedFile, user: current_user`
+    # ability) because the ids come from the session, which a request can forge.
+    # Returns the number destroyed, so the notice can name what actually happened.
+    def discard_staged_uploads
+      ids = wizard_state.uploaded_file_ids
+      return 0 if ids.blank?
+
+      staged = Hyrax::UploadedFile.where(id: ids, user: current_user)
+      staged.count.tap { staged.find_each(&:destroy) }
     end
 
     # Survive the redirect to the done screen, which reads it once. The show path

--- a/app/helpers/hyrax/form_helper_behavior.rb
+++ b/app/helpers/hyrax/form_helper_behavior.rb
@@ -20,8 +20,9 @@ module Hyrax
       local_vocabulary_options_for(source) || remote_vocabulary_options_for(source)
     end
 
-    private
-
+    # The authority name backing +property_name+, or nil when the property isn't
+    # controlled. Public because callers that only need to label a stored value
+    # want the source without building the whole option list.
     def controlled_vocabulary_source_for(property_name)
       if Hyrax.config.flexible?
         schema = Hyrax::FlexibleSchema.order("created_at asc").last
@@ -39,6 +40,8 @@ module Hyrax
         controlled_vocabulary_mapping_for(property_name)
       end
     end
+
+    private
 
     def controlled_vocabulary_mapping_for(property_name)
       # Maps property names in when flexible=false to their corresponding controlled vocabulary service keys

--- a/app/presenters/hyku/deposit_wizard/presenter.rb
+++ b/app/presenters/hyku/deposit_wizard/presenter.rb
@@ -539,20 +539,34 @@ module Hyku
       # The ChangeSet permits its own fields, so raw nested params go straight to
       # #validate, as the stock works controller does. The submitted values (plain
       # strings/arrays) are stored so they serialize into the session.
+      #
+      # The save is unconditional: validation decides where the depositor goes
+      # next, not whether their entries are kept.
       def advance_from_details
         build_work_form
+        save_details_attributes
+        return Transition.advance(back_step('details')) if going_back?
+
         unless work_form.validate(work_params)
           return Transition.rerender('details', alert: 'hyku.deposit_wizard.errors.details_invalid',
                                                 messages: form_error_messages(work_form))
         end
 
-        # The details form owns the work fields, but not the launch-seeded extras
-        # (a collection carried in by the "deposit into THIS collection" handoff).
-        # Replacing wholesale would drop those before commit, so re-apply any that
-        # the form did not submit.
-        submitted = work_params.to_unsafe_h
-        state.attributes = preserved_launch_extras.merge(submitted)
         Transition.advance(next_step('details'))
+      end
+
+      # The details form owns the work fields, but not the launch-seeded extras
+      # (a collection carried in by the "deposit into THIS collection" handoff).
+      # Replacing wholesale would drop those before commit, so re-apply any that
+      # the form did not submit.
+      def save_details_attributes
+        state.attributes = preserved_launch_extras.merge(work_params.to_unsafe_h)
+      end
+
+      # Set by the metadata steps' Back button, which submits the form (saving what
+      # was entered) instead of linking away.
+      def going_back?
+        params[:direction].to_s == 'back'
       end
 
       # Launch-seeded attributes the details form does not manage (today: collection
@@ -565,6 +579,8 @@ module Hyku
         submitted = params.fetch(:file_metadata, {}).permit!.to_h
         allowed = state.uploaded_file_ids.map(&:to_s)
         state.file_metadata = submitted.slice(*allowed)
+        return Transition.advance(back_step('file_meta')) if going_back?
+
         Transition.advance(next_step('file_meta'))
       end
 

--- a/app/presenters/hyku/deposit_wizard/presenter.rb
+++ b/app/presenters/hyku/deposit_wizard/presenter.rb
@@ -416,10 +416,12 @@ module Hyku
       attr_reader :commit_errors
 
       # Create the work, apply per-file embargo/lease, and run the configured
-      # post-commit hook (e.g. downstream nesting). Returns the work, or nil on
-      # validation/transaction failure (recorded in #commit_errors so the
-      # re-rendered review step isn't silent).
+      # post-commit hook (e.g. downstream nesting). Returns the work, or nil if the
+      # nesting is disallowed or on validation/transaction failure (recorded in
+      # #commit_errors so the re-rendered review step isn't silent).
       def deposit
+        return record_commit_failure(I18n.t('hyku.deposit_wizard.errors.parent_not_allowed')) unless nesting_allowed?
+
         work = create_work
         return unless work
 
@@ -505,6 +507,7 @@ module Hyku
 
       def advance_from_select_parent
         return rerender_parent_required if params[:parent_id].blank?
+        return rerender_parent_rejected unless parent_accepts_children?(params[:parent_id])
 
         state.parent_id = params[:parent_id]
         Transition.advance(next_step('select_parent'))
@@ -512,6 +515,36 @@ module Hyku
 
       def rerender_parent_required
         Transition.rerender('select_parent', alert: 'hyku.deposit_wizard.errors.no_parent')
+      end
+
+      def rerender_parent_rejected
+        Transition.rerender('select_parent', alert: 'hyku.deposit_wizard.errors.parent_not_allowed')
+      end
+
+      # The work type usually isn't chosen yet at select_parent, so "accepts
+      # children at all" is the only check available there; #nesting_allowed? does
+      # the full pairing at commit.
+      def parent_accepts_children?(parent_id)
+        child_types_for(parent_id).any?
+      end
+
+      # Checked again at commit because parent_id also arrives by routes that skip
+      # select_parent (the launch handoff), and because AddToParent validates
+      # nothing itself.
+      def nesting_allowed?
+        return true if state.parent_id.blank? || state.work_type.blank?
+
+        child_types_for(state.parent_id).map(&:to_s).include?(state.work_type.to_s)
+      end
+
+      # Empty when the parent can't be read, so an unresolvable parent is refused
+      # at the step that names it rather than surfacing as a transaction failure
+      # after the depositor has filled in the rest of the form.
+      def child_types_for(parent_id)
+        parent = Hyrax.query_service.find_by(id: parent_id)
+        Hyrax::ChildTypes.for(parent: parent.class).to_a
+      rescue Valkyrie::Persistence::ObjectNotFoundError
+        []
       end
 
       def select_work_type(rerender_step: 'known_type')

--- a/app/presenters/hyku/deposit_wizard/presenter.rb
+++ b/app/presenters/hyku/deposit_wizard/presenter.rb
@@ -126,17 +126,91 @@ module Hyku
         terms = (work_form.primary_terms + work_form.secondary_terms) - %i[schema_version contexts]
         terms.filter_map do |term|
           value = review_term_value(term)
-          { label: review_term_label(term), value: value.join(', ') } if value.present?
+          { label: review_term_label(term), value: review_display_values(term, value).join(', ') } if value.present?
         end
       end
 
-      # Compound fields with entries, as {label:, count:} rows (the review shows a
-      # count rather than expanding each nested entry).
+      # Which properties are controlled comes from the metadata profile, so no
+      # property is named here.
+      def review_display_values(term, values)
+        service = controlled_service_for(term)
+        return values if service.nil?
+
+        values.map { |value| service.label(value) { value } }
+      end
+
+      # nil unless the profile declares this property controlled and its authority
+      # resolves. Memoized per request: Qa re-reads and re-parses the whole
+      # authority file on every lookup.
+      def controlled_service_for(term)
+        @controlled_services ||= {}
+        return @controlled_services[term] if @controlled_services.key?(term)
+
+        @controlled_services[term] = build_controlled_service(term)
+      end
+
+      def build_controlled_service(term)
+        source = context.helpers.controlled_vocabulary_source_for(term)
+        return if source.blank?
+
+        # Prefer the registered service (it may add behavior); fall back to a bare
+        # authority lookup so a profile source with no registry entry still labels.
+        registered = Hyrax::ControlledVocabularies.services[source]&.safe_constantize
+        registered ? registered.new : Hyrax::TolerantSelectService.new(source)
+      rescue StandardError => e
+        Hyrax.logger.debug("Deposit wizard: no label service for #{term} (#{source}): #{e.message}")
+        nil
+      end
+
+      # Compound fields with entries, as {label:, count:, values:} rows: the count
+      # summarizes, +values+ carries each entry's controlled sub-property labels.
       def review_compound_terms
         work_form.compound_terms.filter_map do |term|
           entries = review_term_value(term)
-          { label: review_term_label(term), count: entries.size } if entries.present?
+          next if entries.blank?
+
+          { label: review_term_label(term), count: entries.size,
+            values: compound_entry_labels(term, entries) }
         end
+      end
+
+      # Empty when the compound declares no controlled sub-properties, so the row
+      # stays a bare count.
+      def compound_entry_labels(term, entries)
+        specs = compound_subproperty_specs(term)
+        return [] if specs.blank?
+
+        entries.flat_map { |entry| compound_row_labels(specs, entry) }.uniq
+      end
+
+      def compound_row_labels(specs, entry)
+        row = entry.respond_to?(:to_h) ? entry.to_h.with_indifferent_access : {}
+        specs.filter_map do |name, spec|
+          value = row[name]
+          next if value.blank?
+
+          Hyrax::CompoundSubpropertyLabeler.label_for(spec, value).presence
+        end
+      end
+
+      # Only the `controlled` sub-properties: the labeler passes anything else
+      # through unchanged, so filtering here keeps free-text out of the summary.
+      def compound_subproperty_specs(term)
+        @compound_specs ||= {}
+        return @compound_specs[term] if @compound_specs.key?(term)
+
+        definition = compound_schema&.definition_for(term)
+        specs = (definition&.dig(:subproperties) || {}).select { |_n, s| s[:type].to_s == 'controlled' }
+        @compound_specs[term] = specs
+      end
+
+      def compound_schema
+        return @compound_schema if defined?(@compound_schema)
+
+        @compound_schema = Hyrax::CompoundSchema.for(work_form.model)
+      rescue StandardError => e
+        Hyrax.logger.debug("Deposit wizard: no compound schema for review labels: #{e.message}")
+        @compound_schema = nil
       end
 
       def file_type_label(uploaded_file)

--- a/app/presenters/hyku/deposit_wizard/presenter.rb
+++ b/app/presenters/hyku/deposit_wizard/presenter.rb
@@ -290,6 +290,12 @@ module Hyku
         Hyrax::AdminSetService.new(context).search_results(:deposit)
       end
 
+      def can_deposit_in_admin_set?(admin_set_id)
+        return false if admin_set_id.blank?
+
+        admin_set_options_for_display.any? { |option| option[:id].to_s == admin_set_id.to_s }
+      end
+
       # Keep the presenter's data-* hash on each option: the visibility component
       # enforces those visibility/release rules downstream on the details form. The
       # description/workflow prose is built by AdminSetDescription.
@@ -614,8 +620,13 @@ module Hyku
       # Empty when the parent can't be read, so an unresolvable parent is refused
       # at the step that names it rather than surfacing as a transaction failure
       # after the depositor has filled in the rest of the form.
+      # Empty for a parent the depositor cannot edit as well as one that cannot be
+      # read, so a forged parent_id is refused rather than merely type-checked.
+      # Adding a child mutates the parent's member_ids, hence edit rather than read.
       def child_types_for(parent_id)
         parent = Hyrax.query_service.find_by(id: parent_id)
+        return [] unless current_ability.can?(:edit, parent)
+
         Hyrax::ChildTypes.for(parent: parent.class).to_a
       rescue Valkyrie::Persistence::ObjectNotFoundError
         []

--- a/app/views/hyrax/deposit_wizard/_nav.html.erb
+++ b/app/views/hyrax/deposit_wizard/_nav.html.erb
@@ -5,14 +5,27 @@
       next_html  - hash of extra options for the submit button (e.g. disabled,
                    data, class additions). Optional.
       next_form  - a form builder to submit through (f.submit), or nil to use a
-                   plain submit_tag (the button must sit inside a form_tag). %>
+                   plain submit_tag (the button must sit inside a form_tag).
+      back_submit - true to submit the form on Back (saving what was entered)
+                   instead of following back_path as a link. Optional. %>
 <% next_label ||= t('hyku.deposit_wizard.next') %>
 <% next_html ||= {} %>
 <% next_arrow = local_assigns.fetch(:next_arrow, true) %>
+<% back_submit = local_assigns.fetch(:back_submit, false) %>
 <div class="deposit-wizard__nav deposit-wizard__nav--end">
   <div class="deposit-wizard__nav-group">
-    <%= link_to back_path, class: 'btn btn-secondary deposit-wizard__back-btn' do %>
-      <span class="fa fa-arrow-left" aria-hidden="true"></span> <%= t('hyku.deposit_wizard.back') %>
+    <% if back_submit %>
+      <%# formnovalidate: simple_form emits HTML5 `required`, and the browser blocks
+          ANY submit on an invalid form — including this one, whose whole purpose is
+          leaving a half-filled one. %>
+      <%= button_tag(type: 'submit', name: 'direction', value: 'back', formnovalidate: true,
+                     class: 'btn btn-secondary deposit-wizard__back-btn') do %>
+        <span class="fa fa-arrow-left" aria-hidden="true"></span> <%= t('hyku.deposit_wizard.back') %>
+      <% end %>
+    <% else %>
+      <%= link_to back_path, class: 'btn btn-secondary deposit-wizard__back-btn' do %>
+        <span class="fa fa-arrow-left" aria-hidden="true"></span> <%= t('hyku.deposit_wizard.back') %>
+      <% end %>
     <% end %>
     <%= button_tag(type: 'submit',
                    class: "btn btn-primary deposit-wizard__next-btn #{next_html[:class]}".strip,

--- a/app/views/hyrax/deposit_wizard/_nav.html.erb
+++ b/app/views/hyrax/deposit_wizard/_nav.html.erb
@@ -1,4 +1,4 @@
-<%# Shared step footer: Back + Next, grouped on the right.
+<%# Shared step footer: a discard link, then Back + Next grouped on the right.
     Locals:
       back_path  - URL for the Back button (required).
       next_label - text for the primary button (default: "Next").
@@ -12,7 +12,17 @@
 <% next_html ||= {} %>
 <% next_arrow = local_assigns.fetch(:next_arrow, true) %>
 <% back_submit = local_assigns.fetch(:back_submit, false) %>
-<div class="deposit-wizard__nav deposit-wizard__nav--end">
+<%# The discard link fills the footer's left slot, so --end (which right-aligns a
+    lone button group) no longer applies. %>
+<div class="deposit-wizard__nav">
+  <%# rails-ujs builds its own form for a non-GET link, so this doesn't nest a
+      form inside the step's form. %>
+  <%= link_to t('hyku.deposit_wizard.discard'),
+              main_app.deposit_wizard_discard_path,
+              method: :delete,
+              data: { confirm: t('hyku.deposit_wizard.discard_confirm') },
+              class: 'deposit-wizard__discard-link' %>
+
   <div class="deposit-wizard__nav-group">
     <% if back_submit %>
       <%# formnovalidate: simple_form emits HTML5 `required`, and the browser blocks

--- a/app/views/hyrax/deposit_wizard/_review_summary.html.erb
+++ b/app/views/hyrax/deposit_wizard/_review_summary.html.erb
@@ -21,7 +21,14 @@
   <% deposit_wizard.review_compound_terms.each do |row| %>
     <div class="row">
       <dt class="col-sm-3"><%= row[:label] %></dt>
-      <dd class="col-sm-9"><%= t('hyku.deposit_wizard.review.entry_count', count: row[:count]) %></dd>
+      <dd class="col-sm-9">
+        <%= t('hyku.deposit_wizard.review.entry_count', count: row[:count]) %>
+        <%# Names the controlled choices (a license, a rights statement) that a
+            bare count would hide. %>
+        <% if row[:values].present? %>
+          <span class="deposit-wizard__review-compound-values"><%= row[:values].join(', ') %></span>
+        <% end %>
+      </dd>
     </div>
   <% end %>
 

--- a/app/views/hyrax/deposit_wizard/details.html.erb
+++ b/app/views/hyrax/deposit_wizard/details.html.erb
@@ -17,6 +17,6 @@
 
     <%= render 'visibility', f: f, policy: deposit_wizard.visibility_policy %>
 
-    <%= render 'nav', back_path: wizard_back_path('details') %>
+    <%= render 'nav', back_path: wizard_back_path('details'), back_submit: true %>
   <% end %>
 </div>

--- a/app/views/hyrax/deposit_wizard/file_meta.html.erb
+++ b/app/views/hyrax/deposit_wizard/file_meta.html.erb
@@ -15,6 +15,6 @@
       </div>
     </div>
 
-    <%= render 'nav', back_path: wizard_back_path('file_meta') %>
+    <%= render 'nav', back_path: wizard_back_path('file_meta'), back_submit: true %>
   <% end %>
 </div>

--- a/app/views/hyrax/deposit_wizard/files.html.erb
+++ b/app/views/hyrax/deposit_wizard/files.html.erb
@@ -7,6 +7,7 @@
   <%= form_tag main_app.deposit_wizard_advance_path(step: 'files'), method: :patch, class: 'deposit-wizard__files-form' do %>
     <%= render 'file_uploader' %>
 
-    <%= render 'nav', back_path: wizard_back_path('files') %>
+    <%= render 'nav', back_path: wizard_back_path('files'),
+                      next_html: { data: { behavior: 'files-next' } } %>
   <% end %>
 </div>

--- a/app/views/hyrax/deposit_wizard/start.html.erb
+++ b/app/views/hyrax/deposit_wizard/start.html.erb
@@ -12,7 +12,10 @@
       <% paths = deposit_wizard.config.container? ? %w[new add standalone] : %w[new add] %>
       <div class="deposit-wizard__paths">
         <% paths.each do |path| %>
-          <%= button_tag type: 'submit', name: 'path', value: path, class: 'deposit-wizard__path-card' do %>
+          <%# The modifier drives the card's grid placement; see _choices.scss. %>
+          <% container_path = path == 'new' && deposit_wizard.config.container? %>
+          <%= button_tag type: 'submit', name: 'path', value: path,
+                         class: "deposit-wizard__path-card #{'deposit-wizard__path-card--container' if container_path}".strip do %>
             <% icon = t("hyku.deposit_wizard.start.paths.#{path}.icon", default: nil) %>
             <% if icon.present? %>
               <span class="deposit-wizard__path-icon <%= icon %>" aria-hidden="true"></span>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,6 +85,7 @@ en:
         deposit_failed: Your work could not be deposited
         details_invalid: Some details need fixing before you can continue
         no_parent: Please choose a work to add this deposit to.
+        parent_not_allowed: That work cannot contain this deposit. Choose a different one.
         no_work_type: Please choose a work type to continue.
       extras:
         add: Add
@@ -195,6 +196,9 @@ en:
           type: Item type
           upload: Upload files
         label: Deposit progress
+    works:
+      errors:
+        parent_not_allowed: That work cannot contain this deposit.
     admin:
       flash:
         access_denied: You are not authorized to view this page

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -64,6 +64,12 @@ en:
       details:
         heading: Describe your item
         subtext: Add the details for this work. Required fields are marked.
+      discard: Discard this deposit
+      discard_confirm: Discard this deposit? Anything you have entered will be lost, and the files you uploaded will be deleted. This cannot be undone.
+      discarded: Your deposit was discarded.
+      discarded_with_files:
+        one: Your deposit was discarded and the file you had uploaded was deleted.
+        other: Your deposit was discarded and the %{count} files you had uploaded were deleted.
       disabled: The guided deposit wizard is not enabled.
       done:
         deposit_another: Deposit another work

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -164,6 +164,8 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
     get 'deposit_wizard/parent_options', to: 'deposit_wizard#parent_options', as: :deposit_wizard_parent_options
     # Must precede the :step wildcard so it isn't captured as a step.
     post 'deposit_wizard/extras', to: 'deposit_wizard#save_extras', as: :deposit_wizard_extras
+    # Must precede the :step wildcard so it isn't captured as a step.
+    delete 'deposit_wizard/discard', to: 'deposit_wizard#discard', as: :deposit_wizard_discard
     get 'deposit_wizard/:step', to: 'deposit_wizard#show', as: :deposit_wizard_step
     patch 'deposit_wizard/:step', to: 'deposit_wizard#update', as: :deposit_wizard_advance
     post 'deposit_wizard/commit', to: 'deposit_wizard#commit', as: :deposit_wizard_commit

--- a/docs/deposit-wizard.md
+++ b/docs/deposit-wizard.md
@@ -487,3 +487,8 @@ redirect controls, the admin-set description, and the parent/collection Select2
 typeaheads. The details step additionally carries `data-behavior="work-form"` so
 Hyrax's own editor JS binds the autocomplete and controlled-vocabulary fields
 exactly as on the stock form.
+
+Three steps gate their Next button on a `data-behavior` hook: `files-next` stays
+disabled while uploads are in flight (the uploaded-file ids only reach the form as
+each upload completes, so advancing early would drop them), and `parent-next` /
+`type-next` stay disabled until a parent or work type is chosen.

--- a/docs/deposit-wizard.md
+++ b/docs/deposit-wizard.md
@@ -438,6 +438,13 @@ start path or the review-step section), set `parent_types` and the `parent_conne
 config setting (default on). A directed `parent_id` handoff (see
 [Launch with context](#launch-with-context)) nests regardless of that setting.
 
+The parent must be able to contain the work: the parent step refuses a work whose
+type accepts no children, and commit refuses one that cannot contain the chosen
+work type. Both read `Hyrax::ChildTypes`, i.e. the parent class's
+`valid_child_concerns`, so a repository declaring its own nesting rules is honored.
+`add_to_parent` validates none of this itself, so the standard deposit form applies
+the same check on create.
+
 ### Launch with context
 
 Other entry points can hand off into the wizard with a target pre-filled by

--- a/docs/deposit-wizard.md
+++ b/docs/deposit-wizard.md
@@ -172,6 +172,10 @@ Each `Step` declares its own rules; the navigator computes the rest:
   is never a prerequisite.
 - **Back** is the previous visible step (`Flow#back_before`), so views never name
   their predecessor. **Forward** is the next visible step (`Flow#next_after`).
+  On the metadata steps (`details`, `file_meta`) Back submits the form rather than
+  linking, so what was typed is saved on the way out; those steps save
+  unconditionally and validate only to decide whether to advance. The browser's own
+  back button bypasses this, so entries abandoned that way are still lost.
 - **Detours** (`Flow#detour_for`) replace the old per-step redirect rules.
 
 | Step | Purpose | Shown when |

--- a/docs/deposit-wizard.md
+++ b/docs/deposit-wizard.md
@@ -96,8 +96,10 @@ boundary. It wraps — does not replace — Hyrax's create machinery.
 
 - **Controller**: `Hyrax::DepositWizardController`
   (`app/controllers/hyrax/deposit_wizard_controller.rb`). Actions: `start`,
-  `show` (per step), `update` (advance), `commit`, plus the AJAX endpoints
-  `parent_options` (parent typeahead) and `save_extras` (review-step autosave).
+  `show` (per step), `update` (advance), `commit`, `discard` (abandon an
+  in-progress deposit — clears the session state and destroys the uploads staged
+  for it), plus the AJAX endpoints `parent_options` (parent typeahead) and
+  `save_extras` (review-step autosave).
   Each action reads params, calls the presenter for the decision, and turns the
   result into a redirect / render / flash. It memoizes the presenter and exposes
   `wizard_config` / `wizard_state` shorthands; there are no controller concerns.
@@ -120,7 +122,8 @@ boundary. It wraps — does not replace — Hyrax's create machinery.
   - `Hyku::DepositWizard::State` — a thin wrapper over `session[:deposit_wizard]`.
     Exposes named slots (path, work type, uploaded files, …) plus `#extra`, a
     namespaced bag a downstream app writes custom step state into without
-    subclassing State (see "Insertion points").
+    subclassing State (see "Insertion points"). It is cleared on entry at `start`,
+    after a successful `commit`, and by `discard`.
   - `Hyku::DepositWizard::Flow` — the step sequence as data plus its navigator (a
     swappable `Config#flow`); see "Steps and the Flow".
   - `Hyku::DepositWizard::VisibilityPolicy` — a policy object deriving the allowed

--- a/spec/controllers/hyrax/generic_works_controller_spec.rb
+++ b/spec/controllers/hyrax/generic_works_controller_spec.rb
@@ -23,4 +23,38 @@ RSpec.describe Hyrax::GenericWorksController do
       expect(response.status).to eq(200)
     end
   end
+
+  describe '#create with a parent_id' do
+    let(:parent) { FactoryBot.valkyrie_create(:generic_work_resource, depositor: user.user_key) }
+
+    before { sign_in user }
+
+    context 'when the parent accepts no children' do
+      before do
+        @original = GenericWorkResource.valid_child_concerns
+        GenericWorkResource.valid_child_concerns = []
+      end
+
+      after { GenericWorkResource.valid_child_concerns = @original }
+
+      it 'refuses the deposit' do
+        post :create, params: { parent_id: parent.id.to_s,
+                                generic_work: { title: ['Rejected child'] } }
+
+        expect(response).to redirect_to(root_path)
+        expect(flash[:alert]).to eq(I18n.t('hyku.works.errors.parent_not_allowed'))
+      end
+    end
+
+    it 'refuses a parent the user cannot edit' do
+      other = FactoryBot.valkyrie_create(:generic_work_resource,
+                                         depositor: FactoryBot.create(:user).user_key)
+
+      post :create, params: { parent_id: other.id.to_s,
+                              generic_work: { title: ['Not mine'] } }
+
+      expect(response).to redirect_to(root_path)
+      expect(flash[:alert]).to eq(I18n.t('hyku.works.errors.parent_not_allowed'))
+    end
+  end
 end

--- a/spec/controllers/hyrax/generic_works_controller_spec.rb
+++ b/spec/controllers/hyrax/generic_works_controller_spec.rb
@@ -29,6 +29,16 @@ RSpec.describe Hyrax::GenericWorksController do
 
     before { sign_in user }
 
+    it 'allows a child whose type the parent accepts' do
+      editable = FactoryBot.valkyrie_create(:generic_work_resource, edit_users: [user])
+
+      post :create, params: { parent_id: editable.id.to_s,
+                              generic_work: { title: ['Legitimate child'] } }
+
+      expect(flash[:alert]).to be_blank
+      expect(response).not_to redirect_to(root_path)
+    end
+
     context 'when the parent accepts no children' do
       before do
         @original = GenericWorkResource.valid_child_concerns

--- a/spec/presenters/hyku/deposit_wizard/presenter_spec.rb
+++ b/spec/presenters/hyku/deposit_wizard/presenter_spec.rb
@@ -61,12 +61,24 @@ RSpec.describe Hyku::DepositWizard::Presenter do
     end
 
     context 'when a parent is chosen' do
-      let(:params) { ActionController::Parameters.new(step: 'select_parent', parent_id: 'abc123') }
+      let(:parent) { FactoryBot.valkyrie_create(:generic_work_resource) }
+      let(:params) { ActionController::Parameters.new(step: 'select_parent', parent_id: parent.id.to_s) }
 
       it 'stores the parent and advances' do
         transition = presenter.advance_from('select_parent')
         expect(transition).to be_advance
-        expect(presenter.state.parent_id).to eq('abc123')
+        expect(presenter.state.parent_id).to eq(parent.id.to_s)
+      end
+    end
+
+    context 'when the chosen parent cannot contain children' do
+      let(:params) { ActionController::Parameters.new(step: 'select_parent', parent_id: 'abc123') }
+
+      it 're-renders select_parent and leaves the parent unset' do
+        transition = presenter.advance_from('select_parent')
+        expect(transition).not_to be_advance
+        expect(transition.alert).to eq('hyku.deposit_wizard.errors.parent_not_allowed')
+        expect(presenter.state.parent_id).to be_nil
       end
     end
 

--- a/spec/presenters/hyku/deposit_wizard/presenter_spec.rb
+++ b/spec/presenters/hyku/deposit_wizard/presenter_spec.rb
@@ -61,8 +61,13 @@ RSpec.describe Hyku::DepositWizard::Presenter do
     end
 
     context 'when a parent is chosen' do
-      let(:parent) { FactoryBot.valkyrie_create(:generic_work_resource) }
+      let(:user) { FactoryBot.create(:user) }
+      let(:parent) { FactoryBot.valkyrie_create(:generic_work_resource, edit_users: [user]) }
       let(:params) { ActionController::Parameters.new(step: 'select_parent', parent_id: parent.id.to_s) }
+      let(:context) do
+        double(session: session, current_user: user, current_ability: Ability.new(user),
+               params: params, main_app: nil, blacklight_config: nil)
+      end
 
       it 'stores the parent and advances' do
         transition = presenter.advance_from('select_parent')

--- a/spec/requests/deposit_wizard_spec.rb
+++ b/spec/requests/deposit_wizard_spec.rb
@@ -418,8 +418,8 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
           expect(response).to have_http_status(:success)
           expect(response).not_to redirect_to(deposit_wizard_step_path(step: 'review'))
           expect(response.body).to include(I18n.t('hyku.deposit_wizard.errors.details_invalid'))
-          # The submission is not advanced into wizard state on failure.
-          expect(session[:deposit_wizard]['attributes']).to be_blank
+          # Saved even though invalid, so leaving the step doesn't discard the work.
+          expect(session[:deposit_wizard]['attributes']['title']).to eq(['Bad embed'])
           # Entered values survive the re-render so the depositor can correct them.
           expect(response.body).to include('Bad embed')
           expect(response.body).to include('not a url')
@@ -444,7 +444,36 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
                 params: { param_key => { title: [''] } }
 
           expect(response).to have_http_status(:success)
-          expect(session[:deposit_wizard]['attributes']).to be_nil
+          expect(session[:deposit_wizard]['attributes']).to be_present
+        end
+
+        it 'saves what was entered and steps back when Back is submitted' do
+          patch deposit_wizard_advance_path(step: 'details'),
+                params: { direction: 'back',
+                          param_key => { title: ['Half finished'], description: ['Some notes'] } }
+
+          expect(response).to redirect_to(deposit_wizard_step_path(step: 'files'))
+          expect(session[:deposit_wizard]['attributes']['title']).to eq(['Half finished'])
+          expect(session[:deposit_wizard]['attributes']['description']).to eq(['Some notes'])
+        end
+
+        it 'steps back without validating, so an incomplete form is still saved' do
+          patch deposit_wizard_advance_path(step: 'details'),
+                params: { direction: 'back', param_key => { title: [''], description: ['Just a note'] } }
+
+          expect(response).to redirect_to(deposit_wizard_step_path(step: 'files'))
+          expect(flash[:alert]).to be_blank
+          expect(session[:deposit_wizard]['attributes']['description']).to eq(['Just a note'])
+        end
+
+        it 'renders Back as a submit button so entries post on the way out' do
+          get deposit_wizard_step_path(step: 'details')
+
+          # formnovalidate is asserted because a request spec can't exercise the
+          # browser validation it suppresses (see _nav.html.erb).
+          expect(response.body).to match(
+            /<button[^>]*name="direction"[^>]*value="back"[^>]*formnovalidate/
+          )
         end
       end
     end
@@ -522,6 +551,16 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
 
           expect(response).to have_http_status(:success)
           expect(response.body).to include('Cover image')
+        end
+
+        it 'saves per-file metadata and steps back when Back is submitted' do
+          patch deposit_wizard_advance_path(step: 'file_meta'),
+                params: { direction: 'back',
+                          file_metadata: { upload.id.to_s => { title: 'Typed then went back' } } }
+
+          expect(response).to redirect_to(deposit_wizard_step_path(step: 'details'))
+          expect(session[:deposit_wizard]['file_metadata'][upload.id.to_s]['title'])
+            .to eq('Typed then went back')
         end
       end
     end

--- a/spec/requests/deposit_wizard_spec.rb
+++ b/spec/requests/deposit_wizard_spec.rb
@@ -396,6 +396,49 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
         expect(session[:deposit_wizard]['parent_id']).to be_nil
       end
 
+      # Needs a non-admin: an admin can edit everything.
+      context 'as a depositor who cannot edit the chosen parent' do
+        let(:depositor) { FactoryBot.create(:user) }
+
+        before { login_as depositor }
+
+        it 'refuses the parent and leaves it unset' do
+          other = FactoryBot.valkyrie_create(:generic_work_resource,
+                                             depositor: FactoryBot.create(:user).user_key)
+          patch deposit_wizard_advance_path(step: 'start'), params: { path: 'add' }
+
+          patch deposit_wizard_advance_path(step: 'select_parent'), params: { parent_id: other.id.to_s }
+
+          expect(response.body).to include(I18n.t('hyku.deposit_wizard.errors.parent_not_allowed'))
+          expect(session[:deposit_wizard]['parent_id']).to be_nil
+        end
+
+        it 'does not inherit the admin set on a launch handoff' do
+          other = FactoryBot.valkyrie_create(
+            :generic_work_resource,
+            depositor: FactoryBot.create(:user).user_key,
+            admin_set_id: Hyrax::AdminSetCreateService.find_or_create_default_admin_set.id.to_s
+          )
+
+          get deposit_wizard_path(parent_id: other.id.to_s)
+
+          expect(session[:deposit_wizard]['admin_set_id']).to be_blank
+        end
+
+        it 'keeps the parent but stays on start when it cannot deposit in that admin set' do
+          admin_set_id = Hyrax::AdminSetCreateService.find_or_create_default_admin_set.id.to_s
+          parent = FactoryBot.valkyrie_create(:generic_work_resource, edit_users: [depositor],
+                                                                      admin_set_id: admin_set_id)
+
+          get deposit_wizard_path(parent_id: parent.id.to_s)
+
+          expect(response).to have_http_status(:success)
+          expect(response).not_to redirect_to(deposit_wizard_step_path(step: 'select_parent'))
+          expect(session[:deposit_wizard]['parent_id']).to eq(parent.id.to_s)
+          expect(session[:deposit_wizard]['admin_set_id']).to be_blank
+        end
+      end
+
       it 'shows the chosen parent and a Back-to-parent link on the type chooser' do
         parent = FactoryBot.valkyrie_create(:generic_work_resource, title: ['Umbrella'], depositor: admin.user_key)
         patch deposit_wizard_advance_path(step: 'start'), params: { path: 'add' }

--- a/spec/requests/deposit_wizard_spec.rb
+++ b/spec/requests/deposit_wizard_spec.rb
@@ -789,6 +789,36 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
         expect(response.body).to include(I18n.t('hyku.deposit_wizard.review.work_visibility'))
       end
 
+      it 'shows an authority label instead of the stored URI' do
+        uri = 'http://rightsstatements.org/vocab/InC/1.0/'
+        patch deposit_wizard_advance_path(step: 'start'), params: { work_type: work_type }
+        patch deposit_wizard_advance_path(step: 'details'),
+              params: { param_key => { title: ['Labeled'], creator: ['Ada'], rights_statement: [uri] } }
+
+        get deposit_wizard_step_path(step: 'review')
+
+        expect(response.body).to include('In Copyright')
+        expect(response.body).not_to include(uri)
+      end
+
+      it 'leaves an uncontrolled value alone' do
+        fill_in_wizard
+        get deposit_wizard_step_path(step: 'review')
+
+        expect(response.body).to include('Repair Study')
+      end
+
+      it 'falls back to the stored value when the authority has no match' do
+        patch deposit_wizard_advance_path(step: 'start'), params: { work_type: work_type }
+        patch deposit_wizard_advance_path(step: 'details'),
+              params: { param_key => { title: ['Unmatched'], creator: ['Ada'],
+                                       rights_statement: ['http://example.com/not-an-authority-id'] } }
+
+        get deposit_wizard_step_path(step: 'review')
+
+        expect(response.body).to include('http://example.com/not-an-authority-id')
+      end
+
       describe 'autosaving review extras (survive a refresh)' do
         after { Hyku::DepositWizard.reset_config! }
 

--- a/spec/requests/deposit_wizard_spec.rb
+++ b/spec/requests/deposit_wizard_spec.rb
@@ -116,8 +116,6 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
             expect(response).to have_http_status(:success)
           end
 
-          # Skipping start skips its inline admin-set chooser, so the child takes
-          # the parent's set rather than silently falling back to the default.
           it 'inherits the admin set from the handed-off parent' do
             admin_set_id = Hyrax::AdminSetCreateService.find_or_create_default_admin_set.id.to_s
             parent = FactoryBot.valkyrie_create(:generic_work_resource, admin_set_id: admin_set_id)
@@ -428,9 +426,6 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
         expect(response.body).to include(I18n.t('hyku.deposit_wizard.files.heading'))
       end
 
-      # The uploaded_files[] inputs are written by the uploader's download
-      # template on completion, so advancing mid-upload would drop in-flight
-      # files. This hook is what the JS disables until the uploads settle.
       it 'marks the Next button so uploads in flight can block advancing' do
         get deposit_wizard_step_path(step: 'files')
 

--- a/spec/requests/deposit_wizard_spec.rb
+++ b/spec/requests/deposit_wizard_spec.rb
@@ -565,6 +565,63 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
       end
     end
 
+    describe 'discarding an in-progress deposit' do
+      before { patch deposit_wizard_advance_path(step: 'start'), params: { work_type: work_type } }
+
+      it 'offers a discard link on the step footer' do
+        get deposit_wizard_step_path(step: 'files')
+
+        expect(response.body).to include(deposit_wizard_discard_path)
+        expect(response.body).to include(I18n.t('hyku.deposit_wizard.discard'))
+      end
+
+      it 'clears the collected state and returns to the dashboard' do
+        patch deposit_wizard_advance_path(step: 'details'),
+              params: { param_key => { title: ['Abandon me'], creator: ['Ada'] } }
+
+        delete deposit_wizard_discard_path
+
+        expect(response).to redirect_to(hyrax.my_works_path)
+        expect(flash[:notice]).to eq(I18n.t('hyku.deposit_wizard.discarded'))
+        expect(session[:deposit_wizard]).to be_blank
+      end
+
+      it 'destroys the staged uploads, which nothing else would attach to a work' do
+        upload = FactoryBot.create(:uploaded_file, user: admin)
+        patch deposit_wizard_advance_path(step: 'files'), params: { uploaded_files: [upload.id.to_s] }
+        path = upload.file.path
+        expect(File).to exist(path)
+
+        delete deposit_wizard_discard_path
+
+        expect(Hyrax::UploadedFile.where(id: upload.id)).to be_empty
+        # The confirmation prompt promises the files are deleted, so assert the
+        # bytes are gone and not just the row.
+        expect(File).not_to exist(path)
+        expect(flash[:notice]).to eq(
+          I18n.t('hyku.deposit_wizard.discarded_with_files', count: 1)
+        )
+      end
+
+      # The ids come from the session, so a forged request must not be able to
+      # reach another depositor's staged files.
+      it "leaves another user's uploads alone" do
+        other_upload = FactoryBot.create(:uploaded_file, user: FactoryBot.create(:user))
+        patch deposit_wizard_advance_path(step: 'files'),
+              params: { uploaded_files: [other_upload.id.to_s] }
+
+        delete deposit_wizard_discard_path
+
+        expect(Hyrax::UploadedFile.where(id: other_upload.id)).to be_present
+      end
+
+      it 'is a no-op when nothing has been collected yet' do
+        delete deposit_wizard_discard_path
+
+        expect(response).to redirect_to(hyrax.my_works_path)
+      end
+    end
+
     describe 'review and commit' do
       before do
         Hyrax::AdminSetCreateService.find_or_create_default_admin_set

--- a/spec/requests/deposit_wizard_spec.rb
+++ b/spec/requests/deposit_wizard_spec.rb
@@ -413,7 +413,7 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
           expect(session[:deposit_wizard]['parent_id']).to be_nil
         end
 
-        it 'does not inherit the admin set on a launch handoff' do
+        it 'stays on start rather than inheriting the admin set on a launch handoff' do
           other = FactoryBot.valkyrie_create(
             :generic_work_resource,
             depositor: FactoryBot.create(:user).user_key,
@@ -422,6 +422,8 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
 
           get deposit_wizard_path(parent_id: other.id.to_s)
 
+          expect(response).to have_http_status(:success)
+          expect(response).not_to redirect_to(deposit_wizard_step_path(step: 'select_parent'))
           expect(session[:deposit_wizard]['admin_set_id']).to be_blank
         end
 
@@ -746,6 +748,12 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
         expect(response).to redirect_to(hyrax.my_works_path)
         expect(flash[:notice]).to eq(I18n.t('hyku.deposit_wizard.discarded'))
         expect(session[:deposit_wizard]).to be_blank
+      end
+
+      it 'clears an unviewed confirmation so it cannot resurface later' do
+        delete deposit_wizard_discard_path
+
+        expect(session[:deposit_wizard_last]).to be_blank
       end
 
       it 'destroys the staged uploads, which nothing else would attach to a work' do

--- a/spec/requests/deposit_wizard_spec.rb
+++ b/spec/requests/deposit_wizard_spec.rb
@@ -336,6 +336,15 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
         expect(response.body).to include(I18n.t('hyku.deposit_wizard.files.heading'))
       end
 
+      # The uploaded_files[] inputs are written by the uploader's download
+      # template on completion, so advancing mid-upload would drop in-flight
+      # files. This hook is what the JS disables until the uploads settle.
+      it 'marks the Next button so uploads in flight can block advancing' do
+        get deposit_wizard_step_path(step: 'files')
+
+        expect(response.body).to include('data-behavior="files-next"')
+      end
+
       context 'after a work type is chosen' do
         before { patch deposit_wizard_advance_path(step: 'start'), params: { work_type: work_type } }
 

--- a/spec/requests/deposit_wizard_spec.rb
+++ b/spec/requests/deposit_wizard_spec.rb
@@ -1109,6 +1109,7 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
         work = Hyrax.query_service.find_by(id: Valkyrie::ID.new(stashed['id']))
         expect(work).to be_a(resource_class)
         expect(Array(work.title).first).to eq(stashed['title'])
+        expect(stashed['work_type']).to eq(resource_class.to_s)
       end
 
       it 'applies a per-file embargo that differs from the work embargo' do

--- a/spec/requests/deposit_wizard_spec.rb
+++ b/spec/requests/deposit_wizard_spec.rb
@@ -364,6 +364,38 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
         expect(response).to redirect_to(deposit_wizard_path)
       end
 
+      context 'when the chosen parent accepts no children' do
+        let(:childless) { GenericWorkResource }
+
+        before do
+          @original = childless.valid_child_concerns
+          childless.valid_child_concerns = []
+        end
+
+        after { childless.valid_child_concerns = @original }
+
+        it 're-renders select_parent with an alert and does not seed the parent' do
+          parent = FactoryBot.valkyrie_create(:generic_work_resource, depositor: admin.user_key)
+          patch deposit_wizard_advance_path(step: 'start'), params: { path: 'add' }
+
+          patch deposit_wizard_advance_path(step: 'select_parent'), params: { parent_id: parent.id.to_s }
+
+          expect(response).to have_http_status(:success)
+          expect(response.body).to include(I18n.t('hyku.deposit_wizard.errors.parent_not_allowed'))
+          expect(session[:deposit_wizard]['parent_id']).to be_nil
+        end
+      end
+
+      it 're-renders select_parent when the chosen parent cannot be read' do
+        patch deposit_wizard_advance_path(step: 'start'), params: { path: 'add' }
+
+        patch deposit_wizard_advance_path(step: 'select_parent'), params: { parent_id: 'no-such-work' }
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include(I18n.t('hyku.deposit_wizard.errors.parent_not_allowed'))
+        expect(session[:deposit_wizard]['parent_id']).to be_nil
+      end
+
       it 'shows the chosen parent and a Back-to-parent link on the type chooser' do
         parent = FactoryBot.valkyrie_create(:generic_work_resource, title: ['Umbrella'], depositor: admin.user_key)
         patch deposit_wizard_advance_path(step: 'start'), params: { path: 'add' }
@@ -724,6 +756,27 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
         patch deposit_wizard_advance_path(step: 'start'), params: { work_type: work_type }
         patch deposit_wizard_advance_path(step: 'details'),
               params: { param_key => { title: ['Repair Study'], creator: ['Ada Lovelace'] } }
+      end
+
+      context 'when the seeded parent cannot contain the chosen type' do
+        before do
+          @original = GenericWorkResource.valid_child_concerns
+          GenericWorkResource.valid_child_concerns = []
+        end
+
+        after { GenericWorkResource.valid_child_concerns = @original }
+
+        it 'refuses to deposit and re-renders review with an alert' do
+          parent = FactoryBot.valkyrie_create(:generic_work_resource, depositor: admin.user_key)
+          get deposit_wizard_path(parent_id: parent.id.to_s)
+          fill_in_wizard
+
+          expect { post deposit_wizard_commit_path }
+            .not_to change { Hyrax.query_service.find_all_of_model(model: work_type.constantize).count }
+
+          expect(response).to have_http_status(:success)
+          expect(response.body).to include(I18n.t('hyku.deposit_wizard.errors.parent_not_allowed'))
+        end
       end
 
       it 'renders a summary including visibility on the review step' do

--- a/spec/requests/deposit_wizard_spec.rb
+++ b/spec/requests/deposit_wizard_spec.rb
@@ -254,6 +254,26 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
         expect(response.body).to include(I18n.t('hyku.deposit_wizard.start.paths.standalone.title'))
       end
 
+      it 'marks only the container path so it can lead the group' do
+        get deposit_wizard_path
+
+        cards = response.body.scan(/<button[^>]*name="path"[^>]*>/)
+        container_cards = cards.grep(/path-card--container/)
+
+        expect(container_cards.size).to eq(1)
+        expect(container_cards.first).to include('value="new"')
+      end
+
+      it 'marks no path when no container is configured' do
+        Hyku::DepositWizard.config = Hyku::DepositWizard::Config.new do |c|
+          c.parent_connect_placement = :start
+        end
+        get deposit_wizard_path
+
+        expect(response.body).to include(I18n.t('hyku.deposit_wizard.start.paths.new.title'))
+        expect(response.body).not_to include('path-card--container')
+      end
+
       it 'records the chosen path and advances to item_start' do
         patch deposit_wizard_advance_path(step: 'start'), params: { path: 'standalone' }
 

--- a/spec/requests/deposit_wizard_spec.rb
+++ b/spec/requests/deposit_wizard_spec.rb
@@ -56,6 +56,78 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
           expect(session[:deposit_wizard]['parent_id']).to eq('parent-123')
         end
 
+        # The default placement (:review) accepts a handed-off parent and carries on;
+        # only an install that chooses the parent up front lands on that step.
+        it 'renders the path chooser under the default placement' do
+          get deposit_wizard_path(parent_id: 'parent-123')
+
+          expect(response).to have_http_status(:success)
+          expect(session[:deposit_wizard]['parent_id']).to eq('parent-123')
+        end
+
+        context 'when the parent is chosen up front' do
+          before { Hyku::DepositWizard.config.parent_connect_placement = :start }
+
+          it 'skips the path chooser and lands on the parent step, on the add path' do
+            get deposit_wizard_path(parent_id: 'parent-123')
+
+            expect(response).to redirect_to(deposit_wizard_step_path(step: 'select_parent'))
+            # Required for select_parent to be visible at all; without it the step's
+            # on_skip: :entry detour sends the visit straight back to start.
+            expect(session[:deposit_wizard]['path']).to eq('add')
+          end
+
+          it 'renders the parent step with the handed-off parent already chosen' do
+            get deposit_wizard_path(parent_id: 'parent-123')
+            follow_redirect!
+
+            expect(response).to have_http_status(:success)
+            expect(response.body).to include('parent-123')
+          end
+
+          # Back from select_parent returns to start without the param, so the
+          # redirect must not fire again and trap the depositor.
+          it 'does not redirect back out of the path chooser once there' do
+            get deposit_wizard_path(parent_id: 'parent-123')
+            get deposit_wizard_path
+
+            expect(response).to have_http_status(:success)
+            expect(response.body).to include(I18n.t('hyku.deposit_wizard.page_heading'))
+          end
+
+          it 'still renders the path chooser when no parent was handed off' do
+            get deposit_wizard_path
+
+            expect(response).to have_http_status(:success)
+          end
+
+          it 'tolerates a parent that cannot be found' do
+            get deposit_wizard_path(parent_id: 'no-such-work')
+
+            expect(response).to redirect_to(deposit_wizard_step_path(step: 'select_parent'))
+            expect(session[:deposit_wizard]['admin_set_id']).to be_blank
+          end
+
+          # A blank param passes params.present? but seeds nothing, so redirecting
+          # would land on the parent step with no parent chosen.
+          it 'renders the path chooser when the handed-off parent is blank' do
+            get deposit_wizard_path(parent_id: '   ')
+
+            expect(response).to have_http_status(:success)
+          end
+
+          # Skipping start skips its inline admin-set chooser, so the child takes
+          # the parent's set rather than silently falling back to the default.
+          it 'inherits the admin set from the handed-off parent' do
+            admin_set_id = Hyrax::AdminSetCreateService.find_or_create_default_admin_set.id.to_s
+            parent = FactoryBot.valkyrie_create(:generic_work_resource, admin_set_id: admin_set_id)
+
+            get deposit_wizard_path(parent_id: parent.id.to_s)
+
+            expect(session[:deposit_wizard]['admin_set_id']).to eq(admin_set_id)
+          end
+        end
+
         it 'seeds collection membership from add_works_to_collection when the picker is enabled' do
           get deposit_wizard_path(add_works_to_collection: 'coll-9')
 


### PR DESCRIPTION
## Summary
Fixes three ways the guided deposit wizard could lose a depositor's work, adds a way to abandon a deposit, and shows vocabulary terms by name instead of as URLs.

## Details
- Advancing past the upload step mid-upload silently dropped in-flight files; Next is now disabled until uploads settle, including for a file cancelled before it is ever sent.
- The detail steps discarded anything typed when Back was clicked, and the work detail step discarded the whole form when validation failed. Both now save what was entered; validation only decides where the depositor goes next.
- Every step offers "Discard this deposit", which clears the collected state and deletes the files staged for it. Previously the only way out was to re-enter the wizard, which nothing advertised, and also which left orphaned files.
- Nothing validated that a chosen parent could contain the work being deposited, and `Steps::AddToParent` checks neither the type pairing nor access to the parent. The wizard now refuses a parent whose type cannot hold the work, and — since `parent_id` arrives in params — one the depositor cannot edit. The standard deposit form applies the same check on create, which **changes existing behavior there**: posting a `parent_id` for a work you cannot edit was previously allowed.
- A child inherits its parent's admin set when the start screen is skipped, but only when the depositor may deposit into it: edit access to a work does not imply deposit rights to the admin set it sits in. Otherwise the parent is kept and the depositor stays on the start screen to choose one, rather than silently getting the default.
- The review summary shows an authority's label rather than the stored id, driven by the metadata profile so no property is named in code.
- Two changes only apply to installs that configure them, and are inert otherwise: a deposit started from an "attach a child" link opens on the parent step (needs `parent_connect_placement = :start`), and the path that deposits a container leads the start screen full-width (needs `container_type`).

## Testing
- [ ] Turn on `enable_guided_deposit`. Upload a large file on the upload step: Next stays disabled until it completes. Cancel an upload mid-flight and confirm Next re-enables rather than sticking. Queue a file and cancel it before it starts sending — Next should re-enable there too.
- [ ] On the work detail step, type into several fields and click Back, then forward again — the text is still there. Repeat with a required field left blank: the validation error shows, and navigating away and back still retains what was typed. Then repeat both on the file detail step.
- [ ] Click "Discard this deposit" with a file uploaded: it returns to the dashboard, the wizard starts clean, and the staged file is gone.
- [ ] From a work's show page, use "Add child work" and complete the deposit — it should succeed and the child should be nested.
- [ ] Set a work type's `valid_child_concerns` to `[]`, then try to select one of those works as a parent — the parent step refuses it.
- [ ] As a non-admin, try to select a work you cannot edit as a parent — it should be refused. Then post to a work controller with that same `parent_id`; it should also be refused.
- [ ] As a non-admin with edit access to a work in an admin set you cannot deposit into, follow that work's "attach a child" link: you should land on the start screen with an admin-set chooser rather than being skipped past it, and the parent should still be carried through.
- [ ] Enter a rights statement on the work detail step and confirm the review page names it rather than showing the URL.
- [ ] Check the Back and Next buttons still behave on the upload, parent, item type, and review steps — the shared footer changed shape.

