### PR TITLE
Restrict user invitations on public demo tenants

### DIFF
--- a/app/controllers/hyku/invitations_controller.rb
+++ b/app/controllers/hyku/invitations_controller.rb
@@ -2,6 +2,11 @@
 
 module Hyku
   class InvitationsController < Devise::InvitationsController
+    # On public demo tenants, inviting users is restricted to holders of
+    # manage :tenant_controls (i.e. tenant superadmins).
+    # @see Hyrax::Ability::TenantControlAbility
+    before_action :ensure_tenant_controls_on_demo_tenant!, only: :create
+
     # For devise_invitable, specify post-invite path to be 'Manage Users' form
     # (as the user invitation form is also on that page)
     def after_invite_path_for(_resource)
@@ -34,6 +39,12 @@ module Hyku
 
     def user_params
       params.require(:user).permit(:email, :role)
+    end
+
+    def ensure_tenant_controls_on_demo_tenant!
+      return unless Site.account&.public_demo_tenant?
+
+      authorize! :manage, :tenant_controls
     end
   end
 end

--- a/app/controllers/hyku/invitations_controller.rb
+++ b/app/controllers/hyku/invitations_controller.rb
@@ -2,10 +2,12 @@
 
 module Hyku
   class InvitationsController < Devise::InvitationsController
-    # On public demo tenants, inviting users is restricted to holders of
-    # manage :tenant_controls (i.e. tenant superadmins).
+    # devise_invitable's own filter only authenticates the inviter, so without
+    # this any signed-in user could invite. Who may invite is decided entirely
+    # in the ability layer.
+    # @see Hyrax::Ability::UserAbility
     # @see Hyrax::Ability::TenantControlAbility
-    before_action :ensure_tenant_controls_on_demo_tenant!, only: :create
+    before_action -> { authorize! :invite, User }, only: :create
 
     # For devise_invitable, specify post-invite path to be 'Manage Users' form
     # (as the user invitation form is also on that page)
@@ -39,12 +41,6 @@ module Hyku
 
     def user_params
       params.require(:user).permit(:email, :role)
-    end
-
-    def ensure_tenant_controls_on_demo_tenant!
-      return unless Site.account&.public_demo_tenant?
-
-      authorize! :manage, :tenant_controls
     end
   end
 end

--- a/app/models/concerns/hyrax/ability/tenant_control_ability.rb
+++ b/app/models/concerns/hyrax/ability/tenant_control_ability.rb
@@ -7,13 +7,35 @@ module Hyrax
   module Ability
     module TenantControlAbility
       def tenant_control_abilities
-        if admin? && Site.account&.public_demo_tenant? != true
+        if admin? && !public_demo_tenant?
           can [:manage], :tenant_controls
         elsif tenant_superadmin?
           can [:manage], :tenant_controls
         else
           cannot [:manage], :tenant_controls
         end
+
+        user_invite_abilities
+      end
+
+      # Inviting users is a tenant control on a public demo tenant. That flag
+      # means the admin credential is published to visitors, so an admin there
+      # is not a trusted operator and must not be able to send mail from the
+      # tenant's domain to addresses of their choosing. The tenant's superadmin
+      # still can.
+      #
+      # On a standard tenant this leaves :invite where UserAbility and
+      # admin_permissions put it, so behavior is unchanged.
+      def user_invite_abilities
+        can :invite, User if tenant_superadmin?
+
+        cannot :invite, User if public_demo_tenant? && !tenant_superadmin? && !superadmin?
+      end
+
+      private
+
+      def public_demo_tenant?
+        Site.account&.public_demo_tenant? == true
       end
     end
   end

--- a/app/models/concerns/hyrax/ability/user_ability.rb
+++ b/app/models/concerns/hyrax/ability/user_ability.rb
@@ -6,7 +6,7 @@ module Hyrax
       def user_roles
         # Can create, read, and edit/update destroy all Users, cannot become a User
         if user_manager?
-          can %i[create read update edit remove], User
+          can %i[create read update edit remove invite], User
           can %i[create read update edit remove destroy], Hyrax::Group
         # Can read all Users and Groups
         elsif user_reader?

--- a/app/views/hyrax/admin/users/index.html.erb
+++ b/app/views/hyrax/admin/users/index.html.erb
@@ -8,7 +8,8 @@
   <% end %>
 <% end %>
 
-<% if can? :create, User %>
+<%# On public demo tenants, inviting users is restricted to holders of manage :tenant_controls %>
+<% if can?(:create, User) && (!Site.account&.public_demo_tenant? || can?(:manage, :tenant_controls)) %>
   <div class="card users-invite">
     <div class="card-header">
         <%= t('.invite_users') %>

