### PR TITLE
Size DB connection pool per-role via DB_POOL, not a flat 50

### DIFF
--- a/bin/db_pool_env.rb
+++ b/bin/db_pool_env.rb
@@ -1,0 +1,20 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Shared by bin/web and bin/worker: sizes DB_POOL from a role-appropriate thread
+# count and strips DATABASE_URL's ?pool= so database.yml's DB_POOL stays
+# authoritative (the Hyrax Helm chart bakes ?pool= in; see postgresql.poolInUrl).
+module DbPoolEnv
+  def self.configure!(default_pool:)
+    ENV['DB_POOL'] ||= default_pool.to_s
+    return unless ENV['DATABASE_URL']
+
+    require 'uri'
+    uri = URI.parse(ENV['DATABASE_URL'])
+    return unless uri.query
+
+    remaining = URI.decode_www_form(uri.query).reject { |k, _| k == 'pool' }
+    uri.query = remaining.empty? ? nil : URI.encode_www_form(remaining)
+    ENV['DATABASE_URL'] = uri.to_s
+  end
+end

--- a/bin/web
+++ b/bin/web
@@ -7,4 +7,28 @@
 `mkdir -p /app/samvera/branding`
 `ln -snf /app/samvera/branding /app/samvera/hyrax-webapp/public/branding`
 
+# Size the DB connection pool to this process's own concurrency (Puma
+# threads), not a flat guess — avoids self-inflicted pool contention and
+# keeps this web role's worst-case connection footprint predictable
+# against a shared Postgres instance's max_connections. See bin/worker
+# for the job-runner-side equivalent.
+#
+# database.yml's pool: reads DB_POOL, but if you're deploying with the
+# Hyrax Helm chart, DATABASE_URL's own ?pool= (when present) wins over
+# that — the chart bakes in a hardcoded pool=5 unless dbPoolInUrl is set
+# to false there. Rather than rewriting the URL's pool= to match DB_POOL
+# (two calculations that have to be kept in sync by hand), strip it
+# entirely so database.yml's DB_POOL is the one and only place pool
+# size is ever specified, regardless of chart version.
+require 'uri'
+ENV['DB_POOL'] ||= (ENV.fetch('RAILS_MAX_THREADS', 5).to_i + 2).to_s
+if ENV['DATABASE_URL']
+  uri = URI.parse(ENV['DATABASE_URL'])
+  if uri.query
+    remaining = URI.decode_www_form(uri.query).reject { |k, _| k == 'pool' }
+    uri.query = remaining.empty? ? nil : URI.encode_www_form(remaining)
+    ENV['DATABASE_URL'] = uri.to_s
+  end
+end
+
 exec "bundle exec puma -v -b tcp://0.0.0.0:3000"

--- a/bin/web
+++ b/bin/web
@@ -7,19 +7,8 @@
 `mkdir -p /app/samvera/branding`
 `ln -snf /app/samvera/branding /app/samvera/hyrax-webapp/public/branding`
 
-# Size the DB connection pool to this process's own concurrency (Puma
-# threads), not a flat guess — avoids self-inflicted pool contention and
-# keeps this web role's worst-case connection footprint predictable
-# against a shared Postgres instance's max_connections. See bin/worker
-# for the job-runner-side equivalent.
-#
-# database.yml's pool: reads DB_POOL, but if you're deploying with the
-# Hyrax Helm chart, DATABASE_URL's own ?pool= (when present) wins over
-# that — the chart bakes in a hardcoded pool=5 unless dbPoolInUrl is set
-# to false there. Rather than rewriting the URL's pool= to match DB_POOL
-# (two calculations that have to be kept in sync by hand), strip it
-# entirely so database.yml's DB_POOL is the one and only place pool
-# size is ever specified, regardless of chart version.
+# Size pool to Puma's thread count; strip DATABASE_URL's ?pool= so database.yml's
+# DB_POOL stays authoritative (see bin/worker; chart's postgresql.poolInUrl).
 require 'uri'
 ENV['DB_POOL'] ||= (ENV.fetch('RAILS_MAX_THREADS', 5).to_i + 2).to_s
 if ENV['DATABASE_URL']

--- a/bin/web
+++ b/bin/web
@@ -7,17 +7,7 @@
 `mkdir -p /app/samvera/branding`
 `ln -snf /app/samvera/branding /app/samvera/hyrax-webapp/public/branding`
 
-# Size pool to Puma's thread count; strip DATABASE_URL's ?pool= so database.yml's
-# DB_POOL stays authoritative (see bin/worker; chart's postgresql.poolInUrl).
-require 'uri'
-ENV['DB_POOL'] ||= (ENV.fetch('RAILS_MAX_THREADS', 5).to_i + 2).to_s
-if ENV['DATABASE_URL']
-  uri = URI.parse(ENV['DATABASE_URL'])
-  if uri.query
-    remaining = URI.decode_www_form(uri.query).reject { |k, _| k == 'pool' }
-    uri.query = remaining.empty? ? nil : URI.encode_www_form(remaining)
-    ENV['DATABASE_URL'] = uri.to_s
-  end
-end
+require_relative 'db_pool_env'
+DbPoolEnv.configure!(default_pool: ENV.fetch('RAILS_MAX_THREADS', 5).to_i + 2)
 
 exec "bundle exec puma -v -b tcp://0.0.0.0:3000"

