### PR TITLE
WIP Mint DOIs for works in each tenant's own account

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ gem 'googleauth', '~> 1.9.0'
 gem 'google-protobuf'
 gem 'grpc'
 gem 'hyrax', github: 'samvera/hyrax', branch: 'main'
-gem 'hyrax-doi', github: 'samvera-labs/hyrax-doi', branch: 'rails_hyrax_upgrade'
+gem 'hyrax-doi', github: 'samvera-labs/hyrax-doi', branch: 'valkyrie-test-harness'
 gem 'i18n-debug', require: false, group: %i[development test]
 gem 'i18n-tasks', group: %i[development test]
 gem 'iiif_print', '~> 3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,14 +18,15 @@ GIT
 
 GIT
   remote: https://github.com/samvera-labs/hyrax-doi.git
-  revision: e54de9da97c5ff4d6219a395ed143a0b719b7420
-  branch: rails_hyrax_upgrade
+  revision: f574261689764acbd960395b566c838c5f763a90
+  branch: valkyrie-test-harness
   specs:
-    hyrax-doi (0.2.0)
-      bolognese (>= 1.8.6, < 3.0)
+    hyrax-doi (0.3.0)
+      faraday (~> 2.0)
+      faraday-follow_redirects (~> 0.3)
       flipflop (~> 2.3)
-      hyrax (>= 2.9, < 6.0)
-      rails (>= 5.2.4.3, < 8.0)
+      hyrax (>= 5.2, < 7.0)
+      rails (> 6.1, < 8.0)
 
 GIT
   remote: https://github.com/samvera/hyrax.git

--- a/app/forms/etd_resource_form.rb
+++ b/app/forms/etd_resource_form.rb
@@ -6,6 +6,8 @@
 # @see https://github.com/samvera/hyrax/wiki/Hyrax-Valkyrie-Usage-Guide#forms
 # @see https://github.com/samvera/valkyrie/wiki/ChangeSets-and-Dirty-Tracking
 class EtdResourceForm < Hyrax::Forms::ResourceForm(EtdResource)
+  include Hyrax::DOI::DOIFormBehavior
+  include Hyrax::DOI::DataCiteDOIFormBehavior
   if Hyrax.config.work_include_metadata?
     # Commented out basic_metadata because the terms were added to the resource's yaml
     # so we can customize it

--- a/app/forms/generic_work_resource_form.rb
+++ b/app/forms/generic_work_resource_form.rb
@@ -6,6 +6,8 @@
 # @see https://github.com/samvera/hyrax/wiki/Hyrax-Valkyrie-Usage-Guide#forms
 # @see https://github.com/samvera/valkyrie/wiki/ChangeSets-and-Dirty-Tracking
 class GenericWorkResourceForm < Hyrax::Forms::ResourceForm(GenericWorkResource)
+  include Hyrax::DOI::DOIFormBehavior
+  include Hyrax::DOI::DataCiteDOIFormBehavior
   if Hyrax.config.work_include_metadata?
     include Hyrax::FormFields(:basic_metadata)
     include Hyrax::FormFields(:bulkrax_metadata)

--- a/app/forms/image_resource_form.rb
+++ b/app/forms/image_resource_form.rb
@@ -6,6 +6,8 @@
 # @see https://github.com/samvera/hyrax/wiki/Hyrax-Valkyrie-Usage-Guide#forms
 # @see https://github.com/samvera/valkyrie/wiki/ChangeSets-and-Dirty-Tracking
 class ImageResourceForm < Hyrax::Forms::ResourceForm(ImageResource)
+  include Hyrax::DOI::DOIFormBehavior
+  include Hyrax::DOI::DataCiteDOIFormBehavior
   if Hyrax.config.work_include_metadata?
     include Hyrax::FormFields(:basic_metadata)
     include Hyrax::FormFields(:bulkrax_metadata)

--- a/app/forms/oer_resource_form.rb
+++ b/app/forms/oer_resource_form.rb
@@ -6,6 +6,8 @@
 # @see https://github.com/samvera/hyrax/wiki/Hyrax-Valkyrie-Usage-Guide#forms
 # @see https://github.com/samvera/valkyrie/wiki/ChangeSets-and-Dirty-Tracking
 class OerResourceForm < Hyrax::Forms::ResourceForm(OerResource)