--- a/app/views/hyrax/admin/users/index.html.erb
+++ b/app/views/hyrax/admin/users/index.html.erb
@@ -8,8 +8,7 @@
   <% end %>
 <% end %>
 
-<%# Inviting always requires :create on User; public demo tenants additionally require manage :tenant_controls %>
-<% if can?(:create, User) && (!Site.account&.public_demo_tenant? || can?(:manage, :tenant_controls)) %>
+<% if can? :invite, User %>
   <div class="card users-invite">
     <div class="card-header">
         <%= t('.invite_users') %>

--- a/app/views/hyrax/admin/users/index.html.erb
+++ b/app/views/hyrax/admin/users/index.html.erb
@@ -8,7 +8,7 @@
   <% end %>
 <% end %>
 
-<%# On public demo tenants, inviting users is restricted to holders of manage :tenant_controls %>
+<%# Inviting always requires :create on User; public demo tenants additionally require manage :tenant_controls %>
 <% if can?(:create, User) && (!Site.account&.public_demo_tenant? || can?(:manage, :tenant_controls)) %>
   <div class="card users-invite">
     <div class="card-header">

--- a/spec/abilities/tenant_control_ability_spec.rb
+++ b/spec/abilities/tenant_control_ability_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Hyrax::Ability::TenantControlAbility do
   subject { ability }
   let(:tenant_superadmin) { FactoryBot.create(:tenant_superadmin) }
   let(:tenant_admin) { FactoryBot.create(:admin) }
+  let(:user_manager) { FactoryBot.create(:user_manager) }
   let(:basic_user) { FactoryBot.create(:user) }
   let(:ability) { Ability.new(current_user) }
 
@@ -41,6 +42,17 @@ RSpec.describe Hyrax::Ability::TenantControlAbility do
         is_expected.not_to be_able_to(:manage, :tenant_controls)
       end
     end
+
+    # User managers can invite users on standard tenants without holding
+    # :tenant_controls, which is why the invitation gate only authorizes
+    # against :tenant_controls on public demo tenants.
+    describe 'when user manager' do
+      let(:current_user) { user_manager }
+
+      it 'does not grant tenant controls' do
+        is_expected.not_to be_able_to(:manage, :tenant_controls)
+      end
+    end
   end
 
   context 'when in demo tenant' do
@@ -69,6 +81,14 @@ RSpec.describe Hyrax::Ability::TenantControlAbility do
       let(:current_user) { basic_user }
 
       it 'allows all user abilities' do
+        is_expected.not_to be_able_to(:manage, :tenant_controls)
+      end
+    end
+
+    describe 'when user manager' do
+      let(:current_user) { user_manager }
+
+      it 'does not grant tenant controls' do
         is_expected.not_to be_able_to(:manage, :tenant_controls)
       end
     end

--- a/spec/abilities/tenant_control_ability_spec.rb
+++ b/spec/abilities/tenant_control_ability_spec.rb
@@ -25,6 +25,10 @@ RSpec.describe Hyrax::Ability::TenantControlAbility do
       it 'allows all user abilities' do
         is_expected.to be_able_to(:manage, :tenant_controls)
       end
+
+      it 'allows inviting users' do
+        is_expected.to be_able_to(:invite, User)
+      end
     end
 
     describe 'when tenant admin' do
@@ -32,6 +36,10 @@ RSpec.describe Hyrax::Ability::TenantControlAbility do
 
       it 'allows all user abilities' do
         is_expected.to be_able_to(:manage, :tenant_controls)
+      end
+
+      it 'allows inviting users' do
+        is_expected.to be_able_to(:invite, User)
       end
     end
 
@@ -41,16 +49,23 @@ RSpec.describe Hyrax::Ability::TenantControlAbility do
       it 'allows all user abilities' do
         is_expected.not_to be_able_to(:manage, :tenant_controls)
       end
+
+      it 'does not allow inviting users' do
+        is_expected.not_to be_able_to(:invite, User)
+      end
     end
 
-    # User managers can invite users on standard tenants without holding
-    # :tenant_controls, which is why the invitation gate only authorizes
-    # against :tenant_controls on public demo tenants.
     describe 'when user manager' do
       let(:current_user) { user_manager }
 
       it 'does not grant tenant controls' do
         is_expected.not_to be_able_to(:manage, :tenant_controls)
