### PR TITLE
Qa db migration

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,17 +96,16 @@ GIT
 
 GIT
   remote: https://github.com/samvera/questioning_authority.git
-  revision: 54cb5e7047f0261b8ccfd4b737d6f30a0a96d3ba
+  revision: e2ee4225eb1d823c34b3e9df253801d819789b1b
   branch: main
   specs:
-    qa (5.15.0)
+    qa (5.17.0)
       activerecord-import
-      deprecation
       faraday (< 3.0, != 2.0.0)
       geocoder
       ldpath
       nokogiri (~> 1.6)
-      rails (>= 5.0, < 8.1)
+      rails (>= 6.0, < 8.2)
       rdf
 
 GIT

--- a/app/authorities/qa/authorities/local_db_fallback_decorator.rb
+++ b/app/authorities/qa/authorities/local_db_fallback_decorator.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# OVERRIDE Qa 5.x so a local vocabulary is served from the qa_local_authorities
+# tables when the tenant has one, and from config/authorities otherwise.
+module Qa::Authorities
+  module LocalDbFallbackDecorator
+    def subauthority_for(subauthority)
+      resolved = super
+      return resolved unless resolved.is_a?(Qa::Authorities::Local::FileBasedAuthority)
+
+      Qa::Authorities::LocalVocabulary.new(subauthority)
+    rescue Qa::InvalidSubAuthority
+      raise unless Qa::LocalAuthority.exists?(name: subauthority)
+
+      Qa::Authorities::LocalVocabulary.new(subauthority)
+    end
+  end
+end
+
+Qa::Authorities::Local.singleton_class.prepend(Qa::Authorities::LocalDbFallbackDecorator)

--- a/app/authorities/qa/authorities/local_vocabulary.rb
+++ b/app/authorities/qa/authorities/local_vocabulary.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Qa::Authorities
+  class LocalVocabulary < Qa::Authorities::Local::TableBasedAuthority
+    # Point Qa's startup index check at the lower(label) index we actually have.
+    self.table_index = 'index_qa_local_authority_entries_on_lower_label_trgm'
+
+    def all
+      return file_based.all if file_based?
+
+      output_set(base_relation.ordered.limit(1000))
+    end
+
+    def find(uri)
+      return file_based.find(uri) if file_based?
+
+      record = base_relation.find_by(uri:)
+      return {} unless record
+
+      output(record)
+    end
+
+    def search(q)
+      return file_based.search(q) if file_based?
+
+      super
+    end
+
+    private
+
+    # Decided per call, since one tenant can be seeded while another is not.
+    def file_based?
+      local_authority.nil?
+    end
+
+    def file_based
+      Qa::Authorities::Local::FileBasedAuthority.new(subauthority)
+    end
+
+    def output(item)
+      { id: item.uri, label: item.label, term: item.label, active: item.active }.with_indifferent_access
+    end
+  end
+end

--- a/app/models/qa/local_authority.rb
+++ b/app/models/qa/local_authority.rb
@@ -16,7 +16,6 @@ module Qa
                          'starting with a letter or number'
               },
               if: -> { name_changed? && name.present? }
-    validate :name_must_not_shadow_a_file_based_vocabulary, if: :name_changed?
 
     scope :ordered, -> { order(Arel.sql("COALESCE(NULLIF(label, ''), name)")) }
 
@@ -33,16 +32,6 @@ module Qa
 
     def source_key
       "local/#{name}"
-    end
-
-    private
-
-    # A YAML file of the same name wins at registration, hiding these terms.
-    def name_must_not_shadow_a_file_based_vocabulary
-      return if name.blank?
-      return unless self.class.file_based_names.include?(name)
-
-      errors.add(:name, "is already used by a file-based vocabulary (config/authorities/#{name}.yml)")
     end
   end
 end

--- a/app/services/create_account.rb
+++ b/app/services/create_account.rb
@@ -44,6 +44,7 @@ class CreateAccount
     RolesService.create_default_hyrax_groups_with_roles!
     Hyrax::CollectionType.find_or_create_default_collection_type
     Hyrax::CollectionType.find_or_create_admin_set_type
+    LocalVocabularyService.seed!
     return if account.search_only?
 
     Hyrax::AdminSetCreateService.find_or_create_default_admin_set.id