+  include Hyrax::DOI::DOIFormBehavior
+  include Hyrax::DOI::DataCiteDOIFormBehavior
   if Hyrax.config.work_include_metadata?
     # Commented out basic_metadata because the terms were added to the resource's yaml
     # so we can customize it

--- a/app/indexers/etd_resource_indexer.rb
+++ b/app/indexers/etd_resource_indexer.rb
@@ -17,6 +17,10 @@ class EtdResourceIndexer < Hyrax::ValkyrieWorkIndexer
 
   include HykuIndexing
 
+  # Writes doi_state_ssi, which nothing else supplies: the metadata profile indexes the DOI
+  # itself, but not the state DataCite reports for it.
+  include Hyrax::DOI::Indexers::DOIIndexer
+
   # Uncomment this block if you want to add custom indexing behavior:
   #  def to_solr
   #    super.tap do |index_document|

--- a/app/indexers/generic_work_resource_indexer.rb
+++ b/app/indexers/generic_work_resource_indexer.rb
@@ -14,6 +14,10 @@ class GenericWorkResourceIndexer < Hyrax::ValkyrieWorkIndexer
   check_if_flexible(GenericWorkResource)
 
   include HykuIndexing
+
+  # Writes doi_state_ssi, which nothing else supplies: the metadata profile indexes the DOI
+  # itself, but not the state DataCite reports for it.
+  include Hyrax::DOI::Indexers::DOIIndexer
   # Uncomment this block if you want to add custom indexing behavior:
   #  def to_solr
   #    super.tap do |index_document|

--- a/app/indexers/image_resource_indexer.rb
+++ b/app/indexers/image_resource_indexer.rb
@@ -14,6 +14,10 @@ class ImageResourceIndexer < Hyrax::ValkyrieWorkIndexer
   check_if_flexible(ImageResource)
 
   include HykuIndexing
+
+  # Writes doi_state_ssi, which nothing else supplies: the metadata profile indexes the DOI
+  # itself, but not the state DataCite reports for it.
+  include Hyrax::DOI::Indexers::DOIIndexer
   # Uncomment this block if you want to add custom indexing behavior:
   #  def to_solr
   #    super.tap do |index_document|

--- a/app/indexers/oer_resource_indexer.rb
+++ b/app/indexers/oer_resource_indexer.rb
@@ -17,6 +17,10 @@ class OerResourceIndexer < Hyrax::ValkyrieWorkIndexer
 
   include HykuIndexing
 
+  # Writes doi_state_ssi, which nothing else supplies: the metadata profile indexes the DOI
+  # itself, but not the state DataCite reports for it.
+  include Hyrax::DOI::Indexers::DOIIndexer
+
   # Uncomment this block if you want to add custom indexing behavior:
   def to_solr
     super.tap do |index_document|

--- a/app/models/datacite_endpoint.rb
+++ b/app/models/datacite_endpoint.rb
@@ -5,27 +5,28 @@ class DataCiteEndpoint < ::Endpoint
 
   store :options, accessors: %i[mode prefix username password]
 
-  def switch!
-    Hyrax::DOI::DataCiteRegistrar.mode = mode
-    Hyrax::DOI::DataCiteRegistrar.prefix = prefix
-    Hyrax::DOI::DataCiteRegistrar.username = username
-    Hyrax::DOI::DataCiteRegistrar.password = password
-  end
+  # Nothing to switch. Hyku::DataCiteCredentialStore reads this record per registration, so
+  # credentials follow the current tenant without being pushed into process-wide state --
+  # which is what let concurrent workers serving different tenants overwrite each other.
+  def switch!; end
 
   # No special handling just destroy this record
   def remove!
     destroy
   end
 
-  def self.reset!
-    Hyrax::DOI::DataCiteRegistrar.mode = :test
-    Hyrax::DOI::DataCiteRegistrar.prefix = nil
-    Hyrax::DOI::DataCiteRegistrar.username = nil
-    Hyrax::DOI::DataCiteRegistrar.password = nil
-  end
+  def self.reset!; end
 
