### PR TITLE
Download a vocabulary's terms as CSV or YAML

### DIFF
--- a/app/controllers/hyrax/dashboard/controlled_vocabularies_controller.rb
+++ b/app/controllers/hyrax/dashboard/controlled_vocabularies_controller.rb
@@ -19,15 +19,12 @@ module Hyrax
 
       def show
         @entry = ControlledVocabularyCatalog.find!(params[:id])
-        add_breadcrumb t(:'hyrax.controls.home'), root_path
-        add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
-        # main_app, not the bare helper: this controller is namespaced under
-        # Hyrax::, so bare url helpers resolve against the Hyrax engine, which does
-        # not define this route. The engine's `/files/:id` then swallows it.
-        add_breadcrumb t('hyku.admin.controlled_vocabularies'), main_app.controlled_vocabularies_path
-        add_breadcrumb @entry.label, request.path
-        @terms = ControlledVocabularyCatalog.terms_for(@entry)
-        @usage = ControlledVocabularyUsage.citing(@entry.source_key)
+
+        respond_to do |format|
+          format.html { show_page }
+          format.csv { download :csv }
+          format.yaml { download :yml }
+        end
       end
 
       def new
@@ -56,6 +53,27 @@ module Hyrax
       end
 
       private
+
+      def show_page
+        add_breadcrumb t(:'hyrax.controls.home'), root_path
+        add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
+        # main_app, not the bare helper: this controller is namespaced under
+        # Hyrax::, so bare url helpers resolve against the Hyrax engine, which does
+        # not define this route. The engine's `/files/:id` then swallows it.
+        add_breadcrumb t('hyku.admin.controlled_vocabularies'), main_app.controlled_vocabularies_path
+        add_breadcrumb @entry.label, request.path
+        @terms = ControlledVocabularyCatalog.terms_for(@entry)
+        @usage = ControlledVocabularyUsage.citing(@entry.source_key)
+        render :show
+      end
+
+      def download(format)
+        raise ActiveRecord::RecordNotFound, "No terms to export for #{@entry.source_key}" unless @entry.downloadable?
+
+        export = ControlledVocabularyExport.new(@entry)
+        response.set_header('Content-Disposition', "attachment; filename=\"#{export.filename(format)}\"")
+        self.response_body = export.public_send(format)
+      end
 
       # No :name — it is derived from the label on create, and a metadata profile
       # cites it, so staff do not get to set or change it.

--- a/app/services/controlled_vocabulary_catalog.rb
+++ b/app/services/controlled_vocabulary_catalog.rb
@@ -46,6 +46,10 @@ class ControlledVocabularyCatalog
       editable? || origin == :file
     end
 
+    def downloadable?
+      vocabulary.present? || origin == :file
+    end
+
     # nil means the authority needs no credentials, so only a known-missing one is
     # reported unconfigured.
     def configured?

--- a/app/services/controlled_vocabulary_export.rb
+++ b/app/services/controlled_vocabulary_export.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'csv'
+
+# Streams a vocabulary's terms as CSV (the #701 import template) or as a yaml
+# file in the qa authority format.
+class ControlledVocabularyExport
+  COLUMNS = %w[id label active].freeze
+
+  def initialize(entry)
+    @entry = entry
+  end
+
+  def filename(format)
+    "#{@entry.source_key}.#{format}"
+  end
+
+  def csv
+    stream(CSV.generate_line(COLUMNS)) do |term|
+      CSV.generate_line(term.values_at(*COLUMNS))
+    end
+  end
+
+  def yml
+    stream("#{yml_header}terms:\n") do |term|
+      entry = { 'id' => term['id'], 'term' => term['label'], 'active' => term['active'] }
+      { 'terms' => [entry] }.to_yaml.delete_prefix("---\nterms:\n")
+    end
+  end
+
+  private
+
+  # qa's file reader only consumes terms:, so the label and description ride
+  # along for the #701 importer without breaking the config-file format.
+  def yml_header
+    header = { 'source_key' => @entry.source_key, 'label' => @entry.label }
+    header['description'] = @entry.description if @entry.description.present?
+    header.to_yaml.delete_prefix("---\n")
+  end
+
+  # The rows are read up front: a streamed body is drained after Apartment has
+  # switched schemas back, so a query run inside it reads the wrong tenant.
+  def stream(header)
+    rows = terms
+    Enumerator.new do |lines|
+      lines << header
+      rows.each { |term| lines << yield(term) }
+    end
+  end
+
+  def terms
+    return database_terms if @entry.vocabulary
+
+    Qa::Authorities::Local.subauthority_for(@entry.source_key).all.map do |term|
+      term = term.with_indifferent_access
+      { 'id' => term[:id], 'label' => term[:label], 'active' => term[:active] != false }
+    end
+  rescue StandardError => e
+    Rails.logger.warn("Unable to export terms for #{@entry.source_key}: #{e.message}")
+    raise ActiveRecord::RecordNotFound, "No terms to export for #{@entry.source_key}"
+  end
+
+  def database_terms
+    @entry.vocabulary.local_authority_entries.ordered.pluck(:uri, :label, :active).map do |id, label, active|
+      { 'id' => id, 'label' => label, 'active' => active != false }
+    end
+  end
+end