+      end
+
+      # User managers run user administration without holding :tenant_controls,
+      # so inviting cannot be gated on that ability.
+      it 'allows inviting users' do
+        is_expected.to be_able_to(:invite, User)
       end
     end
   end
@@ -67,6 +82,10 @@ RSpec.describe Hyrax::Ability::TenantControlAbility do
       it 'allows all user abilities' do
         is_expected.to be_able_to(:manage, :tenant_controls)
       end
+
+      it 'allows inviting users' do
+        is_expected.to be_able_to(:invite, User)
+      end
     end
 
     describe 'when tenant admin' do
@@ -74,6 +93,10 @@ RSpec.describe Hyrax::Ability::TenantControlAbility do
 
       it 'allows all user abilities' do
         is_expected.not_to be_able_to(:manage, :tenant_controls)
+      end
+
+      it 'does not allow inviting users' do
+        is_expected.not_to be_able_to(:invite, User)
       end
     end
 
@@ -83,6 +106,10 @@ RSpec.describe Hyrax::Ability::TenantControlAbility do
       it 'allows all user abilities' do
         is_expected.not_to be_able_to(:manage, :tenant_controls)
       end
+
+      it 'does not allow inviting users' do
+        is_expected.not_to be_able_to(:invite, User)
+      end
     end
 
     describe 'when user manager' do
@@ -90,6 +117,19 @@ RSpec.describe Hyrax::Ability::TenantControlAbility do
 
       it 'does not grant tenant controls' do
         is_expected.not_to be_able_to(:manage, :tenant_controls)
+      end
+
+      it 'does not allow inviting users' do
+        is_expected.not_to be_able_to(:invite, User)
+      end
+    end
+
+    describe 'when superadmin' do
+      let(:current_user) { FactoryBot.create(:superadmin) }
+
+      # A proprietor-level superadmin administers every tenant, demo or not.
+      it 'allows inviting users' do
+        is_expected.to be_able_to(:invite, User)
       end
     end
   end

--- a/spec/controllers/hyku/invitations_controller_spec.rb
+++ b/spec/controllers/hyku/invitations_controller_spec.rb
@@ -57,5 +57,59 @@ RSpec.describe Hyku::InvitationsController, type: :controller do
         expect(user.groups).to eq([Ability.registered_group_name])
       end
     end
+
+    context 'on a public demo tenant' do
+      before do
+        allow(Site).to receive_message_chain(:account, :public_demo_tenant?).and_return(true)
+        allow(Site).to receive_message_chain(:account, :search_only?).and_return(false)
+      end
+
+      context 'when signed in as a tenant admin' do
+        it 'denies the invitation and does not create the user' do
+          post :create, params: {
+            user: {
+              email: 'uninvited@guest.org',
+              role: 'user_manager'
+            }
+          }
+          expect(User.find_by(email: 'uninvited@guest.org')).to be_nil
+          expect(response).to redirect_to root_path
+        end
+      end
+
+      context 'when signed in as a tenant superadmin' do
+        let(:user) { create(:tenant_superadmin) }
+
+        it 'processes the invitation' do
+          post :create, params: {
+            user: {
+              email: 'invited@guest.org',
+              role: 'user_manager'
+            }
+          }
+          created_user = User.find_by(email: 'invited@guest.org')
+          expect(created_user.roles.map(&:name)).to include('user_manager')
+          expect(response).to redirect_to Hyrax::Engine.routes.url_helpers.admin_users_path(locale: 'en')
+        end
+      end
+    end
+
+    context 'on a standard tenant' do
+      before do
+        allow(Site).to receive_message_chain(:account, :public_demo_tenant?).and_return(false)
+        allow(Site).to receive_message_chain(:account, :search_only?).and_return(false)
+      end
+
+      it 'still allows a tenant admin to invite users' do
+        post :create, params: {
+          user: {
+            email: 'welcome@guest.org',
+            role: 'user_manager'
+          }
+        }
+        expect(User.find_by(email: 'welcome@guest.org')).to be_present
+        expect(response).to redirect_to Hyrax::Engine.routes.url_helpers.admin_users_path(locale: 'en')
+      end
+    end
   end
 end

--- a/spec/controllers/hyku/invitations_controller_spec.rb
+++ b/spec/controllers/hyku/invitations_controller_spec.rb
@@ -32,29 +32,62 @@ RSpec.describe Hyku::InvitationsController, type: :controller do
       expect(flash[:notice]).to eq 'An invitation email has been sent to user@guest.org.'
     end
 
