### PR TITLE
Revert "Develop on multiple hykus (#3164)"

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-# APP_NAME is intentionally left unset here so docker-compose works across checkouts
+APP_NAME=hyku
 CH12N_TOOL=fits_servlet
 CHROME_HOSTNAME=chrome
 COMPOSE_DOCKER_CLI_BUILD=1

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -91,6 +91,5 @@ Rails.application.configure do # rubocop:disable Metrics/BlockLength
 
   config.active_job.queue_adapter = ENV.fetch('HYRAX_ACTIVE_JOB_QUEUE', 'sidekiq')
   # adding `.` wildcard to allow for subdomains
-  # adding regex to allow for COMPOSE_PROJECT_NAME-created hostnames
-  config.hosts << /\A(?:[a-z0-9_-]+\.)?#{Regexp.escape(ENV['HYKU_ROOT_HOST'])}(:\d+)?\z/i
+  config.hosts << "." + ENV['HYKU_ROOT_HOST']
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,7 @@
 # through verbatim, so the container would literally get `${HYKU_ROOT_HOST:-...}`.
 # Keep `.env` values as plain literals and express overridable defaults here.
 x-app-env: &app-env
-  # Falls back to COMPOSE_PROJECT_NAME (the checkout directory name)
-  APP_NAME: ${APP_NAME:-${COMPOSE_PROJECT_NAME}}
+  APP_NAME: ${APP_NAME:-hyku}
   HYRAX_FLEXIBLE: ${HYRAX_FLEXIBLE:-false}
   FCREPO_HOST: ${FCREPO_HOST:-fcrepo}
   HYKU_ROOT_HOST: ${HYKU_ROOT_HOST:-localhost.direct}
@@ -15,8 +14,8 @@ x-app-env: &app-env
   # Derived from APP_NAME. Computed here (not in .env) so the ${APP_NAME}
   # reference resolves on every Compose version; via env_file it would only
   # interpolate on Compose >= ~2.24 and breaks entirely if APP_NAME is unset.
-  HYKU_ADMIN_HOST: admin-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.${HYKU_ROOT_HOST:-localhost.direct}
-  HYKU_DEFAULT_HOST: "%{tenant}-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.${HYKU_ROOT_HOST:-localhost.direct}"
+  HYKU_ADMIN_HOST: admin-${APP_NAME:-hyku}.${HYKU_ROOT_HOST:-localhost.direct}
+  HYKU_DEFAULT_HOST: "%{tenant}-${APP_NAME:-hyku}.${HYKU_ROOT_HOST:-localhost.direct}"
 
 x-app: &app
   build:
@@ -52,10 +51,7 @@ volumes:
   zoo:
 
 networks:
-  # Unnamed: Compose auto-namespaces this per checkout.
   default:
-  # Shared across checkouts so Traefik (`sc proxy up`) can route them all.
-  proxy:
     name: stackcar
 
 services:
@@ -95,18 +91,18 @@ services:
       - SOLR_ENABLE_CLOUD_MODE=yes
       - SOLR_ENABLE_AUTHENTICATION=yes
       - ZK_HOST=zoo:2181
-      # Stable hostname for ZooKeeper's node_name, not the container IP.
+      # Register SolrCloud replicas by this stable hostname instead of the
+      # container IP, so ZooKeeper's node_name stays valid across IP churn on the
+      # shared stackcar network (switching between the Hyku and a knapsack stack).
       - SOLR_HOST=solr
       - VIRTUAL_PORT=8983
       - VIRTUAL_HOST=solr.hyku.test
     labels:
       - "traefik.enable=true"
-      - "traefik.docker.network=stackcar"
-      - "traefik.http.routers.solr-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.tls=true"
-      - "traefik.http.routers.solr-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.entrypoints=websecure"
-      - "traefik.http.routers.solr-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.rule=Host(`solr-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.localhost.direct`)"
-      - "traefik.http.services.solr-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.loadbalancer.server.port=8983"
-    networks: [default, proxy]
+      - "traefik.http.routers.solr-${APP_NAME}.tls=true"
+      - "traefik.http.routers.solr-${APP_NAME}.entrypoints=websecure"
+      - "traefik.http.routers.solr-${APP_NAME}.rule=Host(`solr-${APP_NAME}.localhost.direct`)"
+      - "traefik.http.services.solr-${APP_NAME}.loadbalancer.server.port=8983"
     user: root
     command: bash -c "
       chown -R 8983:8983 /var/solr
