### PR TITLE
Show which properties and work types use a vocabulary

### DIFF
--- a/app/controllers/hyrax/dashboard/controlled_vocabularies_controller.rb
+++ b/app/controllers/hyrax/dashboard/controlled_vocabularies_controller.rb
@@ -28,6 +28,7 @@ module Hyrax
         add_breadcrumb t('hyku.admin.controlled_vocabularies'), main_app.controlled_vocabularies_path
         add_breadcrumb @entry.label, request.path
         @terms = ControlledVocabularyCatalog.terms_for(@entry)
+        @usage = ControlledVocabularyUsage.citing(@entry.source_key)
       end
     end
   end

--- a/app/services/controlled_vocabulary_catalog.rb
+++ b/app/services/controlled_vocabulary_catalog.rb
@@ -55,6 +55,16 @@ class ControlledVocabularyCatalog
     def awaiting_import?
       import_task.present? && term_count.to_i.zero?
     end
+
+    # Where the vocabulary comes from, for display: the service for a remote
+    # authority, otherwise the origin.
+    def source_label
+      if provider
+        I18n.t("hyku.admin.controlled_vocabulary.providers.#{provider}", default: provider.titleize)
+      else
+        I18n.t("hyku.admin.controlled_vocabulary.origins.#{origin}")
+      end
+    end
   end
 
   class << self
@@ -159,9 +169,9 @@ class ControlledVocabularyCatalog
 
     def remote_entry(provider, subauthority, configured)
       Entry.new(source_key: [provider, subauthority].compact.join('/'),
-                # Prefixed with the service: without it a bare "Corporate" or
-                # "Subjects" does not say whose vocabulary it is.
-                label: [provider_label(provider), remote_vocabulary_label(subauthority)].compact.join(' '),
+                # Names the vocabulary, not the key: titleizing `loc/iso639-1`
+                # gives "Loc/Iso639 1", and the service has its own column.
+                label: remote_vocabulary_label(subauthority) || provider_label(provider),
                 origin: :remote,
                 provider: provider,
                 configured: configured)

--- a/app/services/controlled_vocabulary_catalog.rb
+++ b/app/services/controlled_vocabulary_catalog.rb
@@ -159,9 +159,9 @@ class ControlledVocabularyCatalog
 
     def remote_entry(provider, subauthority, configured)
       Entry.new(source_key: [provider, subauthority].compact.join('/'),
-                # Names the vocabulary, not the key: titleizing `loc/iso639-1`
-                # gives "Loc/Iso639 1", and the service has its own column.
-                label: remote_vocabulary_label(subauthority) || provider_label(provider),
+                # Prefixed with the service: without it a bare "Corporate" or
+                # "Subjects" does not say whose vocabulary it is.
+                label: [provider_label(provider), remote_vocabulary_label(subauthority)].compact.join(' '),
                 origin: :remote,
                 provider: provider,
                 configured: configured)

--- a/app/services/controlled_vocabulary_usage.rb
+++ b/app/services/controlled_vocabulary_usage.rb
@@ -36,7 +36,7 @@ class ControlledVocabularyUsage
       properties.filter_map do |name, config|
         next unless config.is_a?(Hash) && cites?(config, key)
 
-        Property.new(name: name, work_types: work_types(profile, config))
+        Property.new(name: name, work_types: work_types(config))
       end
     end
 
@@ -76,15 +76,8 @@ class ControlledVocabularyUsage
       model_classes.filter_map do |klass|
         next unless klass.fields.include?(name.to_sym)
 
-        WorkType.new(name: klass.name, label: model_label(klass))
+        WorkType.new(name: klass.name, label: class_label(klass.name))
       end
-    end
-
-    # The Valkyrie suffix is an implementation detail; staff know these as work
-    # types, matching what a profile-backed tenant sees.
-    def model_label(klass)
-      I18n.t("hyku.admin.controlled_vocabulary.work_types.#{klass.name.underscore}",
-             default: klass.name.demodulize.delete_suffix('Resource').titleize)
     end
 
     # Valkyrie classes only: the registry also lists each type's ActiveFedora
@@ -103,22 +96,18 @@ class ControlledVocabularyUsage
       end
     end
 
-    def work_types(profile, config)
+    def work_types(config)
       Array(config.dig('available_on', 'class')).map do |class_name|
-        WorkType.new(name: class_name, label: work_type_label(profile, class_name))
+        WorkType.new(name: class_name, label: class_label(class_name))
       end
     end
 
-    # Labels the shipped profile got wrong; profiles saved before the fix still
-    # carry them, so they fall through to the locale instead of the profile.
-    MISLABELED_CLASSES = ['pcdmcollection'].freeze
-
-    def work_type_label(profile, class_name)
-      label = profile.dig('classes', class_name, 'display_label').presence
-      return label if label && MISLABELED_CLASSES.exclude?(label)
-
+    # From the class name, not the profile's display_label: profiles have shipped
+    # with labels like "pcdmcollection", and the class name is stable across
+    # tenants. The Valkyrie suffix is an implementation detail staff never see.
+    def class_label(class_name)
       I18n.t("hyku.admin.controlled_vocabulary.work_types.#{class_name.underscore}",
-             default: label || class_name)
+             default: class_name.demodulize.delete_suffix('Resource').titleize)
     end
   end
 end

--- a/app/services/controlled_vocabulary_usage.rb
+++ b/app/services/controlled_vocabulary_usage.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+# What a controlled vocabulary controls: the properties that cite it and the work
+# types each property is available on, read from the tenant's current metadata
+# profile, or from the static form mapping when flexible metadata is off.
+# Configuration only, not a count over deposited works.
+class ControlledVocabularyUsage
+  Property = Struct.new(:name, :work_types, keyword_init: true)
+  WorkType = Struct.new(:name, :label, keyword_init: true)
+
+  class << self
+    # @param source_key [String] the key a profile cites in controlled_values.sources
+    # @return [Array<Property>, nil] nil when usage cannot be determined (flexible
+    #   metadata on but no profile saved yet), which is not the same answer as []:
+    #   an empty array means nothing cites the vocabulary.
+    def citing(source_key)
+      key = source_key.to_s
+
+      properties = if Hyrax.config.flexible?
+                     profile = Hyrax::FlexibleSchema.current_version
+                     return if profile.nil?
+
+                     from_profile(profile, key)
+                   else
+                     from_mappings(key)
+                   end
+
+      properties.sort_by(&:name)
+    end
+
+    private
+
+    def from_profile(profile, key)
+      properties = profile['properties'] || {}
+
+      properties.filter_map do |name, config|
+        next unless config.is_a?(Hash) && cites?(config, key)
+
+        Property.new(name: name, work_types: work_types(profile, config))
+      end
+    end
+
+    # Form partials that read an authority the generic mapping does not list: the
+    # OER form fills resource_type from oer_types, and based_near autocompletes
+    # against geonames. A nil class list means every model defining the property.
+    PARTIAL_SOURCES = {
+      'oer_types' => { property: 'resource_type', classes: ['OerResource'] },
+      'geonames' => { property: 'based_near', classes: nil }
+    }.freeze
+
+    # Without flexible metadata there is no profile; which properties a vocabulary
+    # controls comes from the static mapping the deposit form itself uses, and the
+    # work types from which model classes define the property.
+    def from_mappings(key)
+      mapped = Hyrax::ControlledVocabularies.controlled_vocab_mappings.filter_map do |name, source|
+        next unless source == key
+
+        Property.new(name: name, work_types: model_work_types(name))
+      end
+
+      mapped + partial_properties(key)
+    end
+
+    def partial_properties(key)
+      config = PARTIAL_SOURCES[key]
+      return [] unless config
+
+      work_types = model_work_types(config[:property])
+      work_types = work_types.select { |work_type| config[:classes].include?(work_type.name) } if config[:classes]
+      return [] if work_types.empty?
+
+      [Property.new(name: config[:property], work_types: work_types)]
+    end
+
+    def model_work_types(name)
+      model_classes.filter_map do |klass|
+        next unless klass.fields.include?(name.to_sym)
+
+        WorkType.new(name: klass.name, label: model_label(klass))
+      end
+    end
+
+    # The Valkyrie suffix is an implementation detail; staff know these as work
+    # types, matching what a profile-backed tenant sees.
+    def model_label(klass)
+      I18n.t("hyku.admin.controlled_vocabulary.work_types.#{klass.name.underscore}",
+             default: klass.name.demodulize.delete_suffix('Resource').titleize)
+    end
+
+    # Valkyrie classes only: the registry also lists each type's ActiveFedora
+    # counterpart, which would double every work type shown.
+    def model_classes
+      (Hyrax::ModelRegistry.work_classes +
+        Hyrax::ModelRegistry.collection_classes +
+        Hyrax::ModelRegistry.file_set_classes).select { |klass| klass < Valkyrie::Resource }
+    end
+
+    # Keys are stripped because profiles have shipped them with stray whitespace;
+    # the form helper reads them the same way.
+    def cites?(config, key)
+      Array(config.dig('controlled_values', 'sources')).any? do |source|
+        source.to_s.strip == key
+      end
+    end
+
+    def work_types(profile, config)
+      Array(config.dig('available_on', 'class')).map do |class_name|
+        WorkType.new(name: class_name, label: work_type_label(profile, class_name))
+      end
+    end
+
+    # Labels the shipped profile got wrong; profiles saved before the fix still
+    # carry them, so they fall through to the locale instead of the profile.
+    MISLABELED_CLASSES = ['pcdmcollection'].freeze
+
+    def work_type_label(profile, class_name)
+      label = profile.dig('classes', class_name, 'display_label').presence
+      return label if label && MISLABELED_CLASSES.exclude?(label)
+
+      I18n.t("hyku.admin.controlled_vocabulary.work_types.#{class_name.underscore}",
+             default: label || class_name)
+    end
+  end
+end

