### PR TITLE
Browse controlled vocabularies from the dashboard

### DIFF
--- a/app/assets/stylesheets/hyku.scss
+++ b/app/assets/stylesheets/hyku.scss
@@ -780,3 +780,32 @@ dd {
     font-size: 0.875rem;
     color: #6c757d;
 }
+
+// Status badges for the controlled vocabulary dashboard.
+//
+// Set explicitly rather than reusing badge-warning and friends: the themes
+// flatten most Bootstrap badge colours to grays
+// Needs no action, so it recedes.
+.badge-quiet {
+    background-color: #e9ecef;
+    color: #495057;
+}
+
+// Needs attention.
+.badge-attention {
+    background-color: #b45309;
+    color: #fff;
+}
+
+// The question mark beside a column heading that carries a tooltip
+.column-hint {
+    border: 0;
+    cursor: help;
+    font-size: 0.875em;
+    vertical-align: baseline;
+
+    &:hover,
+    &:focus {
+        text-decoration: none;
+    }
+}

--- a/app/authorities/qa/authorities/local_vocabulary.rb
+++ b/app/authorities/qa/authorities/local_vocabulary.rb
@@ -5,6 +5,12 @@ module Qa::Authorities
     # Point Qa's startup index check at the lower(label) index we actually have.
     self.table_index = 'index_qa_local_authority_entries_on_lower_label_trgm'
 
+    # Staff own these terms: they are whatever this tenant put in the tables, or the
+    # yaml this application ships. Nothing external overwrites them.
+    def locally_owned?
+      true
+    end
+
     def all
       return file_based.all if file_based?
 

--- a/app/authorities/qa/authorities/mesh.rb
+++ b/app/authorities/qa/authorities/mesh.rb
@@ -8,6 +8,13 @@ module Qa::Authorities
       @subauthority = subauthority
     end
 
+    # These terms are imported from a MeSH release by mesh:import_tenant, which
+    # replaces every row, and their identifiers belong to the NLM. Editing them here
+    # would be undone by the next import, so the dashboard offers them read-only.
+    def locally_owned?
+      false
+    end
+
     def search(q, _controller)
       return [] if q.blank?
 

--- a/app/controllers/hyrax/dashboard/controlled_vocabularies_controller.rb
+++ b/app/controllers/hyrax/dashboard/controlled_vocabularies_controller.rb
@@ -20,7 +20,6 @@ module Hyrax
 
       def show
         @entry = ControlledVocabularyCatalog.find!(params[:id])
-        @controlled_vocabulary = @entry.vocabulary
         add_breadcrumb t(:'hyrax.controls.home'), root_path
         add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
         # main_app, not the bare helper: this controller is namespaced under

--- a/app/controllers/hyrax/dashboard/controlled_vocabularies_controller.rb
+++ b/app/controllers/hyrax/dashboard/controlled_vocabularies_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module Dashboard
+    # Read-only listing of every authority a metadata profile can cite, so staff can
+    # find the source key to paste into one.
+    class ControlledVocabulariesController < ApplicationController
+      with_themed_layout 'dashboard'
+
+      before_action do
+        authorize! :view, :controlled_vocabularies
+      end
+
+      def index
+        @controlled_vocabularies = ControlledVocabularyCatalog.all
+        add_breadcrumb t(:'hyrax.controls.home'), root_path
+        add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
+        add_breadcrumb t('hyku.admin.controlled_vocabularies'), request.path
+      end
+
+      def show
+        @entry = ControlledVocabularyCatalog.find!(params[:id])
+        @controlled_vocabulary = @entry.vocabulary
+        add_breadcrumb t(:'hyrax.controls.home'), root_path
+        add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
+        # main_app, not the bare helper: this controller is namespaced under
+        # Hyrax::, so bare url helpers resolve against the Hyrax engine, which does
+        # not define this route. The engine's `/files/:id` then swallows it.
+        add_breadcrumb t('hyku.admin.controlled_vocabularies'), main_app.controlled_vocabularies_path
+        add_breadcrumb @entry.label, request.path
+        @terms = ControlledVocabularyCatalog.terms_for(@entry)
+      end
+    end
+  end
+end

--- a/app/helpers/hyrax/form_helper_behavior.rb
+++ b/app/helpers/hyrax/form_helper_behavior.rb
@@ -3,7 +3,13 @@
 module Hyrax
   module FormHelperBehavior
     def controlled_vocabulary_service_for(source_name)
-      Hyrax::ControlledVocabularies.services[source_name]&.safe_constantize
+      registered = Hyrax::ControlledVocabularies.services[source_name]&.safe_constantize
+      return registered if registered
+
+      # Vocabularies created through the admin dashboard have no entry in the
+      # services registry, so fall back to a bare tolerant lookup. Without this
+      # the field renders as free text instead of a dropdown.
+      database_vocabulary_service_for(source_name)
     end
 
     def remote_authority_config_for(source_name)
@@ -42,6 +48,18 @@ module Hyrax
     end
 
     private
+
+    # A tolerant service for a database-backed vocabulary, or nil when no
+    # vocabulary of that name exists (so remote authorities still get a chance).
+    def database_vocabulary_service_for(source_name)
+      return if source_name.blank?
+      return unless Qa::LocalAuthority.exists?(name: source_name.to_s)
+
+      Hyrax::TolerantSelectService.new(source_name.to_s)
+    rescue StandardError => e
+      Rails.logger.warn "Failed to build a vocabulary service for #{source_name}: #{e.message}"
+      nil
+    end
 
     def controlled_vocabulary_mapping_for(property_name)
       # Maps property names in when flexible=false to their corresponding controlled vocabulary service keys

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -8,6 +8,7 @@ class Ability
   include Hyrax::Ability::UserAbility
   include Hyrax::Ability::WorkAbility
   include Hyrax::Ability::TenantControlAbility
+  include Hyrax::Ability::ControlledVocabularyAbility
 
   self.ability_logic += %i[
     group_permissions
@@ -17,6 +18,7 @@ class Ability
     work_roles
     featured_collection_abilities
     tenant_control_abilities
+    controlled_vocabulary_abilities
   ]
   # If the Groups with Roles feature is disabled, allow registered users to create curation concerns
   # (Works, Collections, and FileSets). Otherwise, omit this ability logic as to not

--- a/app/models/concerns/hyrax/ability/controlled_vocabulary_ability.rb
+++ b/app/models/concerns/hyrax/ability/controlled_vocabulary_ability.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# A module to define abilities related to controlled vocabularies.
+#
+# Viewing is granted to anyone who can deposit, because a depositor needs to see
+# the terms a field offers and which of them are retired. Managing is restricted
+# to admins: a vocabulary's terms are the values works store, so editing one
+# affects every work already citing it.
+module Hyrax
+  module Ability
+    module ControlledVocabularyAbility
+      # +view+ is the action the dashboard checks; +read+ is granted alongside it
+      # because CanCan does not alias the two, and Hyrax callers reach for :read.
+      def controlled_vocabulary_abilities
+        can %i[manage view read], :controlled_vocabularies if admin?
+
+        # Same check Bulkrax uses to gate importing, so anyone who can deposit
+        # through it can also look up the vocabularies behind those fields.
+        can %i[view read], :controlled_vocabularies if can_import_works?
+      end
+    end
+  end
+end

--- a/app/models/qa/local_authority.rb
+++ b/app/models/qa/local_authority.rb
@@ -30,8 +30,10 @@ module Qa
       label.presence || name.to_s.titleize
     end
 
+    # The value staff paste into a metadata profile's controlled_values sources.
+    # Bare, matching how the file-based vocabularies are already cited there.
     def source_key
-      "local/#{name}"
+      name
     end
   end
 end

--- a/app/models/qa/local_authority.rb
+++ b/app/models/qa/local_authority.rb
@@ -19,13 +19,6 @@ module Qa
 
     scope :ordered, -> { order(Arel.sql("COALESCE(NULLIF(label, ''), name)")) }
 
-    def self.file_based_names
-      Qa::Authorities::Local.names
-    rescue Qa::ConfigDirectoryNotFound => e
-      Rails.logger.warn("Unable to list file-based local authorities: #{e.message}")
-      []
-    end
-
     def display_label
       label.presence || name.to_s.titleize
     end

--- a/app/presenters/hyrax/menu_presenter_decorator.rb
+++ b/app/presenters/hyrax/menu_presenter_decorator.rb
@@ -40,7 +40,8 @@ module Hyrax
       can?(:review, :submissions) ||
         can?(:read, User) ||
         can?(:read, Hyrax::Group) ||
-        can?(:read, :admin_dashboard)
+        can?(:read, :admin_dashboard) ||
+        can?(:view, :controlled_vocabularies)
     end
   end
 end

--- a/app/services/controlled_vocabulary_catalog.rb
+++ b/app/services/controlled_vocabulary_catalog.rb
@@ -19,13 +19,14 @@ class ControlledVocabularyCatalog
   # Editable first, then read-only local, then the external services.
   ORIGIN_ORDER = { database: 0, cached: 1, file: 2, remote: 3 }.freeze
 
+  # How many terms a page will list. A vocabulary can hold tens of thousands — the
+  # MeSH release is around 30,000 — and rendering them all serves nobody. The view
+  # compares this against the real count so a truncated list says so.
+  TERM_LIMIT = 500
+
   Entry = Struct.new(:source_key, :label, :origin, :description, :term_count,
                      :vocabulary, :provider, :configured, :import_task,
                      keyword_init: true) do
-    def stored_locally?
-      origin == :database || origin == :cached
-    end
-
     # Not staff's to change: the next import replaces every row, and the identifiers
     # belong to the upstream authority.
     def cached?
@@ -39,10 +40,10 @@ class ControlledVocabularyCatalog
       origin == :database && vocabulary.present?
     end
 
-    # Anything whose terms are stored here, once the row exists, plus the yaml
-    # vocabularies. Remote services are not enumerable, so they never open.
+    # Only what has a term list worth opening. Remote services are not enumerable,
+    # and an imported copy holds too many terms to list.
     def viewable?
-      (stored_locally? && vocabulary.present?) || origin == :file
+      editable? || origin == :file
     end
 
     # nil means the authority needs no credentials, so only a known-missing one is
@@ -105,27 +106,45 @@ class ControlledVocabularyCatalog
       end
     end
 
+    # Checks the database rows first: assembling the whole catalog walks every qa
+    # authority and parses every yaml, which a show page does not need.
+    #
     # @raise [ActiveRecord::RecordNotFound] so an unknown key 404s rather than
     #   rendering an empty page.
     def find!(source_key)
-      all.detect { |entry| entry.source_key == source_key.to_s } ||
-        raise(ActiveRecord::RecordNotFound, "No controlled vocabulary named #{source_key}")
+      key = source_key.to_s
+
+      database.detect { |entry| entry.source_key == key } ||
+        all.detect { |entry| entry.source_key == key } ||
+        raise(ActiveRecord::RecordNotFound, "No controlled vocabulary named #{key}")
     end
 
-    # Terms for any local vocabulary, whether a database row or a yaml file backs
-    # it: Qa::Authorities::LocalVocabulary resolves both and returns the same shape.
-    # Remote authorities are not enumerable, so they get nothing.
+    # Read from the entries table rather than through the authority, whose classes do
+    # not agree: Mesh implements only #search, so #all raises, and LocalVocabulary
+    # silently caps at 1,000.
     #
-    # @return [Array<Hash>, nil] each with id, label, and active
-    # NotImplementedError is rescued alongside StandardError because it descends
-    # from ScriptError: an authority that implements only #search raises rather
-    # than returning nothing when asked for every term.
+    # @return [Array<Hash>, nil] each with id, label, and active; nil when the terms
+    #   cannot be listed at all
     def terms_for(entry)
-      return unless entry.stored_locally? || entry.origin == :file
+      return file_terms(entry.source_key) if entry.origin == :file
+      # Imported copies are not listed at all: a MeSH release runs to about 30,000
+      # terms, and a page of the first few hundred tells a reader nothing useful.
+      return unless entry.origin == :database
+      return [] if entry.vocabulary.nil?
 
-      Qa::Authorities::Local.subauthority_for(entry.source_key).all
+      entry.vocabulary.local_authority_entries.ordered.limit(TERM_LIMIT).map do |term|
+        { 'id' => term.uri, 'label' => term.label, 'active' => term.active }
+      end
+    end
+
+    # A yaml vocabulary has no rows, so its terms come from the authority.
+    def file_terms(name)
+      Qa::Authorities::Local.subauthority_for(name).all.first(TERM_LIMIT).map do |term|
+        term = term.with_indifferent_access
+        { 'id' => term[:id], 'label' => term[:label], 'active' => term[:active] }
+      end
     rescue StandardError, NotImplementedError => e
-      Rails.logger.warn("Unable to list terms for #{entry.source_key}: #{e.message}")
+      Rails.logger.warn("Unable to list terms for #{name}: #{e.message}")
       nil
     end
 
