### PR TITLE
Fixes for enact overrides

### DIFF
--- a/app/assets/javascripts/hyrax/deposit_wizard.js
+++ b/app/assets/javascripts/hyrax/deposit_wizard.js
@@ -23,15 +23,19 @@
       uploadTemplateId: 'deposit-wizard-template-upload',
       downloadTemplateId: 'deposit-wizard-template-download'
     });
-    guardNextWhileUploading(uploader);
+    guardLeavingWhileUploading(uploader);
   }
 
   // The uploaded_files[] hidden input is written only by the download template,
-  // which the plugin swaps in on completion — so advancing mid-upload posts
+  // which the plugin swaps in on completion — so leaving mid-upload posts
   // without the in-flight ids and silently drops those files.
-  function guardNextWhileUploading(uploader) {
-    var next = $('[data-behavior="files-next"]');
-    if (!next.length) return;
+  //
+  // Back is guarded too: it submits the same form, and the guard below binds to
+  // the form's submit rather than to either button, so an enabled Back would look
+  // live while its clicks were silently swallowed.
+  function guardLeavingWhileUploading(uploader) {
+    var leave = $('[data-behavior="files-next"], [data-behavior="back-submit"]');
+    if (!leave.length) return;
     // Tracked per file rather than as a counter so the settle events can overlap
     // without double-counting: an aborted upload fires both 'fail' and 'finished'.
     var pending = [];
@@ -42,20 +46,21 @@
         var at = pending.indexOf(files[i]);
         if (at !== -1) pending.splice(at, 1);
       }
-      next.prop('disabled', pending.length > 0);
+      leave.prop('disabled', pending.length > 0);
     }
 
     uploader.on('fileuploadadded', function (e, data) {
       pending = pending.concat((data && data.files) || []);
-      next.prop('disabled', pending.length > 0);
+      leave.prop('disabled', pending.length > 0);
       // No explicit return: the plugin cancels the upload when an 'added'
       // handler returns false.
     });
 
     // 'finished' covers success and a mid-flight abort, but a file cancelled before
     // it is ever sent has no data.abort, so the plugin fires 'fail' alone — without
-    // that second binding Next would stay disabled until a reload. ('completed'
-    // alone, as Hyrax's save_work/uploaded_files.es6 counts, misses both.)
+    // that second binding the buttons would stay disabled until a reload.
+    // ('completed' alone, as Hyrax's save_work/uploaded_files.es6 counts, misses
+    // both.)
     uploader.on('fileuploadfinished fileuploadfail', function (e, data) {
       settle(data);
     });

--- a/app/assets/stylesheets/deposit_wizard/_choices.scss
+++ b/app/assets/stylesheets/deposit_wizard/_choices.scss
@@ -9,6 +9,18 @@
     margin-bottom: 1.5rem;
   }
 