+  # Confirms both that DataCite is reachable and that these credentials work. Built from this
+  # record rather than the configured store, which resolves the current tenant -- on the
+  # proprietor page every account would otherwise report the same tenant's status.
   def ping
-    # TODO: ping https://api.test.datacite.org/heartbeat or some other endpoint
-    true
+    credentials = Hyrax::DOI::Credentials.new(provider: 'datacite', prefix:, username:,
+                                              password:, mode:)
+    return false unless credentials.complete?
+
+    Hyrax::DOI::DataCiteRegistrar.new(credentials:).ping.success?
+  rescue StandardError
+    false
   end
 end

--- a/app/models/etd_resource.rb
+++ b/app/models/etd_resource.rb
@@ -3,6 +3,8 @@
 # Generated via
 #  `rails generate hyrax:work_resource EtdResource`
 class EtdResource < Hyrax::Work
+  include Hyrax::DOI::DOIBehavior
+  include Hyrax::DOI::DataCiteDOIBehavior
   if Hyrax.config.work_include_metadata?
     include Hyrax::Schema(:core_metadata)
     # Commented out basic_metadata because these terms were added to etd_resource so we can customize it.

--- a/app/models/generic_work_resource.rb
+++ b/app/models/generic_work_resource.rb
@@ -3,6 +3,8 @@
 # Generated via
 #  `rails generate hyrax:work_resource GenericWorkResource`
 class GenericWorkResource < Hyrax::Work
+  include Hyrax::DOI::DOIBehavior
+  include Hyrax::DOI::DataCiteDOIBehavior
   if Hyrax.config.work_include_metadata?
     include Hyrax::Schema(:core_metadata)
     include Hyrax::Schema(:basic_metadata)

--- a/app/models/image_resource.rb
+++ b/app/models/image_resource.rb
@@ -3,6 +3,8 @@
 # Generated via
 #  `rails generate hyrax:work_resource ImageResource`
 class ImageResource < Hyrax::Work
+  include Hyrax::DOI::DOIBehavior
+  include Hyrax::DOI::DataCiteDOIBehavior
   if Hyrax.config.work_include_metadata?
     include Hyrax::Schema(:core_metadata)
     include Hyrax::Schema(:basic_metadata)

--- a/app/models/nil_datacite_endpoint.rb
+++ b/app/models/nil_datacite_endpoint.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
+# Stands in for a tenant with no DataCite account. NilEndpoint supplies switch!, ping, and
+# the rest; these readers exist because the proprietor account form reads them to render
+# empty fields.
 class NilDataCiteEndpoint < NilEndpoint
-  def switch!
-    Hyrax::DOI::DataCiteRegistrar.mode = nil
-    Hyrax::DOI::DataCiteRegistrar.prefix = nil
-    Hyrax::DOI::DataCiteRegistrar.username = nil
-    Hyrax::DOI::DataCiteRegistrar.password = nil
-  end
-
   def mode
     nil
   end
@@ -22,9 +18,5 @@ class NilDataCiteEndpoint < NilEndpoint
 
   def password
     nil
-  end
-
-  def ping
-    false
   end
 end

--- a/app/models/oer_resource.rb
+++ b/app/models/oer_resource.rb
@@ -3,6 +3,8 @@
 # Generated via
 #  `rails generate hyrax:work_resource OerResource`
 class OerResource < Hyrax::Work
+  include Hyrax::DOI::DOIBehavior
+  include Hyrax::DOI::DataCiteDOIBehavior
   if Hyrax.config.work_include_metadata?
     include Hyrax::Schema(:core_metadata)
     # Commented out basic_metadata because these terms were added to etd_resource so we can customize it.

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -10,6 +10,11 @@ class SolrDocument
   # Adds Hyrax behaviors to the SolrDocument.
   include Hyrax::SolrDocumentBehavior
 
+  # Reads the DOI and the state DataCite reports for it. The indexed fields are populated
+  # without these, but nothing on the show page can read them.
+  include Hyrax::DOI::SolrDocument::DOIBehavior
+  include Hyrax::DOI::SolrDocument::DataCiteDOIBehavior
+
   # self.unique_key = 'id'
 
   # Email uses the semantic field mappings below to generate the body of an email.