-    context 'when user already exists' do
-      let(:user) { create(:user) }
-
+    context 'when the invited user already exists' do
       # Mimic the state of a user who is only active in other tenants;
       # i.e. a user who has no roles in this tenant
+      let(:invitee) { create(:user) }
+
       before do
-        user.roles.destroy_all
+        invitee.roles.destroy_all
       end
 
       it 'adds the user to the registered group' do
-        expect(user.roles).to be_empty
-        expect(user.groups).to be_empty
+        expect(invitee.roles).to be_empty
+        expect(invitee.groups).to be_empty
 
         post :create, params: {
           user: {
-            email: user.email,
+            email: invitee.email,
             role: ''
           }
         }
 
-        user.reload
-        expect(user.roles).not_to be_empty
-        expect(user.groups).to eq([Ability.registered_group_name])
+        invitee.reload
+        expect(invitee.roles).not_to be_empty
+        expect(invitee.groups).to eq([Ability.registered_group_name])
+      end
+    end
+
+    context 'when the inviter holds no user-management role' do
+      let(:user) { create(:user) }
+
+      # devise_invitable's authenticate_inviter! only requires a signed-in
+      # user, so without an explicit authorize! any registered user could
+      # invite arbitrary addresses and grant them a role.
+      it 'denies the invitation and does not create the user' do
+        post :create, params: {
+          user: {
+            email: 'stranger@guest.org',
+            role: 'user_manager'
+          }
+        }
+        expect(User.find_by(email: 'stranger@guest.org')).to be_nil
+        expect(response).to redirect_to root_path
+      end
+    end
+
+    context 'when the inviter is a user manager' do
+      let(:user) { create(:user_manager) }
+
+      it 'processes the invitation' do
+        post :create, params: {
+          user: {
+            email: 'colleague@guest.org',
+            role: 'work_depositor'
+          }
+        }
+        expect(User.find_by(email: 'colleague@guest.org')).to be_present
+        expect(response).to redirect_to Hyrax::Engine.routes.url_helpers.admin_users_path(locale: 'en')
       end
     end
 
@@ -70,6 +103,21 @@ RSpec.describe Hyku::InvitationsController, type: :controller do
             user: {
               email: 'uninvited@guest.org',
               role: 'user_manager'
+            }
+          }
+          expect(User.find_by(email: 'uninvited@guest.org')).to be_nil
+          expect(response).to redirect_to root_path
+        end
+      end
+
+      context 'when signed in as a user manager' do
+        let(:user) { create(:user_manager) }
+
+        it 'denies the invitation and does not create the user' do
+          post :create, params: {
+            user: {
+              email: 'uninvited@guest.org',
+              role: 'work_depositor'
             }
           }
           expect(User.find_by(email: 'uninvited@guest.org')).to be_nil

--- a/spec/views/hyrax/admin/users/index_demo_tenant.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/users/index_demo_tenant.html.erb_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# The invite form on the Manage Users page is hidden from plain admins on
+# public demo tenants; tenant superadmins keep it. This lives in its own file
+# (rather than index.html.erb_spec.rb) because the tenant flag must be stubbed
+# before the first render and the sibling spec renders in a top-level before.
+RSpec.describe 'hyrax/admin/users/index.html.erb', type: :view do
+  include Devise::Test::ControllerHelpers
+
+  let(:presenter) { Hyrax::Admin::UsersPresenter.new }
+  let(:page) { Capybara::Node::Simple.new(rendered) }
+
+  before do
+    allow(Site).to receive_message_chain(:account, :public_demo_tenant?).and_return(true)
+    allow(Site).to receive_message_chain(:account, :search_only?).and_return(false)
+    FactoryBot.create(:admin_group, member_users: [current_user])
+    sign_in current_user
+    @invite_roles_options = ::RolesService::DEFAULT_ROLES
+    allow(presenter).to receive(:users).and_return([current_user])
+    assign(:presenter, presenter)
+    render
+  end
+
+  context 'when signed in as a tenant admin' do
+    let(:current_user) do
+      FactoryBot.create(:user,
+                        display_name: 'demo admin',
+                        last_sign_in_at: 15.minutes.ago,
+                        created_at: 3.days.ago)
+    end
+
+    it 'hides the invite form' do
+      expect(page).not_to have_selector('div.users-invite')
+    end
+
+    it 'still draws the user list' do
+      expect(page).to have_selector('div.users-listing')
+    end
+  end
+
+  context 'when signed in as a tenant superadmin' do
+    let(:current_user) do
+      FactoryBot.create(:tenant_superadmin,
+                        display_name: 'demo superadmin',
+                        last_sign_in_at: 15.minutes.ago,
+                        created_at: 3.days.ago)
+    end
+
+    it 'draws the invite form' do
+      expect(page).to have_selector('div.users-invite')
+    end
+  end
+end

