### PR TITLE
🎁 Add columns for staff-managed local vocabularies

### DIFF
--- a/app/models/qa/local_authority.rb
+++ b/app/models/qa/local_authority.rb
@@ -2,6 +2,47 @@
 
 module Qa
   class LocalAuthority < ApplicationRecord
+    NAME_FORMAT = /\A[a-z0-9][a-z0-9_-]*\z/
+
     has_many :local_authority_entries, dependent: :destroy
+
+    validates :name, presence: true
+    # Guarded on name_changed? so rows predating these rules stay editable.
+    validates :name,
+              uniqueness: { case_sensitive: false },
+              format: {
+                with: NAME_FORMAT,
+                message: 'must be lowercase letters, numbers, underscores and hyphens, ' \
+                         'starting with a letter or number'
+              },
+              if: -> { name_changed? && name.present? }
+    validate :name_must_not_shadow_a_file_based_vocabulary, if: :name_changed?
+
+    scope :ordered, -> { order(Arel.sql("COALESCE(NULLIF(label, ''), name)")) }
+
+    def self.file_based_names
+      Qa::Authorities::Local.names
+    rescue Qa::ConfigDirectoryNotFound => e
+      Rails.logger.warn("Unable to list file-based local authorities: #{e.message}")
+      []
+    end
+
+    def display_label
+      label.presence || name.to_s.titleize
+    end
+
+    def source_key
+      "local/#{name}"
+    end
+
+    private
+
+    # A YAML file of the same name wins at registration, hiding these terms.
+    def name_must_not_shadow_a_file_based_vocabulary
+      return if name.blank?
+      return unless self.class.file_based_names.include?(name)
+
+      errors.add(:name, "is already used by a file-based vocabulary (config/authorities/#{name}.yml)")
+    end
   end
 end

--- a/app/models/qa/local_authority_entry.rb
+++ b/app/models/qa/local_authority_entry.rb
@@ -1,7 +1,33 @@
 # frozen_string_literal: true
 
 module Qa
+  # `uri` holds the term identifier and is the value Bulkrax imports. It is not
+  # required to be an actual URI.
   class LocalAuthorityEntry < ApplicationRecord
     belongs_to :local_authority
+
+    store_accessor :data, :alt_labels, :definition
+
+    before_validation { self.uri = nil if uri.blank? }
+
+    validates :uri, presence: true, on: :create
+    validates :uri, uniqueness: { scope: :local_authority_id }, allow_nil: true
+    validate :uri_is_not_reassigned, on: :update
+
+    scope :active, -> { where(active: true) }
+    scope :inactive, -> { where(active: false) }
+    scope :ordered, -> { order(:position, :label) }
+
+    private
+
+    def uri_is_not_reassigned
+      return unless uri_changed?
+
+      errors.add(:uri, 'cannot be changed, because works store it as the term id')
+    end
+
+    scope :active, -> { where(active: true) }
+    scope :inactive, -> { where(active: false) }
+    scope :ordered, -> { order(:position, :label) }
   end
 end

--- a/db/migrate/20260817170000_add_label_and_description_to_qa_local_authorities.rb
+++ b/db/migrate/20260817170000_add_label_and_description_to_qa_local_authorities.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddLabelAndDescriptionToQaLocalAuthorities < ActiveRecord::Migration[7.2]
+  def change
+    add_column :qa_local_authorities, :label, :string
+    add_column :qa_local_authorities, :description, :text
+  end
+end

--- a/db/migrate/20260817170001_add_active_data_and_position_to_qa_local_authority_entries.rb
+++ b/db/migrate/20260817170001_add_active_data_and_position_to_qa_local_authority_entries.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AddActiveDataAndPositionToQaLocalAuthorityEntries < ActiveRecord::Migration[7.2]
+  def change
+    add_column :qa_local_authority_entries, :active, :boolean, default: true, null: false
+    add_column :qa_local_authority_entries, :data, :jsonb, default: {}, null: false
+    add_column :qa_local_authority_entries, :position, :integer
+
+    add_index :qa_local_authority_entries,
+              %i[local_authority_id active],
+              name: 'index_qa_local_authority_entries_on_authority_and_active'
+
+    add_index :qa_local_authority_entries,
+              %i[local_authority_id position label],
+              name: 'index_qa_local_authority_entries_on_authority_and_sequence'
+  end
+end