--- a/app/views/hyrax/dashboard/controlled_vocabularies/index.html.erb
+++ b/app/views/hyrax/dashboard/controlled_vocabularies/index.html.erb
@@ -22,6 +22,11 @@
               </th>
               <th scope="col">
                 <%= render 'column_hint',
+                           label: t('hyku.admin.controlled_vocabulary.origin'),
+                           hint: t('hyku.admin.controlled_vocabulary.origin_hint') %>
+              </th>
+              <th scope="col">
+                <%= render 'column_hint',
                            label: t('hyku.admin.controlled_vocabulary.status'),
                            hint: t('hyku.admin.controlled_vocabulary.status_hint') %>
               </th>
@@ -38,6 +43,7 @@
                   <% end %>
                 </td>
                 <td><code><%= entry.source_key %></code></td>
+                <td><%= entry.source_label %></td>
                 <td>
                   <% if entry.awaiting_import? %>
                     <span class="badge badge-info"
@@ -58,7 +64,7 @@
               </tr>
               <% if entry.description.present? %>
                 <tr class="border-bottom">
-                  <td colspan="3" class="pt-0 text-muted">
+                  <td colspan="4" class="pt-0 text-muted">
                     <%= entry.description %>
                   </td>
                 </tr>

--- a/app/views/hyrax/dashboard/controlled_vocabularies/index.html.erb
+++ b/app/views/hyrax/dashboard/controlled_vocabularies/index.html.erb
@@ -22,11 +22,6 @@
               </th>
               <th scope="col">
                 <%= render 'column_hint',
-                           label: t('hyku.admin.controlled_vocabulary.origin'),
-                           hint: t('hyku.admin.controlled_vocabulary.origin_hint') %>
-              </th>
-              <th scope="col">
-                <%= render 'column_hint',
                            label: t('hyku.admin.controlled_vocabulary.status'),
                            hint: t('hyku.admin.controlled_vocabulary.status_hint') %>
               </th>
@@ -43,14 +38,6 @@
                   <% end %>
                 </td>
                 <td><code><%= entry.source_key %></code></td>
-                <td>
-                  <%= if entry.provider
-                        t("hyku.admin.controlled_vocabulary.providers.#{entry.provider}",
-                          default: entry.provider.titleize)
-                      else
-                        t("hyku.admin.controlled_vocabulary.origins.#{entry.origin}")
-                      end %>
-                </td>
                 <td>
                   <% if entry.awaiting_import? %>
                     <span class="badge badge-info"
@@ -71,7 +58,7 @@
               </tr>
               <% if entry.description.present? %>
                 <tr class="border-bottom">
-                  <td colspan="4" class="pt-0 text-muted">
+                  <td colspan="3" class="pt-0 text-muted">
                     <%= entry.description %>
                   </td>
                 </tr>

--- a/app/views/hyrax/dashboard/controlled_vocabularies/show.html.erb
+++ b/app/views/hyrax/dashboard/controlled_vocabularies/show.html.erb
@@ -46,7 +46,12 @@
         </dt>
         <dd class="col-sm-10">
           <% if @usage.empty? %>
-            <span class="text-muted"><%= t('hyku.admin.controlled_vocabulary.unused') %></span>
+            <span class="text-muted">
+              <%= t('hyku.admin.controlled_vocabulary.unused') %>
+              <% if Hyrax.config.flexible? %>
+                <%= t('hyku.admin.controlled_vocabulary.unused_profile_hint') %>
+              <% end %>
+            </span>
           <% else %>
             <ul class="list-unstyled mb-0">
               <% @usage.each do |property| %>

--- a/app/views/hyrax/dashboard/controlled_vocabularies/show.html.erb
+++ b/app/views/hyrax/dashboard/controlled_vocabularies/show.html.erb
@@ -12,6 +12,9 @@
       <dt class="col-sm-2"><%= t('hyku.admin.controlled_vocabulary.source_key') %></dt>
       <dd class="col-sm-10"><code><%= @entry.source_key %></code></dd>
 
+      <dt class="col-sm-2"><%= t('hyku.admin.controlled_vocabulary.origin') %></dt>
+      <dd class="col-sm-10"><%= @entry.source_label %></dd>
+
       <% if @terms.present? %>
         <dt class="col-sm-2"><%= t('hyku.admin.controlled_vocabulary.terms') %></dt>
         <dd class="col-sm-10">

--- a/app/views/hyrax/dashboard/controlled_vocabularies/show.html.erb
+++ b/app/views/hyrax/dashboard/controlled_vocabularies/show.html.erb
@@ -37,6 +37,32 @@
         <dt class="col-sm-2"><%= t('hyku.admin.controlled_vocabulary.description') %></dt>
         <dd class="col-sm-10"><%= @entry.description %></dd>
       <% end %>
+
+      <% unless @usage.nil? %>
+        <dt class="col-sm-2">
+          <%= render 'column_hint',
+                     label: t('hyku.admin.controlled_vocabulary.used_by'),
+                     hint: t('hyku.admin.controlled_vocabulary.used_by_hint') %>
+        </dt>
+        <dd class="col-sm-10">
+          <% if @usage.empty? %>
+            <span class="text-muted"><%= t('hyku.admin.controlled_vocabulary.unused') %></span>
+          <% else %>
+            <ul class="list-unstyled mb-0">
+              <% @usage.each do |property| %>
+                <li class="mb-1">
+                  <code><%= property.name %></code>
+                  <br>
+                  <small class="text-muted">
+                    <%= t('hyku.admin.controlled_vocabulary.used_by_work_types') %>
+                    <% property.work_types.each_with_index do |work_type, index| %><%= ', ' if index.positive? %><span title="<%= work_type.name %>"><%= work_type.label %></span><% end %>
+                  </small>
+                </li>
+              <% end %>
+            </ul>
+          <% end %>
+        </dd>
+      <% end %>
     </dl>
 
     <% unless @entry.editable? %>
@@ -46,6 +72,15 @@
         <span class="fa fa-info-circle" aria-hidden="true"></span>
         <%= t("hyku.admin.controlled_vocabulary.read_only.#{@entry.origin}",
               default: t('hyku.admin.controlled_vocabulary.read_only.generic')) %>
+      </p>
+    <% end %>
+
+    <%# Only for file-backed entries: a database-backed vocabulary feeds the form
+        from the tenant's own rows, and a remote authority from its service. %>
+    <% if @usage.present? && !Hyrax.config.flexible? && @entry.origin == :file %>
+      <p class="form-text text-muted mt-3 mb-0">
+        <span class="fa fa-info-circle" aria-hidden="true"></span>
+        <%= t('hyku.admin.controlled_vocabulary.static_forms') %>
       </p>
     <% end %>
   </div>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -408,6 +408,13 @@ de:
         name: Vokabular
         no_terms: Dieses Vokabular enthält noch keine Begriffe.
         none: Für diesen Mandanten wurden noch keine kontrollierten Vokabulare eingerichtet.
+        origin: Quelle
+        origin_hint: Wo das Vokabular definiert ist und ob seine Begriffe daher hier bearbeitet werden können.
+        origins:
+          cached: Importierte Kopie
+          database: Dieser Mandant
+          file: Konfigurationsdatei
+          remote: Externer Dienst
         providers:
           crossref: Crossref
           discogs: Discogs

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -408,13 +408,6 @@ de:
         name: Vokabular
         no_terms: Dieses Vokabular enthält noch keine Begriffe.
         none: Für diesen Mandanten wurden noch keine kontrollierten Vokabulare eingerichtet.
-        origin: Quelle
-        origin_hint: Wo das Vokabular definiert ist und ob seine Begriffe daher hier bearbeitet werden können.
-        origins:
-          cached: Importierte Kopie
-          database: Dieser Mandant
-          file: Konfigurationsdatei
-          remote: Externer Dienst
         providers:
           crossref: Crossref
           discogs: Discogs