--- a/app/services/controlled_vocabulary_export.rb
+++ b/app/services/controlled_vocabulary_export.rb
@@ -2,7 +2,7 @@
 
 require 'csv'
 
-# Streams a vocabulary's terms as CSV (the #701 import template) or as a yaml
+# Streams a vocabulary's terms as CSV (the bulk import template) or as a yaml
 # file in the qa authority format.
 class ControlledVocabularyExport
   COLUMNS = %w[id label active].freeze
@@ -31,7 +31,7 @@ class ControlledVocabularyExport
   private
 
   # qa's file reader only consumes terms:, so the label and description ride
-  # along for the #701 importer without breaking the config-file format.
+  # along for the bulk importer without breaking the config-file format.
   def yml_header
     header = { 'source_key' => @entry.source_key, 'label' => @entry.label }
     header['description'] = @entry.description if @entry.description.present?

--- a/app/views/hyrax/dashboard/controlled_vocabularies/_download_menu.html.erb
+++ b/app/views/hyrax/dashboard/controlled_vocabularies/_download_menu.html.erb
@@ -1,0 +1,12 @@
+<div class="dropdown d-inline-block">
+  <button type="button"
+          class="btn <%= local_assigns.fetch(:button_class, 'btn-outline-secondary') %> dropdown-toggle"
+          data-toggle="dropdown"
+          aria-expanded="false">
+    <%= t('hyku.admin.controlled_vocabulary.download') %>
+  </button>
+  <div class="dropdown-menu dropdown-menu-right">
+    <%= link_to 'CSV', main_app.controlled_vocabulary_path(entry.source_key, format: :csv), class: 'dropdown-item' %>
+    <%= link_to 'YAML', main_app.controlled_vocabulary_path(entry.source_key, format: :yml), class: 'dropdown-item' %>
+  </div>
+</div>

--- a/app/views/hyrax/dashboard/controlled_vocabularies/index.html.erb
+++ b/app/views/hyrax/dashboard/controlled_vocabularies/index.html.erb
@@ -38,6 +38,7 @@
                            label: t('hyku.admin.controlled_vocabulary.status'),
                            hint: t('hyku.admin.controlled_vocabulary.status_hint') %>
               </th>
+              <th scope="col"><span class="sr-only"><%= t('hyku.admin.controlled_vocabulary.download') %></span></th>
             </tr>
           </thead>
           <tbody>
@@ -69,10 +70,13 @@
                     </span>
                   <% end %>
                 </td>
+                <td class="text-right">
+                  <%= render 'download_menu', entry: entry, button_class: 'btn-sm btn-outline-secondary' if entry.downloadable? %>
+                </td>
               </tr>
               <% if entry.description.present? %>
                 <tr class="border-bottom">
-                  <td colspan="4" class="pt-0 text-muted">
+                  <td colspan="5" class="pt-0 text-muted">
                     <%= entry.description %>
                   </td>
                 </tr>

--- a/app/views/hyrax/dashboard/controlled_vocabularies/show.html.erb
+++ b/app/views/hyrax/dashboard/controlled_vocabularies/show.html.erb
@@ -6,13 +6,16 @@
   </h1>
 <% end %>
 
-<% if @entry.editable? && can?(:manage, :controlled_vocabularies) %>
-  <div class="mb-3 text-right">
+<div class="mb-3 text-right">
+  <% if @entry.downloadable? %>
+    <%= render 'download_menu', entry: @entry %>
+  <% end %>
+  <% if @entry.editable? && can?(:manage, :controlled_vocabularies) %>
     <%= link_to t('hyku.admin.controlled_vocabulary.new_term_title'),
                 main_app.new_controlled_vocabulary_term_path(@entry.source_key),
                 class: 'btn btn-primary' %>