--- a/app/presenters/hyku/work_show_presenter.rb
+++ b/app/presenters/hyku/work_show_presenter.rb
@@ -13,11 +13,20 @@ module Hyku
     # OVERRIDE Hyrax v2.9.0 here to make featured collections work
     delegate :collection_presenters, to: :member_presenter_factory
 
-    # assumes there can only be one doi
+    # Supplies doi_state and doi_status, which describe what DataCite reports for a DOI this
+    # repository minted. The doi method below overrides the one these provide.
+    include Hyrax::DOI::DOIPresenterBehavior
+    include Hyrax::DOI::DataCiteDOIPresenterBehavior
+
+    # Prefers the dedicated doi field, which is where a minted or recorded DOI lives, and
+    # falls back to scraping identifier -- repositories predating the DOI field keep DOIs
+    # there, and their show pages still displayed them.
     def doi
+      recorded = Array(solr_document.try(:doi)).compact_blank
+      return recorded.first if recorded.any?
+
       doi_regex = %r{10\.\d{4,9}\/[-._;()\/:A-Z0-9]+}i
-      doi = extract_from_identifier(doi_regex)
-      doi&.join
+      extract_from_identifier(doi_regex)&.join
     end
 
     # unlike doi, there can be multiple isbns

--- a/app/services/hyku/datacite_credential_store.rb
+++ b/app/services/hyku/datacite_credential_store.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Hyku
+  # Reads DataCite credentials from the current tenant's DataCiteEndpoint.
+  #
+  # The gem resolves credentials through this on every registration rather than caching
+  # them, so a background job that has switched tenants gets that tenant's account. Nothing
+  # is pushed into process-wide state, which is what made the previous approach unsafe:
+  # concurrent Sidekiq threads serving different tenants overwrote each other's credentials.
+  class DataCiteCredentialStore < Hyrax::DOI::CredentialStore
+    def fetch(provider:)
+      return env_credentials(provider) if Hyku.single_tenant?
+
+      endpoint = Site.instance&.account&.data_cite_endpoint
+
+      Hyrax::DOI::Credentials.new(provider: provider,
+                                  prefix: endpoint&.prefix,
+                                  username: endpoint&.username,
+                                  password: endpoint&.password,
+                                  mode: endpoint&.mode)
+    end
+
+    private
+
+    # A single-tenant install has no proprietor route to store credentials in, so they come
+    # from the environment -- as Solr and Fedora do in that mode.
+    #
+    # Multitenant deliberately does not fall back here. A consortial install has one tenant
+    # per institution, and inheriting an instance-wide account would mint a tenant's DOIs
+    # under someone else's prefix. A blank fieldset there means this tenant does not mint.
+    def env_credentials(provider)
+      Hyrax::DOI::Credentials.new(provider: provider,
+                                  prefix: ENV.fetch('DATACITE_PREFIX', nil),
+                                  username: ENV.fetch('DATACITE_USERNAME', nil),
+                                  password: ENV.fetch('DATACITE_PASSWORD', nil),
+                                  mode: ENV.fetch('DATACITE_MODE', 'test'))
+    end
+  end
+end

--- a/config/initializers/hyrax_doi.rb
+++ b/config/initializers/hyrax_doi.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Credentials come from each tenant's DataCiteEndpoint rather than the environment, which
+# is the whole of Hyku's DOI integration -- the gem registers its own registrar, listener,
+# and helpers.
+Rails.application.config.to_prepare do
+  Hyrax::DOI.configure do |config|
+    config.credential_store = Hyku::DataCiteCredentialStore.new
+  end
+end

--- a/config/metadata_profiles/m3_profile.yaml
+++ b/config/metadata_profiles/m3_profile.yaml
@@ -558,6 +558,61 @@ properties:
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
       - This is a description.