@@ -454,6 +447,7 @@ de:
         unconfigured: Einrichtung erforderlich
         unconfigured_help: Dieser Dienst benötigt Anmeldeinformationen, bevor er verwendet werden kann. Bis dahin akzeptiert ein Feld, das ihn referenziert, Freitext, statt Vorschläge anzubieten.
         unused: Keine Metadaten-Eigenschaft verwendet dieses Vokabular.
+        unused_profile_hint: Um es zu verwenden, fügen Sie den Quellschlüssel dieses Vokabulars den kontrollierten Werten einer Eigenschaft im Metadatenprofil des Mandanten hinzu.
         used_by: Verwendet von Eigenschaften
         used_by_hint: Die von diesem Vokabular kontrollierten Metadaten-Eigenschaften, wie sie in Bulkrax-Importen und Metadatenprofilen benannt sind.
         used_by_work_types: 'Verfügbar für:'

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -396,6 +396,71 @@ de:
           upload: Dateien hochladen
         label: Fortschritt der Einreichung
     admin:
+      controlled_vocabularies: Kontrollierte Vokabulare
+      controlled_vocabulary:
+        active: Aktiv
+        awaiting_import: Nicht importiert
+        awaiting_import_help: 'Dieses Vokabular ist verfügbar, enthält in diesem Mandanten aber noch keine Begriffe. Befüllen Sie es durch Ausführen von: %{task}'
+        description: Beschreibung
+        inactive: Inaktiv
+        label: Bezeichnung
+        label_hint: Was ein Hinterleger im Formular sieht. Kann gefahrlos umformuliert werden, ohne gespeicherte Datensätze zu beeinflussen.
+        name: Vokabular
+        no_terms: Dieses Vokabular enthält noch keine Begriffe.
+        none: Für diesen Mandanten wurden noch keine kontrollierten Vokabulare eingerichtet.
+        origin: Quelle
+        origin_hint: Wo das Vokabular definiert ist und ob seine Begriffe daher hier bearbeitet werden können.
+        origins:
+          cached: Importierte Kopie
+          database: Dieser Mandant
+          file: Konfigurationsdatei
+          remote: Externer Dienst
+        providers:
+          crossref: Crossref
+          discogs: Discogs
+          fast: OCLC FAST
+          geonames: GeoNames
+          getty: Getty
+          loc: Library of Congress
+          mesh: MeSH
+          tgnlang: Getty TGN Languages
+        read_only:
+          cached: Dieses Vokabular ist eine importierte Kopie eines externen Vokabulars. Seine Begriffe können hier nicht geändert werden, und ein erneuter Import ersetzt sie alle.
+          file: Dieses Vokabular ist in einer Konfigurationsdatei definiert, daher können seine Begriffe hier nicht geändert werden.
+          generic: Die Begriffe dieses Vokabulars können hier nicht geändert werden.
+          remote: Dieses Vokabular stammt von einem externen Dienst, daher können seine Begriffe hier nicht geändert werden.
+        ready: Bereit
+        retired_count:
+          one: (%{count} zurückgezogen)
+          other: (%{count} zurückgezogen)
+        show_title: 'Kontrolliertes Vokabular: %{name}'
+        source_key: Quellschlüssel
+        source_key_hint: Fügen Sie dies in ein Feld eines Metadatenprofils ein, um dieses Feld mit diesem Vokabular zu kontrollieren.
+        source_key_help: Fügen Sie einen Quellschlüssel in ein Feld eines Metadatenprofils ein, um dieses Feld mit diesem Vokabular zu kontrollieren. In diesem Mandanten verwaltete Vokabulare können hier bearbeitet werden; in einer Konfigurationsdatei oder von einem externen Dienst definierte Vokabulare nicht.
+        static_forms: Metadatenprofile sind nicht aktiviert, daher lesen Einreichungsformulare dieses Vokabular aus einer Konfigurationsdatei. Änderungen an seinen Begriffen erfordern einen Entwickler.
+        status: Status
+        status_hint: Ob dieses Vokabular einsatzbereit ist oder zuerst etwas eingerichtet werden muss.
+        status_unknown: Nicht angegeben
+        term_id: Begriffs-ID
+        term_limit:
+          one: (der erste %{count} wird angezeigt)
+          other: (die ersten %{count} werden angezeigt)
+        term_id_hint: Der Wert, der in einem Datensatz gespeichert wird, und der Wert, der bei einem Bulkrax-Import anzugeben ist.
+        term_id_help: Die Begriffs-ID ist der Wert, der in einem Datensatz gespeichert wird, und der Wert, der bei einem Bulkrax-Import anzugeben ist. Die Bezeichnung ist nur das, was ein Hinterleger sieht.
+        term_total:
+          one: 1 Begriff
+          other: "%{count} Begriffe"
+        terms: Begriffe
+        unconfigured: Einrichtung erforderlich
+        unconfigured_help: Dieser Dienst benötigt Anmeldeinformationen, bevor er verwendet werden kann. Bis dahin akzeptiert ein Feld, das ihn referenziert, Freitext, statt Vorschläge anzubieten.
+        unused: Keine Metadaten-Eigenschaft verwendet dieses Vokabular.
+        used_by: Verwendet von Eigenschaften
+        used_by_hint: Die von diesem Vokabular kontrollierten Metadaten-Eigenschaften, wie sie in Bulkrax-Importen und Metadatenprofilen benannt sind.
+        used_by_work_types: 'Verfügbar für:'
+        work_types:
+          collection_resource: Sammlung
+          etd_resource: ETD
+          oer_resource: OER
       flash:
         access_denied: Sie sind nicht berechtigt, diese Seite anzuzeigen
       google_analytics_settings:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -280,6 +280,13 @@ en:
         name: Vocabulary
         no_terms: This vocabulary has no terms yet.
         none: No controlled vocabularies have been set up for this tenant yet.
+        origin: Source
+        origin_hint: Where the vocabulary is defined, and therefore whether its terms can be edited here.
+        origins:
+          cached: Imported copy
+          database: This tenant
+          file: Configuration file
+          remote: External service
         providers:
           crossref: Crossref
           discogs: Discogs

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -309,6 +309,7 @@ en:
         source_key: Source key
         source_key_hint: Paste this into a metadata profile field to control that field with this vocabulary.
         source_key_help: Paste a source key into a metadata profile field to control that field with this vocabulary. Vocabularies managed in this tenant can be edited here; those defined in a configuration file or by an external service cannot.
+        static_forms: Metadata profiles are not enabled, so deposit forms read this vocabulary from a configuration file. Changing its terms requires a developer.
         status: Status
         status_hint: Whether this vocabulary is ready to use, or needs something set up first.
         status_unknown: Unspecified
@@ -324,6 +325,14 @@ en:
         terms: Terms
         unconfigured: Needs setup
         unconfigured_help: This service needs credentials before it can be used. Until then a field citing it accepts free text instead of offering suggestions.
+        unused: No metadata property uses this vocabulary.
+        used_by: Used by properties
+        used_by_hint: The metadata properties controlled by this vocabulary, as named in Bulkrax imports and metadata profiles.
+        used_by_work_types: 'Available on:'
+        work_types:
+          collection_resource: Collection
+          etd_resource: ETD
+          oer_resource: OER
       flash:
         access_denied: You are not authorized to view this page
       google_analytics_settings:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -280,13 +280,6 @@ en:
         name: Vocabulary
         no_terms: This vocabulary has no terms yet.
         none: No controlled vocabularies have been set up for this tenant yet.
-        origin: Source
-        origin_hint: Where the vocabulary is defined, and therefore whether its terms can be edited here.
-        origins:
-          cached: Imported copy
-          database: This tenant
-          file: Configuration file
-          remote: External service
         providers:
           crossref: Crossref
           discogs: Discogs
@@ -326,6 +319,7 @@ en:
         unconfigured: Needs setup
         unconfigured_help: This service needs credentials before it can be used. Until then a field citing it accepts free text instead of offering suggestions.
         unused: No metadata property uses this vocabulary.
+        unused_profile_hint: To start using it, add this vocabulary's source key to a property's controlled values in the tenant's metadata profile.
         used_by: Used by properties
         used_by_hint: The metadata properties controlled by this vocabulary, as named in Bulkrax imports and metadata profiles.
         used_by_work_types: 'Available on:'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -397,6 +397,71 @@ es:
           upload: Subir archivos
         label: Progreso del depósito
     admin:
+      controlled_vocabularies: Vocabularios controlados
+      controlled_vocabulary:
+        active: Activo
+        awaiting_import: No importado
+        awaiting_import_help: 'Este vocabulario está disponible pero aún no tiene términos en este inquilino. Puede completarlo ejecutando: %{task}'
+        description: Descripción
+        inactive: Inactivo
+        label: Etiqueta
+        label_hint: Lo que ve un depositante en el formulario. Se puede reformular sin afectar los registros almacenados.
+        name: Vocabulario
+        no_terms: Este vocabulario aún no tiene términos.
+        none: Aún no se ha configurado ningún vocabulario controlado para este inquilino.
+        origin: Fuente
+        origin_hint: Dónde está definido el vocabulario y, por lo tanto, si sus términos se pueden editar aquí.
+        origins:
+          cached: Copia importada
+          database: Este inquilino
+          file: Archivo de configuración
+          remote: Servicio externo
+        providers:
+          crossref: Crossref
+          discogs: Discogs
+          fast: OCLC FAST
+          geonames: GeoNames
+          getty: Getty
+          loc: Library of Congress
+          mesh: MeSH
+          tgnlang: Getty TGN Languages
+        read_only:
+          cached: Este vocabulario es una copia importada de uno externo. Sus términos no se pueden cambiar aquí, y volver a importarlo los reemplaza todos.
+          file: Este vocabulario está definido en un archivo de configuración, por lo que sus términos no se pueden cambiar aquí.
+          generic: Los términos de este vocabulario no se pueden cambiar aquí.
+          remote: Este vocabulario proviene de un servicio externo, por lo que sus términos no se pueden cambiar aquí.
+        ready: Listo
+        retired_count:
+          one: (%{count} retirado)
+          other: (%{count} retirados)
+        show_title: 'Vocabulario controlado: %{name}'
+        source_key: Clave de fuente
+        source_key_hint: Pegue este valor en un campo del perfil de metadatos para controlar ese campo con este vocabulario.
+        source_key_help: Pegue una clave de fuente en un campo del perfil de metadatos para controlar ese campo con este vocabulario. Los vocabularios gestionados en este inquilino se pueden editar aquí; los definidos en un archivo de configuración o por un servicio externo no.
+        static_forms: Los perfiles de metadatos no están habilitados, por lo que los formularios de depósito leen este vocabulario desde un archivo de configuración. Cambiar sus términos requiere un desarrollador.
+        status: Estado
+        status_hint: Indica si este vocabulario está listo para usarse o necesita alguna configuración previa.
+        status_unknown: Sin especificar
+        term_id: ID del término
+        term_limit:
+          one: (mostrando el primer %{count})
+          other: (mostrando los primeros %{count})
+        term_id_hint: El valor almacenado en un registro y el valor que se debe proporcionar en una importación de Bulkrax.
+        term_id_help: El ID del término es el valor almacenado en un registro y el valor que se debe proporcionar en una importación de Bulkrax. La etiqueta es solo lo que ve un depositante.
+        term_total:
+          one: 1 término
+          other: "%{count} términos"
+        terms: Términos
+        unconfigured: Requiere configuración
+        unconfigured_help: Este servicio necesita credenciales antes de poder usarse. Hasta entonces, un campo que lo cite acepta texto libre en lugar de ofrecer sugerencias.
+        unused: Ninguna propiedad de metadatos usa este vocabulario.
+        used_by: Usado por propiedades
+        used_by_hint: Las propiedades de metadatos controladas por este vocabulario, tal como se nombran en las importaciones de Bulkrax y en los perfiles de metadatos.
+        used_by_work_types: 'Disponible en:'
+        work_types:
+          collection_resource: Colección
+          etd_resource: ETD
+          oer_resource: OER
       flash:
         access_denied: No está autorizado a ver esta página
       google_analytics_settings:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -409,13 +409,6 @@ es:
         name: Vocabulario
         no_terms: Este vocabulario aún no tiene términos.
         none: Aún no se ha configurado ningún vocabulario controlado para este inquilino.
-        origin: Fuente
-        origin_hint: Dónde está definido el vocabulario y, por lo tanto, si sus términos se pueden editar aquí.
-        origins:
-          cached: Copia importada
-          database: Este inquilino
-          file: Archivo de configuración
-          remote: Servicio externo
         providers:
           crossref: Crossref
           discogs: Discogs
@@ -455,6 +448,7 @@ es:
         unconfigured: Requiere configuración
         unconfigured_help: Este servicio necesita credenciales antes de poder usarse. Hasta entonces, un campo que lo cite acepta texto libre en lugar de ofrecer sugerencias.
         unused: Ninguna propiedad de metadatos usa este vocabulario.
+        unused_profile_hint: Para empezar a usarlo, agregue la clave de origen de este vocabulario a los valores controlados de una propiedad en el perfil de metadatos del inquilino.
         used_by: Usado por propiedades
         used_by_hint: Las propiedades de metadatos controladas por este vocabulario, tal como se nombran en las importaciones de Bulkrax y en los perfiles de metadatos.
         used_by_work_types: 'Disponible en:'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -409,6 +409,13 @@ es:
         name: Vocabulario
         no_terms: Este vocabulario aún no tiene términos.
         none: Aún no se ha configurado ningún vocabulario controlado para este inquilino.
+        origin: Fuente
+        origin_hint: Dónde está definido el vocabulario y, por lo tanto, si sus términos se pueden editar aquí.
+        origins:
+          cached: Copia importada
+          database: Este inquilino
+          file: Archivo de configuración
+          remote: Servicio externo
         providers:
           crossref: Crossref
           discogs: Discogs

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -409,6 +409,13 @@ fr:
         name: Vocabulaire
         no_terms: Ce vocabulaire ne contient encore aucun terme.
         none: Aucun vocabulaire contrôlé n'a encore été configuré pour ce locataire.
+        origin: Source
+        origin_hint: Où le vocabulaire est défini, et donc si ses termes peuvent être modifiés ici.
+        origins:
+          cached: Copie importée
+          database: Ce locataire
+          file: Fichier de configuration
+          remote: Service externe
         providers:
           crossref: Crossref
           discogs: Discogs

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -409,13 +409,6 @@ fr:
         name: Vocabulaire
         no_terms: Ce vocabulaire ne contient encore aucun terme.
         none: Aucun vocabulaire contrôlé n'a encore été configuré pour ce locataire.
-        origin: Source
-        origin_hint: Où le vocabulaire est défini, et donc si ses termes peuvent être modifiés ici.
-        origins:
-          cached: Copie importée
-          database: Ce locataire
-          file: Fichier de configuration
-          remote: Service externe
         providers:
           crossref: Crossref
           discogs: Discogs
@@ -455,6 +448,7 @@ fr:
         unconfigured: Configuration requise
         unconfigured_help: Ce service a besoin d'identifiants avant de pouvoir être utilisé. D'ici là, un champ qui le référence accepte du texte libre au lieu de proposer des suggestions.
         unused: Aucune propriété de métadonnées n'utilise ce vocabulaire.
+        unused_profile_hint: Pour commencer à l'utiliser, ajoutez la clé source de ce vocabulaire aux valeurs contrôlées d'une propriété dans le profil de métadonnées du locataire.
         used_by: Utilisé par les propriétés
         used_by_hint: Les propriétés de métadonnées contrôlées par ce vocabulaire, telles que nommées dans les importations Bulkrax et les profils de métadonnées.
         used_by_work_types: 'Disponible sur :'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -397,6 +397,71 @@ fr:
           upload: Téléverser des fichiers
         label: Progression du dépôt
     admin:
+      controlled_vocabularies: Vocabulaires contrôlés
+      controlled_vocabulary:
+        active: Actif
+        awaiting_import: Non importé
+        awaiting_import_help: 'Ce vocabulaire est disponible mais ne contient encore aucun terme dans ce locataire. Remplissez-le en exécutant : %{task}'
+        description: Description
+        inactive: Inactif
+        label: Libellé
+        label_hint: Ce qu'un déposant voit dans le formulaire. Peut être reformulé sans affecter les enregistrements stockés.
+        name: Vocabulaire
+        no_terms: Ce vocabulaire ne contient encore aucun terme.
+        none: Aucun vocabulaire contrôlé n'a encore été configuré pour ce locataire.
+        origin: Source
+        origin_hint: Où le vocabulaire est défini, et donc si ses termes peuvent être modifiés ici.
+        origins:
+          cached: Copie importée
+          database: Ce locataire
+          file: Fichier de configuration
+          remote: Service externe
+        providers:
+          crossref: Crossref
+          discogs: Discogs
+          fast: OCLC FAST
+          geonames: GeoNames
+          getty: Getty
+          loc: Library of Congress
+          mesh: MeSH
+          tgnlang: Getty TGN Languages
+        read_only:
+          cached: Ce vocabulaire est une copie importée d'un vocabulaire externe. Ses termes ne peuvent pas être modifiés ici, et une réimportation les remplace tous.
+          file: Ce vocabulaire est défini dans un fichier de configuration, ses termes ne peuvent donc pas être modifiés ici.
+          generic: Les termes de ce vocabulaire ne peuvent pas être modifiés ici.
+          remote: Ce vocabulaire provient d'un service externe, ses termes ne peuvent donc pas être modifiés ici.
+        ready: Prêt
+        retired_count:
+          one: (%{count} retiré)
+          other: (%{count} retirés)
+        show_title: 'Vocabulaire contrôlé : %{name}'
+        source_key: Clé de source
+        source_key_hint: Collez ceci dans un champ de profil de métadonnées pour contrôler ce champ avec ce vocabulaire.
+        source_key_help: Collez une clé de source dans un champ de profil de métadonnées pour contrôler ce champ avec ce vocabulaire. Les vocabulaires gérés dans ce locataire peuvent être modifiés ici ; ceux définis dans un fichier de configuration ou par un service externe ne le peuvent pas.
+        static_forms: Les profils de métadonnées ne sont pas activés, les formulaires de dépôt lisent donc ce vocabulaire depuis un fichier de configuration. La modification de ses termes nécessite un développeur.
+        status: Statut
+        status_hint: Indique si ce vocabulaire est prêt à être utilisé ou si quelque chose doit d'abord être configuré.
+        status_unknown: Non spécifié
+        term_id: ID du terme
+        term_limit:
+          one: (%{count} premier terme affiché)
+          other: (%{count} premiers termes affichés)
+        term_id_hint: La valeur stockée sur un enregistrement, et la valeur à fournir dans une importation Bulkrax.
+        term_id_help: L'ID du terme est la valeur stockée sur un enregistrement, et la valeur à fournir dans une importation Bulkrax. Le libellé est seulement ce qu'un déposant voit.
+        term_total:
+          one: 1 terme
+          other: "%{count} termes"
+        terms: Termes
+        unconfigured: Configuration requise
+        unconfigured_help: Ce service a besoin d'identifiants avant de pouvoir être utilisé. D'ici là, un champ qui le référence accepte du texte libre au lieu de proposer des suggestions.
+        unused: Aucune propriété de métadonnées n'utilise ce vocabulaire.
+        used_by: Utilisé par les propriétés
+        used_by_hint: Les propriétés de métadonnées contrôlées par ce vocabulaire, telles que nommées dans les importations Bulkrax et les profils de métadonnées.
+        used_by_work_types: 'Disponible sur :'
+        work_types:
+          collection_resource: Collection
+          etd_resource: ETD
+          oer_resource: OER
       flash:
         access_denied: Vous n'êtes pas autorisé à afficher cette page
       google_analytics_settings:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -397,6 +397,71 @@ it:
           upload: Carica file
         label: Avanzamento del deposito
     admin:
+      controlled_vocabularies: Vocabolari controllati
+      controlled_vocabulary:
+        active: Attivo
+        awaiting_import: Non importato
+        awaiting_import_help: 'Questo vocabolario è disponibile ma non ha ancora termini in questo tenant. Popolalo eseguendo: %{task}'
+        description: Descrizione
+        inactive: Inattivo
+        label: Etichetta
+        label_hint: Ciò che un depositante vede nel modulo. Può essere riformulata senza influire sui record salvati.
+        name: Vocabolario
+        no_terms: Questo vocabolario non ha ancora termini.
+        none: Nessun vocabolario controllato è stato ancora configurato per questo tenant.
+        origin: Origine
+        origin_hint: Dove è definito il vocabolario, e quindi se i suoi termini possono essere modificati qui.
+        origins:
+          cached: Copia importata
+          database: Questo tenant
+          file: File di configurazione
+          remote: Servizio esterno
+        providers:
+          crossref: Crossref
+          discogs: Discogs
+          fast: OCLC FAST
+          geonames: GeoNames
+          getty: Getty
+          loc: Library of Congress
+          mesh: MeSH
+          tgnlang: Getty TGN Languages
+        read_only:
+          cached: Questo vocabolario è una copia importata di un vocabolario esterno. I suoi termini non possono essere modificati qui e una nuova importazione li sostituisce tutti.
+          file: Questo vocabolario è definito in un file di configurazione, quindi i suoi termini non possono essere modificati qui.
+          generic: I termini di questo vocabolario non possono essere modificati qui.
+          remote: Questo vocabolario proviene da un servizio esterno, quindi i suoi termini non possono essere modificati qui.
+        ready: Pronto
+        retired_count:
+          one: (%{count} ritirato)
+          other: (%{count} ritirati)
+        show_title: 'Vocabolario controllato: %{name}'
+        source_key: Chiave di origine
+        source_key_hint: Incollala in un campo del profilo dei metadati per controllare quel campo con questo vocabolario.
+        source_key_help: Incolla una chiave di origine in un campo del profilo dei metadati per controllare quel campo con questo vocabolario. I vocabolari gestiti in questo tenant possono essere modificati qui; quelli definiti in un file di configurazione o da un servizio esterno no.
+        static_forms: I profili dei metadati non sono abilitati, quindi i moduli di deposito leggono questo vocabolario da un file di configurazione. La modifica dei suoi termini richiede uno sviluppatore.
+        status: Stato
+        status_hint: Indica se questo vocabolario è pronto all'uso o se richiede prima una configurazione.
+        status_unknown: Non specificato
+        term_id: ID del termine
+        term_limit:
+          one: (viene mostrato il primo %{count})
+          other: (vengono mostrati i primi %{count})
+        term_id_hint: Il valore memorizzato su un record e il valore da fornire in un'importazione Bulkrax.
+        term_id_help: L'ID del termine è il valore memorizzato su un record e il valore da fornire in un'importazione Bulkrax. L'etichetta è solo ciò che vede un depositante.
+        term_total:
+          one: 1 termine
+          other: "%{count} termini"
+        terms: Termini
+        unconfigured: Richiede configurazione
+        unconfigured_help: Questo servizio richiede credenziali prima di poter essere utilizzato. Fino ad allora un campo che lo utilizza accetta testo libero invece di offrire suggerimenti.
+        unused: Nessuna proprietà dei metadati utilizza questo vocabolario.
+        used_by: Utilizzato dalle proprietà
+        used_by_hint: Le proprietà dei metadati controllate da questo vocabolario, come denominate nelle importazioni Bulkrax e nei profili dei metadati.
+        used_by_work_types: 'Disponibile su:'
+        work_types:
+          collection_resource: Collezione
+          etd_resource: ETD
+          oer_resource: OER
       flash:
         access_denied: Non sei autorizzato a visualizzare questa pagina
       google_analytics_settings:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -409,6 +409,13 @@ it:
         name: Vocabolario
         no_terms: Questo vocabolario non ha ancora termini.
         none: Nessun vocabolario controllato è stato ancora configurato per questo tenant.
+        origin: Origine
+        origin_hint: Dove è definito il vocabolario, e quindi se i suoi termini possono essere modificati qui.
+        origins:
+          cached: Copia importata
+          database: Questo tenant
+          file: File di configurazione
+          remote: Servizio esterno
         providers:
           crossref: Crossref
           discogs: Discogs

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -409,13 +409,6 @@ it:
         name: Vocabolario
         no_terms: Questo vocabolario non ha ancora termini.
         none: Nessun vocabolario controllato è stato ancora configurato per questo tenant.
-        origin: Origine
-        origin_hint: Dove è definito il vocabolario, e quindi se i suoi termini possono essere modificati qui.
-        origins:
-          cached: Copia importata
-          database: Questo tenant
-          file: File di configurazione
-          remote: Servizio esterno
         providers:
           crossref: Crossref
           discogs: Discogs
@@ -455,6 +448,7 @@ it:
         unconfigured: Richiede configurazione
         unconfigured_help: Questo servizio richiede credenziali prima di poter essere utilizzato. Fino ad allora un campo che lo utilizza accetta testo libero invece di offrire suggerimenti.
         unused: Nessuna proprietà dei metadati utilizza questo vocabolario.
+        unused_profile_hint: Per iniziare a usarlo, aggiungi la chiave di origine di questo vocabolario ai valori controllati di una proprietà nel profilo dei metadati del tenant.
         used_by: Utilizzato dalle proprietà
         used_by_hint: Le proprietà dei metadati controllate da questo vocabolario, come denominate nelle importazioni Bulkrax e nei profili dei metadati.
         used_by_work_types: 'Disponibile su:'

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -291,6 +291,13 @@ pt-BR:
         name: Vocabulário
         no_terms: Este vocabulário ainda não tem termos.
         none: Nenhum vocabulário controlado foi configurado para este locatário ainda.
+        origin: Origem
+        origin_hint: Onde o vocabulário é definido e, portanto, se seus termos podem ser editados aqui.
+        origins:
+          cached: Cópia importada
+          database: Este locatário
+          file: Arquivo de configuração
+          remote: Serviço externo
         providers:
           crossref: Crossref
           discogs: Discogs

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -279,6 +279,71 @@ pt-BR:
           upload: Enviar arquivos
         label: Progresso do depósito
     admin:
+      controlled_vocabularies: Vocabulários controlados
+      controlled_vocabulary:
+        active: Ativo
+        awaiting_import: Não importado
+        awaiting_import_help: 'Este vocabulário está disponível, mas ainda não tem termos neste locatário. Preencha-o executando: %{task}'
+        description: Descrição
+        inactive: Inativo
+        label: Rótulo
+        label_hint: O que um depositante vê no formulário. Pode ser reformulado sem afetar os registros armazenados.
+        name: Vocabulário
+        no_terms: Este vocabulário ainda não tem termos.
+        none: Nenhum vocabulário controlado foi configurado para este locatário ainda.
+        origin: Origem
+        origin_hint: Onde o vocabulário é definido e, portanto, se seus termos podem ser editados aqui.
+        origins:
+          cached: Cópia importada
+          database: Este locatário
+          file: Arquivo de configuração
+          remote: Serviço externo
+        providers:
+          crossref: Crossref
+          discogs: Discogs
+          fast: OCLC FAST
+          geonames: GeoNames
+          getty: Getty
+          loc: Library of Congress
+          mesh: MeSH
+          tgnlang: Getty TGN Languages
+        read_only:
+          cached: Este vocabulário é uma cópia importada de um vocabulário externo. Seus termos não podem ser alterados aqui, e reimportá-lo substitui todos eles.
+          file: Este vocabulário é definido em um arquivo de configuração, portanto seus termos não podem ser alterados aqui.
+          generic: Os termos deste vocabulário não podem ser alterados aqui.
+          remote: Este vocabulário vem de um serviço externo, portanto seus termos não podem ser alterados aqui.
+        ready: Pronto
+        retired_count:
+          one: (%{count} desativado)
+          other: (%{count} desativados)
+        show_title: 'Vocabulário controlado: %{name}'
+        source_key: Chave de origem
+        source_key_hint: Cole isto em um campo do perfil de metadados para controlar esse campo com este vocabulário.
+        source_key_help: Cole uma chave de origem em um campo do perfil de metadados para controlar esse campo com este vocabulário. Os vocabulários gerenciados neste locatário podem ser editados aqui; os definidos em um arquivo de configuração ou por um serviço externo não podem.
+        static_forms: Os perfis de metadados não estão habilitados, então os formulários de depósito leem este vocabulário de um arquivo de configuração. Alterar seus termos requer um desenvolvedor.
+        status: Status
+        status_hint: Se este vocabulário está pronto para uso ou precisa de alguma configuração primeiro.
+        status_unknown: Não especificado
+        term_id: ID do termo
+        term_limit:
+          one: (mostrando o primeiro %{count})
+          other: (mostrando os primeiros %{count})
+        term_id_hint: O valor armazenado em um registro e o valor a fornecer em uma importação do Bulkrax.
+        term_id_help: O ID do termo é o valor armazenado em um registro e o valor a fornecer em uma importação do Bulkrax. O rótulo é apenas o que um depositante vê.
+        term_total:
+          one: 1 termo
+          other: "%{count} termos"
+        terms: Termos
+        unconfigured: Requer configuração
+        unconfigured_help: Este serviço precisa de credenciais antes de poder ser usado. Até lá, um campo que o utiliza aceita texto livre em vez de oferecer sugestões.
+        unused: Nenhuma propriedade de metadados usa este vocabulário.
+        used_by: Usado pelas propriedades
+        used_by_hint: As propriedades de metadados controladas por este vocabulário, conforme nomeadas nas importações do Bulkrax e nos perfis de metadados.
+        used_by_work_types: 'Disponível em:'
+        work_types:
+          collection_resource: Coleção
+          etd_resource: ETD
+          oer_resource: OER
       flash:
         access_denied: Você não está autorizado a visualizar esta página
       google_analytics_settings:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -291,13 +291,6 @@ pt-BR:
         name: Vocabulário
         no_terms: Este vocabulário ainda não tem termos.
         none: Nenhum vocabulário controlado foi configurado para este locatário ainda.
-        origin: Origem
-        origin_hint: Onde o vocabulário é definido e, portanto, se seus termos podem ser editados aqui.
-        origins:
-          cached: Cópia importada
-          database: Este locatário
-          file: Arquivo de configuração
-          remote: Serviço externo
         providers:
           crossref: Crossref
           discogs: Discogs
@@ -337,6 +330,7 @@ pt-BR:
         unconfigured: Requer configuração
         unconfigured_help: Este serviço precisa de credenciais antes de poder ser usado. Até lá, um campo que o utiliza aceita texto livre em vez de oferecer sugestões.
         unused: Nenhuma propriedade de metadados usa este vocabulário.
+        unused_profile_hint: Para começar a usá-lo, adicione a chave de origem deste vocabulário aos valores controlados de uma propriedade no perfil de metadados do locatário.
         used_by: Usado pelas propriedades
         used_by_hint: As propriedades de metadados controladas por este vocabulário, conforme nomeadas nas importações do Bulkrax e nos perfis de metadados.
         used_by_work_types: 'Disponível em:'

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -397,6 +397,71 @@ zh:
           upload: 上传文件
         label: 存缴进度
     admin:
+      controlled_vocabularies: 受控词表
+      controlled_vocabulary:
+        active: 已启用
+        awaiting_import: 未导入
+        awaiting_import_help: '此词表可用，但在此租户中尚无词条。运行以下命令进行填充：%{task}'
+        description: 描述
+        inactive: 未启用
+        label: 标签
+        label_hint: 存缴者在表单中看到的内容。可以放心改写，不会影响已存储的记录。
+        name: 词表
+        no_terms: 此词表尚无词条。
+        none: 此租户尚未设置任何受控词表。
+        origin: 来源
+        origin_hint: 词表的定义位置，并由此决定其词条能否在此处编辑。
+        origins:
+          cached: 导入的副本
+          database: 此租户
+          file: 配置文件
+          remote: 外部服务
+        providers:
+          crossref: Crossref
+          discogs: Discogs
+          fast: OCLC FAST
+          geonames: GeoNames
+          getty: Getty
+          loc: Library of Congress
+          mesh: MeSH
+          tgnlang: Getty TGN Languages
+        read_only:
+          cached: 此词表是外部词表的导入副本。其词条无法在此处修改，重新导入会替换全部词条。
+          file: 此词表在配置文件中定义，因此其词条无法在此处修改。
+          generic: 此词表的词条无法在此处修改。
+          remote: 此词表来自外部服务，因此其词条无法在此处修改。
+        ready: 就绪
+        retired_count:
+          one: （已停用 %{count} 个）
+          other: （已停用 %{count} 个）
+        show_title: '受控词表：%{name}'
+        source_key: 来源键
+        source_key_hint: 将其粘贴到元数据配置档的字段中，即可用此词表控制该字段。
+        source_key_help: 将来源键粘贴到元数据配置档的字段中，即可用此词表控制该字段。在此租户中管理的词表可以在此处编辑；在配置文件中定义或来自外部服务的词表则不能。
+        static_forms: 未启用元数据配置档，因此存缴表单从配置文件读取此词表。修改其词条需要开发人员协助。
+        status: 状态
+        status_hint: 此词表是就绪可用，还是需要先完成某些设置。
+        status_unknown: 未指定
+        term_id: 词条 ID
+        term_limit:
+          one: （显示前 %{count} 个）
+          other: （显示前 %{count} 个）
+        term_id_hint: 存储在记录上的值，也是 Bulkrax 导入时应提供的值。
+        term_id_help: 词条 ID 是存储在记录上的值，也是 Bulkrax 导入时应提供的值。标签只是存缴者看到的内容。
+        term_total:
+          one: 1 个词条
+          other: "%{count} 个词条"
+        terms: 词条
+        unconfigured: 需要设置
+        unconfigured_help: 此服务需要先配置凭据才能使用。在此之前，引用它的字段将接受自由文本，而不提供建议。
+        unused: 没有元数据属性使用此词表。
+        used_by: 使用它的属性
+        used_by_hint: 由此词表控制的元数据属性，其名称与 Bulkrax 导入和元数据配置档中所用的一致。
+        used_by_work_types: '可用于：'
+        work_types:
+          collection_resource: 收藏集
+          etd_resource: ETD
+          oer_resource: OER
       flash:
         access_denied: 您无权查看此页面
       google_analytics_settings:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -409,6 +409,13 @@ zh:
         name: 词表
         no_terms: 此词表尚无词条。
         none: 此租户尚未设置任何受控词表。
+        origin: 来源
+        origin_hint: 词表的定义位置，并由此决定其词条能否在此处编辑。
+        origins:
+          cached: 导入的副本
+          database: 此租户
+          file: 配置文件
+          remote: 外部服务
         providers:
           crossref: Crossref
           discogs: Discogs

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -409,13 +409,6 @@ zh:
         name: 词表
         no_terms: 此词表尚无词条。
         none: 此租户尚未设置任何受控词表。