--- a/spec/views/hyrax/admin/users/index_demo_tenant.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/users/index_demo_tenant.html.erb_spec.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
-# The invite form on the Manage Users page is hidden from plain admins on
-# public demo tenants; tenant superadmins keep it. This lives in its own file
-# (rather than index.html.erb_spec.rb) because the tenant flag must be stubbed
-# before the first render and the sibling spec renders in a top-level before.
+# The Manage Users page draws the invite form from can? :invite, User, so on a
+# public demo tenant a plain admin loses it and a tenant superadmin keeps it.
+# This lives in its own file (rather than index.html.erb_spec.rb) because the
+# tenant flag must be stubbed before the first render and the sibling spec
+# renders in a top-level before.
+# @see Hyrax::Ability::TenantControlAbility
 RSpec.describe 'hyrax/admin/users/index.html.erb', type: :view do
   include Devise::Test::ControllerHelpers
 


### PR DESCRIPTION
Split out of #3127; sibling of #3186 and #3187 (merged). Reworked after @orangewolf asked why a demo tenant needs an extra auth setting, and whether the problem is really demo-specific. It mostly isn't, and the first version was treating a symptom.

## Why this matters

`Hyku::InvitationsController#create` has no authorization of its own. devise_invitable's `authenticate_inviter!` only requires a signed-in user, and our override adds `authorize! :grant_admin_role, User` only when the requested role is `admin`. The `can? :create, User` check lives in the view.

**So on any Hyku tenant, any registered user can POST `/users/invitation` and invite an arbitrary email address with a role attached.** Mail leaves the tenant's domain to a recipient of the sender's choosing, and the recipient lands with `user_manager` if the sender asked for it. Self-registration is on by default (`allow_signup`), so on a public tenant "registered user" means anyone.

That is worth fixing for every adopter regardless of demo tenants. The demo work is just what surfaced it: `public_demo_tenant` publishes the admin credential to visitors, which turns a latent gap into a live one.

## What changed

* `#create` authorizes `:invite` on `User`. Granted to user managers in `Hyrax::Ability::UserAbility` alongside their existing user-administration rights, and to admins via `can :manage, User`. Standard tenants get the behavior their UI already advertised; nothing else about them changes.
* `Hyrax::Ability::TenantControlAbility` denies `:invite` on a `public_demo_tenant`, except to the tenant's superadmin or a proprietor superadmin.
* The controller and `hyrax/admin/users/index` no longer reference `public_demo_tenant?`. Both ask `can? :invite, User`, so the demo flag is one input to the policy instead of a conditional repeated at each call site.

`:invite` is a new ability rather than a reuse of `:create, User`, because line 1 of that view also branches on `:create` to pick the page title; overloading it would silently relabel the page.

## Where it belongs

Hyku, not Hyrax. Hyrax has no user-invitation flow; invitations, the multi-tenant role model, and `public_demo_tenant` are all Hyku concepts, and the vulnerable endpoint is Hyku's own devise_invitable override. Nothing here is worth pushing upstream.

Within Hyku, the policy sits in the ability layer rather than the controller so that both the endpoint and the UI derive from one rule. That is also what makes the demo case expressible without demo-specific code at either call site.

## Verification

`spec/controllers/hyku/invitations_controller_spec.rb` covers the gap directly: "when the inviter holds no user-management role" fails against the previous commit, with the invitee created. Ability specs assert `:invite` for admin, user manager, tenant superadmin, superadmin, and basic user across both tenant modes. The view spec follows `can? :invite, User`. The pre-existing "invited user already exists" example now signs in an admin as the inviter, because it previously relied on the missing authorization.

226 examples green across the abilities, users-controller, invitations-controller, users-view, and user-role feature specs. Rubocop clean; eager load OK.

## Not addressed here

* `Site#add_admins_by_email` calls `User.invite!` directly and never reaches this controller. It is proprietor-only, so it is not part of this exposure, but it deserves the same treatment for symmetry.
* Delete and Activate on Manage Users have the same shape: hidden behind `can? :manage, :tenant_controls` in the view, but `Admin::UsersController` only runs `ensure_admin!`. On a flagged tenant a plain admin can still delete users by issuing the request directly, confirmed locally. Tracked separately rather than widening this PR.