--- a/app/services/local_vocabulary_service.rb
+++ b/app/services/local_vocabulary_service.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class LocalVocabularyService
+  def self.seed!(paths = Qa::Authorities::Local.subauthorities_path)
+    seed_files(paths).map { |file| seed_vocabulary!(file) }
+  end
+
+  # An earlier path wins, matching how HykuKnapsack overrides a Hyku authority.
+  def self.seed_files(paths)
+    Array.wrap(paths).flat_map { |path| Dir.glob(File.join(path, '*.yml')).sort }
+         .uniq { |file| File.basename(file, '.yml') }
+  end
+
+  def self.seed_vocabulary!(file)
+    name = File.basename(file, '.yml')
+    authority = Qa::LocalAuthority.find_or_create_by!(name:)
+
+    Array.wrap((YAML.load_file(file) || {})['terms']).each_with_index do |term, index|
+      authority.local_authority_entries.find_or_create_by!(uri: term['id']) do |entry|
+        entry.label = term['term']
+        entry.active = term.fetch('active', true)
+        entry.position = index
+        entry.data = term.except('id', 'term', 'active')
+      end
+    end
+
+    [name, authority.local_authority_entries.count]
+  end
+end

--- a/lib/tasks/populate_qa_tables.rake
+++ b/lib/tasks/populate_qa_tables.rake
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+desc 'populate qa tables from the authority ymls (AUTHORITIES_PATH overrides config/authorities)'
+task populate_qa: :environment do
+  paths = ENV.fetch('AUTHORITIES_PATH', nil) || Qa::Authorities::Local.subauthorities_path
+
+  Account.find_each do |account|
+    next if account.search_only?
+
+    puts "=============== #{account.name} ==============="
+    Apartment::Tenant.switch(account.tenant) do
+      LocalVocabularyService.seed!(paths).each do |name, count|
+        puts "✓ #{name} (#{count} terms)"
+      end
+    end
+  end
+end

--- a/spec/authorities/qa/authorities/local_vocabulary_spec.rb
+++ b/spec/authorities/qa/authorities/local_vocabulary_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Qa::Authorities::LocalVocabulary do
+  subject(:authority) { Qa::Authorities::Local.subauthority_for('audience') }
+
+  let(:yml_terms) { YAML.load_file(Rails.root.join('config', 'authorities', 'audience.yml'))['terms'] }
+
+  it 'serves the tenant rows when the vocabulary is in the database' do
+    Qa::LocalAuthority.find_by(name: 'audience')
+                      .local_authority_entries
+                      .create!(label: 'Registrar', uri: 'registrar')
+
+    expect(authority.all.map { |term| term[:label] }).to include('Registrar')
+  end
+
+  it 'falls back to config/authorities when the tenant has no row' do
+    Qa::LocalAuthority.where(name: 'audience').destroy_all
+
+    expect(authority.all.map { |term| term[:label] }).to eq yml_terms.map { |term| term['term'] }
+  end
+
+  it 'reports a retired term as inactive' do
+    entry = Qa::LocalAuthority.find_by(name: 'audience').local_authority_entries.first
+    entry.update!(active: false)
+
+    expect(authority.find(entry.uri)['active']).to be false
+  end
+
+  it 'returns an empty hash for an unknown term, as the file-based authority does' do
+    expect(authority.find('no-such-term')).to eq({})
+  end
+end

--- a/spec/models/qa/local_authority_entry_spec.rb
+++ b/spec/models/qa/local_authority_entry_spec.rb
@@ -109,12 +109,12 @@ RSpec.describe Qa::LocalAuthorityEntry, type: :model do
     let!(:pinned) { described_class.create!(local_authority: authority, label: 'Zoology', uri: 'zoo', position: 1) }
 
     it 'separates active from inactive terms' do
-      expect(described_class.active).to contain_exactly(live, pinned)
-      expect(described_class.inactive).to contain_exactly(retired)
+      expect(authority.local_authority_entries.active).to contain_exactly(live, pinned)
+      expect(authority.local_authority_entries.inactive).to contain_exactly(retired)
     end
 
     it 'orders pinned terms first, then unpinned terms by label' do
-      expect(described_class.ordered.to_a).to eq [pinned, retired, live]
+      expect(authority.local_authority_entries.ordered.to_a).to eq [pinned, retired, live]
     end
   end
 end

