### PR TITLE
Update practice research content blocks

### DIFF
--- a/app/assets/stylesheets/themes/practice_research.scss
+++ b/app/assets/stylesheets/themes/practice_research.scss
@@ -13,7 +13,8 @@
   .pr-subject-chip:focus-visible,
   .pr-researcher-link:focus-visible,
   .pr-featured-save:focus-visible,
-  .pr-nav-share:focus-visible {
+  .pr-nav-share:focus-visible,
+  div#announcement a:focus-visible {
     @include pr-focus-ring;
   }
 
@@ -213,6 +214,37 @@
     letter-spacing: 0.12em;
     line-height: 1;
     text-transform: uppercase;
+  }
+
+  // ---- announcement ------------------------------------------------------
+
+  #announcement_text {
+    @include pr-container-inset;
+
+    background: color-mix(in srgb, var(--pr-accent, #f5c400) 16%, #fff);
+    border-bottom: 1px solid color-mix(in srgb, var(--pr-accent, #f5c400) 40%, #fff);
+    padding-block: 0.9375rem;
+  }
+
+  div#announcement {
+    background-color: transparent;
+    border: 0;
+    border-left: 3px solid var(--pr-accent, #f5c400);
+    border-radius: 0;
+    color: $pr-ink;
+    font-size: 1rem;
+    line-height: 1.5;
+    overflow-wrap: anywhere;
+    padding: 0.125rem 0 0.125rem 0.875rem;
+    text-align: left;
+
+    a {
+      color: color-mix(in srgb, var(--pr-link, #{$pr-brand-700}) 78%, #000);
+    }
+
+    p:last-child {
+      margin-bottom: 0;
+    }
   }
 
   // ---- section furniture -------------------------------------------------

--- a/app/assets/stylesheets/themes/practice_research.scss
+++ b/app/assets/stylesheets/themes/practice_research.scss
@@ -23,7 +23,8 @@
   .pr-hero-links a:focus-visible,
   .pr-about-cta:focus-visible,
   .pr-about-prose a:focus-visible,
-  .pr-about-terms:focus-visible {
+  .pr-about-terms:focus-visible,
+  .pr-stats-marketing a:focus-visible {
     @include pr-focus-ring(var(--pr-band-link, #8ed6cd));
   }
 
@@ -167,15 +168,19 @@
 
   .pr-stats {
     background: var(--pr-band-dark, #{$pr-brand-900});
+    border-top: 1px solid color-mix(in srgb, var(--pr-band-text, #ffffff) 14%, transparent);
   }
 
   .pr-stats-inner {
+    padding-bottom: 1.25rem;
+    padding-top: 1.25rem;
+  }
+
+  .pr-stats-counts {
     align-items: baseline;
     display: flex;
     flex-wrap: wrap;
     gap: 4rem;
-    padding-bottom: 1.25rem;
-    padding-top: 1.25rem;
   }
 
   .pr-stat {
@@ -184,6 +189,7 @@
 
   .pr-stat-link {
     align-items: baseline;
+    color: var(--pr-band-link, #8ed6cd);
     display: flex;
     gap: 0.625rem;
     text-decoration: none;
@@ -214,6 +220,68 @@
     letter-spacing: 0.12em;
     line-height: 1;
     text-transform: uppercase;
+  }
+
+  // ---- counts band with marketing text ------------------------------------
+
+  .pr-stats-split {
+    .pr-stats-inner {
+      column-gap: 4rem;
+      display: grid;
+      grid-template-columns: minmax(min-content, 11.875rem) 1fr;
+      padding-bottom: 3rem;
+      padding-top: 2.75rem;
+    }
+
+    .pr-stats-counts {
+      align-items: stretch;
+      flex-direction: column;
+      gap: 1.25rem;
+      min-width: 0;
+    }
+
+    .pr-stat-link {
+      align-items: flex-start;
+      flex-direction: column;
+      gap: 0.3125rem;
+    }
+
+    .pr-stat-number {
+      font-size: 2.25rem;
+    }
+
+    .pr-stat-key {
+      letter-spacing: 0.14em;
+    }
+  }
+
+  .pr-stats-marketing {
+    border-left: 2px solid var(--pr-accent, #f5c400);
+    color: var(--pr-band-text, #ffffff);
+    color: color-mix(in srgb, var(--pr-band-text, #ffffff) 80%, transparent);
+    font-family: var(--pr-serif, Georgia, 'Times New Roman', serif);
+    font-size: 1.125rem;
+    line-height: 1.75;
+    max-width: 43.75rem;
+    min-width: 0;
+    overflow-wrap: anywhere;
+    padding-left: 2rem;
+    text-wrap: pretty;
+
+    p,
+    div {
+      font-family: inherit;
+      font-size: inherit;
+      line-height: inherit;
+    }
+
+    a {
+      color: var(--pr-band-link, #8ed6cd);
+    }
+
+    > :last-child {
+      margin-bottom: 0;
+    }
   }
 
   // ---- announcement ------------------------------------------------------
@@ -862,12 +930,35 @@
       font-size: 1.0625rem;
     }
 
-    .pr-stats-inner {
+    .pr-stats-counts {
       gap: 3rem;
     }
 
     .pr-stat-number {
       font-size: 1.4375rem;
+    }
+
+    .pr-stats-split {
+      .pr-stats-inner {
+        column-gap: 3.25rem;
+        grid-template-columns: minmax(min-content, 10.625rem) 1fr;
+        padding-bottom: 2.75rem;
+        padding-top: 2.5rem;
+      }
+
+      .pr-stats-counts {
+        gap: 1.125rem;
+      }
+
+      .pr-stat-number {
+        font-size: 2rem;
+      }
+    }
+
+    .pr-stats-marketing {
+      font-size: 1.0625rem;
+      max-width: 40rem;
+      padding-left: 1.75rem;
     }
 
     .pr-hero-eyebrow {
@@ -1033,12 +1124,39 @@
       max-width: none;
     }
 
-    .pr-stats-inner {
+    .pr-stats-counts {
       gap: 2rem;
     }
 
     .pr-stat-number {
       font-size: 1.3125rem;
+    }
+
+    .pr-stats-split {
+      .pr-stats-inner {
+        column-gap: 2.25rem;
+        grid-template-columns: minmax(min-content, 8.125rem) 1fr;
+        padding-bottom: 2.375rem;
+        padding-top: 2.125rem;
+      }
+
+      .pr-stats-counts {
+        gap: 1rem;
+      }
+
+      .pr-stat-number {
+        font-size: 1.75rem;
+      }
+
+      .pr-stat-key {
+        font-size: 0.625rem;
+      }
+    }
+
+    .pr-stats-marketing {
+      font-size: 1rem;
+      max-width: none;
+      padding-left: 1.5rem;
     }
 
     .pr-hero-search-submit,
@@ -1184,13 +1302,48 @@
       gap: 0.5rem;
     }
 
-    .pr-stats-inner {
+    .pr-stats-counts {
       flex-direction: column;
       gap: 0.4375rem;
     }
 
     .pr-stat-number {
       font-size: 1.1875rem;
+    }
+
+    .pr-stats-split {
+      .pr-stats-inner {
+        display: flex;
+        flex-direction: column;
+        gap: 1.125rem;
+        padding-bottom: 1.875rem;
+        padding-top: 1.625rem;
+      }
+
+      .pr-stats-counts {
+        align-items: baseline;
+        flex-direction: row;
+        gap: 1.625rem;
+      }
+
+      .pr-stat-link {
+        align-items: baseline;
+        flex-direction: row;
+        gap: 0.5rem;
+      }
+
+      .pr-stat-number {
+        font-size: 1.5rem;
+      }
+
+      .pr-stat-key {
+        font-size: 0.625rem;
+      }
+    }
+
+    .pr-stats-marketing {
+      line-height: 1.7;
+      padding-left: 1.125rem;
     }
 
     .pr-hero-eyebrow {

--- a/app/assets/stylesheets/themes/practice_research.scss
+++ b/app/assets/stylesheets/themes/practice_research.scss
@@ -24,7 +24,7 @@
   .pr-about-cta:focus-visible,
   .pr-about-prose a:focus-visible,
   .pr-about-terms:focus-visible,
-  .pr-stats-marketing a:focus-visible {
+  .pr-stats-intro a:focus-visible {
     @include pr-focus-ring(var(--pr-band-link, #8ed6cd));
   }
 
@@ -222,7 +222,7 @@
     text-transform: uppercase;
   }
 
-  // ---- counts band with marketing text ------------------------------------
+  // ---- counts band with home page text -----------------------------------
 
   .pr-stats-split {
     .pr-stats-inner {
@@ -255,7 +255,7 @@
     }
   }
 
-  .pr-stats-marketing {
+  .pr-stats-intro {
     border-left: 2px solid var(--pr-accent, #f5c400);
     color: var(--pr-band-text, #ffffff);
     color: color-mix(in srgb, var(--pr-band-text, #ffffff) 80%, transparent);
@@ -955,7 +955,7 @@
       }
     }
 
-    .pr-stats-marketing {
+    .pr-stats-intro {
       font-size: 1.0625rem;
       max-width: 40rem;
       padding-left: 1.75rem;
@@ -1153,7 +1153,7 @@
       }
     }
 
-    .pr-stats-marketing {
+    .pr-stats-intro {
       font-size: 1rem;
       max-width: none;
       padding-left: 1.5rem;
@@ -1341,7 +1341,7 @@
       }
     }
 
-    .pr-stats-marketing {
+    .pr-stats-intro {
       line-height: 1.7;
       padding-left: 1.125rem;
     }

--- a/app/assets/stylesheets/themes/practice_research/_shell.scss
+++ b/app/assets/stylesheets/themes/practice_research/_shell.scss
@@ -155,6 +155,7 @@ body.practice_research_show {
 @mixin pr-shell-gutter($gutter) {
   #masthead,
   nav[aria-label='Root Menu'],
+  #announcement_text,
   footer.navbar {
     padding-left: $gutter !important;
     padding-right: $gutter !important;

--- a/app/views/themes/practice_research/hyrax/homepage/_hero.html.erb
+++ b/app/views/themes/practice_research/hyrax/homepage/_hero.html.erb
@@ -2,8 +2,8 @@
   <div class="container pr-hero-inner">
     <p class="pr-hero-eyebrow"><%= application_name %></p>
 
-    <% if @home_text&.value.present? %>
-      <div class="pr-hero-intro"><%= displayable_content_block @home_text %></div>
+    <% if display_content_block? @marketing_text %>
+      <div class="pr-hero-intro"><%= displayable_content_block @marketing_text %></div>
     <% else %>
       <h1 class="pr-hero-title"><%= t('practice_research.homepage.hero.title') %></h1>
       <p class="pr-hero-lede"><%= t('practice_research.homepage.hero.lede') %></p>

--- a/app/views/themes/practice_research/hyrax/homepage/_stats.html.erb
+++ b/app/views/themes/practice_research/hyrax/homepage/_stats.html.erb
@@ -1,8 +1,8 @@
 <% counts = pr_home.counts.reject { |_key, count| count.to_i.zero? } %>
-<% marketing = display_content_block? @marketing_text %>
+<% intro = display_content_block? @home_text %>
 
-<% if counts.any? || marketing %>
-  <div class="<%= class_names('pr-stats', 'pr-stats-split' => marketing && counts.any?) %>">
+<% if counts.any? || intro %>
+  <div class="<%= class_names('pr-stats', 'pr-stats-split' => intro && counts.any?) %>">
     <div class="container pr-stats-inner">
       <% if counts.any? %>
         <div class="pr-stats-counts">
@@ -18,7 +18,7 @@
           <% end %>
         </div>
       <% end %>
-      <%= displayable_content_block @marketing_text, class: 'pr-stats-marketing' %>
+      <%= displayable_content_block @home_text, class: 'pr-stats-intro' %>
     </div>
   </div>
 <% end %>

--- a/app/views/themes/practice_research/hyrax/homepage/_stats.html.erb
+++ b/app/views/themes/practice_research/hyrax/homepage/_stats.html.erb
@@ -1,18 +1,24 @@
 <% counts = pr_home.counts.reject { |_key, count| count.to_i.zero? } %>
+<% marketing = display_content_block? @marketing_text %>
 
-<% if counts.any? %>
-  <div class="pr-stats">
+<% if counts.any? || marketing %>
+  <div class="<%= class_names('pr-stats', 'pr-stats-split' => marketing && counts.any?) %>">
     <div class="container pr-stats-inner">
-      <% paths = { works: main_app.search_catalog_path,
-                   collections: main_app.search_catalog_path(f: { generic_type_sim: ['Collection'] }) } %>
-      <% counts.each do |key, count| %>
-        <p class="pr-stat">
-          <%= link_to paths[key], class: 'pr-stat-link' do %>
-            <span class="pr-stat-number"><%= number_with_delimiter(count) %></span>
-            <span class="pr-stat-key"><%= t("practice_research.homepage.stats.#{key}", count: count) %></span>
+      <% if counts.any? %>
+        <div class="pr-stats-counts">
+          <% paths = { works: main_app.search_catalog_path,
+                       collections: main_app.search_catalog_path(f: { generic_type_sim: ['Collection'] }) } %>
+          <% counts.each do |key, count| %>
+            <p class="pr-stat">
+              <%= link_to paths[key], class: 'pr-stat-link' do %>
+                <span class="pr-stat-number"><%= number_with_delimiter(count) %></span>
+                <span class="pr-stat-key"><%= t("practice_research.homepage.stats.#{key}", count: count) %></span>
+              <% end %>
+            </p>
           <% end %>
-        </p>
+        </div>
       <% end %>
+      <%= displayable_content_block @marketing_text, class: 'pr-stats-marketing' %>
     </div>
   </div>
 <% end %>

--- a/app/views/themes/practice_research/layouts/homepage.html.erb
+++ b/app/views/themes/practice_research/layouts/homepage.html.erb
@@ -1,15 +1,12 @@
 <% content_for(:navbar) do %>
   <%= render '/controls' %>
   <% if controller_name == 'homepage' %>
-    <header>
+    <%= render 'hyrax/homepage/announcement' %>
+    <section aria-label="<%= t('practice_research.homepage.intro_label') %>">
       <%= render 'hyrax/homepage/hero' %>
       <%= render 'hyrax/homepage/stats' %>
-    </header>
+    </section>
   <% end %>
-<% end %>
-
-<% content_for(:precontainer_content) do %>
-  <%= render 'hyrax/homepage/announcement' if controller_name == 'homepage' %>
 <% end %>
 
 <%= render template: 'layouts/hyrax' %>

--- a/config/home_themes.yml
+++ b/config/home_themes.yml
@@ -50,6 +50,6 @@ practice_research:
   banner_image: true
   featured_researcher: true
   home_page_text: true
-  marketing_text: false
+  marketing_text: true
   name: Practice Research
-  notes: A search-led hero over the banner image, a counts band, featured collections and works, browse by work type and subject, recently uploaded, a featured researcher, and an about band. The accent rides the primary button colors, the dark bands ride the header and footer background, and links carry the brand.
+  notes: A search-led hero over the banner image, a counts band that carries the marketing text beside the counts, featured collections and works, browse by work type and subject, recently uploaded, a featured researcher, and an about band. The accent rides the primary button colors, the dark bands ride the header and footer background, and links carry the brand.

--- a/config/home_themes.yml
+++ b/config/home_themes.yml
@@ -52,4 +52,4 @@ practice_research:
   home_page_text: true
   marketing_text: true
   name: Practice Research
-  notes: A search-led hero over the banner image, a counts band that carries the marketing text beside the counts, featured collections and works, browse by work type and subject, recently uploaded, a featured researcher, and an about band. The accent rides the primary button colors, the dark bands ride the header and footer background, and links carry the brand.
+  notes: A search-led hero over the banner image whose intro copy comes from the marketing text, a counts band that carries the home page text beside the counts, featured collections and works, browse by work type and subject, recently uploaded, a featured researcher, and an about band. The accent rides the primary button colors, the dark bands ride the header and footer background, and links carry the brand.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -569,6 +569,7 @@ en:
         contributors_and_others:
           one: "%{names} and 1 other"
           other: "%{names} and %{count} others"
+      intro_label: Repository overview
       stats:
         works:
           one: work


### PR DESCRIPTION
<img width="1705" height="1027" alt="image" src="https://github.com/user-attachments/assets/82f3d353-6017-4dcc-a667-28b36755be8b" />

## 💄 Style and move announcement block

714efb70ba20688e5a4285695692693d50310b12

This commit will style the announcement block to look more like the rest
of the homepage theme and also move it towards the top.

## 💄 Add and style marketing text

29d76f84998816ba389f0392c5751d57ebad11c0

Initial practice research theme did not include the marketing text but
this commit will add it so users can set it.

## 🧹 Swap marketing text and home page text

b7330c4fe42b94c6296b58333c638a64cb72ab6b

Previously, I had the marketing text and the home page text reversed.
This commit will correctly swap them.
