### PR TITLE
Add external: true for docker-compose proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,7 @@ networks:
   # Shared across checkouts so Traefik (`sc proxy up`) can route them all.
   proxy:
     name: stackcar
+    external: true
 
 services:
   zoo:


### PR DESCRIPTION
Add `external: true` for docker-compose proxy. Otherwise we would need to re-name the stackcar network key, which would be hard to coordinate between applications (which was the whole intention of this).

