### PR TITLE
Show a work's existing files on the edit form

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -47,6 +47,7 @@
 //= require bootstrap-datepicker
 
 //= require hyrax
+//= require hyrax/attached_files
 //= require hyrax/deposit_wizard
 //= require bulkrax/application
 

--- a/app/assets/javascripts/hyrax/attached_files.js
+++ b/app/assets/javascripts/hyrax/attached_files.js
@@ -1,0 +1,27 @@
+// Reveals the "new files" heading on the work form's Files tab once the
+// uploader holds a file.
+//
+// This cannot be done in CSS: jQuery File Upload injects the rows at runtime,
+// and the heading precedes their container in the DOM, so there is no sibling
+// selector that reaches them.
+(function () {
+  function initAttachedFilesHeading() {
+    var heading = document.querySelector('[data-behavior="new-files-heading"]');
+    if (!heading) return;
+
+    var rows = document.querySelector('#fileupload tbody.files');
+    if (!rows) return;
+
+    function sync() {
+      heading.hidden = rows.children.length === 0;
+    }
+
+    // The plugin swaps rows in and out (upload template → download template,
+    // and removal on Delete), so watch the container rather than binding to
+    // any one of its events.
+    new MutationObserver(sync).observe(rows, { childList: true });
+    sync();
+  }
+
+  $(document).on('turbolinks:load ready', initAttachedFilesHeading);
+})();

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,6 +8,7 @@ module ApplicationHelper
   include Bulkrax::ApplicationHelper
   include HykuKnapsack::ApplicationHelper
   include Hyrax::FormHelperBehavior
+  include Hyrax::AttachedFilesHelperBehavior
   include Hyku::HomepageHelper
 
   def group_navigation_presenter

--- a/app/helpers/hyrax/attached_files_helper_behavior.rb
+++ b/app/helpers/hyrax/attached_files_helper_behavior.rb
@@ -17,8 +17,9 @@ module Hyrax
                                          .select(&:file_set?)
 
       # Solr does not honor the order of an id list, so restore member order.
+      positions = member_ids.each_with_index.to_h
       documents
-        .sort_by { |document| member_ids.index(document.id) || member_ids.size }
+        .sort_by { |document| positions.fetch(document.id, member_ids.size) }
         .map { |document| Hyrax::FileSetPresenter.new(document, current_ability, request) }
     end
   end

--- a/app/helpers/hyrax/attached_files_helper_behavior.rb
+++ b/app/helpers/hyrax/attached_files_helper_behavior.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Hyrax
+  # Builds the read-only list of file sets already attached to a work, for
+  # display on the form's Files tab.
+  module AttachedFilesHelperBehavior
+    # @param form [Hyrax::Forms::PcdmObjectForm] the work form being rendered
+    # @return [Array<Hyrax::FileSetPresenter>] presenters for the work's
+    #   attached file sets, in the work's member order
+    def attached_file_set_presenters(form)
+      member_ids = Array(form.try(:member_ids)).map(&:to_s).reject(&:blank?)
+      return [] if member_ids.blank?
+
+      documents = Hyrax::SolrQueryService.new
+                                         .with_ids(ids: member_ids)
+                                         .solr_documents(rows: member_ids.size)
+                                         .select(&:file_set?)
+
+      # Solr does not honor the order of an id list, so restore member order.
+      documents
+        .sort_by { |document| member_ids.index(document.id) || member_ids.size }
+        .map { |document| Hyrax::FileSetPresenter.new(document, current_ability, request) }
+    end
+  end
+end

--- a/app/views/hyrax/base/_base_form_files_prepend.html.erb
+++ b/app/views/hyrax/base/_base_form_files_prepend.html.erb
@@ -1,5 +1,11 @@
-<%# OVERRIDE HYRAX 5.2.0 to add show_pdf_viewer to files tab%>
+<%# OVERRIDE Hyrax v5.2.0
+  - add show_pdf_viewer to files tab
+  - list the files already attached to the work above the uploader
+
+  Upstream ships this partial blank as a downstream extension point. %>
 <% if render_show_pdf_behavior_checkbox? %>
   <%= render partial: 'show_pdf_viewer', locals: { f: f } %>
   <%= render partial: 'show_pdf_download_button', locals: { f: f } %>
 <% end %>
