### PR TITLE
Keep at least one superadmin on public demo tenants

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -6,6 +6,7 @@ class Account < ApplicationRecord
   include AccountEndpoints
   include AccountSettings
   include AccountCname
+  include SuperadminRemovalGuard
   attr_readonly :tenant, :public_demo_tenant
 
   has_many :sites, dependent: :destroy
@@ -51,7 +52,6 @@ class Account < ApplicationRecord
 
   # NEW: Validate that search-only accounts have at least one full account selected
   validate :search_only_must_have_full_accounts, if: :search_only?
-  validate :superadmin_removal_permitted
 
   after_save :schedule_jobs_if_settings_changed
 
@@ -182,14 +182,8 @@ class Account < ApplicationRecord
       site.superadmin_emails = emails
       # Carry the refusal up so the proprietor form, which edits an Account,
       # fails validation rather than silently reporting success.
-      @superadmin_removal_blocked = site.superadmin_removal_blocked?
+      self.superadmin_removal_blocked = site.superadmin_removal_blocked?
     end
-  end
-
-  def superadmin_removal_permitted
-    return unless @superadmin_removal_blocked
-
-    errors.add(:superadmin_emails, :cannot_remove_last_superadmin)
   end
 
   def cache_api?

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -51,6 +51,7 @@ class Account < ApplicationRecord
 
   # NEW: Validate that search-only accounts have at least one full account selected
   validate :search_only_must_have_full_accounts, if: :search_only?
+  validate :superadmin_removal_permitted
 
   after_save :schedule_jobs_if_settings_changed
 
@@ -177,8 +178,18 @@ class Account < ApplicationRecord
   def superadmin_emails=(emails)
     # Must run this against proper tenant database
     Apartment::Tenant.switch(tenant) do
-      Site.instance.superadmin_emails = emails
+      site = Site.instance
+      site.superadmin_emails = emails
+      # Carry the refusal up so the proprietor form, which edits an Account,
+      # fails validation rather than silently reporting success.
+      @superadmin_removal_blocked = site.superadmin_removal_blocked?
     end
+  end
+
+  def superadmin_removal_permitted
+    return unless @superadmin_removal_blocked
+
+    errors.add(:superadmin_emails, :cannot_remove_last_superadmin)
   end
 
   def cache_api?

--- a/app/models/concerns/superadmin_removal_guard.rb
+++ b/app/models/concerns/superadmin_removal_guard.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# Refusal plumbing for the public demo tenant superadmin floor, shared by the
+# two models that need it.
+#
+# Role changes apply on assignment rather than on save, so an assignment that
+# would strip the last superadmin skips the removal, records that it did, and
+# fails the save here. Site makes that decision; Account mirrors it, since the
+# proprietor form edits an Account and would otherwise report success.
+module SuperadminRemovalGuard
+  extend ActiveSupport::Concern
+
+  included do
+    validate :superadmin_removal_permitted
+  end
+
+  # True when the last assignment declined to remove a superadmin because it
+  # would have left a public demo tenant with none.
+  def superadmin_removal_blocked?
+    @superadmin_removal_blocked.present?
+  end
+
+  private
+
+  # Records the outcome of the assignment just attempted, and so must be written
+  # on the permitted path too: a flag that only ever latches on would fail a
+  # later, valid save of the same record.
+  attr_writer :superadmin_removal_blocked
+
+  def superadmin_removal_permitted
+    return unless superadmin_removal_blocked?
+
+    errors.add(:superadmin_emails, :cannot_remove_last_superadmin)
+  end
+end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -4,6 +4,7 @@ class Site < ApplicationRecord
   resourcify
 
   validates :application_name, presence: true, allow_nil: true
+  validate :superadmin_removal_permitted
 
   # Allow for uploading of site's banner image
   mount_uploader :banner_image, Hyku::AvatarUploader
@@ -54,6 +55,13 @@ class Site < ApplicationRecord
     User.with_role(:superadmin, self).pluck(:email)
   end
 