-  </div>
-<% end %>
+  <% end %>
+</div>
 
 <div class="card">
   <div class="card-body border-bottom">

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -406,6 +406,7 @@ de:
         created: '%{name} wurde erstellt. Fügen Sie unten die Begriffe hinzu.'
         description: Beschreibung
         description_help: Optional. Erklärt anderen Mitarbeitenden, wofür dieses Vokabular gedacht ist.
+        download: Herunterladen
         inactive: Inaktiv
         label: Bezeichnung
         label_hint: Was ein Hinterleger im Formular sieht. Kann gefahrlos umformuliert werden, ohne gespeicherte Datensätze zu beeinflussen.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -278,6 +278,7 @@ en:
         created: '%{name} was created. Add its terms below.'
         description: Description
         description_help: Optional. Explains to other staff what this vocabulary is for.
+        download: Download
         inactive: Inactive
         label: Label
         label_hint: What a depositor sees in the form. Safe to reword without affecting stored records.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -407,6 +407,7 @@ es:
         created: '%{name} se creó. Agregue sus términos a continuación.'
         description: Descripción
         description_help: Opcional. Explica a otro personal para qué sirve este vocabulario.
+        download: Descargar
         inactive: Inactivo
         label: Etiqueta
         label_hint: Lo que ve un depositante en el formulario. Se puede reformular sin afectar los registros almacenados.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -407,6 +407,7 @@ fr:
         created: '%{name} a été créé. Ajoutez ses termes ci-dessous.'
         description: Description
         description_help: Facultatif. Explique aux autres membres du personnel à quoi sert ce vocabulaire.
+        download: Télécharger
         inactive: Inactif
         label: Libellé
         label_hint: Ce qu'un déposant voit dans le formulaire. Peut être reformulé sans affecter les enregistrements stockés.

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -407,6 +407,7 @@ it:
         created: '%{name} è stato creato. Aggiungi i suoi termini qui sotto.'
         description: Descrizione
         description_help: Facoltativo. Spiega ad altro personale a cosa serve questo vocabolario.
+        download: Scarica
         inactive: Inattivo
         label: Etichetta
         label_hint: Ciò che un depositante vede nel modulo. Può essere riformulata senza influire sui record salvati.

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -289,6 +289,7 @@ pt-BR:
         created: '%{name} foi criado. Adicione seus termos abaixo.'
         description: Descrição
         description_help: Opcional. Explica a outros funcionários para que serve este vocabulário.
+        download: Baixar
         inactive: Inativo
         label: Rótulo
         label_hint: O que um depositante vê no formulário. Pode ser reformulado sem afetar os registros armazenados.

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -407,6 +407,7 @@ zh:
         created: '%{name} 已创建。请在下方添加其词条。'
         description: 描述
         description_help: 可选。向其他工作人员说明此词表的用途。
+        download: 下载
         inactive: 未启用
         label: 标签
         label_hint: 存缴者在表单中看到的内容。可以放心改写，不会影响已存储的记录。

--- a/spec/requests/controlled_vocabularies_spec.rb
+++ b/spec/requests/controlled_vocabularies_spec.rb
@@ -49,6 +49,14 @@ RSpec.describe 'Controlled vocabularies', type: :request, clean: true, multitena
 
         expect(response.body).to include 'Where an item may be consulted on site.'
       end
+
+      it 'offers a download dropdown on downloadable rows only' do
+        get "http://#{account.cname}/dashboard/controlled_vocabularies"
+
+        expect(response.body).to include 'controlled_vocabularies/reading_rooms.csv'
+        expect(response.body).to include 'controlled_vocabularies/reading_rooms.yml'
+        expect(response.body).not_to include 'controlled_vocabularies/geonames.csv'
+      end
     end
 
     describe 'a vocabulary' do
@@ -73,6 +81,43 @@ RSpec.describe 'Controlled vocabularies', type: :request, clean: true, multitena
         get "http://#{account.cname}/dashboard/controlled_vocabularies/reading_rooms"
 
         expect(response.body).to include 'This tenant'