+  // The paths are a fixed set (at most a container lead plus two), not a
+  // variable-length list like __type-cards, so pin the columns. Under auto-fit
+  // three paths resolve to three columns and the two cards below the full-width
+  // lead fill only two of them, leaving a gap.
+  &__paths {
+    grid-template-columns: repeat(2, 1fr);
+
+    @media (max-width: 33rem) {
+      grid-template-columns: 1fr;
+    }
+  }
+
   // The container path creates the thing the other paths deposit into, so it
   // leads the group across the full width rather than sitting beside them.
   &__path-card--container {

--- a/app/presenters/hyku/deposit_wizard/presenter.rb
+++ b/app/presenters/hyku/deposit_wizard/presenter.rb
@@ -156,7 +156,13 @@ module Hyku
         # Prefer the registered service (it may add behavior); fall back to a bare
         # authority lookup so a profile source with no registry entry still labels.
         registered = Hyrax::ControlledVocabularies.services[source]&.safe_constantize
-        registered ? registered.new : Hyrax::TolerantSelectService.new(source)
+        return Hyrax::TolerantSelectService.new(source) unless registered
+
+        # Two service styles exist: a class (Hyrax::LicenseService) and a module
+        # extending AuthorityService (Hyrax::ResourceTypesService), whose `label` is
+        # a module method. Calling `.new` on the module raises, the rescue below
+        # swallows it, and the value renders as the stored id.
+        registered.respond_to?(:new) ? registered.new : registered
       rescue StandardError => e
         Hyrax.logger.debug("Deposit wizard: no label service for #{term} (#{source}): #{e.message}")
         nil

--- a/app/presenters/hyku/deposit_wizard/presenter.rb
+++ b/app/presenters/hyku/deposit_wizard/presenter.rb
@@ -646,11 +646,16 @@ module Hyku
         Transition.rerender(step, alert: 'hyku.deposit_wizard.errors.no_work_type')
       end
 
+      # The save is unconditional, as on the metadata steps: the ids are the only
+      # record of the uploads, so leaving without posting them orphans the files --
+      # invisible to the uploader, to commit, and to the discard cleanup.
       def advance_from_files
         # `uploaded_files[]` is emitted by Hyrax's upload js_templates for each
         # completed upload, matching the param name stock deposit uses.
         state.uploaded_file_ids = params[:uploaded_files]
         state.primary_file_id = params[:primary_file_id]
+        return Transition.advance(back_step('files')) if going_back?
+
         Transition.advance(next_step('files'))
       end
 
@@ -681,8 +686,8 @@ module Hyku
         state.attributes = preserved_launch_extras.merge(work_params.to_unsafe_h)
       end
 
-      # Set by the metadata steps' Back button, which submits the form (saving what
-      # was entered) instead of linking away.
+      # Set by the Back button on steps that submit the form (saving what was
+      # entered) instead of linking away: files, details, file_meta.
       def going_back?
         params[:direction].to_s == 'back'
       end

--- a/app/views/hyrax/deposit_wizard/_nav.html.erb
+++ b/app/views/hyrax/deposit_wizard/_nav.html.erb
@@ -27,8 +27,11 @@
     <% if back_submit %>
       <%# formnovalidate: simple_form emits HTML5 `required`, and the browser blocks
           ANY submit on an invalid form — including this one, whose whole purpose is
-          leaving a half-filled one. %>
+          leaving a half-filled one.
+          data-behavior marks this variant only: `disabled` is inert on the link
+          below, so the files step's upload guard must not match it. %>
       <%= button_tag(type: 'submit', name: 'direction', value: 'back', formnovalidate: true,
+                     data: { behavior: 'back-submit' },
                      class: 'btn btn-secondary deposit-wizard__back-btn') do %>
         <span class="fa fa-arrow-left" aria-hidden="true"></span> <%= t('hyku.deposit_wizard.back') %>
       <% end %>

--- a/app/views/hyrax/deposit_wizard/files.html.erb
+++ b/app/views/hyrax/deposit_wizard/files.html.erb
@@ -8,6 +8,7 @@
     <%= render 'file_uploader' %>
 
     <%= render 'nav', back_path: wizard_back_path('files'),
+                      back_submit: true,
                       next_html: { data: { behavior: 'files-next' } } %>
   <% end %>
 </div>

--- a/app/views/hyrax/deposit_wizard/start.html.erb
+++ b/app/views/hyrax/deposit_wizard/start.html.erb
@@ -18,8 +18,6 @@
                          class: "deposit-wizard__path-card #{'deposit-wizard__path-card--container' if container_path}".strip do %>
             <% icon = t("hyku.deposit_wizard.start.paths.#{path}.icon", default: nil) %>
             <% if icon.present? %>
-              <%# The `fa` family class is added here, as in _stepper, so the locale
-                  supplies a bare icon name. %>
               <span class="deposit-wizard__path-icon fa <%= icon %>" aria-hidden="true"></span>
             <% end %>
             <span class="deposit-wizard__path-title"><%= t("hyku.deposit_wizard.start.paths.#{path}.title") %></span>

--- a/app/views/hyrax/deposit_wizard/start.html.erb
+++ b/app/views/hyrax/deposit_wizard/start.html.erb
@@ -18,7 +18,9 @@
                          class: "deposit-wizard__path-card #{'deposit-wizard__path-card--container' if container_path}".strip do %>
             <% icon = t("hyku.deposit_wizard.start.paths.#{path}.icon", default: nil) %>
             <% if icon.present? %>
-              <span class="deposit-wizard__path-icon <%= icon %>" aria-hidden="true"></span>
+              <%# The `fa` family class is added here, as in _stepper, so the locale
+                  supplies a bare icon name. %>
+              <span class="deposit-wizard__path-icon fa <%= icon %>" aria-hidden="true"></span>
             <% end %>
             <span class="deposit-wizard__path-title"><%= t("hyku.deposit_wizard.start.paths.#{path}.title") %></span>
             <span class="deposit-wizard__path-desc"><%= t("hyku.deposit_wizard.start.paths.#{path}.desc") %></span>

--- a/docs/deposit-wizard.md
+++ b/docs/deposit-wizard.md
@@ -475,10 +475,10 @@ rebrand by overriding the tokens without touching the baseline.
 The start-screen path cards (new / add / standalone) render an optional icon
 above their label, read from an i18n key — mirroring how the work-type cards
 resolve their icon (`Hyrax::ModelIcon` → `hyrax.icons.*`). No icon shows unless the
-key is set, so vanilla installs are unaffected. A consuming app supplies the full
-CSS class string per path under `hyku.deposit_wizard.start.paths.<path>.icon` (the
-value is used verbatim, so include every class the icon needs — e.g. both `fa` and
-`fa-cube` for Font Awesome 4, or whatever your icon set requires):
+key is set, so vanilla installs are unaffected. A consuming app supplies the icon
+name per path under `hyku.deposit_wizard.start.paths.<path>.icon`. The view adds
+the `fa` family class itself (as `_stepper` does), so the value is the bare icon
+name — including `fa` here renders `fa fa fa-cube` and no glyph:
 
 ```yaml
 en:
@@ -487,11 +487,11 @@ en:
       start:
         paths:
           new:
-            icon: fa fa-cube
+            icon: fa-cube
           add:
-            icon: fa fa-sitemap
+            icon: fa-sitemap
           standalone:
-            icon: fa fa-file-o
+            icon: fa-file-o
 ```
 
 ## JavaScript hooks

--- a/docs/deposit-wizard.md
+++ b/docs/deposit-wizard.md
@@ -175,10 +175,12 @@ Each `Step` declares its own rules; the navigator computes the rest:
   is never a prerequisite.
 - **Back** is the previous visible step (`Flow#back_before`), so views never name
   their predecessor. **Forward** is the next visible step (`Flow#next_after`).
-  On the metadata steps (`details`, `file_meta`) Back submits the form rather than
-  linking, so what was typed is saved on the way out; those steps save
-  unconditionally and validate only to decide whether to advance. The browser's own
-  back button bypasses this, so entries abandoned that way are still lost.
+  On the steps carrying depositor input (`files`, `details`, `file_meta`) Back
+  submits the form rather than linking, so what was entered is saved on the way
+  out; those steps save unconditionally and validate only to decide whether to
+  advance. On `files` that save is what keeps an upload from being orphaned: the
+  id only reaches the session by being posted. The browser's own back button
+  bypasses this, so entries abandoned that way are still lost.
 - **Detours** (`Flow#detour_for`) replace the old per-step redirect rules.
 
 | Step | Purpose | Shown when |
@@ -504,5 +506,11 @@ exactly as on the stock form.
 
 Three steps gate their Next button on a `data-behavior` hook: `files-next` stays
 disabled while uploads are in flight (the uploaded-file ids only reach the form as
-each upload completes, so advancing early would drop them), and `parent-next` /
+each upload completes, so leaving early would drop them), and `parent-next` /
 `type-next` stay disabled until a parent or work type is chosen.
