### PR TITLE
Add bullet gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -152,4 +152,6 @@ gem 'willow_sword', github: 'notch8/willow_sword', tag: 'v0.8.5'
 #         of the time use the `samvera-labs/hyku_knapsack` remote branch.
 gem 'hyku_knapsack', github: 'samvera-labs/hyku_knapsack', branch: 'required_for_knapsack_instances'
 
+gem 'bullet', '~> 8.1', group: %i[development test]
+
 # rubocop:enable Metrics/MethodLength

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -388,6 +388,9 @@ GEM
       rdf (>= 2.0.2, < 4.0)
       rubyzip
       simple_form
+    bullet (8.1.3)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     byebug (12.0.0)
     cancancan (3.6.1)
     capybara (3.40.0)
@@ -1573,6 +1576,7 @@ GEM
     unicode-display_width (2.6.0)
     unicode-types (1.11.0)
     unicode_utils (1.4.0)
+    uniform_notifier (1.18.0)
     uri (1.1.1)
     useragent (0.16.11)
     validatable (1.6.7)
@@ -1666,6 +1670,7 @@ DEPENDENCIES
   bootstrap (~> 4.6)
   bootstrap-datepicker-rails
   bulkrax (~> 9.5)
+  bullet (~> 8.1)
   byebug
   capybara
   capybara-screenshot (~> 1.0)

--- a/config/initializers/bullet.rb
+++ b/config/initializers/bullet.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# N+1 / unused-eager-load detection. Only instruments genuine ActiveRecord
+# association loading (Account, collection_type_participants,
+# permission_template_accesses, good_jobs, etc.) - it does NOT see Valkyrie-backed
+# Hyrax::Work queries against orm_resources, since those go through Valkyrie's
+# query service rather than AR associations. Complementary to, not a replacement
+# for, Postgres-level pg_stat_statements/log_min_duration_statement analysis.
+if Rails.env.development? || Rails.env.staging?
+  require 'bullet'
+
+  Rails.application.configure do
+    config.after_initialize do
+      Bullet.enable = true
+      Bullet.rails_logger = true
+
+      Bullet.add_footer = true if Rails.env.development?
+    end
+  end
+end

--- a/config/initializers/bullet.rb
+++ b/config/initializers/bullet.rb
@@ -6,7 +6,12 @@
 # Hyrax::Work queries against orm_resources, since those go through Valkyrie's
 # query service rather than AR associations. Complementary to, not a replacement
 # for, Postgres-level pg_stat_statements/log_min_duration_statement analysis.
-if Rails.env.development? || Rails.env.staging?
+#
+# Gated on an env var, not Rails.env.staging? - real staging deployments run with
+# RAILS_ENV=production (see ops/staging-deploy.tmpl.yaml), so config/environments/
+# staging.rb never actually loads there. Set HYKU_BULLET_ENABLED=true wherever this
+# should run in a deployed environment.
+if Rails.env.development? || ActiveModel::Type::Boolean.new.cast(ENV.fetch('HYKU_BULLET_ENABLED', 'false'))
   require 'bullet'
 
   Rails.application.configure do

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -135,6 +135,8 @@ extraEnvVars: &envVars
     value: good_job
   - name: HYKU_BULKRAX_ENABLED
     value: "true"
+  - name: HYKU_BULLET_ENABLED
+    value: "true"
   - name: HYKU_CONTACT_EMAIL
     value: no-reply@hykustaging.org
   - name: HYKU_FILE_ACL


### PR DESCRIPTION
Adds bullet in development and based on an env variable to allow us to catch ActiveRecord N+1s before they hit production.

Passive logging only (Bullet.rails_logger = true, no Bullet.raise) so a
detected N+1 never turns into a broken request on staging, which real
testers/demos hit. Footer only in development.

Note: only catches genuine ActiveRecord association N+1s - Valkyrie's
Postgres-backed orm_resources lookups go through explicit find calls, not
AR association loading, so Bullet won't see those.