### PR TITLE
Heritage feedback

### DIFF
--- a/app/assets/stylesheets/themes/heritage/_primitives.scss
+++ b/app/assets/stylesheets/themes/heritage/_primitives.scss
@@ -121,7 +121,7 @@
 }
 
 // Blacklight's facet cards, restyled into the theme's continuous ruled column.
-// Shared by the catalog rail and the homepage "Browse the collection" rail so
+// Shared by the catalog rail and the homepage "Browse" rail so
 // both follow the configured facets and read identically.
 @mixin hrt-facets {
   .card.facet-limit {

--- a/app/controllers/hyrax/homepage_controller.rb
+++ b/app/controllers/hyrax/homepage_controller.rb
@@ -102,6 +102,12 @@ module Hyrax
       main_app.search_catalog_path(options)
     end
 
+    # OVERRIDE Blacklight 7.41.0: Blacklight resolves the facet "more" link against the
+    # current controller, which has no facet action, so the modal loaded the homepage.
+    def search_facet_path(options = {})
+      main_app.facet_catalog_path(options)
+    end
+
     private
 
     # shared methods for index and all_collections routes

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -200,7 +200,7 @@ de:
         search_button: Los
         advanced: Erweitert
       browse:
-        heading: Die Sammlung durchstöbern
+        heading: Durchstöbern
         toggle: Facetten anzeigen
       featured:
         unfeature_confirm: "Dies aus der Auswahl entfernen?"
@@ -216,7 +216,7 @@ de:
         view_all: Alle Sammlungen anzeigen
       recent:
         ago: "vor %{time}"
-        heading: Neu katalogisiert
+        heading: Kürzlich hinzugefügt
         view_all: "Alle anzeigen"
       researcher:
         heading: Vorgestellte Forschende

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -61,7 +61,7 @@ en:
         search_button: Go
         advanced: Advanced
       browse:
-        heading: Browse the collection
+        heading: Browse
         toggle: Show facets
       featured:
         unfeature_confirm: "Remove this from the featured list?"
@@ -77,7 +77,7 @@ en:
         view_all: View all collections
       recent:
         ago: "%{time} ago"
-        heading: Newly cataloged
+        heading: Recently added
         view_all: "View all"
       researcher:
         heading: Featured researcher

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -201,7 +201,7 @@ es:
         search_button: Ir
         advanced: Avanzada
       browse:
-        heading: Explorar la colección
+        heading: Explorar
         toggle: Mostrar facetas
       featured:
         unfeature_confirm: "¿Quitar esto de la lista de destacados?"
@@ -217,7 +217,7 @@ es:
         view_all: Ver todas las colecciones
       recent:
         ago: "hace %{time}"
-        heading: Recién catalogado
+        heading: Añadidos recientemente
         view_all: "Ver todo"
       researcher:
         heading: Investigador destacado

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -201,7 +201,7 @@ fr:
         search_button: Rechercher
         advanced: Avancée
       browse:
-        heading: Parcourir la collection
+        heading: Parcourir
         toggle: Afficher les facettes
       featured:
         unfeature_confirm: "Retirer ceci de la liste mise en avant ?"
@@ -217,7 +217,7 @@ fr:
         view_all: Voir toutes les collections
       recent:
         ago: "il y a %{time}"
-        heading: Nouvellement catalogué
+        heading: Ajouts récents
         view_all: "Voir tout"
       researcher:
         heading: Chercheur à la une

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -201,7 +201,7 @@ it:
         search_button: Vai
         advanced: Avanzata
       browse:
-        heading: Sfoglia la collezione
+        heading: Sfoglia
         toggle: Mostra faccette
       featured:
         unfeature_confirm: "Rimuovere questo dagli elementi in evidenza?"
@@ -217,7 +217,7 @@ it:
         view_all: Vedi tutte le collezioni
       recent:
         ago: "%{time} fa"
-        heading: Catalogati di recente
+        heading: Aggiunti di recente
         view_all: "Vedi tutto"
       researcher:
         heading: Ricercatore in evidenza

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -83,7 +83,7 @@ pt-BR:
         search_button: Ir
         advanced: Avançada
       browse:
-        heading: Navegue pelo acervo
+        heading: Navegar
         toggle: Mostrar facetas
       featured:
         unfeature_confirm: "Remover isto da lista de destaques?"
@@ -99,7 +99,7 @@ pt-BR:
         view_all: Ver todas as coleções
       recent:
         ago: "há %{time}"
-        heading: Recém-catalogados
+        heading: Adicionados recentemente
         view_all: "Ver tudo"
       researcher:
         heading: Pesquisador em destaque

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -217,7 +217,7 @@ zh:
         search_button: 检索
         advanced: 高级检索
       browse:
-        heading: 浏览馆藏
+        heading: 浏览
         toggle: 显示分面
       featured:
         unfeature_confirm: "要将其从精选列表中移除吗？"
@@ -233,7 +233,7 @@ zh:
         view_all: 查看全部收藏
       recent:
         ago: "%{time}前"
-        heading: 新编目
+        heading: 最近添加
         view_all: "查看全部"
       researcher:
         heading: 精选研究员

--- a/spec/controllers/hyrax/homepage_controller_spec.rb
+++ b/spec/controllers/hyrax/homepage_controller_spec.rb
@@ -163,5 +163,10 @@ RSpec.describe Hyrax::HomepageController, type: :controller, clean_repo: true do
         end
       end
     end
+
+    it 'sends the facet "more" link to the catalog facet action' do
+      get :index
+      expect(controller.send(:search_facet_path, id: 'creator_sim')).to start_with '/catalog/facet/creator_sim'
+    end
   end
 end


### PR DESCRIPTION
## 🧹 Adjust wording for Heritage theme

4f594209645eda7caeb03dfb1837ac89b2ae8f58

Adjust wording based on community feedback.

## 🐛 Send homepage facet "more" to the catalog

f0a022cdce381f71a04966c9a3d1e4eab8d56aed

The "more" link opened a modal onto the homepage instead of the facet
list. HomepageController inherits CatalogController for the facets, but
upstream #search_facet_path names an action and no controller, so
url_for resolved it against a controller with no facet route.