+<%# OVERRIDE list the work's existing files above the uploader %>
+<%= render partial: 'form_files_attached', locals: { f: f } %>

--- a/app/views/hyrax/base/_form_files_attached.html.erb
+++ b/app/views/hyrax/base/_form_files_attached.html.erb
@@ -5,7 +5,7 @@
   removing happen on the file set's show page, and navigating there from inside
   the form would discard unsaved metadata edits.
 
-  This should accept one locals:
+  This should accept one local:
 
   `f`: The form object %>
 <% attached_file_sets = attached_file_set_presenters(f.object) %>

--- a/app/views/hyrax/base/_form_files_attached.html.erb
+++ b/app/views/hyrax/base/_form_files_attached.html.erb
@@ -10,24 +10,35 @@
   `f`: The form object %>
 <% attached_file_sets = attached_file_set_presenters(f.object) %>
 <% if attached_file_sets.present? %>
-  <p class="attached-files-caption"><%= t('.caption') %></p>
-  <table role="presentation" class="table table-striped attached-files">
-    <tbody>
-      <% attached_file_sets.each do |file_set| %>
-        <tr class="attached-file">
-          <%# Bounded inline rather than in a stylesheet: a thumbnail derivative
-            is not guaranteed to exist, and the fallback is the full-size file. %>
-          <td class="attached-file-preview align-middle" style="width: 80px;">
-            <%= image_tag hyrax.download_path(file_set.id, file: 'thumbnail'),
-                          alt: file_set.solr_document.alt_text_for_view,
-                          class: 'attached-file-thumbnail',
-                          style: 'max-width: 64px; max-height: 64px; width: auto; height: auto;' %>
-          </td>
-          <td class="align-middle">
-            <span class="name"><%= file_set.link_name %></span>
-          </td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
+  <div class="card mb-4 attached-files-card">
+    <div class="card-header">
+      <p class="mb-0 attached-files-caption"><%= t('.caption') %></p>
+    </div>
+    <div class="card-body p-0">
+      <table role="presentation" class="table table-striped mb-0 attached-files">
+        <tbody>
+          <% attached_file_sets.each do |file_set| %>
+            <tr class="attached-file">
+              <%# Bounded inline rather than in a stylesheet: a thumbnail derivative
+                is not guaranteed to exist, and the fallback is the full-size file. %>
+              <td class="attached-file-preview align-middle" style="width: 80px;">
+                <%= image_tag hyrax.download_path(file_set.id, file: 'thumbnail'),
+                              alt: file_set.solr_document.alt_text_for_view,
+                              class: 'attached-file-thumbnail',
+                              style: 'max-width: 64px; max-height: 64px; width: auto; height: auto;' %>
+              </td>
+              <td class="align-middle">
+                <span class="name"><%= file_set.link_name %></span>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <%# Revealed by hyrax/attached_files.js once the uploader holds a file. Only
+    rendered alongside the card above, which is what it contrasts with. %>
+  <p class="new-files-heading font-weight-bold" data-behavior="new-files-heading" hidden>
+    <%= t('.new_files') %>
+  </p>
 <% end %>

--- a/app/views/hyrax/base/_form_files_attached.html.erb
+++ b/app/views/hyrax/base/_form_files_attached.html.erb
@@ -1,0 +1,33 @@
+<%# Read-only list of the file sets already attached to this work.
+
+  The row shape mirrors the uploader's `template-download` rows so attached and
+  pending files read as one list. Deliberately offers no controls: editing and
+  removing happen on the file set's show page, and navigating there from inside
+  the form would discard unsaved metadata edits.
+
+  This should accept one locals:
+
+  `f`: The form object %>
+<% attached_file_sets = attached_file_set_presenters(f.object) %>
+<% if attached_file_sets.present? %>
+  <p class="attached-files-caption"><%= t('.caption') %></p>
+  <table role="presentation" class="table table-striped attached-files">
+    <tbody>
+      <% attached_file_sets.each do |file_set| %>
+        <tr class="attached-file">
+          <%# Bounded inline rather than in a stylesheet: a thumbnail derivative
+            is not guaranteed to exist, and the fallback is the full-size file. %>
+          <td class="attached-file-preview align-middle" style="width: 80px;">
+            <%= image_tag hyrax.download_path(file_set.id, file: 'thumbnail'),
+                          alt: file_set.solr_document.alt_text_for_view,
+                          class: 'attached-file-thumbnail',
+                          style: 'max-width: 64px; max-height: 64px; width: auto; height: auto;' %>
+          </td>
+          <td class="align-middle">
+            <span class="name"><%= file_set.link_name %></span>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -320,6 +320,7 @@ de:
         local_upload_html: "<p> Sie können eine oder mehrere Dateien hinzufügen, die dieser Arbeit zugeordnet werden sollen. </p>"
       form_files_attached:
         caption: "Diese Arbeit enthält derzeit diese Dateien. Vorhandene Dateien können auf ihren jeweiligen Detailseiten bearbeitet oder entfernt werden."