--- a/bin/worker
+++ b/bin/worker
@@ -4,21 +4,8 @@
 
 queue = ENV.fetch('HYRAX_ACTIVE_JOB_QUEUE', 'sidekiq')
 
-# Size the DB connection pool to this process's own concurrency (job
-# runner threads), not a flat guess — avoids self-inflicted pool
-# contention and keeps this worker role's worst-case connection
-# footprint predictable against a shared Postgres instance's
-# max_connections. See bin/web for the Puma-side equivalent.
-#
-# database.yml's pool: reads DB_POOL, but if you're deploying with the
-# Hyrax Helm chart, DATABASE_URL's own ?pool= (when present) wins over
-# that — the chart bakes in a hardcoded pool=5 unless dbPoolInUrl is set
-# to false there. Rather than rewriting the URL's pool= to match DB_POOL
-# (two calculations that have to be kept in sync by hand), strip it
-# entirely so database.yml's DB_POOL is the one and only place pool
-# size is ever specified, regardless of chart version.
-# (Previously this rewrote the URL's "pool=5" substring to "pool=30" —
-# a flat guess untied to either queue backend's actual thread count.)
+# Size pool to the active queue backend's thread count; strip DATABASE_URL's ?pool=
+# so database.yml's DB_POOL stays authoritative (see bin/web; chart's postgresql.poolInUrl).
 require 'uri'
 ENV['DB_POOL'] ||= case queue
                     when 'good_job' then (ENV.fetch('GOOD_JOB_MAX_THREADS', 5).to_i + 2).to_s

--- a/bin/worker
+++ b/bin/worker
@@ -2,13 +2,36 @@
 # frozen_string_literal: true
 `echo "$GOOGLE_OAUTH_PRIVATE_KEY_VALUE" | base64 -d > prod-cred.p12` unless ENV['GOOGLE_OAUTH_PRIVATE_KEY_VALUE'].to_s.strip.empty?
 
-if ENV['DATABASE_URL'].to_s.strip.empty?
-  puts 'DATABASE_URL not set, no pool change needed'
-else
-  ENV['DATABASE_URL'] = ENV['DATABASE_URL'].gsub('pool=5', 'pool=30')
-end
-
 queue = ENV.fetch('HYRAX_ACTIVE_JOB_QUEUE', 'sidekiq')
+
+# Size the DB connection pool to this process's own concurrency (job
+# runner threads), not a flat guess — avoids self-inflicted pool
+# contention and keeps this worker role's worst-case connection
+# footprint predictable against a shared Postgres instance's
+# max_connections. See bin/web for the Puma-side equivalent.
+#
+# database.yml's pool: reads DB_POOL, but if you're deploying with the
+# Hyrax Helm chart, DATABASE_URL's own ?pool= (when present) wins over
+# that — the chart bakes in a hardcoded pool=5 unless dbPoolInUrl is set
+# to false there. Rather than rewriting the URL's pool= to match DB_POOL
+# (two calculations that have to be kept in sync by hand), strip it
+# entirely so database.yml's DB_POOL is the one and only place pool
+# size is ever specified, regardless of chart version.
+# (Previously this rewrote the URL's "pool=5" substring to "pool=30" —
+# a flat guess untied to either queue backend's actual thread count.)
+require 'uri'
+ENV['DB_POOL'] ||= case queue
+                    when 'good_job' then (ENV.fetch('GOOD_JOB_MAX_THREADS', 5).to_i + 2).to_s
+                    else (ENV.fetch('SIDEKIQ_CONCURRENCY', 10).to_i + 2).to_s
+                    end
+if ENV['DATABASE_URL']
+  uri = URI.parse(ENV['DATABASE_URL'])
+  if uri.query
+    remaining = URI.decode_www_form(uri.query).reject { |k, _| k == 'pool' }
+    uri.query = remaining.empty? ? nil : URI.encode_www_form(remaining)
+    ENV['DATABASE_URL'] = uri.to_s
+  end
+end
 case queue
 when 'sidekiq'
   exec "echo $DATABASE_URL && bundle exec sidekiq"

--- a/bin/worker
+++ b/bin/worker
@@ -4,21 +4,8 @@
 
 queue = ENV.fetch('HYRAX_ACTIVE_JOB_QUEUE', 'sidekiq')
 