@@ -132,12 +128,10 @@ services:
       - 8080
     labels:
       - "traefik.enable=true"
-      - "traefik.docker.network=stackcar"
-      - "traefik.http.routers.fits-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.tls=true"
-      - "traefik.http.routers.fits-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.entrypoints=websecure"
-      - "traefik.http.routers.fits-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.rule=Host(`fits-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.localhost.direct`)"
-      - "traefik.http.services.fits-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.loadbalancer.server.port=8080"
-    networks: [default, proxy]
+      - "traefik.http.routers.fits-${APP_NAME}.tls=true"
+      - "traefik.http.routers.fits-${APP_NAME}.entrypoints=websecure"
+      - "traefik.http.routers.fits-${APP_NAME}.rule=Host(`fits-${APP_NAME}.localhost.direct`)"
+      - "traefik.http.services.fits-${APP_NAME}.loadbalancer.server.port=8080"
 
   fcrepo:
     image: ghcr.io/samvera/fcrepo4:4.7.5
@@ -153,12 +147,10 @@ services:
       - 8080
     labels:
       - "traefik.enable=true"
-      - "traefik.docker.network=stackcar"
-      - "traefik.http.routers.fcrepo-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.tls=true"
-      - "traefik.http.routers.fcrepo-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.entrypoints=websecure"
-      - "traefik.http.routers.fcrepo-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.rule=Host(`fcrepo-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.localhost.direct`)"
-      - "traefik.http.services.fcrepo-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.loadbalancer.server.port=8080"
-    networks: [default, proxy]
+      - "traefik.http.routers.fcrepo-${APP_NAME}.tls=true"
+      - "traefik.http.routers.fcrepo-${APP_NAME}.entrypoints=websecure"
+      - "traefik.http.routers.fcrepo-${APP_NAME}.rule=Host(`fcrepo-${APP_NAME}.localhost.direct`)"
+      - "traefik.http.services.fcrepo-${APP_NAME}.loadbalancer.server.port=8080"
 
   db:
     image: postgres:11.1
@@ -182,12 +174,10 @@ services:
       - VIRTUAL_HOST=admin.hyku.test
     labels:
       - "traefik.enable=true"
-      - "traefik.docker.network=stackcar"
-      - "traefik.http.routers.adminer-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.tls=true"
-      - "traefik.http.routers.adminer-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.entrypoints=websecure"
-      - "traefik.http.routers.adminer-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.rule=Host(`adminer-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.localhost.direct`)"
-      - "traefik.http.services.adminer-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.loadbalancer.server.port=8080"
-    networks: [default, proxy]
+      - "traefik.http.routers.adminer-${APP_NAME}.tls=true"
+      - "traefik.http.routers.adminer-${APP_NAME}.entrypoints=websecure"
+      - "traefik.http.routers.adminer-${APP_NAME}.rule=Host(`adminer-${APP_NAME}.localhost.direct`)"
+      - "traefik.http.services.adminer-${APP_NAME}.loadbalancer.server.port=8080"
 
   web:
     <<: *app
@@ -199,13 +189,11 @@ services:
       VIRTUAL_HOST: .hyku.test
     labels:
       - "traefik.enable=true"
-      - "traefik.docker.network=stackcar"
-      - "traefik.http.routers.web-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.tls=true"
-      - "traefik.http.routers.web-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.entrypoints=websecure"
-      - "traefik.http.routers.web-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.priority=10"
-      - "traefik.http.routers.web-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.rule=HostRegexp(`.+-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.localhost.direct`)"
-      - "traefik.http.services.web-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.loadbalancer.server.port=3000"
-    networks: [default, proxy]
+      - "traefik.http.routers.web-${APP_NAME}.tls=true"
+      - "traefik.http.routers.web-${APP_NAME}.entrypoints=websecure"
+      - "traefik.http.routers.web-${APP_NAME}.priority=10"
+      - "traefik.http.routers.web-${APP_NAME}.rule=HostRegexp(`.+-${APP_NAME}.localhost.direct`)"
+      - "traefik.http.services.web-${APP_NAME}.loadbalancer.server.port=3000"
     depends_on:
       db:
         condition: service_started