+        new_files: "Neue Dateien, die dieser Arbeit hinzugefügt werden"
       form_member_of_collections:
         actions:
           remove: Aus der Sammlung entfernen

--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -318,6 +318,8 @@ de:
         dropzone: Dateien hier ablegen.
         local_upload_browse_everything_html: "<p> Sie können eine oder mehrere Dateien hinzufügen, die dieser Arbeit zugeordnet werden sollen. Fügen Sie Dateien von Ihrem lokalen System oder einem Cloud-Anbieter hinzu. </p><p> Beachten Sie, dass der Anbieter Ihre Anfrage möglicherweise nicht bearbeiten kann, wenn Sie einen Cloud-Anbieter verwenden, um innerhalb kurzer Zeit eine große Anzahl von Dateien hochzuladen. Wenn beim Hochladen aus der Cloud Fehler auftreten, teilen Sie uns dies über %{contact_href} mit. </p>"
         local_upload_html: "<p> Sie können eine oder mehrere Dateien hinzufügen, die dieser Arbeit zugeordnet werden sollen. </p>"
+      form_files_attached:
+        caption: "Diese Arbeit enthält derzeit diese Dateien. Vorhandene Dateien können auf ihren jeweiligen Detailseiten bearbeitet oder entfernt werden."
       form_member_of_collections:
         actions:
           remove: Aus der Sammlung entfernen

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -326,6 +326,7 @@ en:
         local_upload_html: "<p>You can add one or more files to associate with this work.</p>"
       form_files_attached:
         caption: This work currently contains these files. Current files can be edited or removed on their individual show pages.
+        new_files: New files to be attached to this work
       form_member_of_collections:
         actions:
           remove: Remove from collection

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -324,6 +324,8 @@ en:
           accommodate your request. If you experience errors uploading from the
           cloud, let us know via the %{contact_href}.</p>
         local_upload_html: "<p>You can add one or more files to associate with this work.</p>"
+      form_files_attached:
+        caption: This work currently contains these files. Current files can be edited or removed on their individual show pages.
       form_member_of_collections:
         actions:
           remove: Remove from collection

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -319,6 +319,8 @@ es:
         dropzone: Suelta los archivos aquí.
         local_upload_browse_everything_html: "<p> Puede agregar uno o más archivos para asociarlos a este trabajo. Agregue archivos de su sistema local o un proveedor de la nube. </p><p> Tenga en cuenta que si utiliza un proveedor de la nube para cargar una gran cantidad de archivos en un corto período de tiempo, es posible que el proveedor no pueda atender su solicitud. Si experimenta errores al cargar desde la nube, infórmenos a través de %{contact_href}. </p>"
         local_upload_html: "<p> Puede agregar uno o más archivos para asociarlos a este trabajo. </p>"
+      form_files_attached:
+        caption: "Este trabajo actualmente contiene estos archivos. Los archivos actuales se pueden editar o eliminar en sus páginas individuales."
       form_member_of_collections:
         actions:
           remove: Eliminar de la colección

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -321,6 +321,7 @@ es:
         local_upload_html: "<p> Puede agregar uno o más archivos para asociarlos a este trabajo. </p>"
       form_files_attached:
         caption: "Este trabajo actualmente contiene estos archivos. Los archivos actuales se pueden editar o eliminar en sus páginas individuales."