+  # True when the last assignment declined to remove a superadmin because it
+  # would have left a public demo tenant with none. Account reads this to
+  # raise the same error on itself, since the proprietor form edits an Account.
+  def superadmin_removal_blocked?
+    @superadmin_removal_blocked.present?
+  end
+
   # Update superadmin emails associated with this site
   # @param [Array<String>] Array of user emails
   def superadmin_emails=(emails)
@@ -61,6 +69,10 @@ class Site < ApplicationRecord
     existing_superadmin_emails = superadmin_emails
     new_superadmin_emails = emails - existing_superadmin_emails
     removed_superadmin_emails = existing_superadmin_emails - emails
+    if removed_superadmin_emails.present? && strips_last_superadmin?(emails)
+      @superadmin_removal_blocked = true
+      removed_superadmin_emails = []
+    end
     add_superadmins_by_email(new_superadmin_emails) if new_superadmin_emails.present?
     remove_superadmins_by_email(removed_superadmin_emails) if removed_superadmin_emails.present?
   end
@@ -112,5 +124,24 @@ class Site < ApplicationRecord
     User.where(email: emails).find_each do |u|
       u.remove_role :superadmin, self
     end
+  end
+
+  def superadmin_removal_permitted
+    return unless @superadmin_removal_blocked
+
+    errors.add(:superadmin_emails, :cannot_remove_last_superadmin)
+  end
+
+  # Public demo tenants must always keep at least one site-scoped superadmin.
+  # Role changes apply on assignment rather than on save, so the removal is
+  # skipped rather than performed and undone; the validation above then fails
+  # the save.
+  # @param [Array<String>] requested_emails the full email list being assigned
+  def strips_last_superadmin?(requested_emails)
+    return false unless account&.public_demo_tenant?
+
+    # Only existing users can hold the role, so an assignment naming none of
+    # them would leave the tenant with no superadmins.
+    User.where(email: requested_emails).none?
   end
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 class Site < ApplicationRecord
+  include SuperadminRemovalGuard
+
   resourcify
 
   validates :application_name, presence: true, allow_nil: true
-  validate :superadmin_removal_permitted
 
   # Allow for uploading of site's banner image
   mount_uploader :banner_image, Hyku::AvatarUploader
@@ -55,13 +56,6 @@ class Site < ApplicationRecord
     User.with_role(:superadmin, self).pluck(:email)
   end
 
-  # True when the last assignment declined to remove a superadmin because it
-  # would have left a public demo tenant with none. Account reads this to
-  # raise the same error on itself, since the proprietor form edits an Account.
-  def superadmin_removal_blocked?
-    @superadmin_removal_blocked.present?
-  end
-
   # Update superadmin emails associated with this site
   # @param [Array<String>] Array of user emails
   def superadmin_emails=(emails)
@@ -69,10 +63,8 @@ class Site < ApplicationRecord
     existing_superadmin_emails = superadmin_emails
     new_superadmin_emails = emails - existing_superadmin_emails
     removed_superadmin_emails = existing_superadmin_emails - emails
-    if removed_superadmin_emails.present? && strips_last_superadmin?(emails)
-      @superadmin_removal_blocked = true
-      removed_superadmin_emails = []
-    end
+    self.superadmin_removal_blocked = removed_superadmin_emails.present? && strips_last_superadmin?(emails)
+    removed_superadmin_emails = [] if superadmin_removal_blocked?
     add_superadmins_by_email(new_superadmin_emails) if new_superadmin_emails.present?
     remove_superadmins_by_email(removed_superadmin_emails) if removed_superadmin_emails.present?
   end
@@ -126,16 +118,8 @@ class Site < ApplicationRecord
     end
   end
 
-  def superadmin_removal_permitted
-    return unless @superadmin_removal_blocked
-
-    errors.add(:superadmin_emails, :cannot_remove_last_superadmin)
-  end
-
   # Public demo tenants must always keep at least one site-scoped superadmin.
