### PR TITLE
Give search result cards an access-status badge and a consistent heading level

### DIFF
--- a/app/views/catalog/_index_header_list_default.html.erb
+++ b/app/views/catalog/_index_header_list_default.html.erb
@@ -1,10 +1,13 @@
 <%# OVERRIDE Hyrax v5.0.1 to collection badge and markdown of links %>
 <div class="search-results-title-row col-12 d-flex flex-row align-items-center pb-2">
-  <h4 class="search-result-title">
+  <%# h3 to match collection results; works-only pages jumped h2 -> h4 (axe heading-order) %>
+  <h3 class="search-result-title">
     <%= link_to markdown(document.title_or_label), generate_work_url(document, request, params) %>
-  </h4>
+  </h3>
 
   <% if document.hydra_model == Hyrax.config.collection_class || document.hydra_model < Hyrax.config.collection_class %>
     <%= Hyrax::CollectionPresenter.new(document, current_ability).collection_type_badge %>
+  <% else %>
+    <%= Hyrax::PermissionBadge.new(document.visibility).render %>
   <% end %>
 </div>

--- a/app/views/catalog/_index_header_list_default.html.erb
+++ b/app/views/catalog/_index_header_list_default.html.erb
@@ -1,6 +1,5 @@
 <%# OVERRIDE Hyrax v5.0.1 to collection badge and markdown of links %>
 <div class="search-results-title-row col-12 d-flex flex-row align-items-center pb-2">
-  <%# h3 to match collection results; works-only pages jumped h2 -> h4 (axe heading-order) %>
   <h3 class="search-result-title">
     <%= link_to markdown(document.title_or_label), generate_work_url(document, request, params) %>
   </h3>

--- a/spec/features/work_search_open_visibility_spec.rb
+++ b/spec/features/work_search_open_visibility_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Users trying to search for a Public Work', type: :feature, clean
     it 'sees the result title as an h3 with an access-status badge' do
       visit '/catalog'
       expect(page).to have_css('h3.search-result-title', text: 'Public GenericWork')
-      expect(page).to have_css('span.badge', text: I18n.t('hyrax.visibility.open.text'))
+      expect(page).to have_css('.search-results-title-row span.badge', text: I18n.t('hyrax.visibility.open.text'))
     end
   end
 

--- a/spec/features/work_search_open_visibility_spec.rb
+++ b/spec/features/work_search_open_visibility_spec.rb
@@ -26,6 +26,12 @@ RSpec.describe 'Users trying to search for a Public Work', type: :feature, clean
       visit '/catalog'
       expect(page).to have_content('Public GenericWork')
     end
+
+    it 'sees the result title as an h3 with an access-status badge' do
+      visit '/catalog'
+      expect(page).to have_css('h3.search-result-title', text: 'Public GenericWork')
+      expect(page).to have_css('span.badge', text: I18n.t('hyrax.visibility.open.text'))
+    end
   end
 
   context 'a registered user' do

--- a/spec/views/catalog/_index_header_list_default.html.erb_spec.rb
+++ b/spec/views/catalog/_index_header_list_default.html.erb_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+RSpec.describe 'catalog/_index_header_list_default.html.erb', type: :view do
+  let(:document) do
+    SolrDocument.new('id' => 'work1',
+                     'has_model_ssim' => ['GenericWork'],
+                     'title_tesim' => ['Assessment of Coastal Ecosystems'],
+                     'read_access_group_ssim' => ['public'],
+                     'visibility_ssi' => 'open')
+  end
+
+  before do
+    allow(view).to receive(:generate_work_url).and_return('/concern/generic_works/work1')
+    render partial: 'catalog/index_header_list_default', locals: { document: }
+  end
+
+  it 'renders the result title at the same heading level as collection results (h3)' do
+    # Collections render h3.search-result-title; works rendered h4, so a
+    # works-only results page jumped h2 -> h4 (axe heading-order).
+    expect(rendered).to have_css('h3.search-result-title', text: 'Assessment of Coastal Ecosystems')
+    expect(rendered).not_to have_css('h4')
+  end
+
+  it 'shows the access-status badge for the work' do
+    expect(rendered).to have_css('span.badge', text: t('hyrax.visibility.open.text'))
+  end
+end

--- a/spec/views/catalog/_index_header_list_default.html.erb_spec.rb
+++ b/spec/views/catalog/_index_header_list_default.html.erb_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'catalog/_index_header_list_default.html.erb', type: :view do
     # Collections render h3.search-result-title; works rendered h4, so a
     # works-only results page jumped h2 -> h4 (axe heading-order).
     expect(rendered).to have_css('h3.search-result-title', text: 'Assessment of Coastal Ecosystems')
-    expect(rendered).not_to have_css('h4')
+    expect(rendered).not_to have_css('h4.search-result-title')
   end
 
   it 'shows the access-status badge for the work' do


### PR DESCRIPTION
### What

Two gaps in the default search results anatomy:

* Work results render their titles as `h4.search-result-title` while collection results render `h3.search-result-title`, so any works-only results page jumps from the sr-only `h2` ("Search Results") straight to `h4` - a moderate axe `heading-order` violation that comes and goes with the mix of results on the page.
* Result rows show no access status, even though the product indexes the full visibility spectrum (open, institution, embargo, lease, private) and already ships a translated badge component for it. Peer repository demos display an access-status badge on every result row, and it is one of the clearest trust signals a repository page can show.

### Fix

`catalog/_index_header_list_default.html.erb`:

* Work titles render as `h3.search-result-title`, matching collections.
* Work rows render `Hyrax::PermissionBadge` for the document's visibility next to the title - the same spot collection rows show their collection-type badge, and the same badge users already see in the dashboard. Labels are already translated in all seven maintained locales, so there are no locale changes.

### Testing

Failing-spec-first history: a view spec pins the heading level and the badge; the open-visibility search feature spec now asserts both end-to-end. Sibling visibility feature specs (institution, private), the catalog query-count spec, and RuboCop run locally in Docker: green. axe on a seeded results page: zero violations.

### Placement

samvera/hyku core: the result-card partial is a Hyku override and the badge component comes from Hyrax.

### Screenshots (1440px and 375px)

Shot on a seeded default-theme tenant. In the after shots, every work row carries a green "Public" badge next to its title (collection rows keep their collection-type badge), and work titles sit at the same heading size as collection titles.

<details><summary>Before - desktop</summary>

![Before - desktop](https://gist.githubusercontent.com/ShanaLMoore/bd4637c9f1a9a77c05eeee8061cd74bc/raw/c9287172523533520e7d8ff9c4e828650b7d76e1/s4-baseline-search-ellison-desktop.png)

</details>

<details><summary>Before - mobile</summary>

![Before - mobile](https://gist.githubusercontent.com/ShanaLMoore/bd4637c9f1a9a77c05eeee8061cd74bc/raw/c9287172523533520e7d8ff9c4e828650b7d76e1/s4-baseline-search-ellison-mobile.png)

</details>

<details><summary>After - desktop</summary>

![After - desktop](https://gist.githubusercontent.com/ShanaLMoore/bd4637c9f1a9a77c05eeee8061cd74bc/raw/c9287172523533520e7d8ff9c4e828650b7d76e1/s4-pr4-after-search-desktop.png)

</details>

<details><summary>After - mobile</summary>

![After - mobile](https://gist.githubusercontent.com/ShanaLMoore/bd4637c9f1a9a77c05eeee8061cd74bc/raw/c9287172523533520e7d8ff9c4e828650b7d76e1/s4-pr4-after-search-mobile.png)

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

