### PR TITLE
Seed a label and description for every local vocabulary

### DIFF
--- a/app/services/local_vocabulary_service.rb
+++ b/app/services/local_vocabulary_service.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class LocalVocabularyService
+  SAMPLE_TERM_COUNT = 3
+
   def self.seed!(paths = Qa::Authorities::Local.subauthorities_path)
     seed_files(paths).map { |file| seed_vocabulary!(file) }
   end
@@ -13,9 +15,17 @@ class LocalVocabularyService
 
   def self.seed_vocabulary!(file)
     name = File.basename(file, '.yml')
-    authority = Qa::LocalAuthority.find_or_create_by!(name:)
+    contents = YAML.load_file(file) || {}
+    terms = Array.wrap(contents['terms'])
+    authority = Qa::LocalAuthority.find_or_initialize_by(name:)
 
-    Array.wrap((YAML.load_file(file) || {})['terms']).each_with_index do |term, index|
+    backfill_metadata(authority,
+                      contents,
+                      term_count: terms.size,
+                      sample_terms: terms.first(SAMPLE_TERM_COUNT).map { |term| term['term'] })
+    authority.save! if authority.changed?
+
+    terms.each_with_index do |term, index|
       authority.local_authority_entries.find_or_create_by!(uri: term['id']) do |entry|
         entry.label = term['term']
         entry.active = term.fetch('active', true)
@@ -25,5 +35,38 @@ class LocalVocabularyService
     end
 
     [name, authority.local_authority_entries.count]
+  end
+
+  # Only blanks are filled, so a value staff edit in the admin UI survives a reseed.
+  def self.backfill_metadata(authority, metadata = {}, term_count: 0, sample_terms: [])
+    authority.label = default_label(authority.name, metadata) if authority.label.blank?
+    authority.description = default_description(metadata, term_count:, sample_terms:) if authority.description.blank?
+    authority
+  end
+
+  def self.default_label(name, metadata = {})
+    metadata['label'].presence || name.to_s.titleize
+  end
+
+  def self.default_description(metadata = {}, term_count: 0, sample_terms: [])
+    metadata['description'].presence || derived_description(term_count, sample_terms)
+  end
+
+  # Stored rather than computed, so it goes stale as terms change. It is a
+  # starting point for staff to replace, not a description that stays true.
+  def self.derived_description(term_count, sample_terms)
+    samples = Array.wrap(sample_terms).compact_blank
+    return nil if term_count.zero?
+
+    count = "#{term_count} #{'term'.pluralize(term_count)}"
+    return "#{count}." if samples.empty?
+    return "#{count}: #{samples.to_sentence}." if term_count <= samples.size
+
+    "#{count}, including #{samples.to_sentence}."
+  end
+
+  def self.metadata_by_name(paths = Qa::Authorities::Local.subauthorities_path)
+    seed_files(paths).index_by { |file| File.basename(file, '.yml') }
+                     .transform_values { |file| (YAML.load_file(file) || {}).except('terms') }
   end
 end

--- a/config/authorities/accessibility_features.yml
+++ b/config/authorities/accessibility_features.yml
@@ -1,3 +1,7 @@
+label: Accessibility Features
+description: >-
+  Accommodations a work provides for readers with disabilities, such as
+  alternative text, captions, or a braille edition.
 terms:
   - id: Alternative Text
     term: Alternative Text

--- a/config/authorities/accessibility_hazards.yml
+++ b/config/authorities/accessibility_hazards.yml
@@ -1,3 +1,7 @@
+label: Accessibility Hazards
+description: >-
+  Characteristics of a work that may pose a risk to some readers, such as
+  flashing, motion, or sound.
 terms:
   - id: Flashing
     term: Flashing

--- a/config/authorities/audience.yml
+++ b/config/authorities/audience.yml
@@ -1,3 +1,6 @@
+label: Audience
+description: >-
+  Who a work is intended for, such as students, instructors, or administrators.
 terms:
   - id: Student
     term: Student

--- a/config/authorities/discipline.yml
+++ b/config/authorities/discipline.yml
@@ -1,3 +1,7 @@
+label: Discipline
+description: >-
+  Academic subject areas a work belongs to, from the arts and humanities through
+  the sciences and professional fields.
 terms:
   - id: Languages - Spanish
     term: Languages - Spanish

--- a/config/authorities/education_levels.yml
+++ b/config/authorities/education_levels.yml
@@ -1,3 +1,7 @@
+label: Education Levels
+description: >-
+  The level of study a work is written for, from community college through
+  graduate and professional programs.
 terms:
   - id: Community college / Lower division
     term: Community college / Lower division

