### PR TITLE
Show public_demo_tenant as read-only on the proprietor account form

### DIFF
--- a/app/views/proprietor/accounts/edit.html.erb
+++ b/app/views/proprietor/accounts/edit.html.erb
@@ -26,7 +26,12 @@
 
           <%= f.input :is_public %>
 
-          <%= f.input :public_demo_tenant, disabled: true, hint: "This field cannot be changed after account creation" %>
+          <%# public_demo_tenant is attr_readonly, so it is shown as read-only text rather than a form control %>
+          <div class="form-group account-public-demo-tenant">
+            <span class="d-block font-weight-bold"><%= t('simple_form.labels.account.public_demo_tenant') %></span>
+            <span><%= @account.public_demo_tenant? ? t('.public_demo_tenant.enabled') : t('.public_demo_tenant.disabled') %></span>
+            <small class="form-text text-muted"><%= t('.public_demo_tenant.immutable') %></small>
+          </div>
 
           <%= f.input :tenant, readonly: @account.persisted? %>
 

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -661,6 +661,10 @@ de:
         data_cite_endpoint: DataCite-Endpunkt
         fcrepo_endpoint: Fedora-Endpunkt
         header: Konto bearbeiten
+        public_demo_tenant:
+          disabled: 'Nein'
+          enabled: 'Ja'
+          immutable: Diese Einstellung wird bei der Kontoerstellung festgelegt und kann nicht geändert werden.
         solr_endpoint: Solr-Endpunkt
       index:
         actions: Aktionen

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -507,6 +507,10 @@ en:
         data_cite_endpoint: DataCite Endpoint
         fcrepo_endpoint: Fedora Endpoint
         header: Editing Account
+        public_demo_tenant:
+          disabled: 'No'
+          enabled: 'Yes'
+          immutable: This setting is defined when the account is created and cannot be changed.
         solr_endpoint: Solr Endpoint
       index:
         actions: Actions

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -658,6 +658,10 @@ es:
         data_cite_endpoint: Extremo de DataCite
         fcrepo_endpoint: Punto final de Fedora
         header: Cuenta de edición
+        public_demo_tenant:
+          disabled: 'No'
+          enabled: 'Sí'
+          immutable: Esta configuración se define al crear la cuenta y no se puede cambiar.
         solr_endpoint: Punto final de Solr
       index:
         actions: Acciones

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -663,6 +663,10 @@ fr:
         data_cite_endpoint: Point de terminaison DataCite
         fcrepo_endpoint: Fedora Endpoint
         header: Modification du compte
+        public_demo_tenant:
+          disabled: 'Non'
+          enabled: 'Oui'
+          immutable: Ce paramètre est défini lors de la création du compte et ne peut pas être modifié.
         solr_endpoint: Solr Endpoint
       index:
         actions: Actions

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -658,6 +658,10 @@ it:
         data_cite_endpoint: Endpoint DataCite
         fcrepo_endpoint: Fedora Endpoint
         header: Modifica account
+        public_demo_tenant:
+          disabled: 'No'
+          enabled: 'Sì'
+          immutable: Questa impostazione viene definita alla creazione dell'account e non può essere modificata.
         solr_endpoint: Solr Endpoint
       index:
         actions: Azioni

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -541,6 +541,10 @@ pt-BR:
         data_cite_endpoint: Terminal DataCite
         fcrepo_endpoint: Ponto de extremidade do Fedora
         header: Editando conta
+        public_demo_tenant:
+          disabled: 'Não'
+          enabled: 'Sim'
+          immutable: Esta configuração é definida na criação da conta e não pode ser alterada.
         solr_endpoint: Ponto final do Solr
       index:
         actions: Ações

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -658,6 +658,10 @@ zh:
         data_cite_endpoint: 数据引用端点
         fcrepo_endpoint: Fedora端点
         header: 编辑帐号
+        public_demo_tenant:
+          disabled: '否'
+          enabled: '是'
+          immutable: 此设置在创建账户时确定，创建后无法更改。
         solr_endpoint: Solr端点
       index:
         actions: 操作

--- a/spec/views/proprietor/accounts/edit.html.erb_spec.rb
+++ b/spec/views/proprietor/accounts/edit.html.erb_spec.rb
@@ -27,4 +27,22 @@ RSpec.describe "proprietor/accounts/edit", type: :view do
       end
     end
   end
+
+  context "with a public demo tenant account" do
+    let(:account) { create(:demo_account) }
+
+    it "renders public_demo_tenant as read-only text instead of an input" do
+      assert_select "input[name=?]", "account[public_demo_tenant]", count: 0
+      assert_select "div.account-public-demo-tenant", text: /Yes/
+    end
+  end
+
+  context "with a standard account" do
+    let(:account) { create(:account) }
+
+    it "renders public_demo_tenant as read-only text instead of an input" do
+      assert_select "input[name=?]", "account[public_demo_tenant]", count: 0
+      assert_select "div.account-public-demo-tenant", text: /No/
+    end
+  end
 end


### PR DESCRIPTION
Split out of #3127 at @orangewolf's request. This is 2 of 3, alongside #3185 (invitation restriction) and the last-superadmin floor.

Picking this up while Nick is out.

## What

`public_demo_tenant` is `attr_readonly`, so rendering it as a disabled checkbox misrepresented it as something that might become editable. It is now read-only text with a note that the value is fixed when the account is created.

## Translations

Addresses your comment about the other languages. The new keys are added to all seven locales, not just English:

```
proprietor.accounts.edit.public_demo_tenant.{enabled,disabled,immutable}
```

I followed each file's existing terminology rather than pasting English, since these files carry real translations. **They have not been checked by native speakers**, so corrections are welcome; the German, Spanish, French, Italian, Portuguese and Chinese strings are my own. All seven files were verified to parse and resolve the keys.

## Notes

`config/locales/en.yml` is also touched by the third PR in a different section, so whichever lands second may need a trivial rebase. 4 examples, 0 failures locally.