@@ -150,7 +169,9 @@ class ControlledVocabularyCatalog
 
     def database_entry(vocabulary, totals)
       Entry.new(source_key: vocabulary.name,
-                label: vocabulary.display_label,
+                # A staff label wins, then the locale, then a titleized name. Skipping
+                # the locale would rename MeSH to "Mesh" once it has a row.
+                label: vocabulary.label.presence || provider_label(vocabulary.name),
                 origin: cached_vocabulary?(vocabulary.name) ? :cached : :database,
                 description: vocabulary.description,
                 term_count: totals.fetch(vocabulary.id, 0),
@@ -215,21 +236,24 @@ class ControlledVocabularyCatalog
       I18n.t("hyku.admin.controlled_vocabulary.providers.#{provider}", default: provider.titleize)
     end
 
-    # nil when an authority needs no credentials, so only the ones that do get
+    # Listed rather than matched on a prefix: `loc` would find `locale_name` and
+    # report the Library of Congress unconfigured.
+    PROVIDER_SETTINGS = { 'discogs' => :discogs_user_token, 'geonames' => :geonames_username }.freeze
+
+    # nil for an authority that needs no credentials, so only the ones that do get
     # flagged.
     #
-    # Read from this tenant's settings rather than from the authority class:
-    # Qa::Authorities::Geonames.username is a class_attribute, so it holds whichever
-    # tenant configured Hyrax most recently in this process, not the one being
-    # viewed.
+    # Read through the account's accessors, not Site.account.settings: the readers
+    # apply the HYKU_/HYRAX_ environment fallbacks, so the raw hash reports a
+    # credential missing when the environment supplies it.
     def remote_configured?(provider)
-      settings = Site.account&.settings
-      return if settings.blank?
+      setting = PROVIDER_SETTINGS[provider]
+      return if setting.nil?
 
-      case provider
-      when 'discogs' then settings['discogs_user_token'].present?
-      when 'geonames' then settings['geonames_username'].present?
-      end
+      account = Site.account
+      return false if account.nil?
+
+      account.public_send(setting).present?
     rescue StandardError => e
       Rails.logger.warn("Unable to check configuration for #{provider}: #{e.message}")
       nil

--- a/app/services/controlled_vocabulary_catalog.rb
+++ b/app/services/controlled_vocabulary_catalog.rb
@@ -4,51 +4,45 @@
 # can see what is available to put in `controlled_values.sources` without reading
 # the code.
 #
-# Three origins:
-#   :database — rows in this tenant, whether staff created them or a seed did
+# Four origins:
+#   :database — rows this tenant owns, whether staff created them or a seed did
+#   :cached   — rows holding a copy of an external vocabulary, replaced on import
 #   :file     — config/authorities/*.yml, deployment-wide
 #   :remote   — external services (LOC, Getty, FAST), deployment-wide
 #
 # Only :database rows are editable, and only once the row exists — see Entry.
 #
-# TODO: over the ClassLength limit while the three assemblers live here. Extract
-# Entry, or one assembler per origin, once term editing settles the shape.
+# TODO: over the ClassLength limit while Entry and the four assemblers live here.
+# Extract them once term editing settles the shape.
 # rubocop:disable Metrics/ClassLength
 class ControlledVocabularyCatalog
-  # Authorities registered as remote whose url actually points at a local table.
-  # `mesh` is the case in hand: it is table-backed and populated by the separate
-  # mesh:import_tenant task, so it belongs with the local vocabularies.
-  LOCAL_URL_PREFIX = '/authorities/search/local/'
-
-  ORIGIN_ORDER = { database: 0, file: 1, remote: 2 }.freeze
-
-  # titleize mangles these, and an acronym expanded wrongly is worse than none.
-  REMOTE_VOCABULARY_LABELS = {
-    'aat' => 'Art & Architecture Thesaurus',
-    'tgn' => 'Thesaurus of Geographic Names',
-    'ulan' => 'Union List of Artist Names',
-    'iso639-1' => 'ISO 639-1 Languages',
-    'iso639-2' => 'ISO 639-2 Languages',
-    'genre_forms' => 'Genre/Form Terms'
-  }.freeze
+  # Editable first, then read-only local, then the external services.
+  ORIGIN_ORDER = { database: 0, cached: 1, file: 2, remote: 3 }.freeze
 
   Entry = Struct.new(:source_key, :label, :origin, :description, :term_count,
                      :vocabulary, :provider, :configured, :import_task,
                      keyword_init: true) do
-    # A registered local authority can have no row yet — mesh before its import —
-    # so :database alone does not mean there is anything to edit.
+    def stored_locally?
+      origin == :database || origin == :cached
+    end
+
+    # Not staff's to change: the next import replaces every row, and the identifiers
+    # belong to the upstream authority.
+    def cached?
+      origin == :cached
+    end
+
+    # Having no terms is not a reason to withhold editing — an empty vocabulary is
+    # where the first term gets added. What is needed is the row itself, which a
+    # registered authority may not have yet.
     def editable?
-      vocabulary.present?
+      origin == :database && vocabulary.present?
     end
 
-    def local?
-      origin == :database
-    end
-
-    # File-based vocabularies are worth opening even though they cannot be edited.
-    # Remote services are not enumerable, so they are not.
+    # Anything whose terms are stored here, once the row exists, plus the yaml
+    # vocabularies. Remote services are not enumerable, so they never open.
     def viewable?
-      editable? || origin == :file
+      (stored_locally? && vocabulary.present?) || origin == :file
     end
 
     # nil means the authority needs no credentials, so only a known-missing one is
@@ -98,20 +92,16 @@ class ControlledVocabularyCatalog
       end
     end
 
-    # Term counts are unknowable without querying the service, so they stay nil.
+    # Built from the qa gem rather than a hand-maintained list, so the page reflects
+    # what qa can actually resolve. Term counts are unknowable without querying the
+    # service, so they stay nil.
     def remote
-      remote_authorities.filter_map do |source_key, config|
-        next if local_url?(config[:url])
+      Qa::AuthorityRegistry.remote_services.flat_map do |provider, klass|
+        configured = remote_configured?(provider)
 
-        provider, vocabulary = source_key.split('/', 2)
-
-        Entry.new(source_key: source_key,
-                  # Names the vocabulary, not the key: titleizing `loc/iso639-1`
-                  # gives "Loc/Iso639 1", and the service has its own column.
-                  label: remote_vocabulary_label(vocabulary) || provider_label(provider),
-                  origin: :remote,
-                  provider: provider,
-                  configured: remote_configured?(provider))
+        Qa::AuthorityRegistry.subauthorities_of(klass).map do |subauthority|
+          remote_entry(provider, subauthority, configured)
+        end
       end
     end
 
@@ -131,7 +121,7 @@ class ControlledVocabularyCatalog
     # from ScriptError: an authority that implements only #search raises rather
     # than returning nothing when asked for every term.
     def terms_for(entry)
-      return unless entry.local? || entry.origin == :file
+      return unless entry.stored_locally? || entry.origin == :file
 
       Qa::Authorities::Local.subauthority_for(entry.source_key).all
     rescue StandardError, NotImplementedError => e
@@ -148,39 +138,63 @@ class ControlledVocabularyCatalog
 
     private
 
-    def remote_authorities
-      Hyrax::ControlledVocabularies.remote_authorities
+    def remote_entry(provider, subauthority, configured)
+      Entry.new(source_key: [provider, subauthority].compact.join('/'),
+                # Names the vocabulary, not the key: titleizing `loc/iso639-1`
+                # gives "Loc/Iso639 1", and the service has its own column.
+                label: remote_vocabulary_label(subauthority) || provider_label(provider),
+                origin: :remote,
+                provider: provider,
+                configured: configured)
     end
 
     def database_entry(vocabulary, totals)
       Entry.new(source_key: vocabulary.name,
                 label: vocabulary.display_label,
-                origin: :database,
+                origin: cached_vocabulary?(vocabulary.name) ? :cached : :database,
                 description: vocabulary.description,
                 term_count: totals.fetch(vocabulary.id, 0),
                 vocabulary: vocabulary,
                 import_task: import_task_for(vocabulary.name))
     end
 
-    # Registered local authorities with no row in this tenant yet, so a manager can
-    # see the vocabulary exists and what it takes to populate it.
+    # Local authorities qa knows about that have neither a row in this tenant nor a
+    # yaml file, so a manager can see the vocabulary exists and what populates it.
+    # mesh is the case in hand: registered at boot, filled by a rake task.
     def unimported_local
-      existing = Qa::LocalAuthority.pluck(:name).map(&:to_s)
+      accounted_for = Qa::LocalAuthority.pluck(:name).map(&:to_s) + file_based_names
 
-      remote_authorities.filter_map do |source_key, config|
-        next unless local_url?(config[:url])
-        next if existing.include?(source_key)
-
-        Entry.new(source_key: source_key,
-                  label: provider_label(source_key),
-                  origin: :database,
+      (registered_local_names - accounted_for).map do |name|
+        Entry.new(source_key: name,
+                  label: provider_label(name),
+                  origin: cached_vocabulary?(name) ? :cached : :database,
                   term_count: 0,
-                  import_task: import_task_for(source_key))
+                  import_task: import_task_for(name))
       end
     end
 
-    def local_url?(url)
-      url.to_s.start_with?(LOCAL_URL_PREFIX)
+    def registered_local_names
+      Qa::Authorities::Local.registry.keys.map(&:to_s)
+    rescue StandardError => e
+      Rails.logger.warn("Unable to list registered local authorities: #{e.message}")
+      []
+    end
+
+    # Whether a locally-stored vocabulary holds a copy of an external one rather than
+    # terms this tenant owns.
+    #
+    # The authority answers for itself: Qa::Authorities::Mesh reports
+    # locally_owned? false because a MeSH import replaces all of its rows. An
+    # authority that does not answer is assumed to be owned here, so a vocabulary is
+    # only ever marked read-only deliberately.
+    def cached_vocabulary?(name)
+      authority = Qa::Authorities::Local.subauthority_for(name)
+      return false unless authority.respond_to?(:locally_owned?)
+
+      !authority.locally_owned?
+    rescue StandardError => e
+      Rails.logger.debug { "Unable to resolve #{name} while checking ownership: #{e.message}" }
+      false
     end
 
     IMPORT_TASKS = { 'mesh' => 'mesh:import_tenant' }.freeze
@@ -192,19 +206,29 @@ class ControlledVocabularyCatalog
     def remote_vocabulary_label(vocabulary)
       return if vocabulary.blank?
 
-      REMOTE_VOCABULARY_LABELS.fetch(vocabulary) { vocabulary.titleize }
+      Qa::AuthorityRegistry.display_name(vocabulary)
     end
 
+    # Locale-driven rather than from the registry: what to call a service in this
+    # dashboard is presentation, and translatable.
     def provider_label(provider)
       I18n.t("hyku.admin.controlled_vocabulary.providers.#{provider}", default: provider.titleize)
     end
 
     # nil when an authority needs no credentials, so only the ones that do get
-    # flagged. Mirrors the checks the form helper already makes before rendering.
+    # flagged.
+    #
+    # Read from this tenant's settings rather than from the authority class:
+    # Qa::Authorities::Geonames.username is a class_attribute, so it holds whichever
+    # tenant configured Hyrax most recently in this process, not the one being
+    # viewed.
     def remote_configured?(provider)
+      settings = Site.account&.settings
+      return if settings.blank?
+
       case provider
-      when 'discogs' then Site.account.respond_to?(:discogs_user_token) && Site.account.discogs_user_token.present?
-      when 'geonames' then Qa::Authorities::Geonames.username.present?
+      when 'discogs' then settings['discogs_user_token'].present?
+      when 'geonames' then settings['geonames_username'].present?
       end
     rescue StandardError => e
       Rails.logger.warn("Unable to check configuration for #{provider}: #{e.message}")

--- a/app/services/controlled_vocabulary_catalog.rb
+++ b/app/services/controlled_vocabulary_catalog.rb
@@ -33,8 +33,8 @@ class ControlledVocabularyCatalog
   }.freeze
 
   Entry = Struct.new(:source_key, :label, :origin, :description, :term_count,
-                     :active_term_count, :vocabulary, :url, :input_type, :provider,
-                     :configured, :import_task, keyword_init: true) do
+                     :vocabulary, :provider, :configured, :import_task,
+                     keyword_init: true) do
     # A registered local authority can have no row yet — mesh before its import —
     # so :database alone does not mean there is anything to edit.
     def editable?
@@ -49,10 +49,6 @@ class ControlledVocabularyCatalog
     # Remote services are not enumerable, so they are not.
     def viewable?
       editable? || origin == :file
-    end
-
-    def counted?
-      !term_count.nil?
     end
 
     # nil means the authority needs no credentials, so only a known-missing one is
@@ -81,12 +77,10 @@ class ControlledVocabularyCatalog
 
     def database
       vocabularies = Qa::LocalAuthority.ordered.to_a
-      # Two grouped counts rather than two per vocabulary.
+      # One grouped count rather than one per vocabulary.
       totals = Qa::LocalAuthorityEntry.where(local_authority: vocabularies).group(:local_authority_id).count
-      actives = Qa::LocalAuthorityEntry.active.where(local_authority: vocabularies)
-                                       .group(:local_authority_id).count
 
-      entries = vocabularies.map { |vocabulary| database_entry(vocabulary, totals, actives) }
+      entries = vocabularies.map { |vocabulary| database_entry(vocabulary, totals) }
 
       (entries + unimported_local).sort_by { |e| e.label.downcase }
     end
@@ -100,8 +94,7 @@ class ControlledVocabularyCatalog
         Entry.new(source_key: name,
                   label: name.titleize,
                   origin: :file,
-                  term_count: file_term_count(name),
-                  input_type: 'select')
+                  term_count: file_term_count(name))
       end
     end
 
@@ -118,8 +111,6 @@ class ControlledVocabularyCatalog
                   label: remote_vocabulary_label(vocabulary) || provider_label(provider),
                   origin: :remote,
                   provider: provider,
-                  url: config[:url],
-                  input_type: config[:type],
                   configured: remote_configured?(provider))
       end
     end
@@ -137,8 +128,8 @@ class ControlledVocabularyCatalog
     #
     # @return [Array<Hash>, nil] each with id, label, and active
     # NotImplementedError is rescued alongside StandardError because it descends
-    # from ScriptError: Qa::Authorities::Mesh implements only #search, so asking it
-    # for every term raises rather than returning nothing.
+    # from ScriptError: an authority that implements only #search raises rather
+    # than returning nothing when asked for every term.
     def terms_for(entry)
       return unless entry.local? || entry.origin == :file
 
@@ -161,15 +152,13 @@ class ControlledVocabularyCatalog
       Hyrax::ControlledVocabularies.remote_authorities
     end
 
-    def database_entry(vocabulary, totals, actives)
+    def database_entry(vocabulary, totals)
       Entry.new(source_key: vocabulary.name,
                 label: vocabulary.display_label,
                 origin: :database,
                 description: vocabulary.description,
                 term_count: totals.fetch(vocabulary.id, 0),
-                active_term_count: actives.fetch(vocabulary.id, 0),
                 vocabulary: vocabulary,
-                input_type: 'select',
                 import_task: import_task_for(vocabulary.name))
     end
 
@@ -186,8 +175,6 @@ class ControlledVocabularyCatalog
                   label: provider_label(source_key),
                   origin: :database,
                   term_count: 0,
-                  active_term_count: 0,
-                  input_type: config[:type],
                   import_task: import_task_for(source_key))
       end
     end