-        origin: 来源
-        origin_hint: 词表的定义位置，并由此决定其词条能否在此处编辑。
-        origins:
-          cached: 导入的副本
-          database: 此租户
-          file: 配置文件
-          remote: 外部服务
         providers:
           crossref: Crossref
           discogs: Discogs
@@ -455,6 +448,7 @@ zh:
         unconfigured: 需要设置
         unconfigured_help: 此服务需要先配置凭据才能使用。在此之前，引用它的字段将接受自由文本，而不提供建议。
         unused: 没有元数据属性使用此词表。
+        unused_profile_hint: 如需启用，请将此词表的源键添加到租户元数据配置档中某个属性的受控值。
         used_by: 使用它的属性
         used_by_hint: 由此词表控制的元数据属性，其名称与 Bulkrax 导入和元数据配置档中所用的一致。
         used_by_work_types: '可用于：'

--- a/config/metadata_profiles/m3_profile.yaml
+++ b/config/metadata_profiles/m3_profile.yaml
@@ -18,7 +18,7 @@ classes:
   AdminSetResource:
     display_label: AdminSetResource
   CollectionResource:
-    display_label: pcdmcollection
+    display_label: Collection
   Hyrax::FileSet:
     display_label: FileSet
 contexts:

--- a/spec/requests/controlled_vocabularies_spec.rb
+++ b/spec/requests/controlled_vocabularies_spec.rb
@@ -64,6 +64,93 @@ RSpec.describe 'Controlled vocabularies', type: :request, clean: true, multitena
 
         expect(response.body).to include 'special-collections'
       end
+
+      context 'with a metadata profile' do
+        before do
+          allow(Hyrax.config).to receive(:flexible?).and_return(true)
+          allow(Hyrax::FlexibleSchema).to receive(:current_version).and_return(
+            'classes' => { 'GenericWorkResource' => { 'display_label' => 'Generic Work' } },
+            'properties' => {
+              'reading_room' => {
+                'available_on' => { 'class' => ['GenericWorkResource'] },
+                'controlled_values' => { 'sources' => ['reading_rooms'] },
+                'display_label' => { 'default' => 'Reading Room' }
+              }
+            }
+          )
+        end
+
+        it 'lists the properties citing the vocabulary with their work types' do
+          get "http://#{account.cname}/dashboard/controlled_vocabularies/reading_rooms"
+
+          expect(response.body).to include '<code>reading_room</code>'
+          expect(response.body).to include 'Generic Work'
+        end
+
+        it 'says when no property cites the vocabulary' do
+          get "http://#{account.cname}/dashboard/controlled_vocabularies/audience"
+
+          expect(response.body).to include 'No metadata property uses this vocabulary'
+        end
+      end
+
+      # Forms read mapped vocabularies from configuration files in this mode, so
+      # the page must say term changes are out of staff hands.
+      context 'without flexible metadata' do
+        before { allow(Hyrax.config).to receive(:flexible?).and_return(false) }
+
+        it 'still lists usage, and says the terms need a developer' do
+          get "http://#{account.cname}/dashboard/controlled_vocabularies/licenses"
+
+          expect(response.body).to include '<code>license</code>'
+          expect(response.body).to include 'Changing its terms requires a developer.'
+        end
+
+        it 'does not warn on a vocabulary no form uses' do
+          get "http://#{account.cname}/dashboard/controlled_vocabularies/reading_rooms"
+
+          expect(response.body).not_to include 'Changing its terms requires a developer.'
+        end
+
+        # based_near autocompletes against GeoNames, so the vocabulary is in use,
+        # but its terms live in the external service, not a configuration file.
+        it 'shows usage for a remote authority without the configuration-file note' do
+          get "http://#{account.cname}/dashboard/controlled_vocabularies/geonames"
+
+          expect(response.body).to include '<code>based_near</code>'
+          expect(response.body).not_to include 'Changing its terms requires a developer.'
+        end
+
+        # Seeded tenants hold licenses as tenant rows, and the qa fallback serves
+        # the form from those rows, so no developer is needed to change them.
+        it 'does not claim a database-backed vocabulary needs a developer' do
+          Apartment::Tenant.switch(account.tenant) do
+            Qa::LocalAuthority.create!(name: 'licenses', label: 'Licenses')
+          end
+
+          get "http://#{account.cname}/dashboard/controlled_vocabularies/licenses"
+
+          expect(response.body).to include '<code>license</code>'
+          expect(response.body).not_to include 'Changing its terms requires a developer.'
+        end
+      end
+
+      # Flexible metadata on but the tenant has not saved a profile yet: usage is
+      # unknowable, which is not the same as unused.
+      context 'with flexible metadata but no profile' do
+        before do
+          allow(Hyrax.config).to receive(:flexible?).and_return(true)
+          allow(Hyrax::FlexibleSchema).to receive(:current_version).and_return(nil)
+        end
+
+        it 'omits the usage row rather than calling the vocabulary unused' do
+          get "http://#{account.cname}/dashboard/controlled_vocabularies/reading_rooms"
+
+          expect(response).to have_http_status(:success)
+          expect(response.body).not_to include 'Used by properties'
+          expect(response.body).not_to include 'No metadata property uses this vocabulary'
+        end
+      end
     end
 
     # A yaml-backed vocabulary has terms worth reading even though staff cannot

--- a/spec/requests/controlled_vocabularies_spec.rb
+++ b/spec/requests/controlled_vocabularies_spec.rb
@@ -65,6 +65,12 @@ RSpec.describe 'Controlled vocabularies', type: :request, clean: true, multitena
         expect(response.body).to include 'special-collections'
       end
 
+      it 'says where the vocabulary comes from' do
+        get "http://#{account.cname}/dashboard/controlled_vocabularies/reading_rooms"
+
+        expect(response.body).to include 'This tenant'
+      end
+
       context 'with a metadata profile' do
         before do
           allow(Hyrax.config).to receive(:flexible?).and_return(true)

--- a/spec/services/controlled_vocabulary_catalog_spec.rb
+++ b/spec/services/controlled_vocabulary_catalog_spec.rb
@@ -161,12 +161,12 @@ RSpec.describe ControlledVocabularyCatalog do
     end
 
     # Titleizing the key gives "Getty/Aat", which names neither the service nor the
-    # vocabulary usefully. The index has no service column, so the label carries
-    # both.
-    it 'names the service and the vocabulary, spelling out acronyms' do
+    # vocabulary usefully. The service has its own column, so the label carries the
+    # vocabulary.
+    it 'names the vocabulary, spelling out acronyms' do
       entry = described_class.remote.detect { |e| e.source_key == 'getty/aat' }
 
-      expect(entry.label).to eq 'Getty Art & Architecture Thesaurus'
+      expect(entry.label).to eq 'Art & Architecture Thesaurus'
     end
 
     it 'falls back to the service name for a single-vocabulary service' do

--- a/spec/services/controlled_vocabulary_catalog_spec.rb
+++ b/spec/services/controlled_vocabulary_catalog_spec.rb
@@ -161,12 +161,12 @@ RSpec.describe ControlledVocabularyCatalog do
     end
 
     # Titleizing the key gives "Getty/Aat", which names neither the service nor the
-    # vocabulary usefully. The service has its own column, so the label carries the
-    # vocabulary.
-    it 'names the vocabulary, spelling out acronyms' do
+    # vocabulary usefully. The index has no service column, so the label carries
+    # both.
+    it 'names the service and the vocabulary, spelling out acronyms' do
       entry = described_class.remote.detect { |e| e.source_key == 'getty/aat' }
 
-      expect(entry.label).to eq 'Art & Architecture Thesaurus'
+      expect(entry.label).to eq 'Getty Art & Architecture Thesaurus'
     end
 
     it 'falls back to the service name for a single-vocabulary service' do

--- a/spec/services/controlled_vocabulary_usage_spec.rb
+++ b/spec/services/controlled_vocabulary_usage_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe ControlledVocabularyUsage do
       expect(Hyrax::FlexibleSchema).to have_received(:current_version).once
     end
 
-    it 'labels each work type from the profile classes section, keeping the class name' do
+    it 'labels each work type from its class name, keeping the class itself' do
       work_types = described_class.citing('licenses').first.work_types
 
       expect(work_types.map(&:label)).to eq ['Generic Work', 'Image', 'File Set']
@@ -66,16 +66,9 @@ RSpec.describe ControlledVocabularyUsage do
       expect(described_class.citing('subjects')).to eq []
     end
 
