### PR TITLE
Render license and rights statement labels under flexible metadata

### DIFF
--- a/app/helpers/hyrax/attributes_helper_decorator.rb
+++ b/app/helpers/hyrax/attributes_helper_decorator.rb
@@ -9,6 +9,11 @@
 # external_link rendering is strictly worse, and forcing it here heals
 # existing tenants without a schema migration. The shipped profile is fixed
 # alongside so new tenants agree with the code.
+#
+# TEMPORARY BRIDGE: this fix is upstreamed as samvera/hyrax#7575, which puts
+# the same logic in Hyrax::AttributesHelper#conform_options itself. Once the
+# pinned hyrax revision includes that change, delete this decorator and its
+# spec - the behavior is identical and double-application is a no-op.
 module Hyrax
   module AttributesHelperDecorator
     SEMANTIC_RENDERERS = {

--- a/app/helpers/hyrax/attributes_helper_decorator.rb
+++ b/app/helpers/hyrax/attributes_helper_decorator.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# OVERRIDE Hyrax v5.2.0: under flexible metadata, attributes render per the
+# m3 profile's view definitions, and the profile Hyku shipped marked license
+# as render_as: external_link - so licenses render as bare URIs instead of
+# their authority labels, and every tenant seeded from that profile carries
+# the setting in its stored schema. For these authority-backed fields the
+# semantic renderer always wins: the label still links to the URI, so an
+# external_link rendering is strictly worse, and forcing it here heals
+# existing tenants without a schema migration. The shipped profile is fixed
+# alongside so new tenants agree with the code.
+module Hyrax
+  module AttributesHelperDecorator
+    SEMANTIC_RENDERERS = {
+      license: :license,
+      rights_statement: :rights_statement
+    }.freeze
+
+    def conform_options(field_name, view_options)
+      options = super
+      semantic = SEMANTIC_RENDERERS[field_name.to_sym]
+      options[:render_as] = semantic if semantic
+      options
+    end
+  end
+end
+
+Hyrax::AttributesHelper.prepend(Hyrax::AttributesHelperDecorator)

--- a/config/metadata_profiles/m3_profile.yaml
+++ b/config/metadata_profiles/m3_profile.yaml
@@ -255,7 +255,7 @@ properties:
     sample_values:
       - http://creativecommons.org/licenses/by/3.0/us/
     view:
-      render_as: external_link
+      render_as: license
       html_dl: true
   abstract:
     available_on:

--- a/spec/helpers/hyrax/attributes_helper_decorator_spec.rb
+++ b/spec/helpers/hyrax/attributes_helper_decorator_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::AttributesHelperDecorator, type: :helper do
+  describe '#conform_options' do
+    it 'restores the license renderer the flexible path loses' do
+      options = helper.conform_options(:license, {})
+      expect(options[:render_as]).to eq(:license)
+    end
+
+    it 'restores the rights statement renderer' do
+      options = helper.conform_options(:rights_statement, {})
+      expect(options[:render_as]).to eq(:rights_statement)
+    end
+
+    it 'overrides a profile-specified external_link for license' do
+      # Tenants seeded before the profile fix store render_as: external_link in
+      # their flexible schema; the semantic renderer must win anyway, since a
+      # license label still links to the URI and a bare URI is strictly worse.
+      options = helper.conform_options(:license, { render_as: 'external_link' })
+      expect(options[:render_as]).to eq(:license)
+    end
+
+    it 'leaves other fields without a semantic renderer' do
+      options = helper.conform_options(:description, {})
+      expect(options[:render_as]).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
### What

On flexible-metadata tenants, a work's license renders as a bare auto-linked URI ("https://creativecommons.org/licenses/by/4.0/") instead of its authority label ("Creative Commons BY Attribution 4.0 International"). Rights statements happen to look right only when their URI resolves through a different display path; licenses never do.

### Why

Under flexible metadata, attribute rendering follows the m3 profile's view options, and the profile Hyku ships marks license as `render_as: external_link` - and every tenant seeded from that profile carries the setting in its stored flexible schema, so fixing the yaml alone would not heal existing tenants.

### Fix

Two pieces, one concern:

* A `conform_options` decorator forces the semantic renderer (`:license`, `:rights_statement`) for these two authority-backed fields. The semantic renderer still links to the URI, so an `external_link` rendering is strictly worse than the label - which is why overriding the stored profile value is safe, and why this heals existing tenants without a schema migration. The license service already resolves both http and https CC URI forms (verified against seeded data).
* The shipped `m3_profile.yaml` license view becomes `render_as: license`, so newly seeded tenants agree with the code.

This also fixes the same rendering on the practice_research show theme, which routes through the same helper.

### Testing

Spec-first helper specs pin the semantic renderer, including the override of a stored `external_link`, and that unrelated fields are untouched. Verified live on an existing seeded tenant: the license row now shows the authority label where it showed the bare URI. RuboCop clean.

### Placement

Per review (Shana): the root fix belongs in Hyrax - `conform_options` and the original profiles are Hyrax's - and is now open upstream as samvera/hyrax#7575. This PR slims accordingly:

* `config/metadata_profiles/m3_profile.yaml` is Hyku's own copy of the profile, so its fix stays here regardless.
* The `conform_options` decorator is marked as a **temporary bridge**: Hyku pins hyrax to `main`, so once #7575 merges and the pinned revision advances, the decorator and its spec get deleted (the upstream logic is identical; double-application is a no-op in the meantime).

### Screenshots

Before - License renders the bare URI (1440px):

![Before: bare license URI](https://gist.githubusercontent.com/ShanaLMoore/bd4637c9f1a9a77c05eeee8061cd74bc/raw/5852f4da60f9fb48c4603bec83d8c5f6970431cd/pr2-before-license.png)

After - the authority label, still linked to the URI (1440px):

![After: license authority label](https://gist.githubusercontent.com/ShanaLMoore/bd4637c9f1a9a77c05eeee8061cd74bc/raw/35b882c4a885ccc21405240ef9a15dfb24cd3b43/s5pr2-after-license-row-v2.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