--- a/app/services/controlled_vocabulary_catalog.rb
+++ b/app/services/controlled_vocabulary_catalog.rb
@@ -1,0 +1,237 @@
+# frozen_string_literal: true
+
+# Assembles every authority a metadata profile can cite into one list, so staff
+# can see what is available to put in `controlled_values.sources` without reading
+# the code.
+#
+# Three origins:
+#   :database — rows in this tenant, whether staff created them or a seed did
+#   :file     — config/authorities/*.yml, deployment-wide
+#   :remote   — external services (LOC, Getty, FAST), deployment-wide
+#
+# Only :database rows are editable, and only once the row exists — see Entry.
+#
+# TODO: over the ClassLength limit while the three assemblers live here. Extract
+# Entry, or one assembler per origin, once term editing settles the shape.
+# rubocop:disable Metrics/ClassLength
+class ControlledVocabularyCatalog
+  # Authorities registered as remote whose url actually points at a local table.
+  # `mesh` is the case in hand: it is table-backed and populated by the separate
+  # mesh:import_tenant task, so it belongs with the local vocabularies.
+  LOCAL_URL_PREFIX = '/authorities/search/local/'
+
+  ORIGIN_ORDER = { database: 0, file: 1, remote: 2 }.freeze
+
+  # titleize mangles these, and an acronym expanded wrongly is worse than none.
+  REMOTE_VOCABULARY_LABELS = {
+    'aat' => 'Art & Architecture Thesaurus',
+    'tgn' => 'Thesaurus of Geographic Names',
+    'ulan' => 'Union List of Artist Names',
+    'iso639-1' => 'ISO 639-1 Languages',
+    'iso639-2' => 'ISO 639-2 Languages',
+    'genre_forms' => 'Genre/Form Terms'
+  }.freeze
+
+  Entry = Struct.new(:source_key, :label, :origin, :description, :term_count,
+                     :active_term_count, :vocabulary, :url, :input_type, :provider,
+                     :configured, :import_task, keyword_init: true) do
+    # A registered local authority can have no row yet — mesh before its import —
+    # so :database alone does not mean there is anything to edit.
+    def editable?
+      vocabulary.present?
+    end
+
+    def local?
+      origin == :database
+    end
+
+    # File-based vocabularies are worth opening even though they cannot be edited.
+    # Remote services are not enumerable, so they are not.
+    def viewable?
+      editable? || origin == :file
+    end
+
+    def counted?
+      !term_count.nil?
+    end
+
+    # nil means the authority needs no credentials, so only a known-missing one is
+    # reported unconfigured.
+    def configured?
+      configured != false
+    end
+
+    def awaiting_import?
+      import_task.present? && term_count.to_i.zero?
+    end
+  end
+
+  class << self
+    # Remote entries sort by provider so services stay together: a bare "Corporate"
+    # or "Master" only makes sense next to the service it belongs to.
+    #
+    # @return [Array<Entry>]
+    def all
+      (database + file_based + remote).sort_by do |entry|
+        [ORIGIN_ORDER.fetch(entry.origin, 9),
+         entry.provider.to_s.downcase,
+         entry.label.downcase]
+      end
+    end
+
+    def database
+      vocabularies = Qa::LocalAuthority.ordered.to_a
+      # Two grouped counts rather than two per vocabulary.
+      totals = Qa::LocalAuthorityEntry.where(local_authority: vocabularies).group(:local_authority_id).count
+      actives = Qa::LocalAuthorityEntry.active.where(local_authority: vocabularies)
+                                       .group(:local_authority_id).count
+
+      entries = vocabularies.map { |vocabulary| database_entry(vocabulary, totals, actives) }
+
+      (entries + unimported_local).sort_by { |e| e.label.downcase }
+    end
+
+    # Excludes names already backed by a database row: the row is what staff see
+    # and edit, so listing both would imply two separate vocabularies.
+    def file_based
+      claimed = Qa::LocalAuthority.pluck(:name).map(&:to_s)
+
+      (file_based_names - claimed).map do |name|
+        Entry.new(source_key: name,
+                  label: name.titleize,
+                  origin: :file,
+                  term_count: file_term_count(name),
+                  input_type: 'select')
+      end
+    end
+
+    # Term counts are unknowable without querying the service, so they stay nil.
+    def remote
+      remote_authorities.filter_map do |source_key, config|
+        next if local_url?(config[:url])
+
+        provider, vocabulary = source_key.split('/', 2)
+
+        Entry.new(source_key: source_key,
+                  # Names the vocabulary, not the key: titleizing `loc/iso639-1`
+                  # gives "Loc/Iso639 1", and the service has its own column.
+                  label: remote_vocabulary_label(vocabulary) || provider_label(provider),
+                  origin: :remote,
+                  provider: provider,
+                  url: config[:url],
+                  input_type: config[:type],
+                  configured: remote_configured?(provider))
+      end
+    end
+
+    # @raise [ActiveRecord::RecordNotFound] so an unknown key 404s rather than
+    #   rendering an empty page.
+    def find!(source_key)
+      all.detect { |entry| entry.source_key == source_key.to_s } ||
+        raise(ActiveRecord::RecordNotFound, "No controlled vocabulary named #{source_key}")
+    end
+
+    # Terms for any local vocabulary, whether a database row or a yaml file backs
+    # it: Qa::Authorities::LocalVocabulary resolves both and returns the same shape.
+    # Remote authorities are not enumerable, so they get nothing.
+    #
+    # @return [Array<Hash>, nil] each with id, label, and active
+    # NotImplementedError is rescued alongside StandardError because it descends
+    # from ScriptError: Qa::Authorities::Mesh implements only #search, so asking it
+    # for every term raises rather than returning nothing.
+    def terms_for(entry)
+      return unless entry.local? || entry.origin == :file
+
+      Qa::Authorities::Local.subauthority_for(entry.source_key).all
+    rescue StandardError, NotImplementedError => e
+      Rails.logger.warn("Unable to list terms for #{entry.source_key}: #{e.message}")
+      nil
+    end
+
+    def file_based_names
+      Qa::Authorities::Local.names
+    rescue Qa::ConfigDirectoryNotFound => e
+      Rails.logger.warn("Unable to list file-based local authorities: #{e.message}")
+      []
+    end
+
+    private
+
+    def remote_authorities
+      Hyrax::ControlledVocabularies.remote_authorities
+    end
+
+    def database_entry(vocabulary, totals, actives)
+      Entry.new(source_key: vocabulary.name,
+                label: vocabulary.display_label,
+                origin: :database,
+                description: vocabulary.description,
+                term_count: totals.fetch(vocabulary.id, 0),
+                active_term_count: actives.fetch(vocabulary.id, 0),
+                vocabulary: vocabulary,
+                input_type: 'select',
+                import_task: import_task_for(vocabulary.name))
+    end
+
+    # Registered local authorities with no row in this tenant yet, so a manager can
+    # see the vocabulary exists and what it takes to populate it.
+    def unimported_local
+      existing = Qa::LocalAuthority.pluck(:name).map(&:to_s)
+
+      remote_authorities.filter_map do |source_key, config|
+        next unless local_url?(config[:url])
+        next if existing.include?(source_key)
+
+        Entry.new(source_key: source_key,
+                  label: provider_label(source_key),
+                  origin: :database,
+                  term_count: 0,
+                  active_term_count: 0,
+                  input_type: config[:type],
+                  import_task: import_task_for(source_key))
+      end
+    end
+
+    def local_url?(url)
+      url.to_s.start_with?(LOCAL_URL_PREFIX)
+    end
+
+    IMPORT_TASKS = { 'mesh' => 'mesh:import_tenant' }.freeze
+
+    def import_task_for(name)
+      IMPORT_TASKS[name]
+    end
+
+    def remote_vocabulary_label(vocabulary)
+      return if vocabulary.blank?
+
+      REMOTE_VOCABULARY_LABELS.fetch(vocabulary) { vocabulary.titleize }
+    end
+
+    def provider_label(provider)
+      I18n.t("hyku.admin.controlled_vocabulary.providers.#{provider}", default: provider.titleize)
+    end
+
+    # nil when an authority needs no credentials, so only the ones that do get
+    # flagged. Mirrors the checks the form helper already makes before rendering.
+    def remote_configured?(provider)
+      case provider
+      when 'discogs' then Site.account.respond_to?(:discogs_user_token) && Site.account.discogs_user_token.present?
+      when 'geonames' then Qa::Authorities::Geonames.username.present?
+      end
+    rescue StandardError => e
+      Rails.logger.warn("Unable to check configuration for #{provider}: #{e.message}")
+      nil
+    end
+
+    # nil rather than 0 on failure, so the view can say "unknown" instead of
+    # claiming an empty vocabulary.
+    def file_term_count(name)
+      Qa::Authorities::Local.subauthority_for(name).all.size
+    rescue StandardError => e
+      Rails.logger.warn("Unable to count terms for #{name}: #{e.message}")
+      nil
+    end
+  end
+end
+# rubocop:enable Metrics/ClassLength

--- a/app/services/qa/authority_registry.rb
+++ b/app/services/qa/authority_registry.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+module Qa
+  # Answers "what authorities does this installation offer, and how are they cited?"
+  #
+  # The qa gem knows all of this about itself but does not expose it: there is no
+  # way to ask for the remote services it provides, and no display names for
+  # either a service or its subauthorities. Every consumer therefore hardcodes a
+  # list, which drifts from what the gem actually resolves — Hyku's own list named
+  # 7 Library of Congress subauthorities where qa supports 43, and cited
+  # `genre_forms` where qa accepts only `genreForms`.
+  #
+  # This is a Hyku class, named under Qa:: because everything it reasons about is.
+  # The gem has no equivalent today.
+  #
+  # TODO: propose it upstream. It has no Hyku dependencies, so the gem could take it
+  # over and this file be deleted — as something like Qa::Authorities.remote_services
+  # and .vocabularies_for. DISPLAY_NAMES is the part that may not belong there, being
+  # presentation rather than capability.
+  class AuthorityRegistry
+    # Constants under Qa::Authorities that are not vocabulary services: the local
+    # backend, abstract bases, the subauthority mixins, the separately-configured
+    # RDF mechanism, and the MeSH import helpers.
+    NON_SERVICES = %w[
+      Base WebServiceBase AuthorityWithSubAuthority Local LinkedData MeshTools
+    ].freeze
+
+    # qa names its classes for the code rather than the reader.
+    SOURCE_KEYS = { 'assign_fast' => 'fast' }.freeze
+
+    # titleize mangles acronyms and camelCase keys, and an acronym expanded wrongly
+    # is worse than none.
+    DISPLAY_NAMES = {
+      'aat' => 'Art & Architecture Thesaurus',
+      'tgn' => 'Thesaurus of Geographic Names',
+      'ulan' => 'Union List of Artist Names',
+      'iso639-1' => 'ISO 639-1 Languages',
+      'iso639-2' => 'ISO 639-2 Languages',
+      'iso639-3' => 'ISO 639-3 Languages',
+      'iso639-5' => 'ISO 639-5 Languages',
+      'genreForms' => 'Genre/Form Terms',
+      'childrensSubjects' => "Children's Subjects",
+      'performanceMediums' => 'Performance Mediums',
+      'graphicMaterials' => 'Graphic Materials',
+      'ethnographicTerms' => 'Ethnographic Terms',
+      'geographicAreas' => 'Geographic Areas'
+    }.freeze
+
+    class << self
+      # The remote services the gem provides, as the source key a metadata profile
+      # cites => the authority class.
+      #
+      # Selected by where the constant is declared, so authorities a host
+      # application adds are excluded without naming them: Hyrax contributes
+      # pickers for works and collections, and Hyku its own local classes.
+      #
+      # @return [Hash{String => Module}]
+      def remote_services
+        Qa::Authorities.constants.sort.each_with_object({}) do |name, services|
+          next if NON_SERVICES.include?(name.to_s)
+          next if name.to_s.end_with?('Subauthority', 'Decorator')
+
+          # Loaded before locating it: qa autoloads these, and
+          # const_source_location reports the autoload stub until the constant is
+          # referenced.
+          klass = authority_class(name)
+          next if klass.nil?
+          next unless defined_in_gem?(name)
+
+          services[source_key_for(name)] = klass
+        end
+      end
+
+      # Every vocabulary a service offers, as the keys a profile can cite.
+      #
+      # @return [Array<String>] e.g. ["loc/subjects", "geonames"]
+      def vocabularies_for(source_key, klass)
+        subauthorities_of(klass).map { |sub| [source_key, sub].compact.join('/') }
+      end
+
+      # @return [String] a name for a service or one of its vocabularies
+      def display_name(key)
+        DISPLAY_NAMES.fetch(key) { key.titleize }
+      end
+
+      # Nil means the service is a single vocabulary, cited by its own key alone
+      # (`geonames`) rather than `service/vocabulary`.
+      def subauthorities_of(klass)
+        return [nil] unless klass.respond_to?(:subauthorities)
+
+        klass.subauthorities.presence || [nil]
+      end
+
+      private
+
+      # Rescued per constant: some authorities read a config file when they load
+      # (Oclcts wants config/oclcts-authorities.yml), and one missing file must not
+      # empty the whole list.
+      def authority_class(name)
+        Qa::Authorities.const_get(name)
+      rescue StandardError, LoadError => e
+        Rails.logger.debug { "Skipping authority #{name}: #{e.message}" }
+        nil
+      end
+
+      # Reads where the constant is declared, which is stable: inspecting the
+      # class's methods would follow inherited ones into the gem, and would also be
+      # perturbed by any method a test stubs onto the class.
+      def defined_in_gem?(name)
+        path, = Qa::Authorities.const_source_location(name)
+
+        path.to_s.include?('questioning_authority')
+      rescue StandardError => e
+        Rails.logger.debug { "Unable to locate authority #{name}: #{e.message}" }
+        false
+      end
+
+      def source_key_for(constant_name)
+        key = constant_name.to_s.underscore
+        SOURCE_KEYS.fetch(key, key)
+      end
+    end
+  end
+end

--- a/app/views/hyrax/dashboard/controlled_vocabularies/_column_hint.html.erb
+++ b/app/views/hyrax/dashboard/controlled_vocabularies/_column_hint.html.erb
@@ -1,0 +1,8 @@
+<%# A column heading whose explanation sits behind a question mark. %>
+<%= label %>
+<button type="button"
+        class="btn btn-link p-0 ml-1 align-baseline column-hint"
+        title="<%= hint %>"
+        aria-label="<%= hint %>">
+  <span class="fa fa-question-circle text-muted" aria-hidden="true"></span>
+</button>

--- a/app/views/hyrax/dashboard/controlled_vocabularies/index.html.erb
+++ b/app/views/hyrax/dashboard/controlled_vocabularies/index.html.erb
@@ -1,71 +1,67 @@
+<% provide :page_title, construct_page_title(t('hyku.admin.controlled_vocabularies'), t('hyku.admin.title')) %>
 <% provide :page_header do %>
   <h1><span class="fa fa-tags" aria-hidden="true"></span> <%= t('hyku.admin.controlled_vocabularies') %></h1>
 <% end %>
 
-<div class="panel panel-default">
-  <div class="panel-body">
-    <p class="text-muted">
-      <%= t('hyku.admin.controlled_vocabulary.source_key_help') %>
-    </p>
-
+<div class="card">
+  <div class="card-header">
+    <%= t('hyku.admin.controlled_vocabulary.source_key_help') %>
+  </div>
+  <div class="card-body pt-1">
     <% if @controlled_vocabularies.any? %>
-      <table class="table table-striped">
-        <caption class="sr-only"><%= t('hyku.admin.controlled_vocabularies') %></caption>
-        <thead>
-          <tr>
-            <th scope="col"><%= t('hyku.admin.controlled_vocabulary.name') %></th>
-            <th scope="col"><%= t('hyku.admin.controlled_vocabulary.source_key') %></th>
-            <th scope="col"><%= t('hyku.admin.controlled_vocabulary.origin') %></th>
-            <th scope="col"><%= t('hyku.admin.controlled_vocabulary.status') %></th>
-          </tr>
-        </thead>
-        <tbody>
-          <% @controlled_vocabularies.each do |entry| %>
+      <div class="table-responsive">
+        <table class="table table-striped table-borderless">
+          <caption class="sr-only"><%= t('hyku.admin.controlled_vocabularies') %></caption>
+          <thead>
             <tr>
