### PR TITLE
Read the attach-child parent from Solr

### DIFF
--- a/app/controllers/concerns/hyku/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyku/works_controller_behavior.rb
@@ -43,22 +43,25 @@ module Hyku
 
     # parent_id reaches Steps::AddToParent straight from params, and that step
     # validates neither the type pairing nor the user's access to the parent.
+    #
+    # Read from Solr, not the persistence layer: only the parent's id and class are
+    # needed, and AddToParent loads the resource itself.
     def ensure_parent_accepts_child
       parent_id = params[:parent_id]
       return if parent_id.blank?
 
-      parent = Hyrax.query_service.find_by(id: parent_id)
+      parent = ::SolrDocument.find(parent_id)
       # Normalize both sides: valid_child_concerns holds the ActiveFedora classes
       # while curation_concern_type is the Valkyrie resource, so comparing class
       # names directly never matches and would reject every legitimate create.
       child_types = Hyrax::ModelRegistry.rdf_representations_from(
-        Hyrax::ChildTypes.for(parent: parent.class).to_a
+        Hyrax::ChildTypes.for(parent: parent.hydra_model).to_a
       )
       child_type = Hyrax::ModelRegistry.rdf_representations_from([self.class.curation_concern_type]).first
       return if current_ability.can?(:edit, parent) && child_types.include?(child_type)
 
       reject_parent
-    rescue Valkyrie::Persistence::ObjectNotFoundError
+    rescue Blacklight::Exceptions::RecordNotFound, Valkyrie::Persistence::ObjectNotFoundError
       reject_parent
     end
 

--- a/app/presenters/hyku/deposit_wizard/presenter.rb
+++ b/app/presenters/hyku/deposit_wizard/presenter.rb
@@ -623,12 +623,14 @@ module Hyku
       # Empty for a parent the depositor cannot edit as well as one that cannot be
       # read, so a forged parent_id is refused rather than merely type-checked.
       # Adding a child mutates the parent's member_ids, hence edit rather than read.
+      # Read from Solr, not the persistence layer: only the parent's id and class
+      # are needed, and AddToParent loads the resource itself at commit.
       def child_types_for(parent_id)
-        parent = Hyrax.query_service.find_by(id: parent_id)
+        parent = ::SolrDocument.find(parent_id)
         return [] unless current_ability.can?(:edit, parent)
 
-        Hyrax::ChildTypes.for(parent: parent.class).to_a
-      rescue Valkyrie::Persistence::ObjectNotFoundError
+        Hyrax::ChildTypes.for(parent: parent.hydra_model).to_a
+      rescue Blacklight::Exceptions::RecordNotFound, Valkyrie::Persistence::ObjectNotFoundError
         []
       end
 

--- a/spec/controllers/hyrax/generic_works_controller_spec.rb
+++ b/spec/controllers/hyrax/generic_works_controller_spec.rb
@@ -39,6 +39,16 @@ RSpec.describe Hyrax::GenericWorksController do
       expect(response).not_to redirect_to(root_path)
     end
 
+    it 'does not load the parent resource to run the guard' do
+      editable = FactoryBot.valkyrie_create(:generic_work_resource, edit_users: [user])
+      allow(Hyrax.query_service).to receive(:find_by).and_call_original
+
+      post :create, params: { parent_id: editable.id.to_s,
+                              generic_work: { title: ['Counted child'] } }
+
+      expect(Hyrax.query_service).not_to have_received(:find_by).with(id: editable.id)
+    end
+
     context 'when the parent accepts no children' do
       before do
         @original = GenericWorkResource.valid_child_concerns

--- a/spec/presenters/hyku/deposit_wizard/presenter_spec.rb
+++ b/spec/presenters/hyku/deposit_wizard/presenter_spec.rb
@@ -74,6 +74,14 @@ RSpec.describe Hyku::DepositWizard::Presenter do
         expect(transition).to be_advance
         expect(presenter.state.parent_id).to eq(parent.id.to_s)
       end
+
+      it 'does not load the parent resource' do
+        parent # created before the spy, so the factory's own lookups aren't counted
+        allow(Hyrax.query_service).to receive(:find_by).and_call_original
+
+        expect(presenter.advance_from('select_parent')).to be_advance
+        expect(Hyrax.query_service).not_to have_received(:find_by).with(id: parent.id)
+      end
     end
 
     context 'when the chosen parent cannot contain children' do


### PR DESCRIPTION
## Summary
- Attaching a child work no longer reads its parent from the database twice.
- Refs samvera/hyku#3183

## Details
- Follow-up to Rob's review comment on #3183: the guard and `add_to_parent` were each loading the same parent.
- The guard only needs the parent's id (for the edit check) and its class (for the type check) — both already in Solr.
- Applied to both the standard deposit form guard and the deposit wizard's parent check, which shared the shape.
- Authorization is unchanged: `Hyrax::Ability::SolrDocumentAbility` runs the same `test_edit(id)` as the resource path.
- Both rescues catch the Solr *and* Valkyrie not-found errors, since `can?(:edit, …)` runs app-defined ability logic that may still query.
- A parent absent from Solr is now refused rather than accepted. It is indexed at creation and can only be reached through the index, so this is an inconsistent-index edge case, not a normal path.