--- a/db/migrate/20260817170002_scope_qa_local_authority_entry_uri_uniqueness.rb
+++ b/db/migrate/20260817170002_scope_qa_local_authority_entry_uri_uniqueness.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class ScopeQaLocalAuthorityEntryUriUniqueness < ActiveRecord::Migration[7.2]
+  GLOBAL_INDEX = 'index_qa_local_authority_entries_on_uri'
+  SCOPED_INDEX = 'index_qa_local_authority_entries_on_authority_and_uri'
+
+  def up
+    remove_index :qa_local_authority_entries, name: GLOBAL_INDEX, if_exists: true
+    add_index :qa_local_authority_entries, %i[local_authority_id uri], unique: true, name: SCOPED_INDEX
+  end
+
+  # Reverting fails if two vocabularies have since been given a term with the
+  # same id, which this migration is what permits.
+  def down
+    remove_index :qa_local_authority_entries, name: SCOPED_INDEX, if_exists: true
+    add_index :qa_local_authority_entries, :uri, unique: true, name: GLOBAL_INDEX
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_08_06_120000) do
+ActiveRecord::Schema[7.2].define(version: 2026_08_17_170002) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_trgm"
@@ -693,6 +693,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_06_120000) do
     t.string "name"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.string "label"
+    t.text "description"
     t.index ["name"], name: "index_qa_local_authorities_on_name", unique: true
   end
 
@@ -702,9 +704,14 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_06_120000) do
     t.string "uri"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.boolean "active", default: true, null: false
+    t.jsonb "data", default: {}, null: false
+    t.integer "position"
     t.index "lower((label)::text) gin_trgm_ops", name: "index_qa_local_authority_entries_on_lower_label_trgm", using: :gin
+    t.index ["local_authority_id", "active"], name: "index_qa_local_authority_entries_on_authority_and_active"
+    t.index ["local_authority_id", "position", "label"], name: "index_qa_local_authority_entries_on_authority_and_sequence"
+    t.index ["local_authority_id", "uri"], name: "index_qa_local_authority_entries_on_authority_and_uri", unique: true
     t.index ["local_authority_id"], name: "index_qa_local_authority_entries_on_local_authority_id"
-    t.index ["uri"], name: "index_qa_local_authority_entries_on_uri", unique: true
   end
 
   create_table "qa_mesh_trees", id: :serial, force: :cascade do |t|

--- a/spec/authorities/qa/authorities/mesh_spec.rb
+++ b/spec/authorities/qa/authorities/mesh_spec.rb
@@ -22,8 +22,14 @@ RSpec.describe Qa::Authorities::Mesh do
     context 'with seeded mesh entries' do
       let!(:mesh_authority) { Qa::LocalAuthority.create!(name: 'mesh') }
 
+      # insert_all rather than create!, matching how `rake mesh:import_tenant`
+      # loads terms. It bypasses the uri presence validation, which is what
+      # keeps the blank-uri fallback below reachable for imported data.
       def add_entry(label, uri: nil)
-        mesh_authority.local_authority_entries.create!(label: label, uri: uri)
+        Qa::LocalAuthorityEntry.insert_all( # rubocop:disable Rails/SkipsModelValidations
+          [{ local_authority_id: mesh_authority.id, label: label, uri: uri,
+             created_at: Time.current, updated_at: Time.current }]
+        )
       end
 
       describe 'ranking tiers' do

--- a/spec/models/qa/local_authority_entry_spec.rb
+++ b/spec/models/qa/local_authority_entry_spec.rb
@@ -3,7 +3,118 @@
 require 'spec_helper'
 
 RSpec.describe Qa::LocalAuthorityEntry, type: :model do
+  let(:authority) { Qa::LocalAuthority.create!(name: 'lab_names') }
+
   it "belongs to a local authority" do
     expect(described_class.reflections['local_authority'].macro).to eq :belongs_to
