### PR TITLE
Drop the invalid listbox role from the neutral-theme carousel

### DIFF
--- a/app/views/themes/neutral_repository/_featured_carousel.html.erb
+++ b/app/views/themes/neutral_repository/_featured_carousel.html.erb
@@ -7,8 +7,6 @@
   </ol>
 
   <!-- Wrapper for slides -->
-  <%# no role="listbox": it is an input role that allows only option children,
-      a Bootstrap 3-era pattern Bootstrap 4 removed (critical axe violation) %>
   <div class="carousel-inner h-100">
     <% @featured_work_list.featured_works.each.with_index(0) do |featured_work, order| %>
       <% work = SolrDocument.find(featured_work.work_id) %>

--- a/app/views/themes/neutral_repository/_featured_carousel.html.erb
+++ b/app/views/themes/neutral_repository/_featured_carousel.html.erb
@@ -7,7 +7,9 @@
   </ol>
 
   <!-- Wrapper for slides -->
-  <div class="carousel-inner h-100" role="listbox">
+  <%# no role="listbox": it is an input role that allows only option children,
+      a Bootstrap 3-era pattern Bootstrap 4 removed (critical axe violation) %>
+  <div class="carousel-inner h-100">
     <% @featured_work_list.featured_works.each.with_index(0) do |featured_work, order| %>
       <% work = SolrDocument.find(featured_work.work_id) %>
       <div class="carousel-item h-100 bg-light <%= order.zero? ? 'active' : '' %>">

--- a/spec/views/themes/neutral_repository/_featured_carousel.html.erb_spec.rb
+++ b/spec/views/themes/neutral_repository/_featured_carousel.html.erb_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.describe 'themes/neutral_repository/_featured_carousel.html.erb', type: :view do
+  let(:work) do
+    SolrDocument.new('id' => 'work1',
+                     'has_model_ssim' => ['GenericWork'],
+                     'title_tesim' => ['Harbor at dusk'],
+                     'thumbnail_alt_text_tesim' => ['Photograph of the harbor at dusk'])
+  end
+  let(:featured_work) { FeaturedWork.new(work_id: 'work1', order: 0) }
+
+  before do
+    assign(:featured_work_list, FeaturedWorkList.new.tap { |l| allow(l).to receive(:featured_works).and_return([featured_work]) })
+    allow(SolrDocument).to receive(:find).with('work1').and_return(work)
+    allow(view).to receive(:render_thumbnail_tag) do |_doc, image_options, _url_options|
+      # rubocop:disable Rails/OutputSafety - fixture markup echoing the options the partial passed
+      %(<img src="thumb.png" alt="#{image_options[:alt]}">).html_safe
+      # rubocop:enable Rails/OutputSafety
+    end
+
+    render partial: 'themes/neutral_repository/featured_carousel'
+  end
+
+  it 'renders the carousel slides' do
+    expect(rendered).to have_css('.carousel-inner .carousel-item')
+  end
+
+  it 'does not give the slide wrapper a listbox role' do
+    # role="listbox" is an input role that requires a label and allows only
+    # option children; on .carousel-inner it produces a critical
+    # aria-required-children and a serious aria-input-field-name axe violation.
+    # Bootstrap 4 dropped this Bootstrap 3-era pattern for exactly this reason.
+    expect(rendered).not_to have_css('[role="listbox"]')
+  end
+end

--- a/spec/views/themes/neutral_repository/_featured_carousel.html.erb_spec.rb
+++ b/spec/views/themes/neutral_repository/_featured_carousel.html.erb_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe 'themes/neutral_repository/_featured_carousel.html.erb', type: :v
   before do
     assign(:featured_work_list, FeaturedWorkList.new.tap { |l| allow(l).to receive(:featured_works).and_return([featured_work]) })
     allow(SolrDocument).to receive(:find).with('work1').and_return(work)
+    allow(view).to receive(:main_app).and_return(main_app)
     allow(view).to receive(:render_thumbnail_tag) do |_doc, image_options, _url_options|
       # rubocop:disable Rails/OutputSafety - fixture markup echoing the options the partial passed
       %(<img src="thumb.png" alt="#{image_options[:alt]}">).html_safe


### PR DESCRIPTION
### What

Every neutral_repository homepage with featured works fails axe with a **critical** `aria-required-children` violation and a serious `aria-input-field-name` violation, both on `.carousel-inner`.

### Why

The featured carousel's slide wrapper carries `role="listbox"` - a Bootstrap 3-era pattern that Bootstrap 4 removed for exactly this reason: listbox is an *input* role, so it requires an accessible name and permits only `option` children, neither of which a carousel of linked slides can satisfy.

### Fix

Remove the role. The div's native semantics are correct for a slide container; the carousel controls and indicators keep their existing roles. axe on a seeded neutral-theme homepage: **zero violations** after (previously 1 critical + 1 serious).

### Testing

Failing-spec-first history: a view spec renders the carousel with a featured work and asserts no `[role="listbox"]` remains. Neutral-theme view specs and RuboCop run locally in Docker: green.

No screenshots: this is a single attribute deletion with no visual effect; the page renders pixel-identically. The axe counts above are the evidence.

### Placement

samvera/hyku core: the theme and its partial live here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)