-# Size pool to the active queue backend's thread count; strip DATABASE_URL's ?pool=
-# so database.yml's DB_POOL stays authoritative (see bin/web; chart's postgresql.poolInUrl).
-require 'uri'
-ENV['DB_POOL'] ||= case queue
-                    when 'good_job' then (ENV.fetch('GOOD_JOB_MAX_THREADS', 5).to_i + 2).to_s
-                    else (ENV.fetch('SIDEKIQ_CONCURRENCY', 10).to_i + 2).to_s
-                    end
-if ENV['DATABASE_URL']
-  uri = URI.parse(ENV['DATABASE_URL'])
-  if uri.query
-    remaining = URI.decode_www_form(uri.query).reject { |k, _| k == 'pool' }
-    uri.query = remaining.empty? ? nil : URI.encode_www_form(remaining)
-    ENV['DATABASE_URL'] = uri.to_s
-  end
-end
+require_relative 'db_pool_env'
+DbPoolEnv.configure!(default_pool: queue == 'good_job' ? ENV.fetch('GOOD_JOB_MAX_THREADS', 5).to_i + 2 : ENV.fetch('SIDEKIQ_CONCURRENCY', 10).to_i + 2)
 case queue
 when 'sidekiq'
   exec "echo $DATABASE_URL && bundle exec sidekiq"

--- a/config/database.yml
+++ b/config/database.yml
@@ -7,12 +7,7 @@ login: &login
   username: <%= ENV['DB_USER'] %>
   password: <%= ENV['DB_PASSWORD'] %>
   database: <%= ENV['DB_NAME'] || 'hyku' %>
-  # Size this to your process's own thread concurrency (e.g. Puma's
-  # RAILS_MAX_THREADS, or a job runner's own thread count) via DB_POOL —
-  # not a flat guess. If you're deploying with the Hyrax Helm chart and
-  # DATABASE_URL is set, its own ?pool= param (when present) overrides
-  # this value entirely; set dbPoolInUrl: false in the chart's values (or
-  # omit ?pool= from DATABASE_URL yourself) so this setting is authoritative.
+  # Size via DB_POOL to your thread count; chart's DATABASE_URL ?pool= (postgresql.poolInUrl) overrides this if left enabled.
   pool: <%= ENV.fetch('DB_POOL', 10).to_i %>
   timeout: 5000
   prepared_statements: <%= ENV.fetch('DB_PREPARED_STATEMENTS', true) %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -7,7 +7,7 @@ login: &login
   username: <%= ENV['DB_USER'] %>
   password: <%= ENV['DB_PASSWORD'] %>
   database: <%= ENV['DB_NAME'] || 'hyku' %>
-  # Size via DB_POOL to your thread count; chart's DATABASE_URL ?pool= (postgresql.poolInUrl) overrides this if left enabled.
+  # Size via DB_POOL to your thread count; DATABASE_URL (including that set by the helm chart) or a `url:` key in this file overrides this value
   pool: <%= ENV.fetch('DB_POOL', 10).to_i %>
   timeout: 5000
   prepared_statements: <%= ENV.fetch('DB_PREPARED_STATEMENTS', true) %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -7,7 +7,13 @@ login: &login
   username: <%= ENV['DB_USER'] %>
   password: <%= ENV['DB_PASSWORD'] %>
   database: <%= ENV['DB_NAME'] || 'hyku' %>
-  pool: 50
+  # Size this to your process's own thread concurrency (e.g. Puma's
+  # RAILS_MAX_THREADS, or a job runner's own thread count) via DB_POOL —
+  # not a flat guess. If you're deploying with the Hyrax Helm chart and
+  # DATABASE_URL is set, its own ?pool= param (when present) overrides
+  # this value entirely; set dbPoolInUrl: false in the chart's values (or
+  # omit ?pool= from DATABASE_URL yourself) so this setting is authoritative.
+  pool: <%= ENV.fetch('DB_POOL', 10).to_i %>
   timeout: 5000
   prepared_statements: <%= ENV.fetch('DB_PREPARED_STATEMENTS', true) %>
   advisory_locks: <%= ENV.fetch('DB_ADVISORY_LOCKS', true) %>


### PR DESCRIPTION
`database.yml` hardcoded `pool: 50` for every process. With the Hyrax Helm chart, `DATABASE_URL`'s own hardcoded `?pool=5` also silently overrides it whenever present, so `database.yml`'s setting was dead code regardless. Hit this directly: `RAILS_MAX_THREADS=12` but only 5 real connections per pod, causing `ActiveRecord::ConnectionTimeoutError` under load.

`bin/web`/`bin/worker` now set `DB_POOL` from their own concurrency knob (Puma threads, or the active job queue's thread count), and strip any `?pool=` from `DATABASE_URL` rather than mirroring it — one calculation, one place. `database.yml` reads `DB_POOL` (fallback 10).

Companion chart change: samvera/hyrax#7586 (adds an opt-in `postgresql.poolInUrl: false` so `DATABASE_URL` can omit `?pool=` at the source — this works today independent of that landing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)