-  # Role changes apply on assignment rather than on save, so the removal is
-  # skipped rather than performed and undone; the validation above then fails
-  # the save.
+  # The refusal itself is carried by SuperadminRemovalGuard.
   # @param [Array<String>] requested_emails the full email list being assigned
   def strips_last_superadmin?(requested_emails)
     return false unless account&.public_demo_tenant?

--- a/app/presenters/proprietor/account_presenter.rb
+++ b/app/presenters/proprietor/account_presenter.rb
@@ -23,8 +23,11 @@ module Proprietor
       superadmin_emails.include?(user.email)
     end
 
-    def can_remove_admin?(_user)
-      !last_admin?
+    # Removing a user's admin role also removes their superadmin role (the
+    # remove-admin form posts both email lists), so this also respects the
+    # last-superadmin floor on public demo tenants.
+    def can_remove_admin?(user)
+      !last_admin? && can_remove_superadmin?(user)
     end
 
     def can_remove_superadmin?(user)

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -10,6 +10,9 @@ de:
     attributes:
       site:
         institution_name_full: Vollständiger Name der Institution
+    errors:
+      messages:
+        cannot_remove_last_superadmin: der letzte Superadministrator eines öffentlichen Demo-Mandanten kann nicht entfernt werden
   application:
     tagline: Die Next-Generation Repository-Lösung
   blacklight:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,6 +10,9 @@ en:
     attributes:
       site:
         institution_name_full: Full institution name
+    errors:
+      messages:
+        cannot_remove_last_superadmin: cannot remove the last tenant superadmin from a public demo tenant
   application:
     tagline: The next-generation repository solution
   blacklight:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -10,6 +10,9 @@ es:
     attributes:
       site:
         institution_name_full: El nombre de la institución
+    errors:
+      messages:
+        cannot_remove_last_superadmin: no se puede eliminar el último superadministrador de un inquilino de demostración público
   application:
     tagline: La solución de repositorio de próxima generación
   blacklight:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -10,6 +10,9 @@ fr:
     attributes:
       site:
         institution_name_full: Nom complet de l'établissement
+    errors:
+      messages:
+        cannot_remove_last_superadmin: impossible de supprimer le dernier superadministrateur d'un locataire de démonstration public
   application:
     tagline: La solution de dépôt de nouvelle génération
   blacklight:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -10,6 +10,9 @@ it:
     attributes:
       site:
         institution_name_full: Nome dell'istituto completo
+    errors:
+      messages:
+        cannot_remove_last_superadmin: impossibile rimuovere l'ultimo superadmin da un inquilino demo pubblico
   application:
     tagline: La soluzione di repository di nuova generazione
   blacklight:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -10,6 +10,9 @@ pt-BR:
     attributes:
       site:
         institution_name_full: Nome completo da instituição
+    errors:
+      messages:
+        cannot_remove_last_superadmin: não é possível remover o último superadministrador de um inquilino de demonstração público
   application:
     tagline: A solução de repos
   blacklight:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -10,6 +10,9 @@ zh:
     attributes:
       site:
         institution_name_full: 完整的机构名称
+    errors:
+      messages:
+        cannot_remove_last_superadmin: 无法移除公开演示租户的最后一名 superadmin
   application:
     tagline: 下一代存储库解决方案
   blacklight:

--- a/spec/controllers/proprietor/accounts_controller_spec.rb
+++ b/spec/controllers/proprietor/accounts_controller_spec.rb
@@ -236,6 +236,37 @@ RSpec.describe Proprietor::AccountsController, type: :controller, multitenant: t
       end
     end
 