@@ -325,9 +313,7 @@ services:
       - VIRTUAL_HOST=chrome.hyku.test
     labels:
       - "traefik.enable=true"
-      - "traefik.docker.network=stackcar"
-      - "traefik.http.routers.chrome-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.tls=true"
-      - "traefik.http.routers.chrome-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.entrypoints=websecure"
-      - "traefik.http.routers.chrome-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.rule=Host(`chrome-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.localhost.direct`)"
-      - "traefik.http.services.chrome-${APP_NAME:-${COMPOSE_PROJECT_NAME}}.loadbalancer.server.port=7900"
-    networks: [default, proxy]
+      - "traefik.http.routers.chrome-${APP_NAME}.tls=true"
+      - "traefik.http.routers.chrome-${APP_NAME}.entrypoints=websecure"
+      - "traefik.http.routers.chrome-${APP_NAME}.rule=Host(`chrome-${APP_NAME}.localhost.direct`)"
+      - "traefik.http.services.chrome-${APP_NAME}.loadbalancer.server.port=7900"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -32,7 +32,7 @@ Start off by setting up a local development environment where you can experiment
     ```bash
     gem install stack_car
     sc proxy cert # Only need this once per stack_car version, requires passwords
-    sc proxy up # Once per Docker re-boot
+    sc proxy up
     ```
 
 3) **Build the Docker images:**
@@ -59,10 +59,7 @@ Start off by setting up a local development environment where you can experiment
     #### Congratulations!!!
 
    You can access the admin app in your browser at
-   `https://admin-<app-name>.localhost.direct` - see
-   [Application name in URL](#application-name-in-url) below for what
-   `<app-name>` is for your checkout. For a checkout directory named `hyku`,
-   that's [https://admin-hyku.localhost.direct](https://admin-hyku.localhost.direct).
+   [https://admin-hyku.localhost.direct](https://admin-hyku.localhost.direct).
    > :thumbsup: You are now ready to start using Hyku! Please refer to **[Using Hyku](./using-hyku.md)**
    > for instructions on getting your first tenant set up.
 
@@ -95,14 +92,9 @@ see the [Configuration Guide](./configuration.md).
 
 #### Application name in URL
 
-The `APP_NAME` environment variable defaults to your checkout directory's name
-(so `git clone .../hyku` gives `APP_NAME=hyku`, a directory named `sandbox`
-gives `APP_NAME=sandbox`, etc.) - this is what lets more than one Hyku/knapsack
-checkout run at the same time without colliding on the same hostname or
-Traefik router. You can still override it explicitly - e.g. `export
-APP_NAME=sandbox` - or via the `.env` file; an explicit value always wins over
-the directory-derived default. The application path will be
-"https://admin-${APP_NAME}.localhost.direct" - e.g.
+The APP_NAME environment variable defaults to `hyku`, You can set this to another value in your
+local environment - e.g. `export APP_NAME=sandbox` - or via the `.env` file. The application path 
+will be "https://admin-${APP_NAME}.localhost.direct" - e.g. 
 [https://admin-**sandbox**.localhost.direct](https://admin-sandbox.localhost.direct).
 
 #### DNS & Certificates


### PR DESCRIPTION
This reverts commit 568665d1503ee3ec40a2557d14d7b715d5b360cc.

The original commit was not sufficiently tested and broke local development.

There are 3 possible fixes:
1. Revert the commit (this PR)
2. Use `external: true` in the docker-compose.yaml file and bring up CI differently, since this would make a plain `docker compose up` without stack_car break.
3. Update stack_car to rename the network from `default` to `proxy`. The new version of stack_car would not work with old versions of Hyku, and vice versa, making coordination of an auxiliary gem difficult.

@samvera/hyku-code-reviewers