+
+On the files step the submitting Back button (`back-submit`) is disabled by that
+same guard. Both directions post the form, and the guard is bound to the form's
+submit rather than to either button, so leaving Back enabled would show a live
+button whose clicks are silently swallowed. The hook marks only the submitting
+variant — `disabled` is inert on the plain-link Back the other steps render.

--- a/spec/presenters/hyku/deposit_wizard/presenter_spec.rb
+++ b/spec/presenters/hyku/deposit_wizard/presenter_spec.rb
@@ -209,4 +209,65 @@ RSpec.describe Hyku::DepositWizard::Presenter do
       expect(presenter.file_type_label(uf)).to eq(I18n.t('hyku.deposit_wizard.file_meta.file'))
     end
   end
+
+  # Hyrax registers controlled vocabularies as two different kinds of object, and
+  # the review step has to label values through both: most (audience, discipline,
+  # resource_types, ...) are modules extending AuthorityService whose `label` is a
+  # module method, while licenses and rights_statements are classes to instantiate.
+  describe '#review_display_values' do
+    let(:context) do
+      double(session: session, current_user: nil, current_ability: nil,
+             params: params, main_app: nil, blacklight_config: nil, helpers: helpers)
+    end
+    let(:helpers) { double }
+
+    before { allow(helpers).to receive(:controlled_vocabulary_source_for).with(:a_term).and_return(source) }
+
+    # Asserted on the resolved service rather than through the returned labels:
+    # every module-backed vocabulary Hyrax ships labels its ids with themselves
+    # ("Article" => "Article"), so a label comparison passes even when the service
+    # failed to resolve and the raw value was echoed instead.
+    context 'when the registered service is a module' do
+      let(:source) { 'resource_types' }
+
+      it 'uses the module itself rather than instantiating it' do
+        expect(presenter.controlled_service_for(:a_term)).to be(Hyrax::ResourceTypesService)
+      end
+
+      it 'labels a value through it' do
+        expect(presenter.review_display_values(:a_term, ['Article'])).to eq(['Article'])
+      end
+    end
+
+    context 'when the registered service is a class' do
+      let(:source) { 'licenses' }
+
+      it 'instantiates it' do
+        expect(presenter.controlled_service_for(:a_term)).to be_a(Hyrax::LicenseService)
+      end
+
+      it 'labels a value through the instance' do
+        value = Hyrax::LicenseService.new.select_all_options.first.last
+
+        expect(presenter.review_display_values(:a_term, [value]))
+          .to eq([Hyrax::LicenseService.new.label(value)])
+      end
+    end
+
+    context 'when the profile names a source with no registry entry' do
+      let(:source) { 'not_registered_anywhere' }
+
+      it 'falls back to a tolerant lookup and echoes the stored value' do
+        expect(presenter.review_display_values(:a_term, ['unmatched'])).to eq(['unmatched'])
+      end
+    end
+
+    context 'when the property is not controlled' do
+      let(:source) { nil }
+
+      it 'returns the values untouched' do
+        expect(presenter.review_display_values(:a_term, %w[one two])).to eq(%w[one two])
+      end
+    end
+  end
 end