+  doi:
+    available_on:
+      class:
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: array
+    display_label:
+      default: DOI
+    index_documentation: displayable, searchable
+    indexing:
+      - doi_ssim
+      - doi_tesim
+    # The DOI tab renders this field itself, so it stays out of the generic
+    # "Additional fields" accordion.
+    form:
+      primary: false
+      display: false
+    property_uri: http://purl.org/ontology/bibo/doi
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - 10.5072/example
+    # render_as doi links the identifier to its resolver and withholds a draft, which is
+    # reserved but does not resolve.
+    view:
+      render_as: doi
+      html_dl: true
+  doi_status_when_public:
+    available_on:
+      class:
+        - GenericWorkResource
+        - ImageResource
+        - OerResource
+        - EtdResource
+    cardinality:
+      minimum: 0
+      maximum: 1
+    data_type: string
+    display_label:
+      default: DOI status when public
+    index_documentation: displayable
+    indexing:
+      - doi_status_when_public_ssi
+    # The depositor's intent, chosen on the DOI tab rather than the metadata form.
+    form:
+      primary: false
+      display: false
+    property_uri: http://samvera.org/ns/hyrax/doi#doi_status_when_public
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+      - findable
   identifier:
     available_on:
       class:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,6 +95,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   mount Blacklight::Engine => '/'
   mount BlacklightAdvancedSearch::Engine => '/'
   mount Hyrax::Engine, at: '/'
+  mount Hyrax::DOI::Engine, at: '/'
   mount Bulkrax::Engine, at: '/' if Hyku.bulkrax_enabled?
   mount BlacklightDynamicSitemap::Engine => '/'
   concern :searchable, Blacklight::Routes::Searchable.new

--- a/db/migrate/20260810180340_create_hyrax_doi_persistent_identifiers.rb
+++ b/db/migrate/20260810180340_create_hyrax_doi_persistent_identifiers.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+# DOI, not Doi: the engine registers `inflect.acronym 'DOI'`, so Rails camelizes this
+# migration's filename to CreateHyraxDOIPersistentIdentifiers and will not find any other
+# spelling.
+class CreateHyraxDOIPersistentIdentifiers < ActiveRecord::Migration[7.2]
+  def change
+    create_table :hyrax_doi_persistent_identifiers do |t|
+      # Valkyrie resource id, as a string rather than a foreign key: Valkyrie
+      # resources are not ActiveRecord rows. Nullable so a draft identifier can be
+      # reserved before the work it will belong to exists.
+      t.string :resource_id
+      t.string :resource_type
+
+      t.string :scheme, null: false
+      t.string :provider, null: false
+      t.string :value, null: false
+
+      # Provider vocabulary, stored verbatim: DataCite's draft/registered/findable
+      # and EZID's reserved/public/unavailable do not map onto a common set without
+      # losing meaning.
+      t.string :state
+
+      # 'minted' or 'external'. Identifiers we did not mint must never be updated
+      # or deleted at the provider.
+      t.string :origin, null: false, default: 'minted'
+
+      t.boolean :primary, null: false, default: true
+
+      t.datetime :minted_at
+      t.datetime :last_synced_at
+      t.text :last_error
+
+      t.timestamps
+    end
+
+    add_index :hyrax_doi_persistent_identifiers,
+              %i[scheme provider value],
+              unique: true,
+              name: 'index_hyrax_doi_pids_on_scheme_provider_value'
+    add_index :hyrax_doi_persistent_identifiers,
+              %i[resource_id scheme],
+              name: 'index_hyrax_doi_pids_on_resource_id_and_scheme'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_07_05_190000) do
+ActiveRecord::Schema[7.2].define(version: 2026_08_10_180340) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_trgm"
@@ -281,6 +281,37 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_05_190000) do
     t.index ["local_authority_id", "domain_term_id"], name: "dtla_by_ids1"
   end
 