-    it 'labels a work type by its class name when the profile does not name it' do
-      profile['classes'].delete('ImageResource')
-
-      labels = described_class.citing('licenses').first.work_types.map(&:label)
-
-      expect(labels).to eq ['Generic Work', 'ImageResource', 'File Set']
-    end
-
-    # Profiles shipped before the fix label CollectionResource "pcdmcollection".
-    it 'corrects a work type label the shipped profile got wrong' do
+    # Some shipped profiles label CollectionResource "pcdmcollection"; the class
+    # name is what is stable, so profile labels are ignored altogether.
+    it 'ignores the profile display_label for work types' do
       profile['classes']['CollectionResource'] = { 'display_label' => 'pcdmcollection' }
       profile['properties']['license']['available_on']['class'] << 'CollectionResource'
 
@@ -83,13 +76,6 @@ RSpec.describe ControlledVocabularyUsage do
 
       expect(labels).to include 'Collection'
       expect(labels).not_to include 'pcdmcollection'
-    end
-
-    it 'keeps a label the tenant chose deliberately' do
-      profile['classes']['CollectionResource'] = { 'display_label' => 'Series' }
-      profile['properties']['license']['available_on']['class'] << 'CollectionResource'
-
-      expect(described_class.citing('licenses').first.work_types.map(&:label)).to include 'Series'
     end
 
     it 'returns nil when the tenant has no profile yet' do

--- a/spec/services/controlled_vocabulary_usage_spec.rb
+++ b/spec/services/controlled_vocabulary_usage_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+RSpec.describe ControlledVocabularyUsage do
+  let(:profile) do
+    {
+      'classes' => {
+        'GenericWorkResource' => { 'display_label' => 'Generic Work' },
+        'ImageResource' => { 'display_label' => 'Image' },
+        'Hyrax::FileSet' => { 'display_label' => 'File Set' }
+      },
+      'properties' => {
+        'license' => {
+          'available_on' => { 'class' => ['GenericWorkResource', 'ImageResource', 'Hyrax::FileSet'] },
+          'controlled_values' => { 'sources' => ['licenses'] },
+          'display_label' => { 'default' => 'blacklight.search.fields.index.license_tesim' }
+        },
+        'rights_statement' => {
+          'available_on' => { 'class' => ['GenericWorkResource'] },
+          # A second source on the same property, and whitespace a shipped
+          # profile has been seen to carry.
+          'controlled_values' => { 'sources' => [' licenses', 'rights_statements'] },
+          'display_label' => { 'default' => 'Rights Statement' }
+        },
+        'creator' => {
+          'available_on' => { 'class' => ['GenericWorkResource'] },
+          'controlled_values' => { 'sources' => ['null'] }
+        }
+      }
+    }
+  end
+
+  before do
+    allow(Hyrax.config).to receive(:flexible?).and_return(true)
+    allow(Hyrax::FlexibleSchema).to receive(:current_version).and_return(profile)
+  end
+
+  describe '.citing' do
+    it 'returns every property citing the vocabulary' do
+      expect(described_class.citing('licenses').map(&:name)).to eq %w[license rights_statement]
+    end
+
+    it 'reads the profile once' do
+      described_class.citing('licenses')
+
+      expect(Hyrax::FlexibleSchema).to have_received(:current_version).once
+    end
+
+    it 'labels each work type from the profile classes section, keeping the class name' do
+      work_types = described_class.citing('licenses').first.work_types
+
+      expect(work_types.map(&:label)).to eq ['Generic Work', 'Image', 'File Set']
+      expect(work_types.map(&:name)).to eq ['GenericWorkResource', 'ImageResource', 'Hyrax::FileSet']
+    end
+
+    it 'keeps the work type list per property' do
+      rights = described_class.citing('licenses').last
+
+      expect(rights.work_types.map(&:name)).to eq ['GenericWorkResource']
+    end
+
+    it 'finds a property through a second source' do
+      expect(described_class.citing('rights_statements').map(&:name)).to eq ['rights_statement']
+    end
+
+    it 'returns an empty array when no property cites the vocabulary' do
+      expect(described_class.citing('subjects')).to eq []
+    end
+
+    it 'labels a work type by its class name when the profile does not name it' do
+      profile['classes'].delete('ImageResource')
+
+      labels = described_class.citing('licenses').first.work_types.map(&:label)
+
+      expect(labels).to eq ['Generic Work', 'ImageResource', 'File Set']
+    end
+
+    # Profiles shipped before the fix label CollectionResource "pcdmcollection".
+    it 'corrects a work type label the shipped profile got wrong' do
+      profile['classes']['CollectionResource'] = { 'display_label' => 'pcdmcollection' }
+      profile['properties']['license']['available_on']['class'] << 'CollectionResource'
+
+      labels = described_class.citing('licenses').first.work_types.map(&:label)
+
+      expect(labels).to include 'Collection'
+      expect(labels).not_to include 'pcdmcollection'
+    end
+
+    it 'keeps a label the tenant chose deliberately' do
+      profile['classes']['CollectionResource'] = { 'display_label' => 'Series' }
+      profile['properties']['license']['available_on']['class'] << 'CollectionResource'
+
+      expect(described_class.citing('licenses').first.work_types.map(&:label)).to include 'Series'
+    end
+
+    it 'returns nil when the tenant has no profile yet' do
+      allow(Hyrax::FlexibleSchema).to receive(:current_version).and_return(nil)
+
+      expect(described_class.citing('licenses')).to be_nil
+    end
+
+    context 'when flexible metadata is off' do
+      before { allow(Hyrax.config).to receive(:flexible?).and_return(false) }
+
+      it 'answers from the form mapping instead of a profile' do
+        properties = described_class.citing('licenses')
+
+        expect(properties.map(&:name)).to eq ['license']
+        expect(Hyrax::FlexibleSchema).not_to have_received(:current_version)
+      end
+
+      it 'lists the work types whose model defines the property' do
+        names = described_class.citing('licenses').first.work_types.map(&:name)
+
+        expect(names).to include 'GenericWorkResource'
+        expect(names).not_to include 'GenericWork'
+      end
+
+      it 'labels the work types without the Valkyrie suffix' do
+        labels = described_class.citing('licenses').first.work_types.map(&:label)
+
+        expect(labels).to include 'Generic Work'
+        expect(labels).to include 'ETD'
+      end
+
+      # The OER form reads resource_type from oer_types through its own partial,
+      # not the generic mapping, so the vocabulary must not read as unused.
+      it 'reports a vocabulary a form partial reads outside the mapping' do
+        properties = described_class.citing('oer_types')
+
+        expect(properties.map(&:name)).to eq ['resource_type']
+        expect(properties.first.work_types.map(&:name)).to eq ['OerResource']
+      end
+
+      it 'returns an empty array for a vocabulary the mapping does not cite' do
+        expect(described_class.citing('reading_rooms')).to eq []
+      end
+    end
+  end
+end


### PR DESCRIPTION
Staff deciding whether a term is safe to deactivate or relabel had no way to see what a vocabulary controls without reading the tenant's metadata profile by hand. The vocabulary show page now lists every property citing the vocabulary and the work types each property is available on, with an explicit empty state when nothing cites it.

Worth a look:
- Properties display by raw profile name only (per LaRita, so they can be matched to the profile or a Bulkrax import), not display label.
- Works with `HYRAX_FLEXIBLE=false` too: usage comes from the static form mapping plus the partials that read an authority directly (`oer_types`, `geonames`), and file-backed vocabularies note their terms need a developer. Database-backed and remote ones don't get that note, since the qa fallback serves tenant rows and remote terms live in the service.
- The shipped profile's `CollectionResource` label "pcdmcollection" is corrected to "Collection", with a locale override for tenants whose saved profile predates the fix.
- The dashboard's locale block is translated into de/es/fr/it/pt-BR/zh (it was English-only).

Testing: `rspec spec/services/controlled_vocabulary_usage_spec.rb spec/requests/controlled_vocabularies_spec.rb` (31 examples, 0 failures), rubocop clean, eager load OK.

Closes notch8/palni_palci_knapsack#708.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Screenshots

**No properties using it (empty state):**

<img width="1352" height="705" alt="vocab-show-unused-empty-state" src="https://github.com/user-attachments/assets/7e0c5220-87df-429b-8b6a-edded2cbdfa8" />

**One property using it:**

<img width="1352" height="705" alt="vocab-show-licenses-used-by" src="https://github.com/user-attachments/assets/d8108f3a-7d9f-4d13-ab6d-0c19024e15db" />

**Multiple properties, per-property work types:**

<img width="1352" height="705" alt="vocab-show-multi-properties" src="https://github.com/user-attachments/assets/4592baf8-e730-4c8f-a7c0-8eb2d3052923" />

**Flexible metadata off, file-backed vocabulary (usage still shown, terms need a developer):**

<img width="1352" height="705" alt="vocab-show-no-profile-mode" src="https://github.com/user-attachments/assets/212940db-0e16-481e-8779-ce44a1bde492" />

**Index with its Source column:**

<img width="1352" height="705" alt="vocab-index-source-column" src="https://github.com/user-attachments/assets/b89374ff-6d8d-4f66-b5b8-241982de9f61" />