+  end
+
+  describe 'uri' do
+    it 'is required on a new term' do
+      entry = described_class.new(local_authority: authority, label: 'Anthropology')
+
+      expect(entry).not_to be_valid
+      expect(entry.errors[:uri]).to be_present
+    end
+
+    it 'rejects a blank one on a new term' do
+      expect(described_class.new(local_authority: authority, label: 'Anthropology', uri: '')).not_to be_valid
+    end
+
+    # Works store the uri as the term id, so reassigning it orphans every record
+    # citing the old value. Deactivating the term is the supported alternative.
+    it 'cannot be changed' do
+      entry = described_class.create!(local_authority: authority, label: 'Anthropology', uri: 'anth')
+
+      expect(entry.update(uri: 'anthropology')).to eq false
+      expect(entry.errors[:uri].join).to include('cannot be changed')
+      expect(entry.reload.uri).to eq 'anth'
+    end
+
+    it 'cannot be cleared' do
+      entry = described_class.create!(local_authority: authority, label: 'Anthropology', uri: 'anth')
+
+      expect(entry.update(uri: nil)).to eq false
+      expect(entry.update(uri: '')).to eq false
+    end
+
+    it 'leaves the rest of a term editable' do
+      entry = described_class.create!(local_authority: authority, label: 'Anthropology', uri: 'anth')
+
+      expect(entry.update(label: 'Anthropology Studies', active: false)).to eq true
+    end
+
+    context 'with a term predating the uri rules' do
+      let(:legacy) do
+        entry = described_class.create!(local_authority: authority, label: 'Anthropology', uri: 'anth')
+        entry.update_columns(uri: nil) # rubocop:disable Rails/SkipsModelValidations
+        entry.reload
+      end
+
+      it 'stays editable without one' do
+        expect(legacy.update(active: false)).to eq true
+      end
+
+      it 'does not accept a missing uri being filled in' do
+        expect(legacy.update(uri: 'anth')).to eq false
+        expect(legacy.reload.uri).to be_nil
+      end
+    end
+
+    it 'is unique within its vocabulary' do
+      described_class.create!(local_authority: authority, label: 'Anthropology', uri: 'other')
+      duplicate = described_class.new(local_authority: authority, label: 'Assorted', uri: 'other')
+
+      expect(duplicate).not_to be_valid
+    end
+
+    # The qa gem indexes uri as globally unique, which stops two vocabularies
+    # in one tenant from each having an "other" term.
+    it 'may repeat across vocabularies' do
+      other_vocabulary = Qa::LocalAuthority.create!(name: 'subjects')
+      described_class.create!(local_authority: authority, label: 'Other', uri: 'other')
+
+      expect(described_class.create!(local_authority: other_vocabulary, label: 'Other', uri: 'other')).to be_persisted
+    end
+  end
+
+  it 'is active by default' do
+    entry = described_class.create!(local_authority: authority, label: 'Anthropology', uri: 'anth')
+
+    expect(entry.active).to eq true
+  end
+
+  it 'defaults data to an empty hash' do
+    entry = described_class.create!(local_authority: authority, label: 'Anthropology', uri: 'anth')
+
+    expect(entry.data).to eq({})
+  end
+
+  it 'stores term attributes in the data hash' do
+    entry = described_class.create!(
+      local_authority: authority,
+      label: 'Anthropology',
+      uri: 'anth',
+      alt_labels: ['Anthro'],
+      definition: 'The study of humans.'
+    )
+
+    expect(entry.reload.data).to eq('alt_labels' => ['Anthro'], 'definition' => 'The study of humans.')
+    expect(entry.alt_labels).to eq ['Anthro']
+  end
+
+  describe 'scopes' do
+    let!(:live) { described_class.create!(local_authority: authority, label: 'Botany', uri: 'bot') }
+    let!(:retired) { described_class.create!(local_authority: authority, label: 'Alchemy', uri: 'alc', active: false) }
+    let!(:pinned) { described_class.create!(local_authority: authority, label: 'Zoology', uri: 'zoo', position: 1) }
+
+    it 'separates active from inactive terms' do
+      expect(described_class.active).to contain_exactly(live, pinned)
+      expect(described_class.inactive).to contain_exactly(retired)
+    end
+
+    it 'orders pinned terms first, then unpinned terms by label' do
+      expect(described_class.ordered.to_a).to eq [pinned, retired, live]
+    end
   end
 end

--- a/spec/models/qa/local_authority_spec.rb
+++ b/spec/models/qa/local_authority_spec.rb
@@ -4,7 +4,77 @@ require 'spec_helper'
 
 RSpec.describe Qa::LocalAuthority, type: :model do
   it "can persist data" do
