### PR TITLE
Size DB connection pool per-role via DB_POOL, not a flat 50

### DIFF
--- a/bin/web
+++ b/bin/web
@@ -7,4 +7,28 @@
 `mkdir -p /app/samvera/branding`
 `ln -snf /app/samvera/branding /app/samvera/hyrax-webapp/public/branding`
 
+# Size the DB connection pool to this process's own concurrency (Puma
+# threads), not a flat guess — avoids self-inflicted pool contention and
+# keeps this web role's worst-case connection footprint predictable
+# against a shared Postgres instance's max_connections. See bin/worker
+# for the job-runner-side equivalent.
+#
+# database.yml's pool: reads DB_POOL, but if you're deploying with the
+# Hyrax Helm chart, DATABASE_URL's own ?pool= (when present) wins over
+# that — the chart bakes in a hardcoded pool=5 unless dbPoolInUrl is set
+# to false there. Rather than rewriting the URL's pool= to match DB_POOL
+# (two calculations that have to be kept in sync by hand), strip it
+# entirely so database.yml's DB_POOL is the one and only place pool
+# size is ever specified, regardless of chart version.
+require 'uri'
+ENV['DB_POOL'] ||= (ENV.fetch('RAILS_MAX_THREADS', 5).to_i + 2).to_s
+if ENV['DATABASE_URL']
+  uri = URI.parse(ENV['DATABASE_URL'])
+  if uri.query
+    remaining = URI.decode_www_form(uri.query).reject { |k, _| k == 'pool' }
+    uri.query = remaining.empty? ? nil : URI.encode_www_form(remaining)
+    ENV['DATABASE_URL'] = uri.to_s
+  end
+end
+
 exec "bundle exec puma -v -b tcp://0.0.0.0:3000"

--- a/bin/worker
+++ b/bin/worker
@@ -2,13 +2,36 @@
 # frozen_string_literal: true
 `echo "$GOOGLE_OAUTH_PRIVATE_KEY_VALUE" | base64 -d > prod-cred.p12` unless ENV['GOOGLE_OAUTH_PRIVATE_KEY_VALUE'].to_s.strip.empty?
 
-if ENV['DATABASE_URL'].to_s.strip.empty?
-  puts 'DATABASE_URL not set, no pool change needed'
-else
-  ENV['DATABASE_URL'] = ENV['DATABASE_URL'].gsub('pool=5', 'pool=30')
-end
-
 queue = ENV.fetch('HYRAX_ACTIVE_JOB_QUEUE', 'sidekiq')
+
+# Size the DB connection pool to this process's own concurrency (job
+# runner threads), not a flat guess — avoids self-inflicted pool
+# contention and keeps this worker role's worst-case connection
+# footprint predictable against a shared Postgres instance's
+# max_connections. See bin/web for the Puma-side equivalent.
+#
+# database.yml's pool: reads DB_POOL, but if you're deploying with the
+# Hyrax Helm chart, DATABASE_URL's own ?pool= (when present) wins over
+# that — the chart bakes in a hardcoded pool=5 unless dbPoolInUrl is set
+# to false there. Rather than rewriting the URL's pool= to match DB_POOL
+# (two calculations that have to be kept in sync by hand), strip it
+# entirely so database.yml's DB_POOL is the one and only place pool
+# size is ever specified, regardless of chart version.
+# (Previously this rewrote the URL's "pool=5" substring to "pool=30" —
+# a flat guess untied to either queue backend's actual thread count.)
+require 'uri'
+ENV['DB_POOL'] ||= case queue
+                    when 'good_job' then (ENV.fetch('GOOD_JOB_MAX_THREADS', 5).to_i + 2).to_s
+                    else (ENV.fetch('SIDEKIQ_CONCURRENCY', 10).to_i + 2).to_s
+                    end
+if ENV['DATABASE_URL']
+  uri = URI.parse(ENV['DATABASE_URL'])
+  if uri.query
+    remaining = URI.decode_www_form(uri.query).reject { |k, _| k == 'pool' }
+    uri.query = remaining.empty? ? nil : URI.encode_www_form(remaining)
+    ENV['DATABASE_URL'] = uri.to_s
+  end
+end
 case queue
 when 'sidekiq'
   exec "echo $DATABASE_URL && bundle exec sidekiq"