-              <td>
-                <%# Linked when there are terms to show, which includes read-only
-                    file-based vocabularies. Remote services are not enumerable. %>
-                <% if entry.viewable? %>
-                  <%= link_to entry.label, main_app.controlled_vocabulary_path(entry.source_key) %>
-                <% else %>
-                  <%= entry.label %>
-                <% end %>
-                <%# Below the name rather than in its own column: only vocabularies
-                    managed here have one, so a column would be mostly empty. %>
-                <% if entry.description.present? %>
-                  <p class="text-muted small mb-0"><%= entry.description %></p>
-                <% end %>
-              </td>
-              <td><code><%= entry.source_key %></code></td>
-              <td>
-                <%# A fact about where the vocabulary lives, not a status, so it is
-                    plain text: badges here would compete with the status column. %>
-                <%= if entry.provider
-                      t("hyku.admin.controlled_vocabulary.providers.#{entry.provider}",
-                        default: entry.provider.titleize)
-                    else
-                      t("hyku.admin.controlled_vocabulary.origins.#{entry.origin}")
-                    end %>
-              </td>
-              <td>
-                <% if entry.awaiting_import? %>
-                  <span class="label label-info"
-                        title="<%= t('hyku.admin.controlled_vocabulary.awaiting_import_help', task: entry.import_task) %>">
-                    <%= t('hyku.admin.controlled_vocabulary.awaiting_import') %>
-                  </span>
-                <% elsif !entry.configured? %>
-                  <span class="label label-warning"
-                        title="<%= t('hyku.admin.controlled_vocabulary.unconfigured_help') %>">
-                    <%= t('hyku.admin.controlled_vocabulary.unconfigured') %>
-                  </span>
-                <% else %>
-                  <span class="text-muted"><%= t('hyku.admin.controlled_vocabulary.ready') %></span>
-                <% end %>
-              </td>
+              <th scope="col"><%= t('hyku.admin.controlled_vocabulary.name') %></th>
+              <th scope="col"><%= t('hyku.admin.controlled_vocabulary.source_key') %></th>
+              <th scope="col"><%= t('hyku.admin.controlled_vocabulary.origin') %></th>
+              <th scope="col"><%= t('hyku.admin.controlled_vocabulary.status') %></th>
             </tr>
-          <% end %>
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            <% @controlled_vocabularies.each do |entry| %>
+              <tr>
+                <td>
+                  <% if entry.viewable? %>
+                    <%= link_to entry.label, main_app.controlled_vocabulary_path(entry.source_key) %>
+                  <% else %>
+                    <%= entry.label %>
+                  <% end %>
+                  <% if entry.description.present? %>
+                    <p class="form-text text-muted mb-0"><%= entry.description %></p>
+                  <% end %>
+                </td>
+                <td><code><%= entry.source_key %></code></td>
+                <td>
+                  <%= if entry.provider
+                        t("hyku.admin.controlled_vocabulary.providers.#{entry.provider}",
+                          default: entry.provider.titleize)
+                      else
+                        t("hyku.admin.controlled_vocabulary.origins.#{entry.origin}")
+                      end %>
+                </td>
+                <td>
+                  <% if entry.awaiting_import? %>
+                    <span class="badge badge-info"
+                          title="<%= t('hyku.admin.controlled_vocabulary.awaiting_import_help', task: entry.import_task) %>">
+                      <%= t('hyku.admin.controlled_vocabulary.awaiting_import') %>
+                    </span>
+                  <% elsif !entry.configured? %>
+                    <span class="badge badge-warning"
+                          title="<%= t('hyku.admin.controlled_vocabulary.unconfigured_help') %>">
+                      <%= t('hyku.admin.controlled_vocabulary.unconfigured') %>
+                    </span>
+                  <% else %>
+                    <span class="text-muted"><%= t('hyku.admin.controlled_vocabulary.ready') %></span>
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
     <% else %>
       <p><%= t('hyku.admin.controlled_vocabulary.none') %></p>
     <% end %>

--- a/app/views/hyrax/dashboard/controlled_vocabularies/index.html.erb
+++ b/app/views/hyrax/dashboard/controlled_vocabularies/index.html.erb
@@ -1,0 +1,73 @@
+<% provide :page_header do %>
+  <h1><span class="fa fa-tags" aria-hidden="true"></span> <%= t('hyku.admin.controlled_vocabularies') %></h1>
+<% end %>
+
+<div class="panel panel-default">
+  <div class="panel-body">
+    <p class="text-muted">
+      <%= t('hyku.admin.controlled_vocabulary.source_key_help') %>
+    </p>
+
+    <% if @controlled_vocabularies.any? %>
+      <table class="table table-striped">
+        <caption class="sr-only"><%= t('hyku.admin.controlled_vocabularies') %></caption>
+        <thead>
+          <tr>
+            <th scope="col"><%= t('hyku.admin.controlled_vocabulary.name') %></th>
+            <th scope="col"><%= t('hyku.admin.controlled_vocabulary.source_key') %></th>
+            <th scope="col"><%= t('hyku.admin.controlled_vocabulary.origin') %></th>
+            <th scope="col"><%= t('hyku.admin.controlled_vocabulary.status') %></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @controlled_vocabularies.each do |entry| %>
+            <tr>
+              <td>
+                <%# Linked when there are terms to show, which includes read-only
+                    file-based vocabularies. Remote services are not enumerable. %>
+                <% if entry.viewable? %>
+                  <%= link_to entry.label, main_app.controlled_vocabulary_path(entry.source_key) %>
+                <% else %>
+                  <%= entry.label %>
+                <% end %>
+                <%# Below the name rather than in its own column: only vocabularies
+                    managed here have one, so a column would be mostly empty. %>
+                <% if entry.description.present? %>
+                  <p class="text-muted small mb-0"><%= entry.description %></p>
+                <% end %>
+              </td>
+              <td><code><%= entry.source_key %></code></td>
+              <td>
+                <%# A fact about where the vocabulary lives, not a status, so it is
+                    plain text: badges here would compete with the status column. %>
+                <%= if entry.provider
+                      t("hyku.admin.controlled_vocabulary.providers.#{entry.provider}",
+                        default: entry.provider.titleize)
+                    else
+                      t("hyku.admin.controlled_vocabulary.origins.#{entry.origin}")
+                    end %>
+              </td>
+              <td>
+                <% if entry.awaiting_import? %>
+                  <span class="label label-info"
+                        title="<%= t('hyku.admin.controlled_vocabulary.awaiting_import_help', task: entry.import_task) %>">
+                    <%= t('hyku.admin.controlled_vocabulary.awaiting_import') %>
+                  </span>
+                <% elsif !entry.configured? %>
+                  <span class="label label-warning"
+                        title="<%= t('hyku.admin.controlled_vocabulary.unconfigured_help') %>">
+                    <%= t('hyku.admin.controlled_vocabulary.unconfigured') %>
+                  </span>
+                <% else %>
+                  <span class="text-muted"><%= t('hyku.admin.controlled_vocabulary.ready') %></span>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% else %>
+      <p><%= t('hyku.admin.controlled_vocabulary.none') %></p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/hyrax/dashboard/controlled_vocabularies/index.html.erb
+++ b/app/views/hyrax/dashboard/controlled_vocabularies/index.html.erb
@@ -10,27 +10,36 @@
   <div class="card-body pt-1">
     <% if @controlled_vocabularies.any? %>
       <div class="table-responsive">
-        <table class="table table-striped table-borderless">
+        <table class="table table-borderless">
           <caption class="sr-only"><%= t('hyku.admin.controlled_vocabularies') %></caption>
           <thead>
             <tr>
               <th scope="col"><%= t('hyku.admin.controlled_vocabulary.name') %></th>
-              <th scope="col"><%= t('hyku.admin.controlled_vocabulary.source_key') %></th>
-              <th scope="col"><%= t('hyku.admin.controlled_vocabulary.origin') %></th>
-              <th scope="col"><%= t('hyku.admin.controlled_vocabulary.status') %></th>
+              <th scope="col">
+                <%= render 'column_hint',
+                           label: t('hyku.admin.controlled_vocabulary.source_key'),
+                           hint: t('hyku.admin.controlled_vocabulary.source_key_hint') %>
+              </th>
+              <th scope="col">
+                <%= render 'column_hint',
+                           label: t('hyku.admin.controlled_vocabulary.origin'),
+                           hint: t('hyku.admin.controlled_vocabulary.origin_hint') %>
+              </th>
+              <th scope="col">
+                <%= render 'column_hint',
+                           label: t('hyku.admin.controlled_vocabulary.status'),
+                           hint: t('hyku.admin.controlled_vocabulary.status_hint') %>
+              </th>
             </tr>
           </thead>
           <tbody>
             <% @controlled_vocabularies.each do |entry| %>
-              <tr>
+              <tr class="<%= 'border-bottom' if entry.description.blank? %>">
                 <td>
                   <% if entry.viewable? %>
                     <%= link_to entry.label, main_app.controlled_vocabulary_path(entry.source_key) %>
                   <% else %>
                     <%= entry.label %>
-                  <% end %>
-                  <% if entry.description.present? %>
-                    <p class="form-text text-muted mb-0"><%= entry.description %></p>
                   <% end %>
                 </td>
                 <td><code><%= entry.source_key %></code></td>
@@ -49,15 +58,24 @@
                       <%= t('hyku.admin.controlled_vocabulary.awaiting_import') %>
                     </span>
                   <% elsif !entry.configured? %>
-                    <span class="badge badge-warning"
+                    <span class="badge badge-attention"
                           title="<%= t('hyku.admin.controlled_vocabulary.unconfigured_help') %>">
                       <%= t('hyku.admin.controlled_vocabulary.unconfigured') %>
                     </span>
                   <% else %>
-                    <span class="text-muted"><%= t('hyku.admin.controlled_vocabulary.ready') %></span>
+                    <span class="badge badge-quiet">
+                      <%= t('hyku.admin.controlled_vocabulary.ready') %>
+                    </span>
                   <% end %>
                 </td>
               </tr>
+              <% if entry.description.present? %>
+                <tr class="border-bottom">
+                  <td colspan="4" class="pt-0 text-muted">
+                    <%= entry.description %>
+                  </td>
+                </tr>
+              <% end %>
             <% end %>
           </tbody>
         </table>

--- a/app/views/hyrax/dashboard/controlled_vocabularies/show.html.erb
+++ b/app/views/hyrax/dashboard/controlled_vocabularies/show.html.erb
@@ -15,15 +15,20 @@
       <% if @terms.present? %>
         <dt class="col-sm-2"><%= t('hyku.admin.controlled_vocabulary.terms') %></dt>
         <dd class="col-sm-10">
-          <%# A retired term still counts toward the total, so name both: the active
-              figure is what a deposit form actually offers. %>
-          <% retired = @terms.count { |term| term['active'] == false } %>
-          <%= t('hyku.admin.controlled_vocabulary.active_count',
-                count: @terms.size - retired, total: @terms.size) %>
-          <% if retired.positive? %>
+          <% total = @entry.term_count || @terms.size %>
+          <% truncated = total > @terms.size %>
+          <%= t('hyku.admin.controlled_vocabulary.term_total', count: total) %>
+          <% if truncated %>
             <span class="text-muted">
-              <%= t('hyku.admin.controlled_vocabulary.retired_count', count: retired) %>
+              <%= t('hyku.admin.controlled_vocabulary.term_limit', count: @terms.size) %>
             </span>
+          <% else %>
+            <% retired = @terms.count { |term| term['active'] == false } %>
+            <% if retired.positive? %>
+              <span class="text-muted">
+                <%= t('hyku.admin.controlled_vocabulary.retired_count', count: retired) %>
+              </span>
+            <% end %>
           <% end %>
         </dd>
       <% end %>

--- a/app/views/hyrax/dashboard/controlled_vocabularies/show.html.erb
+++ b/app/views/hyrax/dashboard/controlled_vocabularies/show.html.erb
@@ -1,0 +1,79 @@
+<% provide :page_header do %>
+  <h1>
+    <span class="fa fa-tag" aria-hidden="true"></span>
+    <%= @entry.label %>
+  </h1>
+<% end %>
+
+<div class="panel panel-default">
+  <div class="panel-body">
+    <dl class="dl-horizontal">
+      <dt><%= t('hyku.admin.controlled_vocabulary.source_key') %></dt>
+      <dd><code><%= @entry.source_key %></code></dd>
+
+      <dt><%= t('hyku.admin.controlled_vocabulary.origin') %></dt>
+      <dd>
+        <%= if @entry.provider
+              t("hyku.admin.controlled_vocabulary.providers.#{@entry.provider}",
+                default: @entry.provider.titleize)
+            else
+              t("hyku.admin.controlled_vocabulary.origins.#{@entry.origin}")
+            end %>
+      </dd>
+
+      <% if @entry.description.present? %>
+        <dt><%= t('hyku.admin.controlled_vocabulary.description') %></dt>
+        <dd><%= @entry.description %></dd>
+      <% end %>
+    </dl>
+
+    <% unless @entry.editable? %>
+      <p class="text-muted">
+        <span class="fa fa-info-circle" aria-hidden="true"></span>
+        <%= t("hyku.admin.controlled_vocabulary.read_only.#{@entry.origin}") %>
+      </p>
+    <% end %>
+  </div>
+</div>
+
+<div class="panel panel-default">
+  <div class="panel-heading">
+    <h2 class="panel-title">
+      <%= t('hyku.admin.controlled_vocabulary.terms') %>
+      <% if @terms.present? %>
+        <span class="badge"><%= @terms.size %></span>
+      <% end %>
+    </h2>
+  </div>
+  <div class="panel-body">
+    <% if @terms.blank? %>
+      <p class="text-muted"><%= t('hyku.admin.controlled_vocabulary.no_terms') %></p>
+    <% else %>
+      <table class="table table-striped">
+        <caption class="sr-only"><%= @entry.label %></caption>
+        <thead>
+          <tr>
+            <th scope="col"><%= t('hyku.admin.controlled_vocabulary.label') %></th>
+            <th scope="col"><%= t('hyku.admin.controlled_vocabulary.term_id') %></th>
+            <th scope="col"><%= t('hyku.admin.controlled_vocabulary.status') %></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @terms.each do |term| %>
+            <tr>
+              <td><%= term['label'] %></td>
+              <td><code><%= term['id'] %></code></td>
+              <td>
+                <% if term['active'] == false %>
+                  <span class="label label-default"><%= t('hyku.admin.controlled_vocabulary.inactive') %></span>
+                <% else %>
+                  <span class="text-muted"><%= t('hyku.admin.controlled_vocabulary.active') %></span>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% end %>
+  </div>
+</div>

--- a/app/views/hyrax/dashboard/controlled_vocabularies/show.html.erb
+++ b/app/views/hyrax/dashboard/controlled_vocabularies/show.html.erb
@@ -1,3 +1,4 @@
+<% provide :page_title, construct_page_title(@entry.label, t('hyku.admin.controlled_vocabularies'), t('hyku.admin.title')) %>
 <% provide :page_header do %>
   <h1>
     <span class="fa fa-tag" aria-hidden="true"></span>
@@ -5,14 +6,14 @@
   </h1>
 <% end %>
 
-<div class="panel panel-default">
-  <div class="panel-body">
-    <dl class="dl-horizontal">
-      <dt><%= t('hyku.admin.controlled_vocabulary.source_key') %></dt>
-      <dd><code><%= @entry.source_key %></code></dd>
+<div class="card">
+  <div class="card-body border-bottom">
+    <dl class="row mb-0">
+      <dt class="col-sm-3"><%= t('hyku.admin.controlled_vocabulary.source_key') %></dt>
+      <dd class="col-sm-9"><code><%= @entry.source_key %></code></dd>
 