-    expect { described_class.create!(name: 'Language') }
+    expect { described_class.create!(name: 'language') }
       .to change(described_class, :count).by(1)
+  end
+
+  describe 'validations' do
+    it 'requires a name' do
+      expect(described_class.new(name: '')).not_to be_valid
+    end
+
+    # name_changed? is false on a new record left at nil, so presence can't be
+    # guarded on it without letting a nameless vocabulary save.
+    it 'rejects a nil name' do
+      expect(described_class.new).not_to be_valid
+      expect(described_class.new(name: nil).save).to eq false
+    end
+
+    it 'rejects a name that is not a usable authority key' do
+      authority = described_class.new(name: 'Lab Names')
+
+      expect(authority).not_to be_valid
+      expect(authority.errors[:name].join).to include('lowercase letters')
+    end
+
+    it 'rejects a name already claimed by a file-based vocabulary' do
+      allow(described_class).to receive(:file_based_names).and_return(%w[licenses])
+      authority = described_class.new(name: 'licenses')
+
+      expect(authority).not_to be_valid
+      expect(authority.errors[:name].join).to include('file-based vocabulary')
+    end
+
+    it 'rejects a duplicate name' do
+      described_class.create!(name: 'lab_names')
+
+      expect(described_class.new(name: 'lab_names')).not_to be_valid
+    end
+
+    it 'lets a row with a legacy name be relabeled' do
+      authority = described_class.create!(name: 'legacy')
+      authority.update_columns(name: 'Legacy Name') # rubocop:disable Rails/SkipsModelValidations
+
+      expect(authority.reload.update(label: 'Legacy Name')).to eq true
+    end
+  end
+
+  describe '#display_label' do
+    it 'uses the label when one is set' do
+      expect(described_class.new(name: 'lab_names', label: 'Laboratory Names').display_label)
+        .to eq 'Laboratory Names'
+    end
+
+    it 'falls back to a titleized name' do
+      expect(described_class.new(name: 'lab_names').display_label).to eq 'Lab Names'
+    end
+  end
+
+  describe '#source_key' do
+    it 'is the value to paste into the metadata profile' do
+      expect(described_class.new(name: 'lab_names').source_key).to eq 'local/lab_names'
+    end
+  end
+
+  describe '.file_based_names' do
+    it 'lists the subauthorities backed by config/authorities YAML' do
+      expect(described_class.file_based_names).to include('licenses')
+    end
+
+    it 'returns an empty list when the authorities directory is missing' do
+      allow(Qa::Authorities::Local).to receive(:names).and_raise(Qa::ConfigDirectoryNotFound, 'no directory')
+
+      expect(described_class.file_based_names).to eq []
+    end
   end
 end


### PR DESCRIPTION
Refs notch8/palni_palci_knapsack#703 (private tracker)

## Why

Adding a local term list today means a developer edits `config/authorities/*.yml` and redeploys, turning a minutes-long metadata task into a days-long developer ticket. This is the schema staff-managed vocabularies need. Database only: no UI and no authority registration yet.

## Worth arguing with

Two changes touch existing behavior. The rest is additive columns and indexes, explained in the commit message.

- `uri` uniqueness moves from global to `[local_authority_id, uri]`. Today two vocabularies in one tenant can't both carry an "Other" term. Strictly looser than what it replaces, so it can't fail on existing rows.
- `uri` is required on new terms and immutable afterward, since works persist it as the term id and reassigning it orphans every record citing the old value.

| action | result |
| --- | --- |
| create a term with no uri, or a blank one | rejected |
| create a duplicate uri within one vocabulary | rejected |
| create the same uri in a different vocabulary | allowed |
| change a term's uri | rejected |
| clear a term's uri | rejected |
| edit label, toggle active, reorder | allowed |
| fill in a uri on a term that has none | rejected |
| several terms with no uri in one vocabulary | allowed |

MeSH is unaffected, since `rake mesh:import_tenant` loads through `insert_all`. File-based vocabularies are untouched and keep working with zero rows in these tables.

## Testing

`bundle exec rspec spec/models/qa spec/authorities/qa spec/db/migrate`, 38 examples, 0 failures.

@samvera/hyku-code-reviewers