--- a/config/authorities/learning_resource_types.yml
+++ b/config/authorities/learning_resource_types.yml
@@ -1,3 +1,7 @@
+label: Learning Resource Types
+description: >-
+  The instructional form of an open educational resource, such as an activity,
+  an assessment, a syllabus, or a full textbook.
 terms:
   - id: Activity/lab
     term: Activity/lab

--- a/config/authorities/licenses.yml
+++ b/config/authorities/licenses.yml
@@ -1,3 +1,6 @@
+label: Licenses
+description: >-
+  Creative Commons and other reuse licenses a depositor can apply to a work.
 terms:
   - id: https://creativecommons.org/licenses/by/4.0/
     term: Creative Commons BY Attribution 4.0 International

--- a/config/authorities/oer_types.yml
+++ b/config/authorities/oer_types.yml
@@ -1,3 +1,7 @@
+label: OER Types
+description: >-
+  The kind of open educational resource being described, such as a collection,
+  a dataset, or an event.
 terms:
   - id: Collection
     term: Collection

--- a/config/authorities/resource_types.yml
+++ b/config/authorities/resource_types.yml
@@ -1,3 +1,6 @@
+label: Resource Types
+description: >-
+  The form a work takes, such as an article, an image, a dataset, or a thesis.
 terms:
   - id: Article
     term: Article

--- a/config/authorities/rights_statements.yml
+++ b/config/authorities/rights_statements.yml
@@ -1,3 +1,7 @@
+label: Rights Statements
+description: >-
+  rightsstatements.org statements describing the copyright status of a work and
+  how it may be reused.
 terms:
 - id: http://rightsstatements.org/vocab/InC/1.0/
   term: "In Copyright"