--- a/spec/models/qa/local_authority_spec.rb
+++ b/spec/models/qa/local_authority_spec.rb
@@ -27,14 +27,6 @@ RSpec.describe Qa::LocalAuthority, type: :model do
       expect(authority.errors[:name].join).to include('lowercase letters')
     end
 
-    it 'rejects a name already claimed by a file-based vocabulary' do
-      allow(described_class).to receive(:file_based_names).and_return(%w[licenses])
-      authority = described_class.new(name: 'licenses')
-
-      expect(authority).not_to be_valid
-      expect(authority.errors[:name].join).to include('file-based vocabulary')
-    end
-
     it 'rejects a duplicate name' do
       described_class.create!(name: 'lab_names')
 
@@ -68,6 +60,8 @@ RSpec.describe Qa::LocalAuthority, type: :model do
 
   describe '.file_based_names' do
     it 'lists the subauthorities backed by config/authorities YAML' do
+      allow(Qa::Authorities::Local).to receive(:names).and_return(%w[licenses])
+
       expect(described_class.file_based_names).to include('licenses')
     end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -127,6 +127,8 @@ Capybara.javascript_driver = :chrome
 # this security while still going through the captcha workflow.
 NegativeCaptcha.test_mode = true
 
+VOCABULARY_TABLES = %w[qa_local_authorities qa_local_authority_entries].freeze
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.file_fixture_path = Rails.root.join('spec', 'fixtures').to_s
@@ -165,6 +167,7 @@ RSpec.configure do |config|
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)
     Account.destroy_all
+    LocalVocabularyService.seed!
     prepare_test_solr
   end
 
@@ -191,7 +194,7 @@ RSpec.configure do |config|
     # (e.g. real Thread.new-based tests, where a spawned thread's own DB connection can't
     # see data created inside the main thread's still-open transaction).
     if (example.metadata[:js] && example.metadata[:type] == :feature) || example.metadata[:truncation]
-      DatabaseCleaner.strategy = :truncation
+      DatabaseCleaner.strategy = :truncation, { except: VOCABULARY_TABLES }
     else
       DatabaseCleaner.strategy = :transaction
       DatabaseCleaner.start
@@ -213,7 +216,7 @@ RSpec.configure do |config|
     Rails.logger.error "DatabaseCleaner error: #{e.message}"
     # Only switch to truncation if we hit a deadlock
     raise e unless e.message.include?('deadlock detected')
-    DatabaseCleaner.strategy = :truncation
+    DatabaseCleaner.strategy = :truncation, { except: VOCABULARY_TABLES }
     DatabaseCleaner.clean
   end
 end


### PR DESCRIPTION
## ⬆️ Update questioning authority gem

b9a0d54bc0ecd72901b276b5cb536207db8a17db


## 🎁 Read local vocabularies from the db, fall back to ymls

10ad982d19dd73636d93b353844208a0517ff99c

Staff cannot edit config/authorities, so the terms need to live in the
qa_local_authorities tables. The ymls stay put and remain the shipped defaults:
`rake populate_qa` seeds every existing tenant from them, CreateAccount seeds
new ones, and a vocabulary with no row in the current tenant still renders from
its yml.

`Qa::Authorities::LocalVocabulary` subclasses the gem's TableBasedAuthority,
which on its own renders licenses as raw URLs and treats retired terms as
active, because Hyrax reads 'term' and 'active'. Terms come back through the
`ordered` scope, since yml order was implicit and a table has none.

It chooses db or yml per call rather than at resolution time, because Hyrax
memoizes `@authority` on the service module for the life of the process: one
tenant's answer would otherwise be served to every other tenant.

`Qa::Authorities::LocalDbFallbackDecorator` wraps whatever the registry resolves
to a file-based authority, and also covers names the registry never knew, which
is any vocabulary staff create later. Named for the fallback because
hyku_knapsack already owns `Qa::Authorities::LocalDecorator`. MeSH keeps its own
class and a typo still raises.

A row may now share a name with a yml, since that is how an override is
expressed, so the shadow validation is gone.

Specs seed once in before(:suite) and keep the qa tables out of truncation, or
the first js feature spec empties them for everything after it. The entry scope
examples query through their authority, since the tables are never empty.