+        new_files: "Nuevos archivos que se adjuntarán a este trabajo"
       form_member_of_collections:
         actions:
           remove: Eliminar de la colección

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -317,6 +317,8 @@ fr:
         dropzone: Déposez les fichiers ici.
         local_upload_browse_everything_html: "<p> Vous pouvez ajouter un ou plusieurs fichiers à associer à ce travail. Ajoutez des fichiers à partir de votre système local ou d'un fournisseur de cloud. </p><p> Notez que si vous utilisez un fournisseur de cloud pour télécharger un grand nombre de fichiers dans un court laps de temps, le fournisseur peut ne pas être en mesure de répondre à votre demande. Si vous rencontrez des erreurs de téléchargement à partir du cloud, faites-le nous savoir via le %{contact_href}. </p>"
         local_upload_html: "<p> Vous pouvez ajouter un ou plusieurs fichiers à associer à ce travail. </p>"
+      form_files_attached:
+        caption: "Cette œuvre contient actuellement ces fichiers. Les fichiers actuels peuvent être modifiés ou supprimés sur leurs pages individuelles."
       form_member_of_collections:
         actions:
           remove: Supprimer de la collection

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -319,6 +319,7 @@ fr:
         local_upload_html: "<p> Vous pouvez ajouter un ou plusieurs fichiers à associer à ce travail. </p>"
       form_files_attached:
         caption: "Cette œuvre contient actuellement ces fichiers. Les fichiers actuels peuvent être modifiés ou supprimés sur leurs pages individuelles."
+        new_files: "Nouveaux fichiers à joindre à cette œuvre"
       form_member_of_collections:
         actions:
           remove: Supprimer de la collection

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -321,6 +321,7 @@ it:
         local_upload_html: "<p> È possibile aggiungere uno o più file da associare a questo lavoro. </p>"
       form_files_attached:
         caption: "Questo lavoro contiene attualmente questi file. I file correnti possono essere modificati o rimossi nelle loro pagine individuali."
+        new_files: "Nuovi file da allegare a questo lavoro"
       form_member_of_collections:
         actions:
           remove: Rimuovi dalla raccolta

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -319,6 +319,8 @@ it:
         dropzone: Trascina i file qui.
         local_upload_browse_everything_html: "<p> È possibile aggiungere uno o più file da associare a questo lavoro. Aggiungi file dal tuo sistema locale o da un provider cloud. </p><p> Se si utilizza un provider cloud per caricare un numero elevato di file in un breve periodo di tempo, il provider potrebbe non essere in grado di soddisfare la richiesta. Se si verificano errori durante il caricamento dal cloud, segnalacelo tramite %{contact_href}. </p>"
         local_upload_html: "<p> È possibile aggiungere uno o più file da associare a questo lavoro. </p>"
+      form_files_attached:
+        caption: "Questo lavoro contiene attualmente questi file. I file correnti possono essere modificati o rimossi nelle loro pagine individuali."
       form_member_of_collections:
         actions:
           remove: Rimuovi dalla raccolta

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -319,6 +319,8 @@ pt-BR:
         dropzone: Solte os arquivos aqui.
         local_upload_browse_everything_html: "<p> Você pode adicionar um ou mais arquivos para associar a este trabalho. Adicione arquivos do seu sistema local ou de um provedor de nuvem. </p><p> Observe que, se você usar um provedor de nuvem para fazer upload de um grande número de arquivos dentro de um curto período, o provedor poderá não conseguir acomodar sua solicitação. Se você encontrar erros ao fazer o upload da nuvem, informe-nos por meio do %{contact_href}. </p>"
         local_upload_html: "<p> Você pode adicionar um ou mais arquivos para associar a este trabalho. </p>"
+      form_files_attached:
+        caption: "Este trabalho atualmente contém esses arquivos. Os arquivos atuais podem ser editados ou removidos em suas páginas individuais."
       form_member_of_collections:
         actions:
           remove: Remover da coleção

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -321,6 +321,7 @@ pt-BR:
         local_upload_html: "<p> Você pode adicionar um ou mais arquivos para associar a este trabalho. </p>"
       form_files_attached:
         caption: "Este trabalho atualmente contém esses arquivos. Os arquivos atuais podem ser editados ou removidos em suas páginas individuais."