--- a/db/migrate/20260818200000_backfill_qa_local_authority_metadata.rb
+++ b/db/migrate/20260818200000_backfill_qa_local_authority_metadata.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# `rake populate_qa` only creates rows it doesn't already find, so a tenant
+# seeded before these columns existed never gets them filled.
+class BackfillQaLocalAuthorityMetadata < ActiveRecord::Migration[7.2]
+  def up
+    Qa::LocalAuthority.reset_column_information
+
+    metadata = LocalVocabularyService.metadata_by_name
+
+    blank = Qa::LocalAuthority.where(label: [nil, ''])
+                              .or(Qa::LocalAuthority.where(description: [nil, '']))
+
+    blank.find_each do |authority|
+      entries = authority.local_authority_entries
+
+      LocalVocabularyService.backfill_metadata(
+        authority,
+        metadata.fetch(authority.name, {}),
+        term_count: entries.count,
+        # Counted and sampled rather than plucked whole: a tenant's MeSH
+        # vocabulary is tens of thousands of rows.
+        sample_terms: entries.ordered.limit(LocalVocabularyService::SAMPLE_TERM_COUNT).pluck(:label)
+      )
+
+      authority.save! if authority.changed?
+    end
+  end
+
+  def down
+    # Nothing to undo: the columns hold no value this migration can distinguish
+    # from one a person typed.
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_08_17_170002) do
+ActiveRecord::Schema[7.2].define(version: 2026_08_18_200000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_trgm"

--- a/spec/services/local_vocabulary_service_spec.rb
+++ b/spec/services/local_vocabulary_service_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LocalVocabularyService do
+  describe '.default_label' do
+    it 'uses the label the vocabulary carries' do
+      expect(described_class.default_label('oer_types', 'label' => 'OER Types')).to eq 'OER Types'
+    end
+
+    it 'titleizes the name of a vocabulary that carries none' do
+      expect(described_class.default_label('lab_names')).to eq 'Lab Names'
+    end
+  end
+
+  describe '.default_description' do
+    it 'uses the description the vocabulary carries' do
+      expect(described_class.default_description({ 'description' => 'Reuse terms.' })).to eq 'Reuse terms.'
+    end
+
+    it 'derives one from the terms for a vocabulary that carries none' do
+      expect(described_class.default_description({}, term_count: 20, sample_terms: %w[Article Audio Book]))
+        .to eq '20 terms, including Article, Audio, and Book.'
+    end
+  end
+
+  describe '.derived_description' do
+    it 'lists the terms outright when there are no more than the sample' do
+      expect(described_class.derived_description(2, %w[Student Instructor]))
+        .to eq '2 terms: Student and Instructor.'
+    end
+
+    it 'counts a vocabulary whose terms have no labels' do
+      expect(described_class.derived_description(4, [])).to eq '4 terms.'
+    end
+
+    it 'is nil for an empty vocabulary, which has nothing to describe' do
+      expect(described_class.derived_description(0, [])).to be_nil
+    end
+  end
+
+  # Hyku's own path, not the resolved one, so a knapsack adding a vocabulary of
+  # its own doesn't fail this.
+  it 'has a label and description on every vocabulary Hyku ships' do
+    described_class.metadata_by_name(File.expand_path('../../config/authorities', __dir__)).each do |name, metadata|
+      expect(metadata['label']).to be_present, "missing label in config/authorities/#{name}.yml"
+      expect(metadata['description']).to be_present, "missing description in config/authorities/#{name}.yml"
+    end
+  end
+
+  describe '.seed_vocabulary!' do
+    # The qa tables are seeded once in before(:suite) and skipped by truncation,
+    # so each example works on a name of its own in a directory of its own.
+    let(:path) { Dir.mktmpdir }
+
+    after { FileUtils.remove_entry(path) }
+
+    def write_vocabulary(name, metadata = {})
+      contents = metadata.merge('terms' => [{ 'id' => 'a', 'term' => 'A' }])
+      File.write(File.join(path, "#{name}.yml"), contents.to_yaml)
+      name
+    end
+
+    it 'takes the label and description off the vocabulary as it creates it' do
+      name = write_vocabulary('described_vocabulary',
+                              'label' => 'Practice Research Types',
+                              'description' => 'Forms of practice research output.')
+
+      described_class.seed!(path)
+
+      authority = Qa::LocalAuthority.find_by(name:)
+      expect(authority.label).to eq 'Practice Research Types'
+      expect(authority.description).to eq 'Forms of practice research output.'
+    end
+
+    # The case a knapsack lands in: its ymls carry neither key.
+    it 'titleizes and describes a vocabulary that carries neither' do
+      name = write_vocabulary('bare_vocabulary')
+
+      described_class.seed!(path)
+
+      authority = Qa::LocalAuthority.find_by(name:)
+      expect(authority.label).to eq 'Bare Vocabulary'
+      expect(authority.description).to eq '1 term: A.'
+    end
+
+    it 'fills a blank label on a vocabulary seeded before the columns existed' do
+      name = write_vocabulary('legacy_vocabulary', 'label' => 'Legacy Terms')
+      Qa::LocalAuthority.create!(name:)
+
+      described_class.seed!(path)
+
+      expect(Qa::LocalAuthority.find_by(name:).label).to eq 'Legacy Terms'
+    end
+
+    it 'leaves a label and description an admin edited alone' do
+      name = write_vocabulary('edited_vocabulary', 'label' => 'Licenses', 'description' => 'Shipped copy.')
+      Qa::LocalAuthority.create!(name:, label: 'Reuse Terms', description: 'What we allow.')
+
+      described_class.seed!(path)
+
+      authority = Qa::LocalAuthority.find_by(name:)
+      expect(authority.label).to eq 'Reuse Terms'
+      expect(authority.description).to eq 'What we allow.'
+    end
+  end
+
+  describe '.metadata_by_name' do
+    let(:path) { Dir.mktmpdir }
+
+    after { FileUtils.remove_entry(path) }
+
+    it 'reads the copy off disk without the terms' do
+      File.write(File.join(path, 'lab_names.yml'),
+                 { 'label' => 'Lab Names', 'terms' => [{ 'id' => 'a', 'term' => 'A' }] }.to_yaml)
+
+      expect(described_class.metadata_by_name(path)).to eq('lab_names' => { 'label' => 'Lab Names' })
+    end
+  end
+end


### PR DESCRIPTION
Loading vocabularies into the database left `label` and `description` null, so the admin UI in #3225 has nothing to show a staff member but a lowercase key like `oer_types`. Reseeding never fixes it because `populate_qa` only creates rows it doesn't already find.

Both values are now derived at seed time: the name titleized, and the term count with up to three example terms.

- A vocabulary can override either by carrying `label:` or `description:` alongside `terms:` in its yml. Qa reads only the `terms` key, so the extra keys are inert to it and a knapsack gets both by editing the yml it already ships. `oer_types` is the only one here that needs it, because titleize renders it "Oer Types".
- Derived text is stored rather than computed, so a description goes stale as terms change. It reads as a starting point for staff to replace, which is why it states what the vocabulary holds rather than what it means.
- The migration skips any row an admin has already edited, as does reseeding.

Testing: `bundle exec rspec spec/services/local_vocabulary_service_spec.rb spec/models/qa spec/authorities/qa` - 42 examples, 0 failures. Migration run across all local tenants, and the derived path checked against real knapsack ymls from enact, adventist, wvu and palni_palci, none of which carry either key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