+      end
+
+      it 'offers a download dropdown next to the add term button' do
+        get "http://#{account.cname}/dashboard/controlled_vocabularies/reading_rooms"
+
+        expect(response.body).to include 'controlled_vocabularies/reading_rooms.csv'
+        expect(response.body).to include 'controlled_vocabularies/reading_rooms.yml'
+      end
+
+      it 'downloads the terms as csv, inactive terms included' do
+        get "http://#{account.cname}/dashboard/controlled_vocabularies/reading_rooms.csv"
+
+        expect(response.headers['Content-Disposition']).to include 'reading_rooms.csv'
+        expect(response.body.lines.first).to eq "id,label,active\n"
+        expect(response.body).to include "closed-stacks,Closed Stacks,false\n"
+      end
+
+      it 'downloads the terms as a qa authority yaml file' do
+        get "http://#{account.cname}/dashboard/controlled_vocabularies/reading_rooms.yml"
+
+        expect(response.headers['Content-Disposition']).to include 'reading_rooms.yml'
+        expect(YAML.safe_load(response.body)['terms'])
+          .to include('id' => 'special-collections', 'term' => 'Special Collections', 'active' => true)
+      end
+
+      it 'downloads without flexible metadata' do
+        allow(Hyrax.config).to receive(:flexible?).and_return(false)
+
+        get "http://#{account.cname}/dashboard/controlled_vocabularies/reading_rooms.csv"
+
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'returns not found for a vocabulary whose terms cannot be exported' do
+        get "http://#{account.cname}/dashboard/controlled_vocabularies/geonames.csv"
+
+        expect(response).to have_http_status(:not_found)
       end
 
       context 'with a metadata profile' do
@@ -183,6 +228,13 @@ RSpec.describe 'Controlled vocabularies', type: :request, clean: true, multitena
         expect(response.body).to include 'North'
         expect(response.body).to include 'configuration file'
       end
+
+      it 'downloads without a database row' do
+        get "http://#{account.cname}/dashboard/controlled_vocabularies/map_regions.csv"
+
+        expect(response.headers['Content-Disposition']).to include 'map_regions.csv'
+        expect(response.body).to include "north,North,true\n"
+      end
     end
 
     it 'returns not found for a vocabulary that does not exist' do
@@ -254,6 +306,13 @@ RSpec.describe 'Controlled vocabularies', type: :request, clean: true, multitena
     before do
       user = Apartment::Tenant.switch(account.tenant) { create(:user) }
       login_as(user, scope: :user)
+    end
+
+    it 'refuses a download' do
+      get "http://#{account.cname}/dashboard/controlled_vocabularies/reading_rooms.csv"
+
+      expect(response).not_to have_http_status(:success)
+      expect(response.headers['Content-Disposition']).to be_nil
     end
 
     it 'refuses the page' do