-      <dt><%= t('hyku.admin.controlled_vocabulary.origin') %></dt>
-      <dd>
+      <dt class="col-sm-3"><%= t('hyku.admin.controlled_vocabulary.origin') %></dt>
+      <dd class="col-sm-9">
         <%= if @entry.provider
               t("hyku.admin.controlled_vocabulary.providers.#{@entry.provider}",
                 default: @entry.provider.titleize)
@@ -21,59 +22,55 @@
             end %>
       </dd>
 
+      <% if @terms.present? %>
+        <dt class="col-sm-3"><%= t('hyku.admin.controlled_vocabulary.terms') %></dt>
+        <dd class="col-sm-9"><%= @terms.size %></dd>
+      <% end %>
+
       <% if @entry.description.present? %>
-        <dt><%= t('hyku.admin.controlled_vocabulary.description') %></dt>
-        <dd><%= @entry.description %></dd>
+        <dt class="col-sm-3"><%= t('hyku.admin.controlled_vocabulary.description') %></dt>
+        <dd class="col-sm-9"><%= @entry.description %></dd>
       <% end %>
     </dl>
 
     <% unless @entry.editable? %>
-      <p class="text-muted">
+      <p class="form-text text-muted mt-3 mb-0">
         <span class="fa fa-info-circle" aria-hidden="true"></span>
         <%= t("hyku.admin.controlled_vocabulary.read_only.#{@entry.origin}") %>
       </p>
     <% end %>
   </div>
-</div>
-
-<div class="panel panel-default">
-  <div class="panel-heading">
-    <h2 class="panel-title">
-      <%= t('hyku.admin.controlled_vocabulary.terms') %>
-      <% if @terms.present? %>
-        <span class="badge"><%= @terms.size %></span>
-      <% end %>
-    </h2>
-  </div>
-  <div class="panel-body">
+  <div class="card-body pt-1">
     <% if @terms.blank? %>
-      <p class="text-muted"><%= t('hyku.admin.controlled_vocabulary.no_terms') %></p>
+      <p class="text-muted mb-0"><%= t('hyku.admin.controlled_vocabulary.no_terms') %></p>
     <% else %>
-      <table class="table table-striped">
-        <caption class="sr-only"><%= @entry.label %></caption>
-        <thead>
-          <tr>
-            <th scope="col"><%= t('hyku.admin.controlled_vocabulary.label') %></th>
-            <th scope="col"><%= t('hyku.admin.controlled_vocabulary.term_id') %></th>
-            <th scope="col"><%= t('hyku.admin.controlled_vocabulary.status') %></th>
-          </tr>
-        </thead>
-        <tbody>
-          <% @terms.each do |term| %>
+      <div class="table-responsive">
+        <table class="table table-striped table-borderless">
+          <caption class="sr-only"><%= @entry.label %></caption>
+          <thead>
             <tr>
-              <td><%= term['label'] %></td>
-              <td><code><%= term['id'] %></code></td>
-              <td>
-                <% if term['active'] == false %>
-                  <span class="label label-default"><%= t('hyku.admin.controlled_vocabulary.inactive') %></span>
-                <% else %>
-                  <span class="text-muted"><%= t('hyku.admin.controlled_vocabulary.active') %></span>
-                <% end %>
-              </td>
+              <th scope="col"><%= t('hyku.admin.controlled_vocabulary.label') %></th>
+              <th scope="col"><%= t('hyku.admin.controlled_vocabulary.term_id') %></th>
+              <th scope="col"><%= t('hyku.admin.controlled_vocabulary.status') %></th>
             </tr>
-          <% end %>
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            <% @terms.each do |term| %>
+              <tr>
+                <td><%= term['label'] %></td>
+                <td><code><%= term['id'] %></code></td>
+                <td>
+                  <% if term['active'] == false %>
+                    <span class="badge badge-secondary"><%= t('hyku.admin.controlled_vocabulary.inactive') %></span>
+                  <% else %>
+                    <span class="text-muted"><%= t('hyku.admin.controlled_vocabulary.active') %></span>
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
     <% end %>
   </div>
 </div>

--- a/app/views/hyrax/dashboard/controlled_vocabularies/show.html.erb
+++ b/app/views/hyrax/dashboard/controlled_vocabularies/show.html.erb
@@ -2,7 +2,7 @@
 <% provide :page_header do %>
   <h1>
     <span class="fa fa-tag" aria-hidden="true"></span>
-    <%= @entry.label %>
+    <%= t('hyku.admin.controlled_vocabulary.show_title', name: @entry.label) %>
   </h1>
 <% end %>
 
@@ -12,19 +12,20 @@
       <dt class="col-sm-2"><%= t('hyku.admin.controlled_vocabulary.source_key') %></dt>
       <dd class="col-sm-10"><code><%= @entry.source_key %></code></dd>
 
-      <dt class="col-sm-2"><%= t('hyku.admin.controlled_vocabulary.origin') %></dt>
-      <dd class="col-sm-10">
-        <%= if @entry.provider
-              t("hyku.admin.controlled_vocabulary.providers.#{@entry.provider}",
-                default: @entry.provider.titleize)
-            else
-              t("hyku.admin.controlled_vocabulary.origins.#{@entry.origin}")
-            end %>
-      </dd>
-
       <% if @terms.present? %>
         <dt class="col-sm-2"><%= t('hyku.admin.controlled_vocabulary.terms') %></dt>
-        <dd class="col-sm-10"><%= @terms.size %></dd>
+        <dd class="col-sm-10">
+          <%# A retired term still counts toward the total, so name both: the active
+              figure is what a deposit form actually offers. %>
+          <% retired = @terms.count { |term| term['active'] == false } %>
+          <%= t('hyku.admin.controlled_vocabulary.active_count',
+                count: @terms.size - retired, total: @terms.size) %>
+          <% if retired.positive? %>
+            <span class="text-muted">
+              <%= t('hyku.admin.controlled_vocabulary.retired_count', count: retired) %>
+            </span>
+          <% end %>
+        </dd>
       <% end %>
 
       <% if @entry.description.present? %>
@@ -34,36 +35,57 @@
     </dl>
 
     <% unless @entry.editable? %>
+      <%# Defaulted because the key is interpolated from the origin: a new origin
+          without a message should read plainly, not raise. %>
       <p class="form-text text-muted mt-3 mb-0">
         <span class="fa fa-info-circle" aria-hidden="true"></span>
-        <%= t("hyku.admin.controlled_vocabulary.read_only.#{@entry.origin}") %>
+        <%= t("hyku.admin.controlled_vocabulary.read_only.#{@entry.origin}",
+              default: t('hyku.admin.controlled_vocabulary.read_only.generic')) %>
       </p>
     <% end %>
+  </div>
+  <div class="card-header">
+    <%= t('hyku.admin.controlled_vocabulary.term_id_help') %>
   </div>
   <div class="card-body pt-1">
     <% if @terms.blank? %>
       <p class="text-muted mb-0"><%= t('hyku.admin.controlled_vocabulary.no_terms') %></p>
     <% else %>
       <div class="table-responsive">
-        <table class="table table-striped table-borderless">
+        <table class="table table-borderless">
           <caption class="sr-only"><%= @entry.label %></caption>
           <thead>
             <tr>
-              <th scope="col"><%= t('hyku.admin.controlled_vocabulary.label') %></th>
-              <th scope="col"><%= t('hyku.admin.controlled_vocabulary.term_id') %></th>
+              <th scope="col">
+                <%= render 'column_hint',
+                           label: t('hyku.admin.controlled_vocabulary.label'),
+                           hint: t('hyku.admin.controlled_vocabulary.label_hint') %>
+              </th>
+              <th scope="col">
+                <%= render 'column_hint',
+                           label: t('hyku.admin.controlled_vocabulary.term_id'),
+                           hint: t('hyku.admin.controlled_vocabulary.term_id_hint') %>
+              </th>
               <th scope="col"><%= t('hyku.admin.controlled_vocabulary.status') %></th>
             </tr>
           </thead>
           <tbody>
             <% @terms.each do |term| %>
-              <tr>
+              <tr class="border-bottom">
                 <td><%= term['label'] %></td>
                 <td><code><%= term['id'] %></code></td>
                 <td>
-                  <% if term['active'] == false %>
+                  <% case term['active'] %>
+                  <% when false %>
                     <span class="badge badge-secondary"><%= t('hyku.admin.controlled_vocabulary.inactive') %></span>
+                  <% when true %>
+                    <span class="badge badge-quiet"><%= t('hyku.admin.controlled_vocabulary.active') %></span>
                   <% else %>
-                    <span class="text-muted"><%= t('hyku.admin.controlled_vocabulary.active') %></span>
+                    <%# A yaml term may omit `active` altogether, so its state is unstated
+                        rather than known. Hyrax treats such a term as usable. %>
+                    <span class="badge badge-quiet">
+                      <%= t('hyku.admin.controlled_vocabulary.status_unknown') %>
+                    </span>
                   <% end %>
                 </td>
               </tr>

--- a/app/views/hyrax/dashboard/controlled_vocabularies/show.html.erb
+++ b/app/views/hyrax/dashboard/controlled_vocabularies/show.html.erb
@@ -9,11 +9,11 @@
 <div class="card">
   <div class="card-body border-bottom">
     <dl class="row mb-0">
-      <dt class="col-sm-3"><%= t('hyku.admin.controlled_vocabulary.source_key') %></dt>
-      <dd class="col-sm-9"><code><%= @entry.source_key %></code></dd>
+      <dt class="col-sm-2"><%= t('hyku.admin.controlled_vocabulary.source_key') %></dt>
+      <dd class="col-sm-10"><code><%= @entry.source_key %></code></dd>
 
-      <dt class="col-sm-3"><%= t('hyku.admin.controlled_vocabulary.origin') %></dt>
-      <dd class="col-sm-9">
+      <dt class="col-sm-2"><%= t('hyku.admin.controlled_vocabulary.origin') %></dt>
+      <dd class="col-sm-10">
         <%= if @entry.provider
               t("hyku.admin.controlled_vocabulary.providers.#{@entry.provider}",
                 default: @entry.provider.titleize)
@@ -23,13 +23,13 @@
       </dd>
 
       <% if @terms.present? %>
-        <dt class="col-sm-3"><%= t('hyku.admin.controlled_vocabulary.terms') %></dt>
-        <dd class="col-sm-9"><%= @terms.size %></dd>
+        <dt class="col-sm-2"><%= t('hyku.admin.controlled_vocabulary.terms') %></dt>
+        <dd class="col-sm-10"><%= @terms.size %></dd>
       <% end %>
 
       <% if @entry.description.present? %>
-        <dt class="col-sm-3"><%= t('hyku.admin.controlled_vocabulary.description') %></dt>
-        <dd class="col-sm-9"><%= @entry.description %></dd>
+        <dt class="col-sm-2"><%= t('hyku.admin.controlled_vocabulary.description') %></dt>
+        <dd class="col-sm-10"><%= @entry.description %></dd>
       <% end %>
     </dl>
 

--- a/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
@@ -2,17 +2,18 @@
 
 <% if menu.show_task? %>
   <li class="h5 nav-item"><%= t('hyrax.admin.sidebar.tasks') %></li>
-<% end %>
 
-<%# The route is defined in Hyku's own routes, so it hangs off main_app rather
-    than the Hyrax engine, even though the controller is namespaced Hyrax::. %>
-<% if can? :view, :controlled_vocabularies %>
-  <%= menu.nav_link(main_app.controlled_vocabularies_path,
-                    class: "nav-link",
-                    onclick: "dontChangeAccordion(event);",
-                    title: t('hyku.admin.controlled_vocabularies')) do %>
-    <span class="fa fa-tags" aria-hidden="true"></span>
-    <span class="sidebar-action-text"><%= t('hyku.admin.controlled_vocabularies') %></span>
+  <%# main_app because the route is Hyku's own, even though the controller is
+      namespaced Hyrax::. show_task? covers this ability too, so the heading above is
+      never missing when this renders. %>
+  <% if can? :view, :controlled_vocabularies %>
+    <%= menu.nav_link(main_app.controlled_vocabularies_path,
+                      class: "nav-link",
+                      onclick: "dontChangeAccordion(event);",
+                      title: t('hyku.admin.controlled_vocabularies')) do %>
+      <span class="fa fa-tags" aria-hidden="true"></span>
+      <span class="sidebar-action-text"><%= t('hyku.admin.controlled_vocabularies') %></span>
+    <% end %>
   <% end %>
 <% end %>
 

--- a/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_tasks.html.erb
@@ -4,6 +4,18 @@
   <li class="h5 nav-item"><%= t('hyrax.admin.sidebar.tasks') %></li>
 <% end %>
 
