### PR TITLE
Align the masthead and root menu with the page column

### DIFF
--- a/app/assets/stylesheets/_masthead_alignment.scss
+++ b/app/assets/stylesheets/_masthead_alignment.scss
@@ -1,0 +1,71 @@
+// Aligns the full-bleed site chrome (masthead, root menu) with the page
+// column, so the logo and menu items sit on the same left edge as the
+// content below them instead of hugging the viewport.
+//
+// CSS rather than view overrides, because a stale markup override silently
+// drops whatever upstream adds. Scoped to .public-facing: the dashboard
+// layout has no .container to align to.
+
+// Mirrors Bootstrap's .container content edge onto a full-bleed band. The
+// widths are tracked by hand from Bootstrap 4's $container-max-widths, so a
+// Bootstrap bump shows up as misalignment. !important because the markup
+// carries px-2/px-3 and Bootstrap's spacing utilities ship !important.
+// Defined here (imported before themes/*) so theme sheets can reuse it.
+@mixin container-inset {
+  padding-left: 15px !important;
+  padding-right: 15px !important;
+
+  @media (min-width: 576px) {
+    padding-left: calc((100% - 540px) / 2 + 15px) !important;
+    padding-right: calc((100% - 540px) / 2 + 15px) !important;
+  }
+
+  @media (min-width: 768px) {
+    padding-left: calc((100% - 720px) / 2 + 15px) !important;
+    padding-right: calc((100% - 720px) / 2 + 15px) !important;
+  }
+
+  @media (min-width: 992px) {
+    padding-left: calc((100% - 960px) / 2 + 15px) !important;
+    padding-right: calc((100% - 960px) / 2 + 15px) !important;
+  }
+
+  @media (min-width: 1200px) {
+    padding-left: calc((100% - 1140px) / 2 + 15px) !important;
+    padding-right: calc((100% - 1140px) / 2 + 15px) !important;
+  }
+}
+
+.public-facing #masthead {
+  @include container-inset;
+
+  // The inset provides the breathing room the margin used to fake.
+  #logo {
+    margin-left: 0;
+  }
+}
+
+.public-facing #user_utility_links {
+  padding-right: 0 !important;
+
+  > li:last-child > .nav-link {
+    padding-right: 0;
+  }
+}
+
+.public-facing nav[aria-label='Root Menu'] {
+  @include container-inset;
+
+  // Bootstrap only sets row direction from 576px up, and this nav has no
+  // .navbar-collapse, so below that the menu items stack vertically.
+  .navbar-nav {
+    flex-direction: row;
+  }
+
+  // The nav owns the inset now, so the columns inside must not add their
+  // own gutters.
+  [class*='col-'] {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}

--- a/app/assets/stylesheets/hyrax.scss
+++ b/app/assets/stylesheets/hyrax.scss
@@ -16,6 +16,7 @@
 @import "font-awesome";
 @import "hyrax/hyrax";
 @import "hyku";
+@import "masthead_alignment";
 @import "accounts";
 @import "viewer";
 


### PR DESCRIPTION
### What

Stock Hyku centers page content in a Bootstrap `.container`, but the full-bleed chrome bands above it (masthead, root menu) pin their content to the viewport edge - the logo sits ~10px from the left screen edge while everything below it starts at the container margin. This PR insets the bands' content to the container edge so the whole page shares one left line, and fixes the root menu stacking vertically below 576px (Bootstrap only sets row direction from 576px up and this nav has no `.navbar-collapse`).

### Where it comes from

This is a port of the chrome-alignment sheet that has run in production in a Hyku knapsack since May; its comments already argue the upstream case, including that Hyku's own institutional_repository theme zeroes the logo margin. The `container-inset` mixin (Bootstrap 4's `$container-max-widths` table mirrored onto full-bleed bands) is defined once and imported before `themes/*`, so theme stylesheets can reuse it instead of carrying their own copies - #3181's `_primitives.scss` carries an identical-lineage mixin today and could consume this one as a follow-up once both merge.

The `!important`s are confined to the mixin and are required: the band markup carries `px-2`/`px-3`, and Bootstrap's spacing utilities themselves ship `!important`. Scoped to `.public-facing` because the dashboard layout has no container to align to.

### Testing

CSS-only, no behavior change, so no feature spec. Verified live on a seeded tenant: the logo's left edge lands exactly on the container content edge at 1440px (bounding-box check, 165px = container x + 15px padding), the root menu lays out horizontally at 375px, and axe reports zero new violations (the page's pre-existing violations on main are unchanged and are fixed separately in #3197).

### Placement

samvera/hyku core: generally useful chrome polish, theme-agnostic, and the shared mixin is groundwork for the in-review theme work.

### Screenshots

The delta to look for: the logo and root-menu items shift right to sit on the same left edge as the page content below.

Before - home, 1440px:

![Before](https://gist.githubusercontent.com/ShanaLMoore/bd4637c9f1a9a77c05eeee8061cd74bc/raw/85fa2d329bcaf62e989b6cf107c67a364ea8b01c/s4b-pr1-before-home-desktop.png)

After - home, 1440px:

![After](https://gist.githubusercontent.com/ShanaLMoore/bd4637c9f1a9a77c05eeee8061cd74bc/raw/85fa2d329bcaf62e989b6cf107c67a364ea8b01c/s4b-pr1-after-home-desktop.png)

After - masthead band crop, 1440px:

![After masthead band](https://gist.githubusercontent.com/ShanaLMoore/bd4637c9f1a9a77c05eeee8061cd74bc/raw/85fa2d329bcaf62e989b6cf107c67a364ea8b01c/s4b-pr1-after-masthead-band.png)

<details><summary>After - home, 375px</summary>

![After mobile](https://gist.githubusercontent.com/ShanaLMoore/bd4637c9f1a9a77c05eeee8061cd74bc/raw/85fa2d329bcaf62e989b6cf107c67a364ea8b01c/s4b-pr1-after-home-mobile.png)

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