--- a/spec/services/controlled_vocabulary_export_spec.rb
+++ b/spec/services/controlled_vocabulary_export_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+RSpec.describe ControlledVocabularyExport do
+  subject(:export) { described_class.new(entry) }
+
+  context 'with a database-backed vocabulary' do
+    let(:vocabulary) { Qa::LocalAuthority.create!(name: 'reading_rooms', label: 'Reading Rooms') }
+    let(:entry) do
+      ControlledVocabularyCatalog::Entry.new(source_key: 'reading_rooms', origin: :database, vocabulary: vocabulary,
+                                             label: 'Reading Rooms', description: 'Where an item may be consulted.')
+    end
+
+    before do
+      vocabulary.local_authority_entries.create!(label: 'Special Collections', uri: 'special-collections', position: 2)
+      vocabulary.local_authority_entries.create!(label: 'Closed Stacks', uri: 'closed-stacks', position: 1,
+                                                 active: false)
+    end
+
+    it 'streams csv in the import template columns, in table order' do
+      expect(export.csv).to be_a(Enumerator)
+      expect(export.csv.to_a).to eq [
+        "id,label,active\n",
+        "closed-stacks,Closed Stacks,false\n",
+        "special-collections,Special Collections,true\n"
+      ]
+    end
+
+    it 'streams yaml in the qa authority format, carrying the vocabulary metadata' do
+      file = YAML.safe_load(export.yml.to_a.join)
+
+      expect(file['source_key']).to eq 'reading_rooms'
+      expect(file['label']).to eq 'Reading Rooms'
+      expect(file['description']).to eq 'Where an item may be consulted.'
+      expect(file['terms']).to eq [
+        { 'id' => 'closed-stacks', 'term' => 'Closed Stacks', 'active' => false },
+        { 'id' => 'special-collections', 'term' => 'Special Collections', 'active' => true }
+      ]
+    end
+
+    it 'names the file after the vocabulary' do
+      expect(export.filename(:csv)).to eq 'reading_rooms.csv'
+      expect(export.filename(:yml)).to eq 'reading_rooms.yml'
+    end
+
+    it 'exports past the page display cap' do
+      stub_const('ControlledVocabularyCatalog::TERM_LIMIT', 3)
+      5.times { |n| vocabulary.local_authority_entries.create!(label: "Term #{n}", uri: "term-#{n}") }
+
+      expect(export.csv.count).to eq 8
+    end
+  end
+
+  context 'with a config-file vocabulary' do
+    let(:entry) { ControlledVocabularyCatalog::Entry.new(source_key: 'map_regions', origin: :file, label: 'Map Regions') }
+
+    before do
+      allow(Qa::Authorities::Local).to receive(:subauthority_for).with('map_regions').and_return(
+        instance_double(Qa::Authorities::Local::FileBasedAuthority,
+                        all: [{ 'id' => 'north', 'label' => 'North' },
+                              { 'id' => 'south', 'label' => 'South', 'active' => false }])
+      )
+    end
+
+    it 'exports the file terms, treating an unstated active flag as true' do
+      expect(export.csv.to_a).to eq [
+        "id,label,active\n",
+        "north,North,true\n",
+        "south,South,false\n"
+      ]
+    end
+
+    it 'exports yaml with the label and no description key' do
+      file = YAML.safe_load(export.yml.to_a.join)
+
+      expect(file['source_key']).to eq 'map_regions'
+      expect(file['label']).to eq 'Map Regions'
+      expect(file).not_to have_key 'description'
+      expect(file['terms'].map { |t| t['id'] }).to eq %w[north south]
+    end
+
+    it 'reports not found when the file cannot be read' do
+      allow(Qa::Authorities::Local).to receive(:subauthority_for)
+        .with('map_regions').and_raise(Psych::SyntaxError.allocate)
+
+      expect { export.csv }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
+  context 'with an imported copy of an external vocabulary' do
+    let(:vocabulary) { Qa::LocalAuthority.create!(name: 'mesh', label: 'MeSH') }
+    let(:entry) do
+      ControlledVocabularyCatalog::Entry.new(source_key: 'mesh', origin: :cached, vocabulary: vocabulary)
+    end
+
+    before { vocabulary.local_authority_entries.create!(label: 'Diabetes', uri: 'mesh:diabetes') }
+
+    it 'exports the cached rows' do
+      expect(entry.downloadable?).to be true
+      expect(export.csv.to_a).to include "mesh:diabetes,Diabetes,true\n"
+    end
+  end
+end


### PR DESCRIPTION
Staff bulk-editing or auditing a vocabulary had no way to get the current term list out; the coming CSV import (#701 in the PALS tracker) needs a matching export or "bulk edit" means retyping from memory. The vocabulary show page and each index row now download terms as CSV (columns id, label, active, the import template) or as yaml in the qa authority file format, usable directly as a config-file vocabulary.

Worth a look:
- Works with `HYRAX_FLEXIBLE` true or false; downloads gate on the entry having terms to list (tenant row or config file), so remote authorities 404.
- Inactive terms export with `active=false`, rows follow the terms-table order, filenames are the source key (`licenses.csv`), so a yml download drops straight into `config/authorities/`.
- The yaml opens with the source key, label, and description above `terms:`; qa ignores the extra keys, and the bulk importer can use them to create or update a whole vocabulary from one file. Position is deliberately not exported: row order carries it in both formats.
- The response streams, but term rows are read eagerly inside the request: a query left inside the streamed body runs after Apartment has switched schemas back and exports another tenant's terms. The request spec caught this live.
- Round-trip acceptance criteria moved from the export ticket to the import ticket, which owns that behavior.

Testing: `rspec spec/services/controlled_vocabulary_export_spec.rb spec/requests/controlled_vocabularies_spec.rb` (41 examples, 0 failures), rubocop clean, downloads verified in the browser in both formats.

Closes notch8/palni_palci_knapsack#709.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
## Screenshots

**Show page, download dropdown next to Add term:**

<img width="1352" height="761" alt="vocab-show-download-dropdown" src="https://github.com/user-attachments/assets/3ef21bf0-50b1-492c-b4b7-146d50883f5d" />

**Index, per-row download dropdown:**

<img width="1352" height="761" alt="vocab-index-download-dropdown" src="https://github.com/user-attachments/assets/84dac631-ed2f-4f45-9d3c-78c697c3ff3b" />

# EXAMPLE DOWNLOADS

[accessibility_features.yml](https://github.com/user-attachments/files/31282173/accessibility_features.yml)

[accessibility_features.csv](https://github.com/user-attachments/files/31282176/accessibility_features.csv)