+        new_files: "Novos arquivos a serem anexados a este trabalho"
       form_member_of_collections:
         actions:
           remove: Remover da coleção

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -319,6 +319,8 @@ zh:
         dropzone: 将文件放在这里。
         local_upload_browse_everything_html: "<p>您可以添加一个或多个文件来与此工作相关联。从本地系统或云提供商添加文件。 </p><p>请注意，如果您使用云提供商在短时间内上传大量文件，则提供商可能无法满足您的请求。如果您从云端上传时遇到错误，请通过%{contact_href}告诉我们。 </p>"
         local_upload_html: "<p>您可以添加一个或多个文件来与此工作相关联。 </p>"
+      form_files_attached:
+        caption: "该作品目前包含这些文件。当前文件可以在各自的详情页面上编辑或删除。"
       form_member_of_collections:
         actions:
           remove: 从收藏中删除

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -321,6 +321,7 @@ zh:
         local_upload_html: "<p>您可以添加一个或多个文件来与此工作相关联。 </p>"
       form_files_attached:
         caption: "该作品目前包含这些文件。当前文件可以在各自的详情页面上编辑或删除。"
+        new_files: "将附加到该作品的新文件"
       form_member_of_collections:
         actions:
           remove: 从收藏中删除

--- a/spec/helpers/hyrax/attached_files_helper_behavior_spec.rb
+++ b/spec/helpers/hyrax/attached_files_helper_behavior_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::AttachedFilesHelperBehavior, type: :helper do
+  describe '#attached_file_set_presenters' do
+    let(:form) { double('WorkForm', member_ids: member_ids) }
+    let(:query_service) { instance_double(Hyrax::SolrQueryService) }
+
+    # The presenters take the current ability; helper specs have no Warden.
+    before { allow(helper).to receive(:current_ability).and_return(Ability.new(nil)) }
+
+    def solr_document(id:, file_set: true)
+      instance_double(SolrDocument, id: id, file_set?: file_set)
+    end
+
+    context 'when the work has no members' do
+      let(:member_ids) { [] }
+
+      it 'returns no presenters' do
+        expect(helper.attached_file_set_presenters(form)).to eq([])
+      end
+
+      it 'does not query solr, which rejects an empty id list' do
+        expect(Hyrax::SolrQueryService).not_to receive(:new)
+
+        helper.attached_file_set_presenters(form)
+      end
+    end
+
+    context 'when the work has members' do
+      let(:member_ids) { ['fs-1', 'fs-2'] }
+      let(:documents) { [solr_document(id: 'fs-2'), solr_document(id: 'fs-1')] }
+
+      before do
+        allow(Hyrax::SolrQueryService).to receive(:new).and_return(query_service)
+        allow(query_service).to receive(:with_ids).with(ids: member_ids).and_return(query_service)
+        allow(query_service).to receive(:solr_documents).and_return(documents)
+      end
+
+      it 'returns a presenter per attached file set' do
+        presenters = helper.attached_file_set_presenters(form)
+
+        expect(presenters).to all(be_a(Hyrax::FileSetPresenter))
+      end
+
+      it 'restores the work member order, which solr does not preserve' do
+        presenters = helper.attached_file_set_presenters(form)
+
+        expect(presenters.map(&:id)).to eq(['fs-1', 'fs-2'])
+      end
+
+      it 'requests enough rows to cover every member' do
+        expect(query_service).to receive(:solr_documents).with(rows: 2).and_return(documents)
+
+        helper.attached_file_set_presenters(form)
+      end
+    end
+
+    context 'when a member is a child work rather than a file set' do
+      let(:member_ids) { ['fs-1', 'work-2'] }
+      let(:documents) do
+        [solr_document(id: 'fs-1'), solr_document(id: 'work-2', file_set: false)]
+      end
+
+      before do
+        allow(Hyrax::SolrQueryService).to receive(:new).and_return(query_service)
+        allow(query_service).to receive(:with_ids).and_return(query_service)
+        allow(query_service).to receive(:solr_documents).and_return(documents)
+      end
+
+      it 'lists only the file sets' do
+        presenters = helper.attached_file_set_presenters(form)
+
+        expect(presenters.map(&:id)).to eq(['fs-1'])
+      end
+    end
+
+    context 'when the form has no member_ids at all' do
+      let(:form) { double('WorkForm') }
+
+      it 'returns no presenters' do
+        expect(helper.attached_file_set_presenters(form)).to eq([])
+      end
+    end
+  end
+end