--- a/spec/requests/deposit_wizard_spec.rb
+++ b/spec/requests/deposit_wizard_spec.rb
@@ -528,6 +528,46 @@ RSpec.describe 'Deposit wizard', type: :request, singletenant: true, clean: true
           expect(session[:deposit_wizard]['primary_file_id']).to eq('7')
           expect(response).to redirect_to(deposit_wizard_step_path(step: 'details'))
         end
+
+        it 'keeps the uploads and steps back when Back is submitted' do
+          patch deposit_wizard_advance_path(step: 'files'),
+                params: { direction: 'back', uploaded_files: %w[3 7], primary_file_id: '7' }
+
+          expect(response).to redirect_to(deposit_wizard_step_path(step: 'known_type'))
+          expect(session[:deposit_wizard]['uploaded_file_ids']).to eq(%w[3 7])
+          expect(session[:deposit_wizard]['primary_file_id']).to eq('7')
+        end
+
+        it 'still lists a file uploaded before Back when the step is revisited' do
+          upload = FactoryBot.create(:uploaded_file, user: admin)
+          # Follow the Back button all the way: the redirect must land on the
+          # previous step, not advance past it, or this asserts the wrong journey.
+          patch deposit_wizard_advance_path(step: 'files'),
+                params: { direction: 'back', uploaded_files: [upload.id.to_s] }
+          expect(response).to redirect_to(deposit_wizard_step_path(step: 'known_type'))
+
+          get deposit_wizard_step_path(step: 'files')
+
+          expect(response).to have_http_status(:success)
+          # The uploader's own seed row, not merely the id appearing somewhere.
+          expect(response.body).to match(
+            /<input[^>]*name="uploaded_files\[\]"[^>]*value="#{upload.id}"/
+          )
+        end
+
+        it 'renders Back as a submit button so uploads post on the way out' do
+          get deposit_wizard_step_path(step: 'files')
+
+          expect(response.body).to match(
+            /<button[^>]*name="direction"[^>]*value="back"[^>]*formnovalidate/
+          )
+        end
+
+        it 'marks the Back button so uploads in flight can block leaving' do
+          get deposit_wizard_step_path(step: 'files')
+
+          expect(response.body).to include('data-behavior="back-submit"')
+        end
       end
     end
 


### PR DESCRIPTION
## Summary
Fixes three bugs in the guided deposit wizard: files uploaded before pressing Back were silently lost, most controlled-vocabulary values showed raw ids instead of labels on the review screen, and the start screen's path cards had a lopsided layout with missing icons.

Ref https://github.com/research-technologies/enact_knapsack/pull/183

## Details
- Back on the files step now submits the form. The uploaded-file ids reach the session only by being posted, so a plain-link Back orphaned any file added during that visit — invisible to the uploader, uncounted at commit, and missed by the discard cleanup.
- Both Back and Next are disabled while an upload is in flight. The guard binds to the form's submit, not to either button, so Back was already blocked but stayed visually live.
- The review step labels values from module-backed vocabularies, not just the two backed by a class. Eight of the ten registered services were affected.
- Start-screen path cards use a fixed two-column grid, and their icons get the `fa` family class from the view.
- **Breaking for apps setting path-card icons:** the `start.paths.*.icon` locale value is now the bare icon name (`fa-cube`), not the full class string (`fa fa-cube`). Docs updated.

## Testing
- Enable `enable_guided_deposit`, start a guided deposit, and upload a file. Press Back, then return to the files step — the file should still be listed, and should attach to the finished work.
- While an upload is in progress, confirm both Back and Next are disabled, and that both re-enable after the upload finishes and after a failed upload.
- On the review step, confirm controlled-vocabulary fields (resource type, audience, discipline) show labels rather than raw ids.
- On the start screen, confirm the path cards sit in an even grid and their icons render.

## Notes