+    describe 'PUT #update with superadmin_emails' do
+      let(:account) { FactoryBot.create(:demo_account) }
+      let!(:sole_superadmin) { FactoryBot.create(:user, email: 'onlysuper@example.com') }
+
+      before do
+        allow(Apartment::Tenant).to receive(:switch).with(account.tenant) do |&block|
+          block.call
+        end
+        sole_superadmin.add_role :superadmin, Site.instance
+      end
+
+      it 'refuses to remove the last superadmin from a public demo tenant' do
+        put :update, params: { id: account.to_param, account: { superadmin_emails: [''] } }
+        expect(response).to render_template('edit')
+        expect(account.superadmin_emails).to include('onlysuper@example.com')
+      end
+
+      it 'reports the error on the account' do
+        put :update, params: { id: account.to_param, account: { superadmin_emails: [''] } }
+        expect(assigns(:account).errors[:superadmin_emails]).to be_present
+      end
+
+      it 'allows replacing the last superadmin with another user in one assignment' do
+        replacement = FactoryBot.create(:user, email: 'newsuper@example.com')
+        put :update, params: { id: account.to_param, account: { superadmin_emails: [replacement.email] } }
+        expect(response).to redirect_to([:proprietor, account])
+        expect(account.superadmin_emails).to include(replacement.email)
+        expect(account.superadmin_emails).not_to include('onlysuper@example.com')
+      end
+    end
+
     after do
       account.reset!
     end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -113,6 +113,86 @@ RSpec.describe Site, type: :model do
     end
   end
 
+  describe ".superadmin_emails=" do
+    subject { described_class.instance }
+
+    context "on a public demo tenant" do
+      let(:account) { FactoryBot.create(:demo_account) }
+
+      before do
+        subject.update(account:)
+        admin1.add_role :superadmin, subject
+      end
+
+      # The removal is refused outright rather than performed and reported, so
+      # the role must survive a rejected assignment.
+      it "keeps the superadmin and fails validation when passed an empty array" do
+        subject.superadmin_emails = []
+
+        expect(subject).not_to be_valid
+        expect(subject.errors[:superadmin_emails])
+          .to include(I18n.t('activerecord.errors.messages.cannot_remove_last_superadmin'))
+        expect(subject.superadmin_emails).to eq([admin1.email])
+      end
+
+      it "keeps the superadmin and fails validation when passed only blank values" do
+        subject.superadmin_emails = ['']
+
+        expect(subject).not_to be_valid
+        expect(subject.superadmin_emails).to eq([admin1.email])
+      end
+
+      it "keeps the superadmin and fails validation when the emails match no existing users" do
+        subject.superadmin_emails = ['ghost@nowhere.org']
+
+        expect(subject).not_to be_valid
+        expect(subject.superadmin_emails).to eq([admin1.email])
+      end
+
+      it "does not block an assignment that keeps a superadmin" do
+        subject.superadmin_emails = [admin1.email, admin2.email]
+
+        expect(subject).to be_valid
+      end
+
+      it "allows swapping the last superadmin for another existing user in one assignment" do
+        subject.superadmin_emails = [admin2.email]
+        expect(subject.superadmin_emails).to eq([admin2.email])
+      end
+
+      it "allows removing one of several superadmins" do
+        admin2.add_role :superadmin, subject
+        subject.superadmin_emails = [admin1.email]
+        expect(subject.superadmin_emails).to eq([admin1.email])
+      end
+    end
+
+    context "on a standard tenant" do
+      let(:account) { FactoryBot.create(:account) }
+
+      before do
+        subject.update(account:)
+        admin1.add_role :superadmin, subject
+      end
+
+      it "clears out all superadmins when passed an empty array" do
+        subject.superadmin_emails = []
+        expect(subject.superadmin_emails).to eq([])
+      end
+    end
+
+    context "when the site has no account" do
+      before do
+        admin1.add_role :superadmin, subject
+      end
+
+      it "clears out all superadmins when passed an empty array" do
+        subject.superadmin_emails = []
+        expect(subject.superadmin_emails).to eq([])
+      end
+    end
+  end
+
   describe '#institution_label' do
     let(:site) { FactoryBot.create(:site) }
 

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -165,6 +165,18 @@ RSpec.describe Site, type: :model do
         subject.superadmin_emails = [admin1.email]
         expect(subject.superadmin_emails).to eq([admin1.email])
       end