--- a/spec/views/hyrax/base/_base_form_files_prepend.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_base_form_files_prepend.html.erb_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+RSpec.describe 'hyrax/base/_base_form_files_prepend.html.erb', type: :view do
+  let(:form) { double('FormBuilder', object: double('WorkForm')) }
+
+  def render_prepend
+    render 'hyrax/base/base_form_files_prepend', f: form
+  end
+
+  before do
+    # Both concerns of this partial are stubbed at their boundary; each has its
+    # own spec. What matters here is that they coexist, in the right order.
+    stub_template 'hyrax/base/_show_pdf_viewer.html.erb' => '<div id="pdf-viewer-checkbox"></div>'
+    stub_template 'hyrax/base/_show_pdf_download_button.erb' => '<div id="pdf-download-checkbox"></div>'
+    stub_template 'hyrax/base/_form_files_attached.html.erb' => '<div id="attached-files"></div>'
+  end
+
+  context 'when the work has a PDF, so the viewer checkboxes render' do
+    before { allow(view).to receive(:render_show_pdf_behavior_checkbox?).and_return(true) }
+
+    it 'renders both the PDF controls and the attached-files list' do
+      render_prepend
+
+      expect(rendered).to have_selector('#pdf-viewer-checkbox')
+      expect(rendered).to have_selector('#pdf-download-checkbox')
+      expect(rendered).to have_selector('#attached-files')
+    end
+
+    it 'keeps the PDF controls above the attached-files list' do
+      render_prepend
+
+      expect(rendered.index('pdf-viewer-checkbox')).to be < rendered.index('attached-files')
+      expect(rendered.index('pdf-download-checkbox')).to be < rendered.index('attached-files')
+    end
+  end
+
+  context 'when the work has no PDF' do
+    before { allow(view).to receive(:render_show_pdf_behavior_checkbox?).and_return(false) }
+
+    it 'omits the PDF controls but still lists the attached files' do
+      render_prepend
+
+      expect(rendered).not_to have_selector('#pdf-viewer-checkbox')
+      expect(rendered).not_to have_selector('#pdf-download-checkbox')
+      expect(rendered).to have_selector('#attached-files')
+    end
+  end
+end

--- a/spec/views/hyrax/base/_form_files_attached.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_files_attached.html.erb_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+RSpec.describe 'hyrax/base/_form_files_attached.html.erb', type: :view do
+  let(:work_form) { double('WorkForm') }
+  let(:form) { double('FormBuilder', object: work_form) }
+
+  let(:document) { double('SolrDocument', id: 'fs-1', alt_text_for_view: 'A scanned cover') }
+
+  let(:file_set) do
+    double('FileSetPresenter',
+           id: 'fs-1',
+           solr_document: document,
+           link_name: 'cover.jpg')
+  end
+
+  def render_list
+    render 'hyrax/base/form_files_attached', f: form
+  end
+
+  context 'when the work has attached file sets' do
+    before { allow(view).to receive(:attached_file_set_presenters).with(work_form).and_return([file_set]) }
+
+    it 'names the attached file' do
+      render_list
+
+      expect(rendered).to have_selector('.attached-files .name', text: 'cover.jpg')
+    end
+
+    it 'renders the thumbnail derivative rather than the full-size file' do
+      render_list
+
+      expect(rendered).to have_selector("img[src='/downloads/fs-1?file=thumbnail'][alt='A scanned cover']")
+    end
+
+    it 'bounds the thumbnail inline, so it stays small without a stylesheet' do
+      render_list
+
+      expect(rendered).to have_selector("img.attached-file-thumbnail[style*='max-width: 64px']")
+      expect(rendered).to have_selector("img.attached-file-thumbnail[style*='max-height: 64px']")
+    end
+
+    it 'tells the depositor where files can be edited or removed' do
+      render_list
+
+      expect(rendered).to have_text('Current files can be edited or removed on their individual show pages.')
+    end
+
+    it 'introduces the list before the files, not after' do
+      render_list
+
+      caption = rendered.index(I18n.t('hyrax.base.form_files_attached.caption'))
+      first_file = rendered.index('cover.jpg')
+
+      expect(caption).to be < first_file
+    end
+
+    it 'does not render column headings' do
+      render_list
+
+      expect(rendered).not_to have_selector('.attached-files th')
+    end
+
+    it 'is entirely read-only: no inputs, and no links or buttons off the form' do
+      render_list
+
+      expect(rendered).not_to have_selector('.attached-files input')
+      expect(rendered).not_to have_selector('.attached-files select')
+      expect(rendered).not_to have_selector('.attached-files a')
+      expect(rendered).not_to have_selector('.attached-files button')
+    end
+  end
+
+  context 'when the work has no attached file sets' do
+    before { allow(view).to receive(:attached_file_set_presenters).with(work_form).and_return([]) }
+
+    it 'renders nothing at all' do
+      render_list
+
+      expect(rendered.strip).to be_empty
+    end
+  end
+end