+<%# The route is defined in Hyku's own routes, so it hangs off main_app rather
+    than the Hyrax engine, even though the controller is namespaced Hyrax::. %>
+<% if can? :view, :controlled_vocabularies %>
+  <%= menu.nav_link(main_app.controlled_vocabularies_path,
+                    class: "nav-link",
+                    onclick: "dontChangeAccordion(event);",
+                    title: t('hyku.admin.controlled_vocabularies')) do %>
+    <span class="fa fa-tags" aria-hidden="true"></span>
+    <span class="sidebar-action-text"><%= t('hyku.admin.controlled_vocabularies') %></span>
+  <% end %>
+<% end %>
+
 <% if can? :review, :submissions %>
   <%= menu.nav_link(hyrax.admin_workflows_path,
                     class: "nav-link",

--- a/config/authorities/blerp.yml
+++ b/config/authorities/blerp.yml
@@ -1,0 +1,7 @@
+terms:
+  - id: Student
+    term: Student
+  - id: Instructor
+    term: Instructor
+  - id: Administrator
+    term: Administrator

--- a/config/authorities/blerp.yml
+++ b/config/authorities/blerp.yml
@@ -1,7 +1,0 @@
-terms:
-  - id: Student
-    term: Student
-  - id: Instructor
-    term: Instructor
-  - id: Administrator
-    term: Administrator

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -299,7 +299,6 @@ en:
         source_key: Source key
         source_key_help: Paste a source key into a metadata profile field to control that field with this vocabulary. Vocabularies managed in this tenant can be edited here; those defined in a configuration file or by an external service cannot.
         status: Status
-        term_count_unknown: Varies
         term_id: Term ID
         terms: Terms
         unconfigured: Needs setup

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -268,6 +268,42 @@ en:
       errors:
         parent_not_allowed: That work cannot contain this deposit.
     admin:
+      controlled_vocabularies: Controlled Vocabularies
+      controlled_vocabulary:
+        active: Active
+        awaiting_import: Not imported
+        awaiting_import_help: 'This vocabulary is available but has no terms in this tenant yet. Populate it by running: %{task}'
+        description: Description
+        inactive: Inactive
+        label: Label
+        name: Vocabulary
+        no_terms: This vocabulary has no terms yet.
+        none: No controlled vocabularies have been set up for this tenant yet.
+        origin: Source
+        origins:
+          database: This tenant
+          file: Configuration file
+          remote: External service
+        providers:
+          discogs: Discogs
+          fast: OCLC FAST
+          geonames: GeoNames
+          getty: Getty
+          loc: Library of Congress
+          mesh: MeSH
+        read_only:
+          database: This vocabulary has no terms in this tenant yet.
+          file: This vocabulary is defined in a configuration file, so its terms cannot be changed here.
+          remote: This vocabulary comes from an external service, so its terms cannot be changed here.
+        ready: Ready
+        source_key: Source key
+        source_key_help: Paste a source key into a metadata profile field to control that field with this vocabulary. Vocabularies managed in this tenant can be edited here; those defined in a configuration file or by an external service cannot.
+        status: Status
+        term_count_unknown: Varies
+        term_id: Term ID
+        terms: Terms
+        unconfigured: Needs setup
+        unconfigured_help: This service needs credentials before it can be used. Until then a field citing it accepts free text instead of offering suggestions.
       flash:
         access_denied: You are not authorized to view this page
       google_analytics_settings:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -271,35 +271,51 @@ en:
       controlled_vocabularies: Controlled Vocabularies
       controlled_vocabulary:
         active: Active
+        active_count: "%{count} of %{total} active"
         awaiting_import: Not imported
         awaiting_import_help: 'This vocabulary is available but has no terms in this tenant yet. Populate it by running: %{task}'
         description: Description
         inactive: Inactive
         label: Label
+        label_hint: What a depositor sees in the form. Safe to reword without affecting stored records.
         name: Vocabulary
         no_terms: This vocabulary has no terms yet.
         none: No controlled vocabularies have been set up for this tenant yet.
         origin: Source
+        origin_hint: Where the vocabulary is defined, and therefore whether its terms can be edited here.
         origins:
+          cached: Imported copy
           database: This tenant
           file: Configuration file
           remote: External service
         providers:
+          crossref: Crossref
           discogs: Discogs
           fast: OCLC FAST
           geonames: GeoNames
           getty: Getty
           loc: Library of Congress
           mesh: MeSH
+          tgnlang: Getty TGN Languages
         read_only:
-          database: This vocabulary has no terms in this tenant yet.
+          cached: This vocabulary is an imported copy of an external one. Its terms cannot be changed here, and re-importing replaces all of them.
           file: This vocabulary is defined in a configuration file, so its terms cannot be changed here.
+          generic: This vocabulary's terms cannot be changed here.
           remote: This vocabulary comes from an external service, so its terms cannot be changed here.
         ready: Ready
+        retired_count:
+          one: (%{count} retired)
+          other: (%{count} retired)
+        show_title: 'Controlled Vocabulary: %{name}'
         source_key: Source key
+        source_key_hint: Paste this into a metadata profile field to control that field with this vocabulary.
         source_key_help: Paste a source key into a metadata profile field to control that field with this vocabulary. Vocabularies managed in this tenant can be edited here; those defined in a configuration file or by an external service cannot.
         status: Status
+        status_hint: Whether this vocabulary is ready to use, or needs something set up first.
+        status_unknown: Unspecified
         term_id: Term ID
+        term_id_hint: The value stored on a record, and the value to supply in a Bulkrax import.
+        term_id_help: The term ID is the value stored on a record, and the value to supply in a Bulkrax import. The label is only what a depositor sees.
         terms: Terms
         unconfigured: Needs setup
         unconfigured_help: This service needs credentials before it can be used. Until then a field citing it accepts free text instead of offering suggestions.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -271,7 +271,6 @@ en:
       controlled_vocabularies: Controlled Vocabularies
       controlled_vocabulary:
         active: Active
-        active_count: "%{count} of %{total} active"
         awaiting_import: Not imported
         awaiting_import_help: 'This vocabulary is available but has no terms in this tenant yet. Populate it by running: %{task}'
         description: Description
@@ -314,8 +313,14 @@ en:
         status_hint: Whether this vocabulary is ready to use, or needs something set up first.
         status_unknown: Unspecified
         term_id: Term ID
+        term_limit:
+          one: (showing the first %{count})
+          other: (showing the first %{count})
         term_id_hint: The value stored on a record, and the value to supply in a Bulkrax import.
         term_id_help: The term ID is the value stored on a record, and the value to supply in a Bulkrax import. The label is only what a depositor sees.
+        term_total:
+          one: 1 term
+          other: "%{count} terms"
         terms: Terms
         unconfigured: Needs setup
         unconfigured_help: This service needs credentials before it can be used. Until then a field citing it accepts free text instead of offering suggestions.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -157,6 +157,11 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
     resources :featured_collection_lists, path: 'featured_collections', only: :create
   end
 
+  # Controlled vocabularies, viewable only from the dashboard
+  scope :dashboard, module: 'hyrax/dashboard' do
+    resources :controlled_vocabularies, only: [:index, :show]
+  end
+
   # Guided deposit wizard
   scope :dashboard, module: 'hyrax' do
     get 'deposit_wizard', to: 'deposit_wizard#start', as: :deposit_wizard

--- a/spec/abilities/controlled_vocabulary_ability_spec.rb
+++ b/spec/abilities/controlled_vocabulary_ability_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'cancan/matchers'
+
+RSpec.describe Hyrax::Ability::ControlledVocabularyAbility do
+  subject { ability }
+
+  let(:ability) { Ability.new(current_user) }
+  let(:current_user) { user }
+
+  describe 'an admin' do
+    let(:user) { create(:admin) }
+
+    it { is_expected.to be_able_to(:manage, :controlled_vocabularies) }
+    it { is_expected.to be_able_to(:view, :controlled_vocabularies) }
+  end
+
+  # Stubbed on the class rather than the instance: CanCan evaluates ability_logic
+  # when the Ability is built, so an instance stub lands too late to affect it.
+  describe 'a user who can deposit' do
+    let(:user) { create(:user) }
+
+    # Anyone who can deposit through Bulkrax needs to see which terms a field
+    # offers, and which of them are retired.
+    before { allow_any_instance_of(Ability).to receive(:can_import_works?).and_return(true) }
+
+    it { is_expected.to be_able_to(:view, :controlled_vocabularies) }
+    it { is_expected.not_to be_able_to(:manage, :controlled_vocabularies) }
+  end
+
+  describe 'a user who cannot deposit' do
+    let(:user) { create(:user) }
+
+    before { allow_any_instance_of(Ability).to receive(:can_import_works?).and_return(false) }
+
+    it { is_expected.not_to be_able_to(:view, :controlled_vocabularies) }
+    it { is_expected.not_to be_able_to(:manage, :controlled_vocabularies) }
+  end
+end

--- a/spec/authorities/qa/authorities/local_vocabulary_spec.rb
+++ b/spec/authorities/qa/authorities/local_vocabulary_spec.rb
@@ -7,6 +7,12 @@ RSpec.describe Qa::Authorities::LocalVocabulary do
 
   let(:yml_terms) { YAML.load_file(Rails.root.join('config', 'authorities', 'audience.yml'))['terms'] }
 
+  describe '#locally_owned?' do
+    it 'is true, because nothing external overwrites these terms' do
+      expect(authority).to be_locally_owned
+    end
+  end
+
   it 'serves the tenant rows when the vocabulary is in the database' do
     Qa::LocalAuthority.find_by(name: 'audience')
                       .local_authority_entries

--- a/spec/authorities/qa/authorities/mesh_spec.rb
+++ b/spec/authorities/qa/authorities/mesh_spec.rb
@@ -5,6 +5,14 @@ require 'rails_helper'
 RSpec.describe Qa::Authorities::Mesh do
   subject(:authority) { described_class.new }
 
+  # A MeSH import replaces every row, so the dashboard must not offer these terms
+  # for editing.
+  describe '#locally_owned?' do
+    it 'is false, because the terms come from a MeSH release' do
+      expect(authority).not_to be_locally_owned
+    end
+  end
+
   describe '#search' do
     context 'when the mesh authority does not exist' do
       it 'returns an empty array' do

--- a/spec/helpers/hyrax/form_helper_behavior_spec.rb
+++ b/spec/helpers/hyrax/form_helper_behavior_spec.rb
@@ -18,4 +18,56 @@ RSpec.describe Hyrax::FormHelperBehavior, type: :helper do
       end
     end
   end
+
+  describe '#controlled_vocabulary_service_for' do
+    it 'returns the registered service class for a built-in vocabulary' do
+      expect(helper.controlled_vocabulary_service_for('licenses')).to eq Hyrax::LicenseService
+    end
+
+    context 'with a vocabulary created through the dashboard' do
+      before { Qa::LocalAuthority.create!(name: 'reading_rooms') }
+
+      # No entry in the services registry, so without the fallback the field
+      # would render as free text instead of a dropdown.
+      it 'returns a tolerant service bound to that vocabulary' do
+        service = helper.controlled_vocabulary_service_for('reading_rooms')
+
+        expect(service).to be_a Hyrax::TolerantSelectService
+        expect(service.authority).to be_a Qa::Authorities::LocalVocabulary
+      end
+
+      it 'resolves the source_key a profile cites' do
+        vocabulary = Qa::LocalAuthority.find_by(name: 'reading_rooms')
+
+        expect(helper.controlled_vocabulary_service_for(vocabulary.source_key))
+          .to be_a Hyrax::TolerantSelectService
+      end
+    end
+
+    it 'returns nil for a source that is neither registered nor in the database' do
+      expect(helper.controlled_vocabulary_service_for('nothing_here')).to be_nil
+    end
+  end
+
+  describe '#controlled_vocabulary_options_for' do
+    context 'with a vocabulary created through the dashboard' do
+      let!(:vocabulary) { Qa::LocalAuthority.create!(name: 'reading_rooms') }
+
+      before do
+        Qa::LocalAuthorityEntry.create!(local_authority: vocabulary,
+                                        label: 'Special Collections',
+                                        uri: 'https://example.com/special-collections')
+        allow(helper).to receive(:controlled_vocabulary_source_for).with(:reading_room).and_return('reading_rooms')
+      end
+
+      # Options are [label, uri]: the label is shown, the uri is submitted and
+      # stored on the work.
+      it 'renders as a select showing labels and submitting uris' do
+        config = helper.controlled_vocabulary_options_for(:reading_room)
+
+        expect(config[:type]).to eq 'select'
+        expect(config[:options]).to eq [['Special Collections', 'https://example.com/special-collections']]
+      end
+    end
+  end
 end

--- a/spec/models/qa/local_authority_spec.rb
+++ b/spec/models/qa/local_authority_spec.rb
@@ -53,8 +53,10 @@ RSpec.describe Qa::LocalAuthority, type: :model do
   end
 
   describe '#source_key' do
+    # Bare, matching how the file-based vocabularies are cited in
+    # config/metadata_profiles (e.g. `- licenses`).
     it 'is the value to paste into the metadata profile' do
-      expect(described_class.new(name: 'lab_names').source_key).to eq 'local/lab_names'
+      expect(described_class.new(name: 'lab_names').source_key).to eq 'lab_names'
     end
   end
 

--- a/spec/models/qa/local_authority_spec.rb
+++ b/spec/models/qa/local_authority_spec.rb
@@ -59,18 +59,4 @@ RSpec.describe Qa::LocalAuthority, type: :model do
       expect(described_class.new(name: 'lab_names').source_key).to eq 'lab_names'
     end
   end
-
-  describe '.file_based_names' do
-    it 'lists the subauthorities backed by config/authorities YAML' do
-      allow(Qa::Authorities::Local).to receive(:names).and_return(%w[licenses])
-
-      expect(described_class.file_based_names).to include('licenses')
-    end
-
-    it 'returns an empty list when the authorities directory is missing' do
-      allow(Qa::Authorities::Local).to receive(:names).and_raise(Qa::ConfigDirectoryNotFound, 'no directory')
-
-      expect(described_class.file_based_names).to eq []
-    end
-  end
 end

--- a/spec/requests/controlled_vocabularies_spec.rb
+++ b/spec/requests/controlled_vocabularies_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Controlled vocabularies', type: :request, clean: true, multitenant: true do
+  let(:account) { create(:account) }
+
+  # Users and roles are per-tenant, so an admin created outside the switch has no
+  # privileges inside it and every request redirects.
+  attr_reader :admin
+
+  before do
+    WebMock.disable!
+    Apartment::Tenant.create(account.tenant)
+    Apartment::Tenant.switch(account.tenant) do
+      Site.update(account:)
+      @admin = create(:admin)
+      vocabulary = Qa::LocalAuthority.create!(name: 'reading_rooms',
+                                              label: 'Reading Rooms',
+                                              description: 'Where an item may be consulted on site.')
+      vocabulary.local_authority_entries.create!(label: 'Special Collections', uri: 'special-collections')
+      vocabulary.local_authority_entries.create!(label: 'Closed Stacks', uri: 'closed-stacks', active: false)
+    end
+  end
+
+  after do
+    WebMock.enable!
+    Apartment::Tenant.drop(account.tenant)
+  end
+
+  context 'as an admin' do
+    before { login_as(admin, scope: :user) }
+
+    describe 'the index' do
+      it 'lists each vocabulary with the key to paste into a metadata profile' do
+        get "http://#{account.cname}/dashboard/controlled_vocabularies"
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include 'Reading Rooms'
+        expect(response.body).to include 'reading_rooms'
+      end
+
+      # Only vocabularies managed here have one, so it sits under the name rather
+      # than in a column that would be empty for most rows.
+      it 'shows the description of a vocabulary that has one' do
+        get "http://#{account.cname}/dashboard/controlled_vocabularies"
+
+        expect(response.body).to include 'Where an item may be consulted on site.'
+      end
+    end
+
+    describe 'a vocabulary' do
+      # Looked up by name rather than database id, so the url matches the key a
+      # metadata profile cites.
+      it 'lists the terms, marking the retired one' do
+        get "http://#{account.cname}/dashboard/controlled_vocabularies/reading_rooms"
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include 'Special Collections'
+        expect(response.body).to include 'Closed Stacks'
+        expect(response.body).to include 'Inactive'
+      end
+
+      it 'shows the term id works store' do
+        get "http://#{account.cname}/dashboard/controlled_vocabularies/reading_rooms"
+
+        expect(response.body).to include 'special-collections'
+      end
+    end
+
+    # A yaml-backed vocabulary has terms worth reading even though staff cannot
+    # change them here. The suite seeds every real yaml name into the tables, so
+    # this stands in a vocabulary that only a file backs.
+    describe 'a vocabulary defined in a configuration file' do
+      before do
+        allow(ControlledVocabularyCatalog).to receive(:file_based_names).and_return(%w[map_regions])
+        allow(Qa::Authorities::Local).to receive(:subauthority_for).and_call_original
+        allow(Qa::Authorities::Local).to receive(:subauthority_for)
+          .with('map_regions')
+          .and_return(instance_double(Qa::Authorities::Local::FileBasedAuthority,
+                                      all: [{ 'id' => 'north', 'label' => 'North', 'active' => true }]))
+      end
+
+      it 'lists its terms and says they cannot be changed here' do
+        get "http://#{account.cname}/dashboard/controlled_vocabularies/map_regions"
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include 'North'
+        expect(response.body).to include 'configuration file'
+      end
+    end
+
+    it 'returns not found for a vocabulary that does not exist' do
+      get "http://#{account.cname}/dashboard/controlled_vocabularies/not_a_vocabulary"
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  context 'as a user who cannot manage the tenant' do
+    before do
+      user = Apartment::Tenant.switch(account.tenant) { create(:user) }
+      login_as(user, scope: :user)
+    end
+
+    it 'denies access' do
+      get "http://#{account.cname}/dashboard/controlled_vocabularies"
+
+      expect(response).not_to have_http_status(:success)
+    end
+  end
+
+  # Vocabularies live in per-tenant Apartment schemas, so one tenant's terms must
+  # never appear in another's dashboard.
+  context 'in another tenant' do
+    let(:other_account) { create(:account) }
+
+    before do
+      Apartment::Tenant.create(other_account.tenant)
+      other_admin = Apartment::Tenant.switch(other_account.tenant) do
+        Site.update(account: other_account)
+        create(:admin)
+      end
+      login_as(other_admin, scope: :user)
+    end
+
+    after { Apartment::Tenant.drop(other_account.tenant) }
+
+    it 'does not show the first tenant\'s vocabulary' do
+      get "http://#{other_account.cname}/dashboard/controlled_vocabularies"
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).not_to include 'Reading Rooms'
+    end
+  end
+end