--- a/config/database.yml
+++ b/config/database.yml
@@ -7,7 +7,13 @@ login: &login
   username: <%= ENV['DB_USER'] %>
   password: <%= ENV['DB_PASSWORD'] %>
   database: <%= ENV['DB_NAME'] || 'hyku' %>
-  pool: 50
+  # Size this to your process's own thread concurrency (e.g. Puma's
+  # RAILS_MAX_THREADS, or a job runner's own thread count) via DB_POOL —
+  # not a flat guess. If you're deploying with the Hyrax Helm chart and
+  # DATABASE_URL is set, its own ?pool= param (when present) overrides
+  # this value entirely; set dbPoolInUrl: false in the chart's values (or
+  # omit ?pool= from DATABASE_URL yourself) so this setting is authoritative.
+  pool: <%= ENV.fetch('DB_POOL', 10).to_i %>
   timeout: 5000
   prepared_statements: <%= ENV.fetch('DB_PREPARED_STATEMENTS', true) %>
   advisory_locks: <%= ENV.fetch('DB_ADVISORY_LOCKS', true) %>


### PR DESCRIPTION
## Summary
- `config/database.yml` hardcoded `pool: 50` for every process, regardless of role or thread count.
- Deployments using the Hyrax Helm chart also get `DATABASE_URL` with a hardcoded `?pool=5` baked in, and ActiveRecord treats `DATABASE_URL`'s `?pool=` as authoritative over `database.yml`'s `pool:` whenever it's present — so `database.yml`'s setting was silently dead code for any chart-based deployment, regardless of what it said.
- We hit this directly on a downstream app: `RAILS_MAX_THREADS=12` (Puma) but the app was still only ever opening 5 real DB connections per pod, causing `ActiveRecord::ConnectionTimeoutError` under load well before the database itself had a real capacity problem.

## Change
- `bin/web` now sets `DB_POOL` from `RAILS_MAX_THREADS` (+2 headroom) before exec'ing Puma.
- `bin/worker` now sets `DB_POOL` from whichever queue backend is active — `GOOD_JOB_MAX_THREADS` for GoodJob, `SIDEKIQ_CONCURRENCY` for Sidekiq (+2 headroom either way) — replacing its previous hardcoded `pool=5` → `pool=30` rewrite, which was a flat guess untied to either backend's actual thread count.
- Both entrypoints strip any `?pool=` param from `DATABASE_URL` (via `URI`, so it's safe regardless of what other query params are present) rather than rewriting it to match `DB_POOL`. Pool size should be calculated once and live in exactly one place; mirroring it into a second place (the URL) is the same shape of bug that caused this issue — two sources of truth that can silently drift out of sync.
- `config/database.yml`'s `pool:` now reads `ENV.fetch('DB_POOL', 10).to_i`.

## Companion chart change
[samvera/hyrax#7585](https://github.com/samvera/hyrax/pull/7585) adds a `dbPoolInUrl` chart value (opt-in, defaults to `true`/unchanged behavior) so `DATABASE_URL` can omit `?pool=` at the source. Until an app is deployed on a chart version that has it, these entrypoints strip the param locally regardless of what's baked in — so this works today independent of that PR's timeline.

## Test plan
- [x] `ruby -c bin/web` / `ruby -c bin/worker` — syntax OK
- [x] Verified the `URI`-based strip logic against both a single-param (`?pool=5`) and multi-param (`?pool=5&sslmode=require`) URL
- [ ] Deploy and confirm `DATABASE_URL`/`DB_POOL` resolve as expected per role

🤖 Generated with [Claude Code](https://claude.com/claude-code)