--- a/spec/views/hyrax/base/_form_files_attached.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_files_attached.html.erb_spec.rb
@@ -54,6 +54,19 @@ RSpec.describe 'hyrax/base/_form_files_attached.html.erb', type: :view do
       expect(caption).to be < first_file
     end
 
+    it 'sets the list apart from the uploader in its own card' do
+      render_list
+
+      expect(rendered).to have_selector('.card.attached-files-card .card-header .attached-files-caption')
+      expect(rendered).to have_selector('.card.attached-files-card .card-body table.attached-files')
+    end
+
+    it 'renders the new-files heading hidden, for the uploader JS to reveal' do
+      render_list
+
+      expect(rendered).to have_selector('[data-behavior="new-files-heading"][hidden]', visible: :all)
+    end
+
     it 'does not render column headings' do
       render_list
 


### PR DESCRIPTION
## Summary
- Depositors editing a work can now see which files are already attached, directly on the form's Files tab, instead of opening the work's show page in another tab to check.
- Refs https://github.com/research-technologies/enact_knapsack/issues/157

## Details
- The Files tab lists each attached file with a small thumbnail and its file name, in a card above the uploader. A bold "New files to be attached to this work" heading appears below the card once something is added, so existing and pending files read as two distinct lists.
- The list is read-only by design: editing and removing files happen on each file set's show page, and offering those controls inside an open form would risk discarding unsaved metadata edits. The caption points depositors there.
- Files are listed in the work's member order. Solr does not preserve the order of an id list, so the order is restored after the query.
- The "new files" heading is toggled by a small script : the uploader injects its rows after the page renders. Its table is a later sibling than this partial, so nothing server-side or selector-based can tell whether new files exist.
- Optionally could be contributed back to Hyrax.

## Screenshots

<details>
<summary>**Before more files are attached**</summary>
<img width="848" height="756" alt="Screenshot 2026-08-10 at 12 35 35 PM" src="https://github.com/user-attachments/assets/0e5783df-a38c-4394-819c-cfd569ecb034" />
</details>

<details>
<summary>**After more files are attached**</summary>
<img width="809" height="805" alt="Screenshot 2026-08-10 at 12 39 47 PM" src="https://github.com/user-attachments/assets/05322b14-4bf7-4194-b3e2-bbdba8512345" />

</details>

## Testing
- [ ] Edit a work that already has files. On the Files tab, confirm the attached files are listed in a card above the uploader, each with a small thumbnail and its file name.
- [ ] Confirm the thumbnails render small, not full size, including for a work whose files have no thumbnail derivative.
- [ ] Add a new file. Confirm the "New files to be attached to this work" heading appears between the card and the new file, and that the card is unchanged.
- [ ] Delete the pending file before saving. Confirm the heading disappears again.
- [ ] Edit a work with no files, and create a new work. Confirm no card and no heading appear.
- [ ] On a work with a PDF, confirm the "Show PDF.js Viewer" and "Show Download PDF button" checkboxes still render above the card.