+  create_table "enact_contributors", force: :cascade do |t|
+    t.string "display_name", null: false
+    t.string "agent_type", default: "person", null: false
+    t.string "orcid"
+    t.integer "user_id"
+    t.jsonb "metadata", default: {}, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["agent_type"], name: "index_enact_contributors_on_agent_type"
+    t.index ["display_name"], name: "index_enact_contributors_on_display_name"
+    t.index ["orcid"], name: "index_enact_contributors_on_orcid", unique: true, where: "(orcid IS NOT NULL)"
+    t.index ["user_id"], name: "index_enact_contributors_on_user_id", unique: true, where: "(user_id IS NOT NULL)"
+  end
+
+  create_table "enact_profile_requests", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "contributor_id"
+    t.string "status", default: "pending", null: false
+    t.text "note"
+    t.text "review_note"
+    t.integer "reviewed_by_id"
+    t.datetime "reviewed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["contributor_id"], name: "index_enact_profile_requests_on_contributor_id"
+    t.index ["created_at"], name: "index_enact_profile_requests_on_created_at"
+    t.index ["status"], name: "index_enact_profile_requests_on_status"
+    t.index ["user_id", "status"], name: "index_enact_profile_requests_on_user_id_and_status"
+    t.index ["user_id"], name: "index_enact_profile_requests_on_pending_user", unique: true, where: "((status)::text = 'pending'::text)"
+  end
+
   create_table "endpoints", id: :serial, force: :cascade do |t|
     t.string "type"
     t.binary "options"
@@ -468,6 +499,24 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_05_190000) do
     t.string "default_admin_set_id", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+  end
+
+  create_table "hyrax_doi_persistent_identifiers", force: :cascade do |t|
+    t.string "resource_id"
+    t.string "resource_type"
+    t.string "scheme", null: false
+    t.string "provider", null: false
+    t.string "value", null: false
+    t.string "state"
+    t.string "origin", default: "minted", null: false
+    t.boolean "primary", default: true, null: false
+    t.datetime "minted_at"
+    t.datetime "last_synced_at"
+    t.text "last_error"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["resource_id", "scheme"], name: "index_hyrax_doi_pids_on_resource_id_and_scheme"
+    t.index ["scheme", "provider", "value"], name: "index_hyrax_doi_pids_on_scheme_provider_value", unique: true
   end
 
   create_table "hyrax_features", id: :serial, force: :cascade do |t|

--- a/spec/services/hyku/datacite_credential_store_spec.rb
+++ b/spec/services/hyku/datacite_credential_store_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyku::DataCiteCredentialStore do
+  subject(:store) { described_class.new }
+
+  let(:credentials) { store.fetch(provider: 'datacite') }
+
+  describe 'in a multitenant install' do
+    before { allow(Hyku).to receive(:single_tenant?).and_return(false) }
+
+    context 'when the current tenant has a DataCite endpoint' do
+      let(:endpoint) do
+        DataCiteEndpoint.new(mode: 'test', prefix: '10.5072',
+                             username: 'tenant-user', password: 'tenant-pass')
+      end
+      let(:account) { Account.new(data_cite_endpoint: endpoint) }
+
+      before { allow(Site).to receive(:instance).and_return(Site.new(account: account)) }
+
+      it "reads that tenant's credentials" do
+        expect(credentials.prefix).to eq '10.5072'
+        expect(credentials.username).to eq 'tenant-user'
+        expect(credentials).to be_complete
+      end
+    end
+
+    # The protection a consortial install depends on. Each tenant is a separate
+    # institution, so inheriting an instance-wide account would mint one institution's
+    # DOIs under another's prefix. A blank fieldset means this tenant does not mint.
+    context 'when the current tenant has no credentials but the environment does' do
+      before do
+        allow(Site).to receive(:instance).and_return(Site.new(account: Account.new(data_cite_endpoint: DataCiteEndpoint.new)))
+        stub_const('ENV', ENV.to_hash.merge('DATACITE_PREFIX' => '10.9999',
+                                            'DATACITE_USERNAME' => 'instance-user',
+                                            'DATACITE_PASSWORD' => 'instance-pass'))
+      end
+
+      it 'does not fall back to the environment' do
+        expect(credentials.prefix).to be_blank
+        expect(credentials.username).to be_blank
+        expect(credentials).not_to be_complete
+      end
+    end
+
+    context 'when there is no account at all' do
+      before { allow(Site).to receive(:instance).and_return(nil) }
+
+      it 'reports incomplete rather than raising' do
+        expect { credentials }.not_to raise_error
+        expect(credentials).not_to be_complete
+      end
+    end
+  end
+
+  # A single-tenant install has no proprietor route to store credentials in, so they come
+  # from the environment as Solr and Fedora do.
+  describe 'in a single-tenant install' do
+    before { allow(Hyku).to receive(:single_tenant?).and_return(true) }
+
+    context 'when the environment supplies credentials' do
+      before do
+        stub_const('ENV', ENV.to_hash.merge('DATACITE_PREFIX' => '10.9999',
+                                            'DATACITE_USERNAME' => 'env-user',
+                                            'DATACITE_PASSWORD' => 'env-pass',
+                                            'DATACITE_MODE' => 'production'))
+      end
+
+      it 'reads them' do
+        expect(credentials.prefix).to eq '10.9999'
+        expect(credentials.username).to eq 'env-user'
+        expect(credentials.mode).to eq :production
+        expect(credentials).to be_complete
+      end
+
+      it 'ignores any account record, since one tenant means one configuration' do
+        allow(Site).to receive(:instance).and_return(
+          Site.new(account: Account.new(data_cite_endpoint: DataCiteEndpoint.new(prefix: '10.1111')))
+        )
+
+        expect(credentials.prefix).to eq '10.9999'
+      end
+    end
+
+    context 'when the environment supplies nothing' do
+      before do
+        stub_const('ENV', ENV.to_hash.except('DATACITE_PREFIX', 'DATACITE_USERNAME',
+                                             'DATACITE_PASSWORD', 'DATACITE_MODE'))
+      end
+
+      it 'reports incomplete rather than raising' do
+        expect { credentials }.not_to raise_error
+        expect(credentials).not_to be_complete
+      end
+
+      it 'defaults to the test environment, never production' do
+        expect(credentials.mode).to eq :test
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Brings in an updated hyrax-doi gem and configures its use:
- Works can be given a DOI — minted through DataCite or recorded from elsewhere — on Generic Work, Image, OER, and ETD.
- Each tenant mints under its own DataCite account. A tenant with no credentials mints nothing rather.
- Refs 
  - https://github.com/research-technologies/enact_knapsack/issues/156
  - https://github.com/samvera-labs/hyrax-doi/pull/58