--- a/spec/requests/controlled_vocabularies_spec.rb
+++ b/spec/requests/controlled_vocabularies_spec.rb
@@ -95,16 +95,30 @@ RSpec.describe 'Controlled vocabularies', type: :request, clean: true, multitena
     end
   end
 
-  context 'as a user who cannot manage the tenant' do
+  context 'as a user with no deposit access' do
     before do
       user = Apartment::Tenant.switch(account.tenant) { create(:user) }
       login_as(user, scope: :user)
     end
 
-    it 'denies access' do
+    it 'refuses the page' do
       get "http://#{account.cname}/dashboard/controlled_vocabularies"
 
       expect(response).not_to have_http_status(:success)
+    end
+  end
+
+  context 'as a user who can deposit' do
+    before do
+      user = Apartment::Tenant.switch(account.tenant) { create(:user) }
+      allow_any_instance_of(Ability).to receive(:can_import_works?).and_return(true)
+      login_as(user, scope: :user)
+    end
+
+    it 'allows the page' do
+      get "http://#{account.cname}/dashboard/controlled_vocabularies"
+
+      expect(response).to have_http_status(:success)
     end
   end
 

--- a/spec/services/controlled_vocabulary_catalog_spec.rb
+++ b/spec/services/controlled_vocabulary_catalog_spec.rb
@@ -16,9 +16,6 @@ RSpec.describe ControlledVocabularyCatalog do
     allow(Qa::Authorities::Local).to receive(:subauthority_for)
       .with('map_regions').and_return(instance_double(Qa::Authorities::Local::FileBasedAuthority,
                                                       all: [{ id: 'north', label: 'North' }]))
-    # Qa::LocalAuthority rejects a name a yaml file already covers, and it reads
-    # that list from Qa directly rather than through this service.
-    allow(Qa::LocalAuthority).to receive(:file_based_names).and_return([])
   end
 
   describe '.all' do
@@ -53,11 +50,10 @@ RSpec.describe ControlledVocabularyCatalog do
       vocabulary.local_authority_entries.create!(label: 'Closed Stacks', uri: 'closed-stacks', active: false)
     end
 
-    it 'counts active terms separately from the total' do
+    it 'counts the terms in the tenant' do
       entry = described_class.database.detect { |e| e.source_key == 'reading_rooms' }
 
       expect(entry.term_count).to eq 2
-      expect(entry.active_term_count).to eq 1
     end
 
     it 'is editable' do
@@ -96,17 +92,15 @@ RSpec.describe ControlledVocabularyCatalog do
       entry = described_class.file_based.detect { |e| e.source_key == 'geo_regions' }
 
       expect(entry.term_count).to be_nil
-      expect(entry).not_to be_counted
     end
   end
 
   describe '.remote' do
-    it 'carries the search url and input type instead of a term count' do
+    it 'names the service instead of counting terms' do
       entry = described_class.remote.detect { |e| e.source_key == 'loc/subjects' }
 
-      expect(entry.url).to eq '/authorities/search/loc/subjects'
-      expect(entry.input_type).to eq 'autocomplete'
-      expect(entry).not_to be_counted
+      expect(entry.provider).to eq 'loc'
+      expect(entry.term_count).to be_nil
     end
 
     it 'is not editable' do

--- a/spec/services/controlled_vocabulary_catalog_spec.rb
+++ b/spec/services/controlled_vocabulary_catalog_spec.rb
@@ -61,6 +61,18 @@ RSpec.describe ControlledVocabularyCatalog do
 
       expect(entry).to be_editable
     end
+
+    # An empty vocabulary is where the first term gets added, so having no terms must
+    # not close the page that adds them.
+    it 'is editable and viewable before it has any terms' do
+      Qa::LocalAuthority.create!(name: 'lab_names', label: 'Lab Names')
+
+      entry = described_class.database.detect { |e| e.source_key == 'lab_names' }
+
+      expect(entry.term_count).to eq 0
+      expect(entry).to be_editable
+      expect(entry).to be_viewable
+    end
   end
 
   describe '.file_based' do
@@ -124,40 +136,98 @@ RSpec.describe ControlledVocabularyCatalog do
       expect(described_class.remote.detect { |e| e.source_key == 'geonames' }.label).to eq 'GeoNames'
     end
 
-    it 'flags a service whose credentials are missing' do
-      allow(Qa::Authorities::Geonames).to receive(:username).and_return(nil)
+    # The list comes from qa, not a hand-maintained hash, so every subauthority the
+    # gem supports is offered and each key is one qa can actually resolve.
+    it 'offers every subauthority the gem reports' do
+      keys = described_class.remote.map(&:source_key)
 
-      expect(described_class.remote.detect { |e| e.source_key == 'geonames' }).not_to be_configured
+      expect(keys).to include(*Qa::Authorities::Getty.subauthorities.map { |s| "getty/#{s}" })
     end
 
-    it 'does not flag a service that needs no credentials' do
-      expect(described_class.remote.detect { |e| e.source_key == 'loc/subjects' }).to be_configured
+    it 'spells a subauthority the way qa expects it' do
+      keys = described_class.remote.map(&:source_key)
+
+      expect(keys).to include 'loc/genreForms'
+      expect(keys).not_to include 'loc/genre_forms'
     end
 
-    # mesh is registered as remote but its url points at a local table, so it is
-    # not an external service.
-    it 'omits authorities whose url is a local lookup' do
+    it 'picks up a service the previous hardcoded list omitted' do
+      expect(described_class.remote.map(&:provider)).to include 'crossref'
+    end
+
+    # mesh reads a local table, so it is not an external service.
+    it 'omits mesh' do
       expect(described_class.remote.map(&:source_key)).not_to include 'mesh'
+    end
+
+    # Read from this tenant's settings, not from Qa::Authorities::Geonames.username:
+    # that is a class_attribute holding whichever tenant configured Hyrax last.
+    context 'with a tenant' do
+      let(:account) { instance_double(Account, settings: settings) }
+
+      before { allow(Site).to receive(:account).and_return(account) }
+
+      context 'whose credentials are set' do
+        let(:settings) { { 'geonames_username' => 'scientist' } }
+
+        it 'does not flag the service' do
+          expect(described_class.remote.detect { |e| e.source_key == 'geonames' }).to be_configured
+        end
+      end
+
+      context 'whose credentials are missing' do
+        let(:settings) { { 'geonames_username' => '' } }
+
+        it 'flags the service' do
+          expect(described_class.remote.detect { |e| e.source_key == 'geonames' }).not_to be_configured
+        end
+
+        it 'leaves a service that needs no credentials alone' do
+          expect(described_class.remote.detect { |e| e.source_key == 'loc/subjects' }).to be_configured
+        end
+      end
     end
   end
 
-  describe 'a registered local authority with no terms yet' do
-    it 'is listed as local, awaiting its import task' do
+  # mesh keeps its terms in the same tables as a staff vocabulary, but a MeSH import
+  # replaces all of them, so Qa::Authorities::Mesh reports locally_owned? false and
+  # the catalog files it separately.
+  describe 'a vocabulary holding an imported copy' do
+    it 'is listed as cached, awaiting its import task' do
       entry = described_class.database.detect { |e| e.source_key == 'mesh' }
 
-      expect(entry.origin).to eq :database
+      expect(entry.origin).to eq :cached
+      expect(entry).to be_cached
       expect(entry.term_count).to eq 0
       expect(entry).to be_awaiting_import
       expect(entry.import_task).to eq 'mesh:import_tenant'
     end
 
-    # There is no row to open, so the listing must not link it.
-    it 'is not editable, because it has no record yet' do
+    # Its terms are not staff's to change, whether or not they are imported yet.
+    it 'is never editable' do
+      Qa::LocalAuthority.create!(name: 'mesh')
+                        .local_authority_entries.create!(label: 'Diabetes', uri: 'mesh:diabetes')
+
       entry = described_class.database.detect { |e| e.source_key == 'mesh' }
 
       expect(entry).not_to be_editable
-      expect(entry).to be_local
-      expect(entry.vocabulary).to be_nil
+      expect(entry).to be_stored_locally
+    end
+
+    # Read-only, but worth opening: a depositor needs to look up the term id.
+    it 'is viewable once its terms are imported' do
+      Qa::LocalAuthority.create!(name: 'mesh')
+                        .local_authority_entries.create!(label: 'Diabetes', uri: 'mesh:diabetes')
+
+      entry = described_class.database.detect { |e| e.source_key == 'mesh' }
+
+      expect(entry).to be_viewable
+    end
+
+    it 'is not viewable before then, because there is nothing to show' do
+      entry = described_class.database.detect { |e| e.source_key == 'mesh' }
+
+      expect(entry).not_to be_viewable
     end
 
     it 'stops awaiting import once terms exist' do

--- a/spec/services/controlled_vocabulary_catalog_spec.rb
+++ b/spec/services/controlled_vocabulary_catalog_spec.rb
@@ -75,6 +75,43 @@ RSpec.describe ControlledVocabularyCatalog do
     end
   end
 
+  describe '.terms_for' do
+    let(:vocabulary) { Qa::LocalAuthority.create!(name: 'reading_rooms', label: 'Reading Rooms') }
+
+    it 'reads the terms a database row holds' do
+      vocabulary.local_authority_entries.create!(label: 'Special Collections', uri: 'special-collections')
+      entry = described_class.database.detect { |e| e.source_key == 'reading_rooms' }
+
+      expect(described_class.terms_for(entry).first)
+        .to include('id' => 'special-collections', 'label' => 'Special Collections', 'active' => true)
+    end
+
+    it 'returns nothing for an imported copy, which holds too many terms to list' do
+      mesh = Qa::LocalAuthority.create!(name: 'mesh')
+      mesh.local_authority_entries.create!(label: 'Diabetes', uri: 'mesh:diabetes')
+      entry = described_class.database.detect { |e| e.source_key == 'mesh' }
+
+      expect(described_class.terms_for(entry)).to be_nil
+    end
+
+    # A vocabulary can hold tens of thousands of terms, so the page caps the list.
+    # The cap has to be visible to the caller, or a reader concludes a term is absent.
+    it 'stops at the term limit' do
+      stub_const("#{described_class}::TERM_LIMIT", 2)
+      3.times { |i| vocabulary.local_authority_entries.create!(label: "Room #{i}", uri: "room-#{i}") }
+      entry = described_class.database.detect { |e| e.source_key == 'reading_rooms' }
+
+      expect(described_class.terms_for(entry).size).to eq 2
+      expect(entry.term_count).to eq 3
+    end
+
+    it 'returns nothing for a remote service, which cannot be enumerated' do
+      entry = described_class.remote.detect { |e| e.source_key == 'loc/subjects' }
+
+      expect(described_class.terms_for(entry)).to be_nil
+    end
+  end
+
   describe '.file_based' do
     it 'lists the yaml vocabularies no database row claims' do
       expect(described_class.file_based.map(&:source_key)).to contain_exactly('map_regions', 'geo_regions')
@@ -160,15 +197,21 @@ RSpec.describe ControlledVocabularyCatalog do
       expect(described_class.remote.map(&:source_key)).not_to include 'mesh'
     end
 
-    # Read from this tenant's settings, not from Qa::Authorities::Geonames.username:
-    # that is a class_attribute holding whichever tenant configured Hyrax last.
+    # Read through the account's accessors, not Site.account.settings and not
+    # Qa::Authorities::Geonames.username. The hash skips the environment fallbacks
+    # the reader applies, and the qa class attribute holds whichever tenant
+    # configured Hyrax last in this process.
     context 'with a tenant' do
-      let(:account) { instance_double(Account, settings: settings) }
+      let(:account) do
+        instance_double(Account, geonames_username: geonames, discogs_user_token: discogs)
+      end
+
+      let(:discogs) { '' }
 
       before { allow(Site).to receive(:account).and_return(account) }
 
       context 'whose credentials are set' do
-        let(:settings) { { 'geonames_username' => 'scientist' } }
+        let(:geonames) { 'qrtfhx' }
 
         it 'does not flag the service' do
           expect(described_class.remote.detect { |e| e.source_key == 'geonames' }).to be_configured
@@ -176,7 +219,7 @@ RSpec.describe ControlledVocabularyCatalog do
       end
 
       context 'whose credentials are missing' do
-        let(:settings) { { 'geonames_username' => '' } }
+        let(:geonames) { '' }
 
         it 'flags the service' do
           expect(described_class.remote.detect { |e| e.source_key == 'geonames' }).not_to be_configured
@@ -186,6 +229,38 @@ RSpec.describe ControlledVocabularyCatalog do
           expect(described_class.remote.detect { |e| e.source_key == 'loc/subjects' }).to be_configured
         end
       end
+
+      # The reader returns whatever the HYKU_/HYRAX_ fallback supplies, so a
+      # credential set only in the environment still counts as configured.
+      context 'whose credentials come from the environment' do
+        let(:geonames) { 'zmbvkp' }
+
+        it 'does not flag the service' do
+          expect(described_class.remote.detect { |e| e.source_key == 'geonames' }).to be_configured
+        end
+      end
+    end
+
+    # A tenant whose settings have never been written must not read as configured:
+    # the credential is genuinely absent.
+    context 'with a tenant that has no settings' do
+      before do
+        allow(Site).to receive(:account)
+          .and_return(instance_double(Account, geonames_username: nil, discogs_user_token: nil))
+      end
+
+      it 'flags the services that need credentials' do
+        expect(described_class.remote.detect { |e| e.source_key == 'geonames' }).not_to be_configured
+        expect(described_class.remote.detect { |e| e.provider == 'discogs' }).not_to be_configured
+      end
+    end
+
+    context 'with no tenant at all' do
+      before { allow(Site).to receive(:account).and_return(nil) }
+
+      it 'flags the services that need credentials' do
+        expect(described_class.remote.detect { |e| e.source_key == 'geonames' }).not_to be_configured
+      end
     end
   end
 