+
+      # The refusal describes the assignment just attempted. If it latched on,
+      # correcting the mistake would still fail to save.
+      it "stops reporting the refusal once a later assignment is acceptable" do
+        subject.superadmin_emails = []
+        expect(subject).not_to be_valid
+
+        subject.superadmin_emails = [admin1.email, admin2.email]
+
+        expect(subject).to be_valid
+        expect(subject.errors[:superadmin_emails]).to be_empty
+      end
     end
 
     context "on a standard tenant" do

--- a/spec/presenters/proprietor/account_presenter_spec.rb
+++ b/spec/presenters/proprietor/account_presenter_spec.rb
@@ -102,6 +102,29 @@ RSpec.describe Proprietor::AccountPresenter do
         expect(presenter.can_remove_admin?(user)).to be false
       end
     end
+
+    # Removing a user's admin role also strips their superadmin role, so the
+    # remove-admin action must respect the last-superadmin floor on public
+    # demo tenants.
+    context 'when the user is the last superadmin on a public demo tenant' do
+      let(:user) { instance_double(User, email: 'superadmin1@example.com') }
+      let(:superadmin_emails) { ['superadmin1@example.com'] }
+      let(:public_demo_tenant) { true }
+
+      it 'returns false' do
+        expect(presenter.can_remove_admin?(user)).to be false
+      end
+    end
+
+    context 'when the user is the last superadmin on a non-demo tenant' do
+      let(:user) { instance_double(User, email: 'superadmin1@example.com') }
+      let(:superadmin_emails) { ['superadmin1@example.com'] }
+      let(:public_demo_tenant) { false }
+
+      it 'returns true' do
+        expect(presenter.can_remove_admin?(user)).to be true
+      end
+    end
   end
 
   describe '#can_remove_superadmin?' do


### PR DESCRIPTION
Split out of #3127 at @orangewolf's request. This is 3 of 3, alongside #3185 (invitation restriction) and #3186 (read-only field). All four of your inline comments landed on this one.

Picking this up while Nick is out.

## What

A public demo tenant publishes its credentials, so losing its last superadmin locks it. Assignments that would strip the last one are refused.

## Addressing the review

**"this should not be an exception" / "render a proper error, not raise an exception please"**

You were right, and the original comment defending the exception was reasoning from the wrong constraint. It argued that because role changes apply on assignment rather than on save, the guard had to raise, since a validation would not roll the removal back. But that assumes the removal has to happen first. It doesn't: the removal is simply not performed, a flag is set, and an ordinary validation fails the save. Nothing mutates, so nothing needs rolling back.

`Site::LastSuperadminRemovalError` is deleted.

This also fixed a real bug. The old code removed the role and *then* raised, so a refused assignment still stripped the superadmin. Verified against a live demo tenant that the role now survives:

```
demo valid after blocked removal? false
demo error: ["cannot remove the last tenant superadmin from a public demo tenant"]
demo roles retained: ["resettestadmin@demo.test", "admin@example.com"]
RETAINED_OK: true

standard tenant: valid, removal proceeds  (unaffected)
```

**"fix the classes length please, don't just turn it off"**

The `rubocop:disable Metrics/ClassLength` is gone, and not by raising the threshold. Removing the `rescue` and its bespoke error responder took the class back under the limit on its own, since those were the lines that pushed it over. `rubocop` passes clean on the controller.

**"the rest of the languages need to be filled in"**

`cannot_remove_last_superadmin` is now in all seven locales, using each file's existing terms for *tenant* and *superadmin* (Mandant/Superadministrator, inquilino, locataire, 租户). **Not reviewed by native speakers**, so corrections welcome.

## Note

`Account#superadmin_emails=` delegates into `Site`, but the proprietor form edits an `Account`, so the refusal is carried up and validated there too. Without that the form would report success while silently changing nothing.

65 examples, 0 failures; no rubocop offenses. `config/locales/en.yml` is also touched by #3186 in a different section, so whichever lands second may need a trivial rebase.