## Details

- **Not ready to merge.** The Gemfile pins `hyrax-doi` to the `valkyrie-test-harness` branch. That branch needs releasing, or the pin changing, before this lands.
- Credentials are read per registration rather than pushed into class-level state, where concurrent workers serving different tenants could overwrite each other's.
- Multi-tenant deliberately has no environment fallback: in a consortial install each tenant is a separate institution, so inheriting an instance-wide account would mint one institution's DOIs under another's prefix. Single-tenant reads the environment, as Solr and Fedora do.
- Connection status builds credentials from the account being asked about, so the proprietor page no longer reports the current tenant's health for every row.
- A draft DOI is withheld from the show page because it does not resolve yet.
- The guided deposit wizard is **not** covered — the DOI section needs to split across three steps (reserve at file upload, autofill before work details, minting intent at review) and is deferred.

## Testing

Set DataCite test credentials on a tenant first (**Account settings → DataCite**).

- [ ] Deposit a work leaving DOI status blank → no DOI, no DataCite call
- [ ] Deposit with **Draft** → DOI minted; the show page does *not* display it
- [ ] Deposit with **Registered**, with publisher, date, and resource type filled in → DOI minted and displayed as a working link
- [ ] Deposit with **Registered** leaving those blank → a dialog names the missing fields and says no DOI will be created; confirm none is
- [ ] **Reserve a DOI now** → the DOI appears in its own field with a Copy button before saving; save and confirm the same DOI persists
- [ ] Paste an existing DOI, click **Fill in this form from that DOI** → fields populate
- [ ] Edit a work that has a DOI → confirm in Fabrica that metadata re-synced
- [ ] Edit a work with no DOI and no status → still no DOI
- [ ] Set a second tenant's DataCite credentials to a different prefix → confirm each tenant mints under its own
- [ ] Leave a tenant's DataCite fieldset blank → confirm it mints nothing

See the minted DOIs by logging into https://doi.test.datacite.org/repositories/