@@ -193,6 +268,14 @@ RSpec.describe ControlledVocabularyCatalog do
   # replaces all of them, so Qa::Authorities::Mesh reports locally_owned? false and
   # the catalog files it separately.
   describe 'a vocabulary holding an imported copy' do
+    # The locale names it, so importing must not rename it: display_label alone would
+    # titleize the source key and turn "MeSH" into "Mesh".
+    it 'keeps its name once imported' do
+      Qa::LocalAuthority.create!(name: 'mesh')
+
+      expect(described_class.database.detect { |e| e.source_key == 'mesh' }.label).to eq 'MeSH'
+    end
+
     it 'is listed as cached, awaiting its import task' do
       entry = described_class.database.detect { |e| e.source_key == 'mesh' }
 
@@ -211,23 +294,19 @@ RSpec.describe ControlledVocabularyCatalog do
       entry = described_class.database.detect { |e| e.source_key == 'mesh' }
 
       expect(entry).not_to be_editable
-      expect(entry).to be_stored_locally
+      expect(entry).to be_cached
     end
 
-    # Read-only, but worth opening: a depositor needs to look up the term id.
-    it 'is viewable once its terms are imported' do
+    # A MeSH release runs to about 30,000 terms, so the list is not offered at all
+    # and the index does not link it.
+    it 'has no term list, imported or not' do
       Qa::LocalAuthority.create!(name: 'mesh')
                         .local_authority_entries.create!(label: 'Diabetes', uri: 'mesh:diabetes')
 
       entry = described_class.database.detect { |e| e.source_key == 'mesh' }
 
-      expect(entry).to be_viewable
-    end
-
-    it 'is not viewable before then, because there is nothing to show' do
-      entry = described_class.database.detect { |e| e.source_key == 'mesh' }
-
       expect(entry).not_to be_viewable
+      expect(described_class.terms_for(entry)).to be_nil
     end
 
     it 'stops awaiting import once terms exist' do

--- a/spec/services/controlled_vocabulary_catalog_spec.rb
+++ b/spec/services/controlled_vocabulary_catalog_spec.rb
@@ -1,0 +1,196 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ControlledVocabularyCatalog do
+  # The suite seeds every real yaml vocabulary into the tables, so an unstubbed
+  # file_based_names would be entirely claimed by database rows. Naming a fictional
+  # file set keeps these examples independent of that seed state, and clear of
+  # Qa::LocalAuthority's validation against shadowing a real yaml file.
+  #
+  # `map_regions` stands for a file present on disk, `geo_regions` for one named in
+  # a profile but missing, so the uncountable path is covered too.
+  before do
+    allow(described_class).to receive(:file_based_names).and_return(%w[map_regions geo_regions])
+    allow(Qa::Authorities::Local).to receive(:subauthority_for).and_call_original
+    allow(Qa::Authorities::Local).to receive(:subauthority_for)
+      .with('map_regions').and_return(instance_double(Qa::Authorities::Local::FileBasedAuthority,
+                                                      all: [{ id: 'north', label: 'North' }]))
+    # Qa::LocalAuthority rejects a name a yaml file already covers, and it reads
+    # that list from Qa directly rather than through this service.
+    allow(Qa::LocalAuthority).to receive(:file_based_names).and_return([])
+  end
+
+  describe '.all' do
+    it 'includes file-based and remote authorities alongside the editable ones' do
+      Qa::LocalAuthority.create!(name: 'reading_rooms', label: 'Reading Rooms')
+
+      expect(described_class.all.map(&:origin).uniq).to include(:database, :file, :remote)
+    end
+
+    it 'lists editable vocabularies first' do
+      Qa::LocalAuthority.create!(name: 'zzz_last_alphabetically', label: 'Zzz')
+
+      expect(described_class.all.first.origin).to eq :database
+    end
+
+    it 'gives every authority a source key a profile can cite' do
+      expect(described_class.all.map(&:source_key)).to all(be_present)
+    end
+
+    it 'does not list the same source key twice' do
+      keys = described_class.all.map(&:source_key)
+
+      expect(keys).to eq keys.uniq
+    end
+  end
+
+  describe '.database' do
+    let!(:vocabulary) { Qa::LocalAuthority.create!(name: 'reading_rooms', label: 'Reading Rooms') }
+
+    before do
+      vocabulary.local_authority_entries.create!(label: 'Special Collections', uri: 'special-collections')
+      vocabulary.local_authority_entries.create!(label: 'Closed Stacks', uri: 'closed-stacks', active: false)
+    end
+
+    it 'counts active terms separately from the total' do
+      entry = described_class.database.detect { |e| e.source_key == 'reading_rooms' }
+
+      expect(entry.term_count).to eq 2
+      expect(entry.active_term_count).to eq 1
+    end
+
+    it 'is editable' do
+      entry = described_class.database.detect { |e| e.source_key == 'reading_rooms' }
+
+      expect(entry).to be_editable
+    end
+  end
+
+  describe '.file_based' do
+    it 'lists the yaml vocabularies no database row claims' do
+      expect(described_class.file_based.map(&:source_key)).to contain_exactly('map_regions', 'geo_regions')
+    end
+
+    it 'is not editable' do
+      expect(described_class.file_based.map(&:editable?).uniq).to eq [false]
+    end
+
+    # The row is what staff see and edit, so listing both would read as two
+    # separate vocabularies.
+    it 'omits a name a database row already claims' do
+      Qa::LocalAuthority.create!(name: 'map_regions')
+
+      expect(described_class.file_based.map(&:source_key)).to contain_exactly('geo_regions')
+    end
+
+    it 'counts the terms in the yaml file' do
+      entry = described_class.file_based.detect { |e| e.source_key == 'map_regions' }
+
+      expect(entry.term_count).to be_positive
+    end
+
+    # A yaml file named in the profile but absent from disk must not blow up the
+    # whole listing.
+    it 'reports an uncountable vocabulary rather than claiming it is empty' do
+      entry = described_class.file_based.detect { |e| e.source_key == 'geo_regions' }
+
+      expect(entry.term_count).to be_nil
+      expect(entry).not_to be_counted
+    end
+  end
+
+  describe '.remote' do
+    it 'carries the search url and input type instead of a term count' do
+      entry = described_class.remote.detect { |e| e.source_key == 'loc/subjects' }
+
+      expect(entry.url).to eq '/authorities/search/loc/subjects'
+      expect(entry.input_type).to eq 'autocomplete'
+      expect(entry).not_to be_counted
+    end
+
+    it 'is not editable' do
+      expect(described_class.remote.map(&:editable?).uniq).to eq [false]
+    end
+
+    it 'names the service behind each authority' do
+      expect(described_class.remote.detect { |e| e.source_key == 'getty/aat' }.provider).to eq 'getty'
+    end
+
+    # Titleizing the key gives "Getty/Aat", which names neither the service nor the
+    # vocabulary usefully. The service has its own column, so the label carries the
+    # vocabulary.
+    it 'names the vocabulary, spelling out acronyms' do
+      entry = described_class.remote.detect { |e| e.source_key == 'getty/aat' }
+
+      expect(entry.label).to eq 'Art & Architecture Thesaurus'
+    end
+
+    it 'falls back to the service name for a single-vocabulary service' do
+      expect(described_class.remote.detect { |e| e.source_key == 'geonames' }.label).to eq 'GeoNames'
+    end
+
+    it 'flags a service whose credentials are missing' do
+      allow(Qa::Authorities::Geonames).to receive(:username).and_return(nil)
+
+      expect(described_class.remote.detect { |e| e.source_key == 'geonames' }).not_to be_configured
+    end
+
+    it 'does not flag a service that needs no credentials' do
+      expect(described_class.remote.detect { |e| e.source_key == 'loc/subjects' }).to be_configured
+    end
+
+    # mesh is registered as remote but its url points at a local table, so it is
+    # not an external service.
+    it 'omits authorities whose url is a local lookup' do
+      expect(described_class.remote.map(&:source_key)).not_to include 'mesh'
+    end
+  end
+
+  describe 'a registered local authority with no terms yet' do
+    it 'is listed as local, awaiting its import task' do
+      entry = described_class.database.detect { |e| e.source_key == 'mesh' }
+
+      expect(entry.origin).to eq :database
+      expect(entry.term_count).to eq 0
+      expect(entry).to be_awaiting_import
+      expect(entry.import_task).to eq 'mesh:import_tenant'
+    end
+
+    # There is no row to open, so the listing must not link it.
+    it 'is not editable, because it has no record yet' do
+      entry = described_class.database.detect { |e| e.source_key == 'mesh' }
+
+      expect(entry).not_to be_editable
+      expect(entry).to be_local
+      expect(entry.vocabulary).to be_nil
+    end
+
+    it 'stops awaiting import once terms exist' do
+      vocabulary = Qa::LocalAuthority.create!(name: 'mesh')
+      vocabulary.local_authority_entries.create!(label: 'Diabetes', uri: 'mesh:diabetes')
+
+      entry = described_class.database.detect { |e| e.source_key == 'mesh' }
+
+      expect(entry).not_to be_awaiting_import
+    end
+  end
+
+  # Qa::Authorities::LocalVocabulary decides per call: a database row serves the
+  # terms, and a vocabulary with no row falls back to its yaml file. So a row and a
+  # file of the same name are one vocabulary, listed once, served from the row.
+  describe 'a vocabulary with both a database row and a yaml file' do
+    before { Qa::LocalAuthority.create!(name: 'map_regions') }
+
+    it 'is listed once, as editable' do
+      matching = described_class.all.select { |e| e.source_key == 'map_regions' }
+
+      expect(matching.size).to eq 1
+      expect(matching.first).to be_editable
+    end
+
+    it 'is not listed as file-based' do
+      expect(described_class.file_based.map(&:source_key)).not_to include 'map_regions'
+    end
+  end
+end

--- a/spec/services/qa/authority_registry_spec.rb
+++ b/spec/services/qa/authority_registry_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Asserts what the qa gem reports about itself, with no Hyku fixtures, so these
+# examples travel with the class if it is ever contributed upstream.
+RSpec.describe Qa::AuthorityRegistry do
+  describe '.remote_services' do
+    subject(:services) { described_class.remote_services }
+
+    it 'finds the external services the gem provides' do
+      expect(services.keys).to include('loc', 'getty', 'geonames', 'fast', 'discogs')
+    end
+
+    it 'maps each key to its authority class' do
+      expect(services['getty']).to eq Qa::Authorities::Getty
+    end
+
+    # The class is AssignFast, but the vocabulary is cited as fast/*.
+    it 'uses the source key a profile cites, not the class name' do
+      expect(services.keys).to include 'fast'
+      expect(services.keys).not_to include 'assign_fast'
+    end
+
+    it 'excludes the local backend' do
+      expect(services.keys).not_to include 'local'
+    end
+
+    it 'excludes abstract base classes' do
+      expect(services.keys).not_to include('base', 'web_service_base')
+    end
+
+    # Hyrax adds authorities for picking works and collections, and Hyku adds its
+    # own local classes. Neither is an external vocabulary, and both are excluded by
+    # where they are defined rather than by name.
+    it 'excludes authorities a host application defines' do
+      expect(services.keys).not_to include('collections', 'find_works', 'compound_works', 'local_vocabulary', 'mesh')
+    end
+
+    it 'excludes the subauthority mixins' do
+      expect(services.keys.grep(/subauthority/)).to be_empty
+    end
+
+    # Qa::Authorities::Oclcts reads config/oclcts-authorities.yml when it loads, so
+    # a host without that file must still get the rest of the list.
+    it 'skips an authority that cannot be loaded' do
+      expect(services.keys).to include('loc')
+    end
+  end
+
+  describe '.subauthorities_of' do
+    it 'lists the vocabularies a multi-vocabulary service offers' do
+      expect(described_class.subauthorities_of(Qa::Authorities::Getty)).to contain_exactly('aat', 'tgn', 'ulan')
+    end
+
+    # A single-vocabulary service is cited by its own key alone, with nothing after
+    # the slash, so nil stands in for the missing subauthority.
+    it 'yields a single nil for a service with no subauthorities' do
+      expect(described_class.subauthorities_of(Qa::Authorities::Geonames)).to eq [nil]
+    end
+  end
+
+  describe '.vocabularies_for' do
+    it 'builds the keys a profile cites' do
+      expect(described_class.vocabularies_for('getty', Qa::Authorities::Getty))
+        .to contain_exactly('getty/aat', 'getty/tgn', 'getty/ulan')
+    end
+
+    it 'omits the slash for a single-vocabulary service' do
+      expect(described_class.vocabularies_for('geonames', Qa::Authorities::Geonames)).to eq ['geonames']
+    end
+
+    # qa spells this one in camelCase, and subauthority_for rejects genre_forms.
+    it 'keeps the spelling qa resolves' do
+      keys = described_class.vocabularies_for('loc', Qa::Authorities::Loc)
+
+      expect(keys).to include 'loc/genreForms'
+      expect(keys).not_to include 'loc/genre_forms'
+    end
+  end
+
+  describe '.display_name' do
+    it 'spells out an acronym' do
+      expect(described_class.display_name('aat')).to eq 'Art & Architecture Thesaurus'
+    end
+
+    it 'reads a camelCase key as words' do
+      expect(described_class.display_name('genreForms')).to eq 'Genre/Form Terms'
+    end
+
+    it 'titleizes a key it has no name for' do
+      expect(described_class.display_name('countries')).to eq 'Countries'
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Adds a dashboard page listing every controlled vocabulary available to a tenant, and a read-only page showing the terms of each local one.

Refs 
- notch8/palni_palci_knapsack#698
- notch8/palni_palci_knapsack#699

## Details
- The index lists locally-managed, file-based, and external-service vocabularies together, with the source key to paste into a metadata profile.
- External services come from the questioning_authority gem rather than a hardcoded list.
- The show page lists a local vocabulary's terms with the term ID that gets stored on a record and supplied in a Bulkrax import.
- Vocabularies holding an imported copy of an external one, such as MeSH, are listed but not opened — a MeSH release runs to roughly 30,000 terms. Each authority declares whether it owns its terms, so this is not a hardcoded exception.
- Depositors can view; only admins will be able to edit. A new ability module separates the two, gated on the same check Bulkrax uses for importing.
- Neither ticket is closed by this. Term editing, activate/deactivate toggles, copy-to-clipboard for import values, pagination, and sorting remain open on 699; usage locations within the metadata profile remain open on 698.

## Testing
- Visit Dashboard → Tasks → Controlled Vocabularies as an admin. Confirm the list includes vocabularies from all three sources and that only locally-managed ones are links.
- Open a local vocabulary and confirm its terms show a label, a term ID, and a status.
- Confirm MeSH appears with a "Not imported" badge and is not a link.
- Sign in as a user who can deposit but is not an admin. Confirm the menu item appears under a "Tasks" heading and the page loads.
- Sign in as a user who cannot deposit. Confirm the menu item is absent and the URL is refused.
- Set a GeoNames username in account settings, then confirm GeoNames reads "Ready" rather than "Needs setup".

