### PR TITLE
Vocabulary dashboard follow-ups: review step, terms, and source key resolution

### DIFF
--- a/app/assets/stylesheets/hyku.scss
+++ b/app/assets/stylesheets/hyku.scss
@@ -797,8 +797,28 @@ dd {
     color: #fff;
 }
 
-// The question mark beside a column heading that carries a tooltip
+// Restores the scroll Bootstrap gives .table-responsive: Hyrax sets `overflow-x:
+// visible` on it app-wide in _file-listing.scss, so without this the table is cut
+// off at the container edge. Scoped here so Hyrax's own tables keep its behavior.
+.controlled-vocabularies-scroll {
+    overflow-x: auto;
+}
+
+// One line per cell, so a narrow container scrolls instead of breaking words
+// mid-letter ("Accessibilit / y"). The description spans the row and wraps.
+.controlled-vocabularies {
+    th,
+    td:not(.controlled-vocabulary-description) {
+        white-space: nowrap;
+    }
+}
+
+// The explanation behind a column heading's question mark. CSS rather than
+// Bootstrap's tooltip plugin, which nothing initializes on these pages.
 .column-hint {
+    position: relative;
+    display: inline-block;
+    margin-left: 0.25rem;
     border: 0;
     cursor: help;
     font-size: 0.875em;
@@ -808,4 +828,43 @@ dd {
     &:focus {
         text-decoration: none;
     }
+
+    // Opens downward, into the table: above a header-row heading the bubble is cut
+    // off by whatever sits over the table.
+    .column-hint-text {
+        position: absolute;
+        top: 100%;
+        left: 0;
+        z-index: 3;
+        // Fixed, not max-content: a cell held to one line gives no useful intrinsic
+        // width to resolve against.
+        width: 14rem;
+        margin-top: 0.35rem;
+        padding: 0.4rem 0.6rem;
+        border-radius: 0.25rem;
+        background-color: #000;
+        color: #fff;
+        // The heading is one line; the explanation itself wraps.
+        white-space: normal;
+        font-weight: 400;
+        font-size: 0.8125rem;
+        line-height: 1.3;
+        text-align: left;
+        opacity: 0;
+        visibility: hidden;
+        transition: opacity 0.1s ease-in;
+    }
+
+    &:hover .column-hint-text,
+    &:focus .column-hint-text {
+        opacity: 1;
+        visibility: visible;
+    }
+}
+
+// The last column has no room to its right inside the scroll container, which clips
+// horizontally, so its bubble opens leftward instead.
+.controlled-vocabularies th:last-child .column-hint .column-hint-text {
+    right: 0;
+    left: auto;
 }

--- a/app/controllers/hyrax/dashboard/controlled_vocabularies_controller.rb
+++ b/app/controllers/hyrax/dashboard/controlled_vocabularies_controller.rb
@@ -27,29 +27,28 @@ module Hyrax
         end
       end
 
+      # Prefilled when the review step sends its values back, so correcting a typo
+      # there does not mean retyping the rest.
       def new
-        @controlled_vocabulary = Qa::LocalAuthority.new
+        @controlled_vocabulary = Qa::LocalAuthority.new(prefill_params)
         add_breadcrumb t(:'hyrax.controls.home'), root_path
         add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
         add_breadcrumb t('hyku.admin.controlled_vocabularies'), main_app.controlled_vocabularies_path
         add_breadcrumb t('hyku.admin.controlled_vocabulary.new_title'), main_app.new_controlled_vocabulary_path
       end
 
+      # Creation is a two-step process so the entry can be confirmed since there is no delete option.
       def create
-        @controlled_vocabulary = Qa::LocalAuthority.new(controlled_vocabulary_params)
+        @controlled_vocabulary = Qa::LocalAuthority.new(controlled_vocabulary_params
+                                                          .merge(staff_created: true))
 
-        if @controlled_vocabulary.save
-          redirect_to main_app.controlled_vocabulary_path(@controlled_vocabulary.name),
-                      notice: t('hyku.admin.controlled_vocabulary.created',
-                                name: @controlled_vocabulary.display_label)
-        else
-          add_breadcrumb t(:'hyrax.controls.home'), root_path
-          add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
-          add_breadcrumb t('hyku.admin.controlled_vocabularies'), main_app.controlled_vocabularies_path
-          # The form route, not request.path: on a POST that is the index.
-          add_breadcrumb t('hyku.admin.controlled_vocabulary.new_title'), main_app.new_controlled_vocabulary_path
-          render :new, status: :unprocessable_entity
-        end
+        return redisplay_form unless @controlled_vocabulary.valid?
+        return confirm_creation unless confirmed?
+        return redisplay_form unless save_vocabulary
+
+        redirect_to main_app.controlled_vocabulary_path(@controlled_vocabulary.name),
+                    notice: t('hyku.admin.controlled_vocabulary.created',
+                              name: @controlled_vocabulary.display_label)
       end
 
       private
@@ -75,10 +74,52 @@ module Hyrax
         self.response_body = export.public_send(format)
       end
 
+      # Cast rather than tested for presence: the row cannot be deleted once written,
+      # so `confirmed=` or `confirmed=false` has to mean not confirmed.
+      def confirmed?
+        ActiveModel::Type::Boolean.new.cast(params[:confirmed]).present?
+      end
+
+      # The unique index is what actually settles a collision: the review step invites
+      # a re-submit, so two confirmations of one name can both pass validation and
+      # only one can insert.
+      def save_vocabulary
+        @controlled_vocabulary.save
+      rescue ActiveRecord::RecordNotUnique
+        @controlled_vocabulary.errors.add(:name, :taken_as_source_key,
+                                          value: @controlled_vocabulary.name)
+        false
+      end
+
+      def confirm_creation
+        creation_breadcrumbs
+        render :confirm
+      end
+
+      def redisplay_form
+        creation_breadcrumbs
+        render :new, status: :unprocessable_entity
+      end
+
+      def creation_breadcrumbs
+        add_breadcrumb t(:'hyrax.controls.home'), root_path
+        add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
+        add_breadcrumb t('hyku.admin.controlled_vocabularies'), main_app.controlled_vocabularies_path
+        # The form route, not request.path: these trails are drawn on a POST, where
+        # request.path is the index.
+        add_breadcrumb t('hyku.admin.controlled_vocabulary.new_title'), main_app.new_controlled_vocabulary_path
+      end
+
       # No :name — it is derived from the label on create, and a metadata profile
       # cites it, so staff do not get to set or change it.
       def controlled_vocabulary_params
         params.require(:local_authority).permit(:label, :description)
+      end
+
+      def prefill_params
+        return {} if params[:local_authority].blank?
+
+        controlled_vocabulary_params
       end
     end
   end

--- a/app/controllers/hyrax/dashboard/controlled_vocabulary_terms_controller.rb
+++ b/app/controllers/hyrax/dashboard/controlled_vocabulary_terms_controller.rb
@@ -28,13 +28,17 @@ module Hyrax
 
       private
 
-      # Only a vocabulary this tenant owns takes new terms. A yaml-backed or imported
-      # one has no row to attach them to, and find_by! keeps that a 404 rather than a
-      # form that cannot save.
+      # An imported copy has a database row, so find_by! alone would let a term through;
+      # its terms are not this tenant's to change. Checked here because the view only
+      # hides the button.
       def load_vocabulary
         @vocabulary = Qa::LocalAuthority.find_by!(name: params[:controlled_vocabulary_id])
+        return if ControlledVocabularyCatalog.find!(@vocabulary.name).editable?
+
+        raise ActiveRecord::RecordNotFound, "#{@vocabulary.name} does not take terms added here"
       end
 
+      # No :position — the model assigns it, so it cannot be posted.
       def term_params
         params.require(:local_authority_entry).permit(:label, :uri)
       end

--- a/app/helpers/hyrax/form_helper_behavior.rb
+++ b/app/helpers/hyrax/form_helper_behavior.rb
@@ -6,10 +6,9 @@ module Hyrax
       registered = Hyrax::ControlledVocabularies.services[source_name]&.safe_constantize
       return registered if registered
 
-      # Vocabularies created through the admin dashboard have no entry in the
-      # services registry, so fall back to a bare tolerant lookup. Without this
-      # the field renders as free text instead of a dropdown.
-      database_vocabulary_service_for(source_name)
+      # Dashboard-created vocabularies and unregistered yaml files are not in the
+      # registry; without this fallback their fields render as free text.
+      local_vocabulary_service_for(source_name)
     end
 
     def remote_authority_config_for(source_name)
@@ -49,16 +48,26 @@ module Hyrax
 
     private
 
-    # A tolerant service for a database-backed vocabulary, or nil when no
-    # vocabulary of that name exists (so remote authorities still get a chance).
-    def database_vocabulary_service_for(source_name)
-      return if source_name.blank?
-      return unless Qa::LocalAuthority.exists?(name: source_name.to_s)
+    # nil when neither a row nor a yaml file backs the name, so remote authorities
+    # still get a chance.
+    def local_vocabulary_service_for(source_name)
+      name = source_name.to_s
+      return if name.blank?
+      return unless Qa::LocalAuthority.exists?(name: name) || file_based_authority?(name)
 
-      Hyrax::TolerantSelectService.new(source_name.to_s)
+      Hyrax::TolerantSelectService.new(name)
     rescue StandardError => e
       Rails.logger.warn "Failed to build a vocabulary service for #{source_name}: #{e.message}"
       nil
+    end
+
+    # Rescued because qa raises ConfigDirectoryNotFound when a deployment has no
+    # config/authorities — no yaml vocabularies to match, not a broken form.
+    def file_based_authority?(name)
+      Qa::Authorities::Local.names.include?(name)
+    rescue StandardError => e
+      Rails.logger.debug { "Unable to list file-based local authorities: #{e.message}" }
+      false
     end
 
     def controlled_vocabulary_mapping_for(property_name)

--- a/app/models/qa/local_authority.rb
+++ b/app/models/qa/local_authority.rb
@@ -6,20 +6,28 @@ module Qa
 
     has_many :local_authority_entries, dependent: :destroy
 
+    # Set by the dashboard only, so the mesh import task can still create its own row
+    # under a name staff are not allowed to use.
+    attr_accessor :staff_created
+
     # Create only: a metadata profile cites the name and works store terms found
     # through it, so a later relabel must not move it.
     before_validation :derive_name_from_label, on: :create
 
     validates :name, presence: true
-    # Guarded on name_changed? so rows predating these rules stay editable.
+    # Guarded on name_changed? so rows predating these rules stay editable. The
+    # message names the key because it is derived: "Café Terms" and "Cafe Terms" both
+    # give `cafe_terms`, so a label collision is not obvious from the label.
     validates :name,
-              uniqueness: { case_sensitive: false },
+              uniqueness: { case_sensitive: false, message: :taken_as_source_key },
               format: {
                 with: NAME_FORMAT,
                 message: 'must be lowercase letters, numbers, underscores and hyphens, ' \
                          'starting with a letter or number'
               },
               if: -> { name_changed? && name.present? }
+
+    validate :name_is_not_already_an_authority, if: -> { staff_created && name.present? }
 
     scope :ordered, -> { order(Arel.sql("COALESCE(NULLIF(label, ''), name)")) }
 
@@ -42,6 +50,51 @@ module Qa
 
     def derive_name_from_label
       self.name = self.class.name_for(label) if name.blank? && label.present?
+    end
+
+    # The form helper resolves a row before a remote service, so a row named
+    # `geonames` would hijack that field. Taking a yaml name is allowed on purpose: the
+    # row is used in place of the file, which is how a tenant owns a shipped list.
+    def name_is_not_already_an_authority
+      return unless reserved_names.include?(name.to_s.downcase)
+
+      errors.add(:name, :already_an_authority)
+    end
+
+    def reserved_names
+      (remote_source_keys + cached_authority_names).map(&:downcase).uniq
+    end
+
+    # Service keys only: the format rule rejects a slash first, so `service/vocabulary`
+    # forms could never match here.
+    def remote_source_keys
+      Qa::AuthorityRegistry.remote_services.keys
+    end
+
+    # Authorities whose terms a re-import replaces wholesale, mesh being the case in
+    # hand.
+    def cached_authority_names
+      registered_names.select { |registered| cached_authority?(registered) }
+    end
+
+    def registered_names
+      Qa::Authorities::Local.registry.keys.map(&:to_s)
+    rescue StandardError => e
+      Rails.logger.warn("Unable to list the registered authorities: #{e.message}")
+      []
+    end
+
+    # Rescued per name, not around the list: one unresolvable authority would
+    # otherwise reserve nothing, letting a row named `mesh` through. An authority that
+    # does not answer is treated as owned here, so a name is reserved only on purpose.
+    def cached_authority?(name)
+      authority = Qa::Authorities::Local.subauthority_for(name)
+      return false unless authority.respond_to?(:locally_owned?)
+
+      !authority.locally_owned?
+    rescue StandardError => e
+      Rails.logger.debug { "Unable to resolve #{name} while listing cached authorities: #{e.message}" }
+      false
     end
   end
 end

--- a/app/models/qa/local_authority_entry.rb
+++ b/app/models/qa/local_authority_entry.rb
@@ -11,6 +11,7 @@ module Qa
     before_validation { self.uri = nil if uri.blank? }
     # After the blanking above, or the label would be wiped straight away.
     before_validation :default_uri_to_label, on: :create
+    before_create :default_position_to_last
 
     validates :uri, presence: true, on: :create
     validates :uri, uniqueness: { scope: :local_authority_id }, allow_nil: true
@@ -30,6 +31,16 @@ module Qa
 
     def default_uri_to_label
       self.uri = label if uri.blank?
+    end
+
+    # Counted as well as measured: rows predating this hold NULL, so the highest
+    # assigned position can still be below them and reusing it would collide once
+    # they are numbered.
+    def default_position_to_last
+      return if position.present? || local_authority_id.blank?
+
+      siblings = self.class.where(local_authority_id: local_authority_id)
+      self.position = [siblings.maximum(:position).to_i, siblings.count].max + 1
     end
   end
 end

--- a/app/presenters/hyku/deposit_wizard/presenter.rb
+++ b/app/presenters/hyku/deposit_wizard/presenter.rb
@@ -140,8 +140,8 @@ module Hyku
       end
 
       # nil unless the profile declares this property controlled and its authority
-      # resolves. Memoized per request: Qa re-reads and re-parses the whole
-      # authority file on every lookup.
+      # resolves. Memoized per request: each lookup re-reads the profile and then
+      # queries the vocabulary's terms, and the review step labels every value.
       def controlled_service_for(term)
         @controlled_services ||= {}
         return @controlled_services[term] if @controlled_services.key?(term)
@@ -149,20 +149,20 @@ module Hyku
         @controlled_services[term] = build_controlled_service(term)
       end
 
+      # Resolved by the helper, which is also what renders the field on the deposit
+      # form, so the review step cannot disagree with it about what controls a
+      # property.
       def build_controlled_service(term)
         source = context.helpers.controlled_vocabulary_source_for(term)
         return if source.blank?
 
-        # Prefer the registered service (it may add behavior); fall back to a bare
-        # authority lookup so a profile source with no registry entry still labels.
-        registered = Hyrax::ControlledVocabularies.services[source]&.safe_constantize
-        return Hyrax::TolerantSelectService.new(source) unless registered
+        service = context.helpers.controlled_vocabulary_service_for(source)
 
         # Two service styles exist: a class (Hyrax::LicenseService) and a module
         # extending AuthorityService (Hyrax::ResourceTypesService), whose `label` is
         # a module method. Calling `.new` on the module raises, the rescue below
         # swallows it, and the value renders as the stored id.
-        registered.respond_to?(:new) ? registered.new : registered
+        service.respond_to?(:new) ? service.new : service
       rescue StandardError => e
         Hyrax.logger.debug("Deposit wizard: no label service for #{term} (#{source}): #{e.message}")
         nil

--- a/app/services/controlled_vocabulary_catalog.rb
+++ b/app/services/controlled_vocabulary_catalog.rb
@@ -40,9 +40,9 @@ class ControlledVocabularyCatalog
       origin == :database && vocabulary.present?
     end
 
-    # Only what has a term list worth opening. Remote services are not enumerable,
-    # and an imported copy holds too many terms to list.
-    def viewable?
+    # A remote service is not enumerable, and an imported copy holds far too many
+    # terms to page through.
+    def listable?
       editable? || origin == :file
     end
 
@@ -77,29 +77,33 @@ class ControlledVocabularyCatalog
     #
     # @return [Array<Entry>]
     def all
-      (database + file_based + remote).sort_by do |entry|
+      # One read, shared: two reads that disagreed would emit the same source key
+      # under two origins.
+      yaml_names = file_based_names
+
+      (database(yaml_names) + file_based(yaml_names) + remote).sort_by do |entry|
         [ORIGIN_ORDER.fetch(entry.origin, 9),
          entry.provider.to_s.downcase,
-         entry.label.downcase]
+         entry.label.to_s.downcase]
       end
     end
 
-    def database
+    def database(yaml_names = file_based_names)
       vocabularies = Qa::LocalAuthority.ordered.to_a
       # One grouped count rather than one per vocabulary.
       totals = Qa::LocalAuthorityEntry.where(local_authority: vocabularies).group(:local_authority_id).count
 
       entries = vocabularies.map { |vocabulary| database_entry(vocabulary, totals) }
 
-      (entries + unimported_local).sort_by { |e| e.label.downcase }
+      (entries + unimported_local(yaml_names)).sort_by { |e| e.label.to_s.downcase }
     end
 
     # Excludes names already backed by a database row: the row is what staff see
     # and edit, so listing both would imply two separate vocabularies.
-    def file_based
+    def file_based(yaml_names = file_based_names)
       claimed = Qa::LocalAuthority.pluck(:name).map(&:to_s)
 
-      (file_based_names - claimed).map do |name|
+      (yaml_names - claimed).map do |name|
         Entry.new(source_key: name,
                   label: name.titleize,
                   origin: :file,
@@ -120,16 +124,15 @@ class ControlledVocabularyCatalog
       end
     end
 
-    # Checks the database rows first: assembling the whole catalog walks every qa
-    # authority and parses every yaml, which a show page does not need.
-    #
     # @raise [ActiveRecord::RecordNotFound] so an unknown key 404s rather than
     #   rendering an empty page.
     def find!(source_key)
       key = source_key.to_s
 
-      database.detect { |entry| entry.source_key == key } ||
-        all.detect { |entry| entry.source_key == key } ||
+      # After a direct miss, so a vocabulary named with the alternate spelling still
+      # answers for itself.
+      find_by_source_key(key) ||
+        aliases_for(key).lazy.filter_map { |alt| find_by_source_key(alt) }.first ||
         raise(ActiveRecord::RecordNotFound, "No controlled vocabulary named #{key}")
     end
 
@@ -169,7 +172,31 @@ class ControlledVocabularyCatalog
       []
     end
 
+    # Two keys on one url in remote_authorities are the same vocabulary
+    # (`loc/genre_forms`, `loc/genreForms`), so an alias added there needs nothing
+    # here. Emitting every spelling from .remote would list one vocabulary twice.
+    def aliases_for(key)
+      authorities = Hyrax::ControlledVocabularies.remote_authorities
+      url = authorities.dig(key.to_s, :url)
+      return [] if url.blank?
+
+      authorities.each_with_object([]) do |(sibling, config), found|
+        found << sibling if sibling != key.to_s && config[:url] == url
+      end
+    end
+
     private
+
+    # Database rows first: the other origins walk every qa authority and parse every
+    # yaml, which a hit here avoids.
+    def find_by_source_key(key)
+      return if key.blank?
+
+      yaml_names = file_based_names
+
+      database(yaml_names).detect { |entry| entry.source_key == key } ||
+        (file_based(yaml_names) + remote).detect { |entry| entry.source_key == key }
+    end
 
     def remote_entry(provider, subauthority, configured)
       Entry.new(source_key: [provider, subauthority].compact.join('/'),
@@ -196,8 +223,8 @@ class ControlledVocabularyCatalog
     # Local authorities qa knows about that have neither a row in this tenant nor a
     # yaml file, so a manager can see the vocabulary exists and what populates it.
     # mesh is the case in hand: registered at boot, filled by a rake task.
-    def unimported_local
-      accounted_for = Qa::LocalAuthority.pluck(:name).map(&:to_s) + file_based_names
+    def unimported_local(yaml_names = file_based_names)
+      accounted_for = Qa::LocalAuthority.pluck(:name).map(&:to_s) + yaml_names
 
       (registered_local_names - accounted_for).map do |name|
         Entry.new(source_key: name,
@@ -270,7 +297,9 @@ class ControlledVocabularyCatalog
       account.public_send(setting).present?
     rescue StandardError => e
       Rails.logger.warn("Unable to check configuration for #{provider}: #{e.message}")
-      nil
+      # false, not nil: nil reads as configured, sending staff to debug a form that
+      # was never going to work.
+      false
     end
 
     # nil rather than 0 on failure, so the view can say "unknown" instead of

--- a/app/services/controlled_vocabulary_usage.rb
+++ b/app/services/controlled_vocabulary_usage.rb
@@ -30,23 +30,48 @@ class ControlledVocabularyUsage
 
     private
 
-    def from_profile(profile, key)
-      properties = profile['properties'] || {}
-
-      properties.filter_map do |name, config|
-        next unless config.is_a?(Hash) && cites?(config, key)
-
-        Property.new(name: name, work_types: work_types(config))
-      end
-    end
-
-    # Form partials that read an authority the generic mapping does not list: the
-    # OER form fills resource_type from oer_types, and based_near autocompletes
-    # against geonames. A nil class list means every model defining the property.
+    # Form partials that hardcode an authority the profile and the generic mapping
+    # do not name: the OER form fills resource_type from oer_types, and based_near
+    # autocompletes against geonames. A nil class list means every model defining
+    # the property.
     PARTIAL_SOURCES = {
       'oer_types' => { property: 'resource_type', classes: ['OerResource'] },
       'geonames' => { property: 'based_near', classes: nil }
     }.freeze
+
+    def from_profile(profile, key)
+      properties = profile['properties'] || {}
+      # Every spelling, because the dashboard resolves a legacy key to the entry
+      # keyed canonically and then asks for that key's usage.
+      keys = [key] + ControlledVocabularyCatalog.aliases_for(key)
+
+      declared = properties.filter_map do |name, config|
+        next unless config.is_a?(Hash) && cites?(config, keys)
+
+        Property.new(name: name, work_types: work_types(config))
+      end
+
+      declared + profile_partial_properties(profile, key, declared)
+    end
+
+    # A partial that hardcodes its authority leaves the profile with nothing to
+    # declare — based_near carries `sources: ["null"]` while its form partial
+    # autocompletes against geonames. The property is still controlled, and the
+    # profile is still where its work types come from.
+    def profile_partial_properties(profile, key, declared)
+      config = PARTIAL_SOURCES[key]
+      return [] if config.nil?
+      return [] if declared.any? { |property| property.name == config[:property] }
+
+      property_config = (profile['properties'] || {})[config[:property]]
+      return [] unless property_config.is_a?(Hash)
+
+      types = work_types(property_config)
+      types = types.select { |type| config[:classes].include?(type.name) } if config[:classes]
+      return [] if types.empty?
+
+      [Property.new(name: config[:property], work_types: types)]
+    end
 
     # Without flexible metadata there is no profile; which properties a vocabulary
     # controls comes from the static mapping the deposit form itself uses, and the
@@ -88,11 +113,11 @@ class ControlledVocabularyUsage
         Hyrax::ModelRegistry.file_set_classes).select { |klass| klass < Valkyrie::Resource }
     end
 
-    # Keys are stripped because profiles have shipped them with stray whitespace;
+    # Sources are stripped because profiles have shipped them with stray whitespace;
     # the form helper reads them the same way.
-    def cites?(config, key)
+    def cites?(config, keys)
       Array(config.dig('controlled_values', 'sources')).any? do |source|
-        source.to_s.strip == key
+        keys.include?(source.to_s.strip)
       end
     end
 

--- a/app/services/local_vocabulary_service.rb
+++ b/app/services/local_vocabulary_service.rb
@@ -19,24 +19,36 @@ class LocalVocabularyService
   end
 
   # @param files [Array<String>] every yml this name resolves to, overriding path first
+  # @return [Array(String, Integer, Boolean)] name, term count, and whether this run
+  #   seeded it — false for a vocabulary the tenant already had
   def self.seed_vocabulary!(name, files)
     contents = files.map { |file| YAML.load_file(file) || {} }
-    terms = Array.wrap(contents.first['terms'])
     authority = Qa::LocalAuthority.find_or_initialize_by(name:)
+    seeded = authority.persisted? # read before the save below creates it
 
     backfill_metadata(authority, merged_metadata(contents))
     save_authority!(authority, files.first)
 
+    # Terms on creation only: once a tenant has the vocabulary the rows are theirs, so
+    # a term they deleted stays deleted and their wording survives a later run. The
+    # dashboard import is how an existing vocabulary gains terms.
+    seed_terms!(authority, Array.wrap(contents.first['terms'])) unless seeded
+
+    [name, authority.local_authority_entries.count, !seeded]
+  end
+
+  # find_or_create_by! rather than create!: a shipped file can list one id twice
+  # (licenses.yml does, for two Creative Commons URIs), and uri is unique per
+  # vocabulary.
+  def self.seed_terms!(authority, terms)
     terms.each_with_index do |term, index|
       authority.local_authority_entries.find_or_create_by!(uri: term['id']) do |entry|
         entry.label = term['term']
         entry.active = term.fetch('active', true)
-        entry.position = index
+        entry.position = index + 1 # from one, as the model numbers a term added later
         entry.data = term.except('id', 'term', 'active')
       end
     end
-
-    [name, authority.local_authority_entries.count]
   end
 
   # Raised through the instance, not the class: RecordInvalid#initialize takes a record,

--- a/app/services/qa/authority_registry.rb
+++ b/app/services/qa/authority_registry.rb
@@ -54,21 +54,14 @@ module Qa
       # application adds are excluded without naming them: Hyrax contributes
       # pickers for works and collections, and Hyku its own local classes.
       #
+      # Memoized for the life of the process: the walk loads and locates every
+      # constant under Qa::Authorities, the index asks once per remote vocabulary,
+      # and what the gem provides cannot change while the process runs. Unlike the
+      # local authorities, none of this is per-tenant.
+      #
       # @return [Hash{String => Module}]
       def remote_services
-        Qa::Authorities.constants.sort.each_with_object({}) do |name, services|
-          next if NON_SERVICES.include?(name.to_s)
-          next if name.to_s.end_with?('Subauthority', 'Decorator')
-
-          # Loaded before locating it: qa autoloads these, and
-          # const_source_location reports the autoload stub until the constant is
-          # referenced.
-          klass = authority_class(name)
-          next if klass.nil?
-          next unless defined_in_gem?(name)
-
-          services[source_key_for(name)] = klass
-        end
+        @remote_services ||= build_remote_services
       end
 
       # Every vocabulary a service offers, as the keys a profile can cite.
@@ -92,6 +85,22 @@ module Qa
       end
 
       private
+
+      def build_remote_services
+        Qa::Authorities.constants.sort.each_with_object({}) do |name, services|
+          next if NON_SERVICES.include?(name.to_s)
+          next if name.to_s.end_with?('Subauthority', 'Decorator')
+
+          # Loaded before locating it: qa autoloads these, and
+          # const_source_location reports the autoload stub until the constant is
+          # referenced.
+          klass = authority_class(name)
+          next if klass.nil?
+          next unless defined_in_gem?(name)
+
+          services[source_key_for(name)] = klass
+        end
+      end
 
       # Rescued per constant: some authorities read a config file when they load
       # (Oclcts wants config/oclcts-authorities.yml), and one missing file must not

--- a/app/views/hyrax/dashboard/controlled_vocabularies/_column_hint.html.erb
+++ b/app/views/hyrax/dashboard/controlled_vocabularies/_column_hint.html.erb
@@ -1,8 +1,10 @@
-<%# A column heading whose explanation sits behind a question mark. %>
-<%= label %>
-<button type="button"
-        class="btn btn-link p-0 ml-1 align-baseline column-hint"
-        title="<%= hint %>"
-        aria-label="<%= hint %>">
-  <span class="fa fa-question-circle text-muted" aria-hidden="true"></span>
-</button>
+<%# A heading whose explanation appears on hover. Not a button — clicking does
+    nothing — but tabindex keeps it reachable by keyboard, and aria-label names it
+    there: the visible hint is `visibility: hidden` until hover, so it is out of the
+    accessibility tree exactly when a focused tab stop needs a name. role="note"
+    because ARIA does not allow naming the implicit generic role, whatever a given
+    browser does with it. The hint is real text, not a data- attribute drawn by CSS:
+    a generated box will not size to its own text inside a cell held to one line. %>
+<%= label %><span class="column-hint" tabindex="0" role="note" aria-label="<%= hint %>"><span
+        class="fa fa-question-circle text-muted" aria-hidden="true"></span><span
+        class="column-hint-text" aria-hidden="true"><%= hint %></span></span>

--- a/app/views/hyrax/dashboard/controlled_vocabularies/confirm.html.erb
+++ b/app/views/hyrax/dashboard/controlled_vocabularies/confirm.html.erb
@@ -1,0 +1,63 @@
+<% provide :page_title, construct_page_title(t('hyku.admin.controlled_vocabulary.confirm_title'),
+                                             t('hyku.admin.controlled_vocabularies'),
+                                             t('hyku.admin.title')) %>
+<% provide :page_header do %>
+  <h1>
+    <span class="fa fa-tag" aria-hidden="true"></span>
+    <%= t('hyku.admin.controlled_vocabulary.confirm_title') %>
+  </h1>
+<% end %>
+
+<div class="card">
+  <div class="card-header">
+    <%= t('hyku.admin.controlled_vocabulary.confirm_help') %>
+  </div>
+  <div class="card-body">
+    <dl class="row">
+      <dt class="col-sm-3"><%= t('hyku.admin.controlled_vocabulary.name') %></dt>
+      <dd class="col-sm-9"><%= @controlled_vocabulary.label %></dd>
+
+      <%# The value a metadata profile will cite. %>
+      <dt class="col-sm-3">
+        <%= render 'column_hint',
+                   label: t('hyku.admin.controlled_vocabulary.source_key'),
+                   hint: t('hyku.admin.controlled_vocabulary.source_key_hint') %>
+      </dt>
+      <dd class="col-sm-9"><code><%= @controlled_vocabulary.name %></code></dd>
+
+      <dt class="col-sm-3"><%= t('hyku.admin.controlled_vocabulary.description') %></dt>
+      <dd class="col-sm-9">
+        <% if @controlled_vocabulary.description.present? %>
+          <%= @controlled_vocabulary.description %>
+        <% else %>
+          <span class="text-muted"><%= t('hyku.admin.controlled_vocabulary.no_description') %></span>
+        <% end %>
+      </dd>
+    </dl>
+
+    <p class="form-text text-muted">
+      <span class="fa fa-info-circle" aria-hidden="true"></span>
+      <%= t('hyku.admin.controlled_vocabulary.confirm_permanent') %>
+    </p>
+
+    <%= form_for @controlled_vocabulary, url: main_app.controlled_vocabularies_path do |f| %>
+      <%# Carried forward rather than held in the session: the review step owns no
+          state, so a reload or a Back cannot leave a half-finished vocabulary. %>
+      <%= f.hidden_field :label %>
+      <%= f.hidden_field :description %>
+      <%= hidden_field_tag :confirmed, true %>
+
+      <%= f.submit t('hyku.admin.controlled_vocabulary.confirm_create'), class: 'btn btn-primary' %>
+    <% end %>
+
+    <%# Outside the form, carrying the values itself: submitting the form with
+        formmethod="get" would put its authenticity_token in the query string, and from
+        there into logs, history, and Referer headers. %>
+    <%= link_to t('hyku.admin.controlled_vocabulary.confirm_back'),
+                main_app.new_controlled_vocabulary_path(
+                  local_authority: { label: @controlled_vocabulary.label,
+                                      description: @controlled_vocabulary.description }
+                ),
+                class: 'btn btn-link' %>
+  </div>
+</div>

--- a/app/views/hyrax/dashboard/controlled_vocabularies/index.html.erb
+++ b/app/views/hyrax/dashboard/controlled_vocabularies/index.html.erb
@@ -17,8 +17,10 @@
   </div>
   <div class="card-body pt-1">
     <% if @controlled_vocabularies.any? %>
-      <div class="table-responsive">
-        <table class="table table-borderless">
+      <%# controlled-vocabularies-scroll restores the scroll Hyrax disables on
+          .table-responsive app-wide; see hyku.scss. %>
+      <div class="table-responsive controlled-vocabularies-scroll">
+        <table class="table table-borderless controlled-vocabularies">
           <caption class="sr-only"><%= t('hyku.admin.controlled_vocabularies') %></caption>
           <thead>
             <tr>
@@ -45,11 +47,7 @@
             <% @controlled_vocabularies.each do |entry| %>
               <tr class="<%= 'border-bottom' if entry.description.blank? %>">
                 <td>
-                  <% if entry.viewable? %>
-                    <%= link_to entry.label, main_app.controlled_vocabulary_path(entry.source_key) %>
-                  <% else %>
-                    <%= entry.label %>
-                  <% end %>
+                  <%= link_to entry.label, main_app.controlled_vocabulary_path(entry.source_key) %>
                 </td>
                 <td><code><%= entry.source_key %></code></td>
                 <td><%= entry.source_label %></td>
@@ -76,7 +74,8 @@
               </tr>
               <% if entry.description.present? %>
                 <tr class="border-bottom">
-                  <td colspan="5" class="pt-0 text-muted">
+                  <%# Spans the row, so it wraps rather than widening the table. %>
+                  <td colspan="5" class="pt-0 text-muted controlled-vocabulary-description">
                     <%= entry.description %>
                   </td>
                 </tr>

--- a/app/views/hyrax/dashboard/controlled_vocabularies/new.html.erb
+++ b/app/views/hyrax/dashboard/controlled_vocabularies/new.html.erb
@@ -26,21 +26,11 @@
         </div>
       <% end %>
 
+      <%# No source-key preview here: the review step shows the derived key before
+          anything is written. %>
       <div class="form-group">
         <%= f.label :label, t('hyku.admin.controlled_vocabulary.name'), class: 'control-label' %>
-        <%= f.text_field :label,
-                         class: 'form-control',
-                         required: true,
-                         'aria-describedby' => 'vocabulary-source-key' %>
-        <small id="vocabulary-source-key" class="form-text text-muted">
-          <% derived = Qa::LocalAuthority.name_for(@controlled_vocabulary.label) %>
-          <% if derived.present? %>
-            <%= t('hyku.admin.controlled_vocabulary.source_key_will_be_html',
-                  key: tag.code(derived)) %>
-          <% else %>
-            <%= t('hyku.admin.controlled_vocabulary.source_key_from_name') %>
-          <% end %>
-        </small>
+        <%= f.text_field :label, class: 'form-control', required: true %>
       </div>
 
       <div class="form-group">
@@ -51,6 +41,8 @@
         </small>
       </div>
 
+      <%# Submitting reviews rather than saves: create renders the derived source key
+          for confirmation before writing the row. %>
       <%= f.submit t('hyku.admin.controlled_vocabulary.create'), class: 'btn btn-primary' %>
       <%= link_to t('helpers.action.cancel', default: 'Cancel'),
                   main_app.controlled_vocabularies_path,

--- a/app/views/hyrax/dashboard/controlled_vocabularies/show.html.erb
+++ b/app/views/hyrax/dashboard/controlled_vocabularies/show.html.erb
@@ -20,15 +20,15 @@
 <div class="card">
   <div class="card-body border-bottom">
     <dl class="row mb-0">
-      <dt class="col-sm-2"><%= t('hyku.admin.controlled_vocabulary.source_key') %></dt>
-      <dd class="col-sm-10"><code><%= @entry.source_key %></code></dd>
+      <dt class="col-sm-3"><%= t('hyku.admin.controlled_vocabulary.source_key') %></dt>
+      <dd class="col-sm-9"><code><%= @entry.source_key %></code></dd>
 
-      <dt class="col-sm-2"><%= t('hyku.admin.controlled_vocabulary.origin') %></dt>
-      <dd class="col-sm-10"><%= @entry.source_label %></dd>
+      <dt class="col-sm-3"><%= t('hyku.admin.controlled_vocabulary.origin') %></dt>
+      <dd class="col-sm-9"><%= @entry.source_label %></dd>
 
       <% if @terms.present? %>
-        <dt class="col-sm-2"><%= t('hyku.admin.controlled_vocabulary.terms') %></dt>
-        <dd class="col-sm-10">
+        <dt class="col-sm-3"><%= t('hyku.admin.controlled_vocabulary.terms') %></dt>
+        <dd class="col-sm-9">
           <% total = @entry.term_count || @terms.size %>
           <% truncated = total > @terms.size %>
           <%= t('hyku.admin.controlled_vocabulary.term_total', count: total) %>
@@ -48,17 +48,17 @@
       <% end %>
 
       <% if @entry.description.present? %>
-        <dt class="col-sm-2"><%= t('hyku.admin.controlled_vocabulary.description') %></dt>
-        <dd class="col-sm-10"><%= @entry.description %></dd>
+        <dt class="col-sm-3"><%= t('hyku.admin.controlled_vocabulary.description') %></dt>
+        <dd class="col-sm-9"><%= @entry.description %></dd>
       <% end %>
 
       <% unless @usage.nil? %>
-        <dt class="col-sm-2">
+        <dt class="col-sm-3">
           <%= render 'column_hint',
                      label: t('hyku.admin.controlled_vocabulary.used_by'),
                      hint: t('hyku.admin.controlled_vocabulary.used_by_hint') %>
         </dt>
-        <dd class="col-sm-10">
+        <dd class="col-sm-9">
           <% if @usage.empty? %>
             <span class="text-muted">
               <%= t('hyku.admin.controlled_vocabulary.unused') %>
@@ -84,13 +84,13 @@
       <% end %>
     </dl>
 
-    <% unless @entry.editable? %>
-      <%# Defaulted because the key is interpolated from the origin: a new origin
-          without a message should read plainly, not raise. %>
+    <%# A yaml vocabulary is the one case with a term list staff cannot edit, so it is
+        the one that needs saying. Where there is no list, the note below it already
+        explains where the terms live. %>
+    <% if @entry.origin == :file %>
       <p class="form-text text-muted mt-3 mb-0">
         <span class="fa fa-info-circle" aria-hidden="true"></span>
-        <%= t("hyku.admin.controlled_vocabulary.read_only.#{@entry.origin}",
-              default: t('hyku.admin.controlled_vocabulary.read_only.generic')) %>
+        <%= t('hyku.admin.controlled_vocabulary.read_only.file') %>
       </p>
     <% end %>
 
@@ -103,15 +103,26 @@
       </p>
     <% end %>
   </div>
+  <%# Only where a term list is possible. A remote service holds its terms and is
+      searched as staff type, and an imported copy runs to tens of thousands, so
+      neither gets a terms panel to explain the absence of. %>
+  <% if @entry.listable? %>
   <div class="card-header">
     <%= t('hyku.admin.controlled_vocabulary.term_id_help') %>
   </div>
   <div class="card-body pt-1">
-    <% if @terms.blank? %>
+    <% if @terms.nil? %>
+      <%# nil is "cannot say", not "none": the yaml is missing or unreadable, and
+          reporting it empty would send staff looking for terms they never added. %>
+      <p class="text-muted mb-0"><%= t('hyku.admin.controlled_vocabulary.terms_unavailable') %></p>
+    <% elsif @terms.empty? %>
       <p class="text-muted mb-0"><%= t('hyku.admin.controlled_vocabulary.no_terms') %></p>
     <% else %>
-      <div class="table-responsive">
-        <table class="table table-borderless">
+      <%# controlled-vocabularies-scroll restores the scroll Hyrax disables on
+          .table-responsive app-wide; see hyku.scss. A term id can be a full uri, so
+          this table overflows readily. %>
+      <div class="table-responsive controlled-vocabularies-scroll">
+        <table class="table table-borderless controlled-vocabularies">
           <caption class="sr-only"><%= @entry.label %></caption>
           <thead>
             <tr>
@@ -154,4 +165,15 @@
       </div>
     <% end %>
   </div>
+  <% else %>
+    <div class="card-body pt-0">
+      <p class="form-text text-muted mb-0">
+        <span class="fa fa-info-circle" aria-hidden="true"></span>
+        <%# Defaulted because the key is interpolated from the origin: a new origin
+            without a message should read plainly, not raise. %>
+        <%= t("hyku.admin.controlled_vocabulary.terms_elsewhere.#{@entry.origin}",
+              default: t('hyku.admin.controlled_vocabulary.terms_elsewhere.generic')) %>
+      </p>
+    </div>
+  <% end %>
 </div>

--- a/config/initializers/hyrax_controlled_vocabularies.rb
+++ b/config/initializers/hyrax_controlled_vocabularies.rb
@@ -44,6 +44,14 @@ module Hyrax
             url: "/authorities/search/loc/names",
             type: 'autocomplete'
           },
+          # Spelled as qa resolves it, which is also what the vocabularies dashboard
+          # advertises.
+          'loc/genreForms' => {
+            url: "/authorities/search/loc/genreForms",
+            type: 'autocomplete'
+          },
+          # Kept for profiles written before the dashboard advertised the camelCase
+          # key. Both resolve, so an existing profile keeps working.
           'loc/genre_forms' => {
             url: "/authorities/search/loc/genreForms",
             type: 'autocomplete'

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -12,6 +12,8 @@ de:
         institution_name_full: Vollständiger Name der Institution
     errors:
       messages:
+        already_an_authority: wird bereits von einem anderen kontrollierten Vokabular verwendet
+        taken_as_source_key: '%{value} ist bereits der Quellschlüssel eines anderen kontrollierten Vokabulars'
         cannot_remove_last_superadmin: der letzte Superadministrator eines öffentlichen Demo-Mandanten kann nicht entfernt werden
   application:
     tagline: Die Next-Generation Repository-Lösung
@@ -401,7 +403,12 @@ de:
         active: Aktiv
         awaiting_import: Nicht importiert
         awaiting_import_help: 'Dieses Vokabular ist verfügbar, enthält in diesem Mandanten aber noch keine Begriffe. Befüllen Sie es durch Ausführen von: %{task}'
-        create: Vokabular erstellen
+        confirm_back: Zurück zum Bearbeiten
+        confirm_create: Bestätigen und erstellen
+        confirm_help: Prüfen Sie diese Werte, bevor das Vokabular erstellt wird.
+        confirm_permanent: Ein Vokabular kann nach dem Erstellen nicht gelöscht werden, und sein Quellschlüssel kann danach nicht geändert werden, sodass ein Metadatenprofil, das darauf verweist, weiterhin funktioniert.
+        confirm_title: Neues Vokabular bestätigen
+        create: Vokabular prüfen
         create_term: Begriff hinzufügen
         created: '%{name} wurde erstellt. Fügen Sie unten die Begriffe hinzu.'
         description: Beschreibung
@@ -416,6 +423,7 @@ de:
         new_term_help: Benennen Sie den Begriff so, wie Einreichende ihn sehen sollen. Die Begriffs-ID ist, was ein Datensatz speichert, und kann nicht mehr geändert werden, sobald Begriffe verwendet werden.
         new_term_title: Begriff hinzufügen
         new_title: Neues Vokabular
+        no_description: Keine angegeben
         no_terms: Dieses Vokabular enthält noch keine Begriffe.
         none: Für diesen Mandanten wurden noch keine kontrollierten Vokabulare eingerichtet.
         origin: Quelle
@@ -435,20 +443,15 @@ de:
           mesh: MeSH
           tgnlang: Getty TGN Languages
         read_only:
-          cached: Dieses Vokabular ist eine importierte Kopie eines externen Vokabulars. Seine Begriffe können hier nicht geändert werden, und ein erneuter Import ersetzt sie alle.
           file: Dieses Vokabular ist in einer Konfigurationsdatei definiert, daher können seine Begriffe hier nicht geändert werden.
-          generic: Die Begriffe dieses Vokabulars können hier nicht geändert werden.
-          remote: Dieses Vokabular stammt von einem externen Dienst, daher können seine Begriffe hier nicht geändert werden.
         ready: Bereit
         retired_count:
           one: (%{count} zurückgezogen)
           other: (%{count} zurückgezogen)
         show_title: 'Kontrolliertes Vokabular: %{name}'
         source_key: Quellschlüssel
-        source_key_from_name: Der Quellschlüssel wird aus dem obigen Namen gebildet.
         source_key_hint: Fügen Sie dies in ein Feld eines Metadatenprofils ein, um dieses Feld mit diesem Vokabular zu kontrollieren.
         source_key_help: Fügen Sie einen Quellschlüssel in ein Feld eines Metadatenprofils ein, um dieses Feld mit diesem Vokabular zu kontrollieren. In diesem Mandanten verwaltete Vokabulare können hier bearbeitet werden; in einer Konfigurationsdatei oder von einem externen Dienst definierte Vokabulare nicht.
-        source_key_will_be_html: Gespeichert wird mit dem Quellschlüssel %{key}.
         static_forms: Metadatenprofile sind nicht aktiviert, daher lesen Einreichungsformulare dieses Vokabular aus einer Konfigurationsdatei. Änderungen an seinen Begriffen erfordern einen Entwickler.
         status: Status
         status_hint: Ob dieses Vokabular einsatzbereit ist oder zuerst etwas eingerichtet werden muss.
@@ -466,6 +469,11 @@ de:
           one: 1 Begriff
           other: "%{count} Begriffe"
         terms: Begriffe
+        terms_elsewhere:
+          cached: Dieses Vokabular enthält eine importierte Kopie eines externen Vokabulars, die für eine Auflistung hier viel zu umfangreich ist. Seine Begriffe werden im Abgabeformular angeboten.
+          generic: Die Begriffe dieses Vokabulars werden hier nicht aufgeführt.
+          remote: Die Begriffe stammen vom externen Dienst, daher gibt es hier keine Liste anzuzeigen.
+        terms_unavailable: Die Begriffe dieses Vokabulars können nicht gelesen werden und werden daher hier nicht aufgeführt. Möglicherweise fehlt seine Konfigurationsdatei.
         unconfigured: Einrichtung erforderlich
         unconfigured_help: Dieser Dienst benötigt Anmeldeinformationen, bevor er verwendet werden kann. Bis dahin akzeptiert ein Feld, das ihn referenziert, Freitext, statt Vorschläge anzubieten.
         unused: Keine Metadaten-Eigenschaft verwendet dieses Vokabular.
@@ -474,7 +482,6 @@ de:
         used_by_hint: Die von diesem Vokabular kontrollierten Metadaten-Eigenschaften, wie sie in Bulkrax-Importen und Metadatenprofilen benannt sind.
         used_by_work_types: 'Verfügbar für:'
         work_types:
-          collection_resource: Sammlung
           etd_resource: ETD
           oer_resource: OER
       flash:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,7 +12,9 @@ en:
         institution_name_full: Full institution name
     errors:
       messages:
+        already_an_authority: is already in use by another controlled vocabulary
         cannot_remove_last_superadmin: cannot remove the last tenant superadmin from a public demo tenant
+        taken_as_source_key: '%{value} is already the source key of another controlled vocabulary'
   application:
     tagline: The next-generation repository solution
   blacklight:
@@ -273,7 +275,12 @@ en:
         active: Active
         awaiting_import: Not imported
         awaiting_import_help: 'This vocabulary is available but has no terms in this tenant yet. Populate it by running: %{task}'
-        create: Create vocabulary
+        confirm_back: Back to edit
+        confirm_create: Confirm and create
+        confirm_help: Check these values before the vocabulary is created.
+        confirm_permanent: A vocabulary cannot be deleted once created, and its source key cannot be changed afterwards, so a metadata profile citing it keeps working.
+        confirm_title: Confirm new vocabulary
+        create: Review vocabulary
         create_term: Add term
         created: '%{name} was created. Add its terms below.'
         description: Description
@@ -288,6 +295,7 @@ en:
         new_term_help: Name the term as a depositor should see it. The term id is what a record stores, and cannot be changed once terms are in use.
         new_term_title: Add term
         new_title: New vocabulary
+        no_description: None given
         no_terms: This vocabulary has no terms yet.
         none: No controlled vocabularies have been set up for this tenant yet.
         origin: Source
@@ -307,20 +315,15 @@ en:
           mesh: MeSH
           tgnlang: Getty TGN Languages
         read_only:
-          cached: This vocabulary is an imported copy of an external one. Its terms cannot be changed here, and re-importing replaces all of them.
           file: This vocabulary is defined in a configuration file, so its terms cannot be changed here.
-          generic: This vocabulary's terms cannot be changed here.
-          remote: This vocabulary comes from an external service, so its terms cannot be changed here.
         ready: Ready
         retired_count:
           one: (%{count} retired)
           other: (%{count} retired)
         show_title: 'Controlled Vocabulary: %{name}'
         source_key: Source key
-        source_key_from_name: The source key is set from the name above.
         source_key_help: Paste a source key into a metadata profile field to control that field with this vocabulary. Vocabularies managed in this tenant can be edited here; those defined in a configuration file or by an external service cannot.
         source_key_hint: Paste this into a metadata profile field to control that field with this vocabulary.
-        source_key_will_be_html: This will be saved with the source key %{key}.
         static_forms: Metadata profiles are not enabled, so deposit forms read this vocabulary from a configuration file. Changing its terms requires a developer.
         status: Status
         status_hint: Whether this vocabulary is ready to use, or needs something set up first.
@@ -338,6 +341,11 @@ en:
           one: 1 term
           other: "%{count} terms"
         terms: Terms
+        terms_elsewhere:
+          cached: This vocabulary holds an imported copy of an external one, far too large to list here. Its terms are offered on the deposit form.
+          generic: This vocabulary's terms are not listed here.
+          remote: Terms come from the external service, so there is no list to show here.
+        terms_unavailable: This vocabulary's terms cannot be read, so they are not listed here. Its configuration file may be missing.
         unconfigured: Needs setup
         unconfigured_help: This service needs credentials before it can be used. Until then a field citing it accepts free text instead of offering suggestions.
         unused: No metadata property uses this vocabulary.
@@ -346,7 +354,6 @@ en:
         used_by_hint: The metadata properties controlled by this vocabulary, as named in Bulkrax imports and metadata profiles.
         used_by_work_types: 'Available on:'
         work_types:
-          collection_resource: Collection
           etd_resource: ETD
           oer_resource: OER
       flash:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -12,6 +12,8 @@ es:
         institution_name_full: El nombre de la institución
     errors:
       messages:
+        already_an_authority: ya está en uso por otro vocabulario controlado
+        taken_as_source_key: '%{value} ya es la clave de origen de otro vocabulario controlado'
         cannot_remove_last_superadmin: no se puede eliminar el último superadministrador de un inquilino de demostración público
   application:
     tagline: La solución de repositorio de próxima generación
@@ -402,7 +404,12 @@ es:
         active: Activo
         awaiting_import: No importado
         awaiting_import_help: 'Este vocabulario está disponible pero aún no tiene términos en este inquilino. Puede completarlo ejecutando: %{task}'
-        create: Crear vocabulario
+        confirm_back: Volver a editar
+        confirm_create: Confirmar y crear
+        confirm_help: Compruebe estos valores antes de crear el vocabulario.
+        confirm_permanent: Un vocabulario no se puede eliminar una vez creado, y su clave de origen no se puede cambiar después, de modo que un perfil de metadatos que la cite seguirá funcionando.
+        confirm_title: Confirmar el nuevo vocabulario
+        create: Revisar vocabulario
         create_term: Agregar término
         created: '%{name} se creó. Agregue sus términos a continuación.'
         description: Descripción
@@ -417,6 +424,7 @@ es:
         new_term_help: Nombre el término tal como debe verlo un depositante. El id del término es lo que almacena un registro y no se puede cambiar una vez que los términos están en uso.
         new_term_title: Agregar término
         new_title: Nuevo vocabulario
+        no_description: No indicada
         no_terms: Este vocabulario aún no tiene términos.
         none: Aún no se ha configurado ningún vocabulario controlado para este inquilino.
         origin: Fuente
@@ -436,20 +444,15 @@ es:
           mesh: MeSH
           tgnlang: Getty TGN Languages
         read_only:
-          cached: Este vocabulario es una copia importada de uno externo. Sus términos no se pueden cambiar aquí, y volver a importarlo los reemplaza todos.
           file: Este vocabulario está definido en un archivo de configuración, por lo que sus términos no se pueden cambiar aquí.
-          generic: Los términos de este vocabulario no se pueden cambiar aquí.
-          remote: Este vocabulario proviene de un servicio externo, por lo que sus términos no se pueden cambiar aquí.
         ready: Listo
         retired_count:
           one: (%{count} retirado)
           other: (%{count} retirados)
         show_title: 'Vocabulario controlado: %{name}'
         source_key: Clave de fuente
-        source_key_from_name: La clave de origen se establece a partir del nombre anterior.
         source_key_hint: Pegue este valor en un campo del perfil de metadatos para controlar ese campo con este vocabulario.
         source_key_help: Pegue una clave de fuente en un campo del perfil de metadatos para controlar ese campo con este vocabulario. Los vocabularios gestionados en este inquilino se pueden editar aquí; los definidos en un archivo de configuración o por un servicio externo no.
-        source_key_will_be_html: Se guardará con la clave de origen %{key}.
         static_forms: Los perfiles de metadatos no están habilitados, por lo que los formularios de depósito leen este vocabulario desde un archivo de configuración. Cambiar sus términos requiere un desarrollador.
         status: Estado
         status_hint: Indica si este vocabulario está listo para usarse o necesita alguna configuración previa.
@@ -467,6 +470,11 @@ es:
           one: 1 término
           other: "%{count} términos"
         terms: Términos
+        terms_elsewhere:
+          cached: Este vocabulario contiene una copia importada de uno externo, demasiado extensa para enumerarla aquí. Sus términos se ofrecen en el formulario de depósito.
+          generic: Los términos de este vocabulario no se enumeran aquí.
+          remote: Los términos provienen del servicio externo, por lo que no hay ninguna lista que mostrar aquí.
+        terms_unavailable: Los términos de este vocabulario no se pueden leer, por lo que no se enumeran aquí. Puede faltar su archivo de configuración.
         unconfigured: Requiere configuración
         unconfigured_help: Este servicio necesita credenciales antes de poder usarse. Hasta entonces, un campo que lo cite acepta texto libre en lugar de ofrecer sugerencias.
         unused: Ninguna propiedad de metadatos usa este vocabulario.
@@ -475,7 +483,6 @@ es:
         used_by_hint: Las propiedades de metadatos controladas por este vocabulario, tal como se nombran en las importaciones de Bulkrax y en los perfiles de metadatos.
         used_by_work_types: 'Disponible en:'
         work_types:
-          collection_resource: Colección
           etd_resource: ETD
           oer_resource: OER
       flash:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -12,6 +12,8 @@ fr:
         institution_name_full: Nom complet de l'établissement
     errors:
       messages:
+        already_an_authority: est déjà utilisé par un autre vocabulaire contrôlé
+        taken_as_source_key: '%{value} est déjà la clé source d''un autre vocabulaire contrôlé'
         cannot_remove_last_superadmin: impossible de supprimer le dernier superadministrateur d'un locataire de démonstration public
   application:
     tagline: La solution de dépôt de nouvelle génération
@@ -402,7 +404,12 @@ fr:
         active: Actif
         awaiting_import: Non importé
         awaiting_import_help: 'Ce vocabulaire est disponible mais ne contient encore aucun terme dans ce locataire. Remplissez-le en exécutant : %{task}'
-        create: Créer le vocabulaire
+        confirm_back: Revenir à la modification
+        confirm_create: Confirmer et créer
+        confirm_help: Vérifiez ces valeurs avant la création du vocabulaire.
+        confirm_permanent: Un vocabulaire ne peut pas être supprimé une fois créé, et sa clé source ne peut pas être modifiée ensuite, de sorte qu'un profil de métadonnées qui la cite continue de fonctionner.
+        confirm_title: Confirmer le nouveau vocabulaire
+        create: Vérifier le vocabulaire
         create_term: Ajouter un terme
         created: '%{name} a été créé. Ajoutez ses termes ci-dessous.'
         description: Description
@@ -417,6 +424,7 @@ fr:
         new_term_help: Nommez le terme tel qu'un déposant doit le voir. L'identifiant du terme est ce qu'un enregistrement stocke et ne peut plus être modifié une fois les termes utilisés.
         new_term_title: Ajouter un terme
         new_title: Nouveau vocabulaire
+        no_description: Non renseignée
         no_terms: Ce vocabulaire ne contient encore aucun terme.
         none: Aucun vocabulaire contrôlé n'a encore été configuré pour ce locataire.
         origin: Source
@@ -436,20 +444,15 @@ fr:
           mesh: MeSH
           tgnlang: Getty TGN Languages
         read_only:
-          cached: Ce vocabulaire est une copie importée d'un vocabulaire externe. Ses termes ne peuvent pas être modifiés ici, et une réimportation les remplace tous.
           file: Ce vocabulaire est défini dans un fichier de configuration, ses termes ne peuvent donc pas être modifiés ici.
-          generic: Les termes de ce vocabulaire ne peuvent pas être modifiés ici.
-          remote: Ce vocabulaire provient d'un service externe, ses termes ne peuvent donc pas être modifiés ici.
         ready: Prêt
         retired_count:
           one: (%{count} retiré)
           other: (%{count} retirés)
         show_title: 'Vocabulaire contrôlé : %{name}'
         source_key: Clé de source
-        source_key_from_name: La clé source est établie à partir du nom ci-dessus.
         source_key_hint: Collez ceci dans un champ de profil de métadonnées pour contrôler ce champ avec ce vocabulaire.
         source_key_help: Collez une clé de source dans un champ de profil de métadonnées pour contrôler ce champ avec ce vocabulaire. Les vocabulaires gérés dans ce locataire peuvent être modifiés ici ; ceux définis dans un fichier de configuration ou par un service externe ne le peuvent pas.
-        source_key_will_be_html: Ce sera enregistré avec la clé source %{key}.
         static_forms: Les profils de métadonnées ne sont pas activés, les formulaires de dépôt lisent donc ce vocabulaire depuis un fichier de configuration. La modification de ses termes nécessite un développeur.
         status: Statut
         status_hint: Indique si ce vocabulaire est prêt à être utilisé ou si quelque chose doit d'abord être configuré.
@@ -467,6 +470,11 @@ fr:
           one: 1 terme
           other: "%{count} termes"
         terms: Termes
+        terms_elsewhere:
+          cached: Ce vocabulaire contient une copie importée d'un vocabulaire externe, bien trop volumineuse pour être répertoriée ici. Ses termes sont proposés dans le formulaire de dépôt.
+          generic: Les termes de ce vocabulaire ne sont pas répertoriés ici.
+          remote: Les termes proviennent du service externe ; il n'y a donc aucune liste à afficher ici.
+        terms_unavailable: Les termes de ce vocabulaire ne peuvent pas être lus et ne sont donc pas répertoriés ici. Son fichier de configuration est peut-être absent.
         unconfigured: Configuration requise
         unconfigured_help: Ce service a besoin d'identifiants avant de pouvoir être utilisé. D'ici là, un champ qui le référence accepte du texte libre au lieu de proposer des suggestions.
         unused: Aucune propriété de métadonnées n'utilise ce vocabulaire.
@@ -475,7 +483,6 @@ fr:
         used_by_hint: Les propriétés de métadonnées contrôlées par ce vocabulaire, telles que nommées dans les importations Bulkrax et les profils de métadonnées.
         used_by_work_types: 'Disponible sur :'
         work_types:
-          collection_resource: Collection
           etd_resource: ETD
           oer_resource: OER
       flash:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -12,6 +12,8 @@ it:
         institution_name_full: Nome dell'istituto completo
     errors:
       messages:
+        already_an_authority: è già utilizzato da un altro vocabolario controllato
+        taken_as_source_key: '%{value} è già la chiave di origine di un altro vocabolario controllato'
         cannot_remove_last_superadmin: impossibile rimuovere l'ultimo superadmin da un inquilino demo pubblico
   application:
     tagline: La soluzione di repository di nuova generazione
@@ -402,7 +404,12 @@ it:
         active: Attivo
         awaiting_import: Non importato
         awaiting_import_help: 'Questo vocabolario è disponibile ma non ha ancora termini in questo tenant. Popolalo eseguendo: %{task}'
-        create: Crea vocabolario
+        confirm_back: Torna alla modifica
+        confirm_create: Conferma e crea
+        confirm_help: Controlla questi valori prima che il vocabolario venga creato.
+        confirm_permanent: Un vocabolario non può essere eliminato dopo la creazione e la sua chiave di origine non può essere modificata in seguito, quindi un profilo di metadati che la cita continua a funzionare.
+        confirm_title: Conferma il nuovo vocabolario
+        create: Rivedi vocabolario
         create_term: Aggiungi termine
         created: '%{name} è stato creato. Aggiungi i suoi termini qui sotto.'
         description: Descrizione
@@ -417,6 +424,7 @@ it:
         new_term_help: Assegna al termine il nome che un depositante deve vedere. L'id del termine è ciò che un record memorizza e non può essere cambiato una volta che i termini sono in uso.
         new_term_title: Aggiungi termine
         new_title: Nuovo vocabolario
+        no_description: Non indicata
         no_terms: Questo vocabolario non ha ancora termini.
         none: Nessun vocabolario controllato è stato ancora configurato per questo tenant.
         origin: Origine
@@ -436,20 +444,15 @@ it:
           mesh: MeSH
           tgnlang: Getty TGN Languages
         read_only:
-          cached: Questo vocabolario è una copia importata di un vocabolario esterno. I suoi termini non possono essere modificati qui e una nuova importazione li sostituisce tutti.
           file: Questo vocabolario è definito in un file di configurazione, quindi i suoi termini non possono essere modificati qui.
-          generic: I termini di questo vocabolario non possono essere modificati qui.
-          remote: Questo vocabolario proviene da un servizio esterno, quindi i suoi termini non possono essere modificati qui.
         ready: Pronto
         retired_count:
           one: (%{count} ritirato)
           other: (%{count} ritirati)
         show_title: 'Vocabolario controllato: %{name}'
         source_key: Chiave di origine
-        source_key_from_name: La chiave di origine viene impostata dal nome sopra.
         source_key_hint: Incollala in un campo del profilo dei metadati per controllare quel campo con questo vocabolario.
         source_key_help: Incolla una chiave di origine in un campo del profilo dei metadati per controllare quel campo con questo vocabolario. I vocabolari gestiti in questo tenant possono essere modificati qui; quelli definiti in un file di configurazione o da un servizio esterno no.
-        source_key_will_be_html: Verrà salvato con la chiave di origine %{key}.
         static_forms: I profili dei metadati non sono abilitati, quindi i moduli di deposito leggono questo vocabolario da un file di configurazione. La modifica dei suoi termini richiede uno sviluppatore.
         status: Stato
         status_hint: Indica se questo vocabolario è pronto all'uso o se richiede prima una configurazione.
@@ -467,6 +470,11 @@ it:
           one: 1 termine
           other: "%{count} termini"
         terms: Termini
+        terms_elsewhere:
+          cached: Questo vocabolario contiene una copia importata di uno esterno, troppo estesa per essere elencata qui. I suoi termini vengono offerti nel modulo di deposito.
+          generic: I termini di questo vocabolario non sono elencati qui.
+          remote: I termini provengono dal servizio esterno, quindi non c'è alcun elenco da mostrare qui.
+        terms_unavailable: I termini di questo vocabolario non possono essere letti e quindi non sono elencati qui. Il suo file di configurazione potrebbe essere mancante.
         unconfigured: Richiede configurazione
         unconfigured_help: Questo servizio richiede credenziali prima di poter essere utilizzato. Fino ad allora un campo che lo utilizza accetta testo libero invece di offrire suggerimenti.
         unused: Nessuna proprietà dei metadati utilizza questo vocabolario.
@@ -475,7 +483,6 @@ it:
         used_by_hint: Le proprietà dei metadati controllate da questo vocabolario, come denominate nelle importazioni Bulkrax e nei profili dei metadati.
         used_by_work_types: 'Disponibile su:'
         work_types:
-          collection_resource: Collezione
           etd_resource: ETD
           oer_resource: OER
       flash:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -12,6 +12,8 @@ pt-BR:
         institution_name_full: Nome completo da instituição
     errors:
       messages:
+        already_an_authority: já está em uso por outro vocabulário controlado
+        taken_as_source_key: '%{value} já é a chave de origem de outro vocabulário controlado'
         cannot_remove_last_superadmin: não é possível remover o último superadministrador de um inquilino de demonstração público
   application:
     tagline: A solução de repos
@@ -284,7 +286,12 @@ pt-BR:
         active: Ativo
         awaiting_import: Não importado
         awaiting_import_help: 'Este vocabulário está disponível, mas ainda não tem termos neste locatário. Preencha-o executando: %{task}'
-        create: Criar vocabulário
+        confirm_back: Voltar para editar
+        confirm_create: Confirmar e criar
+        confirm_help: Verifique estes valores antes de o vocabulário ser criado.
+        confirm_permanent: Um vocabulário não pode ser excluído depois de criado, e sua chave de origem não pode ser alterada posteriormente, de modo que um perfil de metadados que a cite continua funcionando.
+        confirm_title: Confirmar novo vocabulário
+        create: Revisar vocabulário
         create_term: Adicionar termo
         created: '%{name} foi criado. Adicione seus termos abaixo.'
         description: Descrição
@@ -299,6 +306,7 @@ pt-BR:
         new_term_help: Nomeie o termo como um depositante deve vê-lo. O id do termo é o que um registro armazena e não pode ser alterado depois que os termos estão em uso.
         new_term_title: Adicionar termo
         new_title: Novo vocabulário
+        no_description: Não informada
         no_terms: Este vocabulário ainda não tem termos.
         none: Nenhum vocabulário controlado foi configurado para este locatário ainda.
         origin: Origem
@@ -318,20 +326,15 @@ pt-BR:
           mesh: MeSH
           tgnlang: Getty TGN Languages
         read_only:
-          cached: Este vocabulário é uma cópia importada de um vocabulário externo. Seus termos não podem ser alterados aqui, e reimportá-lo substitui todos eles.
           file: Este vocabulário é definido em um arquivo de configuração, portanto seus termos não podem ser alterados aqui.
-          generic: Os termos deste vocabulário não podem ser alterados aqui.
-          remote: Este vocabulário vem de um serviço externo, portanto seus termos não podem ser alterados aqui.
         ready: Pronto
         retired_count:
           one: (%{count} desativado)
           other: (%{count} desativados)
         show_title: 'Vocabulário controlado: %{name}'
         source_key: Chave de origem
-        source_key_from_name: A chave de origem é definida a partir do nome acima.
         source_key_hint: Cole isto em um campo do perfil de metadados para controlar esse campo com este vocabulário.
         source_key_help: Cole uma chave de origem em um campo do perfil de metadados para controlar esse campo com este vocabulário. Os vocabulários gerenciados neste locatário podem ser editados aqui; os definidos em um arquivo de configuração ou por um serviço externo não podem.
-        source_key_will_be_html: Será salvo com a chave de origem %{key}.
         static_forms: Os perfis de metadados não estão habilitados, então os formulários de depósito leem este vocabulário de um arquivo de configuração. Alterar seus termos requer um desenvolvedor.
         status: Status
         status_hint: Se este vocabulário está pronto para uso ou precisa de alguma configuração primeiro.
@@ -349,6 +352,11 @@ pt-BR:
           one: 1 termo
           other: "%{count} termos"
         terms: Termos
+        terms_elsewhere:
+          cached: Este vocabulário contém uma cópia importada de um vocabulário externo, grande demais para ser listada aqui. Seus termos são oferecidos no formulário de depósito.
+          generic: Os termos deste vocabulário não são listados aqui.
+          remote: Os termos vêm do serviço externo, portanto não há lista a exibir aqui.
+        terms_unavailable: Os termos deste vocabulário não podem ser lidos e, portanto, não são listados aqui. Seu arquivo de configuração pode estar ausente.
         unconfigured: Requer configuração
         unconfigured_help: Este serviço precisa de credenciais antes de poder ser usado. Até lá, um campo que o utiliza aceita texto livre em vez de oferecer sugestões.
         unused: Nenhuma propriedade de metadados usa este vocabulário.
@@ -357,7 +365,6 @@ pt-BR:
         used_by_hint: As propriedades de metadados controladas por este vocabulário, conforme nomeadas nas importações do Bulkrax e nos perfis de metadados.
         used_by_work_types: 'Disponível em:'
         work_types:
-          collection_resource: Coleção
           etd_resource: ETD
           oer_resource: OER
       flash:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -12,6 +12,8 @@ zh:
         institution_name_full: 完整的机构名称
     errors:
       messages:
+        already_an_authority: 已被另一个受控词表使用
+        taken_as_source_key: '%{value} 已是另一个受控词表的源键'
         cannot_remove_last_superadmin: 无法移除公开演示租户的最后一名 superadmin
   application:
     tagline: 下一代存储库解决方案
@@ -418,7 +420,12 @@ zh:
         active: 已启用
         awaiting_import: 未导入
         awaiting_import_help: '此词表可用，但在此租户中尚无词条。运行以下命令进行填充：%{task}'
-        create: 创建词表
+        confirm_back: 返回编辑
+        confirm_create: 确认并创建
+        confirm_help: 请在创建词表前检查这些值。
+        confirm_permanent: 词表创建后无法删除，其来源键此后也无法更改，因此引用该键的元数据配置文件将持续有效。
+        confirm_title: 确认新词表
+        create: 检查词表
         create_term: 添加词条
         created: '%{name} 已创建。请在下方添加其词条。'
         description: 描述
@@ -433,6 +440,7 @@ zh:
         new_term_help: 按存缴者应看到的形式为词条命名。词条 ID 是记录所存储的值，词条一旦使用便无法更改。
         new_term_title: 添加词条
         new_title: 新建词表
+        no_description: 未填写
         no_terms: 此词表尚无词条。
         none: 此租户尚未设置任何受控词表。
         origin: 来源
@@ -452,20 +460,15 @@ zh:
           mesh: MeSH
           tgnlang: Getty TGN Languages
         read_only:
-          cached: 此词表是外部词表的导入副本。其词条无法在此处修改，重新导入会替换全部词条。
           file: 此词表在配置文件中定义，因此其词条无法在此处修改。
-          generic: 此词表的词条无法在此处修改。
-          remote: 此词表来自外部服务，因此其词条无法在此处修改。
         ready: 就绪
         retired_count:
           one: （已停用 %{count} 个）
           other: （已停用 %{count} 个）
         show_title: '受控词表：%{name}'
         source_key: 来源键
-        source_key_from_name: 源键由上方名称生成。
         source_key_hint: 将其粘贴到元数据配置档的字段中，即可用此词表控制该字段。
         source_key_help: 将来源键粘贴到元数据配置档的字段中，即可用此词表控制该字段。在此租户中管理的词表可以在此处编辑；在配置文件中定义或来自外部服务的词表则不能。
-        source_key_will_be_html: 将以源键 %{key} 保存。
         static_forms: 未启用元数据配置档，因此存缴表单从配置文件读取此词表。修改其词条需要开发人员协助。
         status: 状态
         status_hint: 此词表是就绪可用，还是需要先完成某些设置。
@@ -483,6 +486,11 @@ zh:
           one: 1 个词条
           other: "%{count} 个词条"
         terms: 词条
+        terms_elsewhere:
+          cached: 此词表包含一份外部词表的导入副本，数量过多，无法在此处列出。其词条会在提交表单中提供。
+          generic: 此词表的词条未在此处列出。
+          remote: 词条来自外部服务，因此此处没有可显示的列表。
+        terms_unavailable: 无法读取此词表的词条，因此未在此处列出。其配置文件可能缺失。
         unconfigured: 需要设置
         unconfigured_help: 此服务需要先配置凭据才能使用。在此之前，引用它的字段将接受自由文本，而不提供建议。
         unused: 没有元数据属性使用此词表。
@@ -491,7 +499,6 @@ zh:
         used_by_hint: 由此词表控制的元数据属性，其名称与 Bulkrax 导入和元数据配置档中所用的一致。
         used_by_work_types: '可用于：'
         work_types:
-          collection_resource: 收藏集
           etd_resource: ETD
           oer_resource: OER
       flash:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -159,9 +159,20 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
 
   # Controlled vocabularies, viewable only from the dashboard
   scope :dashboard, module: 'hyrax/dashboard' do
-    resources :controlled_vocabularies, only: [:index, :show, :new, :create] do
+    resources :controlled_vocabularies, only: [:index, :new, :create] do
       resources :terms, only: [:new, :create], controller: 'controlled_vocabulary_terms'
     end
+    # Declared separately so a remote source key keeps its slash: profiles cite
+    # `loc/subjects`, and the default segment stops at one. Anchored to a single
+    # slash, and placed after the collection routes so `new` is not read as a key.
+    #
+    # The glob would otherwise swallow the download formats, so `.csv` and `.yml` are
+    # excluded from the key and declared as the format instead.
+    get 'controlled_vocabularies/*id',
+        to: 'controlled_vocabularies#show',
+        as: :controlled_vocabulary,
+        constraints: { id: %r{[^/.]+(?:/[^/.]+)?} },
+        format: /csv|yml|yaml|html/
   end
 
   # Guided deposit wizard

--- a/docs/controlled-vocabularies.md
+++ b/docs/controlled-vocabularies.md
@@ -36,10 +36,16 @@ properties:
 
 ## Local Controlled Vocabularies
 
-Local vocabularies are stored as YAML files in `config/authorities/` and provide dropdown select options.
+Local vocabularies provide dropdown select options. They come from YAML files shipped
+in `config/authorities/` and from per-tenant database rows that administrators manage in
+the dashboard. See [Managing Local Vocabularies](#managing-local-vocabularies).
 
 ### Available Local Vocabularies
 
+Shipped with the application:
+
+- `accessibility_features` - Accommodations a work provides, such as alternative text or captions
+- `accessibility_hazards` - Characteristics that may pose a risk to some readers, such as flashing
 - `audience` - Target audiences for educational resources
 - `discipline` - Academic disciplines and subject areas
 - `education_levels` - Educational levels (K-12, undergraduate, etc.)
@@ -48,6 +54,8 @@ Local vocabularies are stored as YAML files in `config/authorities/` and provide
 - `licenses` - Creative Commons and other license options for the work
 - `resource_types` - Types of resources, such as "Article" or "Image"
 - `rights_statements` - Rights statements indicating the copyright status of the work
+
+A tenant can add more, which are listed alongside these in the dashboard.
 
 ### Usage in Profile YAML
 
@@ -79,7 +87,8 @@ Remote vocabularies query external services through the Questioning Authority ge
 
 - `loc/subjects` - Library of Congress Subject Headings
 - `loc/names` - Library of Congress Name Authority File
-- `loc/genre_forms` - Library of Congress Genre/Form Terms
+- `loc/genreForms` - Library of Congress Genre/Form Terms
+  - Also configured as `loc/genre_forms` to support older profiles
 - `loc/countries` - Library of Congress Countries
 - `loc/iso639-1` - Library of Congress major/common languages
 - `loc/iso639-2` - Library of Congress bibliographic standard for languages
@@ -419,9 +428,92 @@ properties:
 
 ## Managing Local Vocabularies
 
-### Current Method
+Local vocabularies come from two places, and both work:
 
-Local authority files are managed by editing the YAML files directly in `config/authorities/`. After making changes, restart the application for changes to take effect.
+- **YAML files** in `config/authorities/`, shipped with the application and shared by
+  every tenant. They need no migration to keep working.
+- **Database rows**, held per tenant and editable in the dashboard. A new tenant is
+  seeded from the YAML files when it is created; an existing tenant can be migrated
+  with a rake task. See [Seeding Vocabularies from YAML](#seeding-vocabularies-from-yaml).
+
+A vocabulary is cited in a metadata profile by its bare source key either way, so a
+profile does not record which kind is behind it. Where a tenant has both, the database
+row is used.
+
+### The Vocabularies Dashboard
+
+`/dashboard/controlled_vocabularies` lists every authority a metadata profile can
+cite, whatever backs it, so the source key to paste into a profile can be read off the
+page. Administrators can manage vocabularies; users who can import works can view
+them.
+
+Each vocabulary has a page reporting which properties cite it and the work types those
+properties appear on. Terms are listed where they can be: a tenant-owned vocabulary
+and a YAML file both show theirs, while a remote service holds its terms externally
+and an imported copy holds too many to page through.
+
+The listing marks each authority with its origin:
+
+| Origin | Backed by | Editable |
+|---|---|---|
+| This tenant | A database row | Yes |
+| Imported copy | A database row replaced wholesale by an import task, such as MeSH | No |
+| Configuration file | `config/authorities/*.yml` | No |
+| External service | A remote authority such as LOC or Getty | No |
+
+### Creating a Vocabulary
+
+Administrators can create a vocabulary from the dashboard. The name is typed; the
+source key is derived from it (`Lab Names` becomes `lab_names`, and accented
+characters are transliterated), and the derived key is shown for confirmation before
+anything is written — a vocabulary cannot be deleted and its source key is fixed at
+creation, because profiles cite it and works store the terms found through it.
+
+A name that collides with a remote service key, or with a vocabulary registered to an
+import task, is refused. Taking the name of a YAML vocabulary is allowed on purpose:
+the new row is used in place of the file, which is how a tenant takes ownership of a
+shipped list.
+
+### Adding Terms
+
+Terms can be added to a vocabulary this tenant owns. A term has a label and an
+optional term ID; leaving the ID blank sets it to the label. The ID is what works
+store, so it cannot be changed once the term exists — the label can.
+
+A new term is assigned a sequence number placing it after the terms already in the
+vocabulary. Terms that predate this have no sequence number, and sort after the ones
+that do until they are assigned theirs.
+
+### Seeding Vocabularies from YAML
+
+Loading the YAML files into a tenant's database is what makes those vocabularies
+editable in the dashboard. A tenant that has not been seeded keeps reading the files,
+so this is a migration to run when convenient rather than a prerequisite.
+
+New tenants are seeded automatically as part of account creation. For tenants that
+already exist:
+
+```bash
+bundle exec rake populate_qa
+```
+
+It runs for every tenant except search-only ones, reporting each vocabulary and its
+term count. `AUTHORITIES_PATH` overrides which directories are read; passing more than
+one lets a knapsack's copy of a vocabulary take precedence over Hyku's, with the
+earlier path winning.
+
+The task is safe to run more than once. Terms are matched on their term ID, so
+existing ones are not duplicated, and a label or description edited in the dashboard is
+kept — only blank fields are filled from the file. A vocabulary is named after its
+file, so a file whose name is not a usable source key aborts the task before any tenant
+is touched, rather than part way through.
+
+Because terms are matched rather than replaced, a term deleted from a YAML file stays
+in the database of a tenant already seeded from it.
+
+Terms are keyed on their ID, so a file listing the same ID twice — `licenses.yml` does,
+for two Creative Commons URIs — yields one row rather than two. A term's `active` flag
+carries over, and an inactive term is kept rather than skipped.
 
 ### File Structure
 
@@ -434,17 +526,47 @@ terms:
     term: "Biology"
 ```
 
-### Future Enhancement
+A file may also carry a `label` and `description`, used for the vocabulary's name and
+description when it is seeded.
 
-A UI for managing local vocabularies through the admin dashboard is planned to make vocabulary management more user-friendly for repository administrators.
+Editing a YAML file requires an application restart before the change takes effect, and
+affects only tenants that have not been seeded. Vocabularies in the dashboard take
+effect immediately and are per-tenant.
 
 ## Adding New Vocabularies
 
 ### Adding Local Vocabularies
 
+Either create one through the dashboard, which needs no deployment, or ship a YAML
+file:
+
 1. Create a YAML file in `config/authorities/` following the existing pattern
 2. Reference the file name (without .yml extension) in your metadata profile's `sources` array
 3. Restart the application
+
+A YAML vocabulary is deployment-wide; a dashboard-created one belongs to the tenant it
+was created in.
+
+### Registering a Service Class
+
+Registering a service class in the `services` method of
+`config/initializers/hyrax_controlled_vocabularies.rb` is **optional**. A vocabulary
+with no entry there still renders as a dropdown and still turns a stored value back
+into a label — the fallback reads the vocabulary directly and offers the same options.
+
+Register one when a vocabulary needs behavior beyond listing its terms, which is
+usually presentation of the stored value. `Hyrax::LicenseService`, for example, holds
+the logic for rendering a license URI as its name and link.
+
+A registered service is asked before the database and the YAML file, but none of the
+shipped services carry their own term list: each reads the vocabulary's database rows
+when the tenant has them and falls back to the YAML file when it does not. So editing
+terms in the dashboard changes what a depositor sees even for a vocabulary that has a
+service class, and a tenant that has never been seeded still gets its terms from the
+file. What the service adds is the handling around the terms, not the terms.
+
+Vocabularies created through the dashboard have no service class, which is the ordinary
+case.
 
 ### Adding Remote Vocabularies
 
@@ -460,5 +582,17 @@ The flexible metadata system processes controlled vocabularies as follows:
 2. **Form Rendering**: The form metadata partial checks each property's configuration
 3. **Dynamic Rendering**: Properties with `sources` other than `["null"]` are rendered as controlled vocabulary fields
 4. **Authority URLs**: Remote authorities automatically get the correct autocomplete URL pattern
+
+A source key resolves in a fixed order, and the first match wins:
+
+1. A registered service class
+2. A database row belonging to this tenant
+3. A YAML file in `config/authorities/`
+4. A remote authority
+
+So when a tenant has a database row and a YAML file of the same name, the row is used
+and the file is not. This is also why a vocabulary cannot be created under a remote
+service's key: the row would be found first and would answer for that field in place
+of the service.
 
 This system automatically handles both single and multi-value fields for both local and remote vocabularies, providing a seamless experience for repository administrators and depositors.

--- a/docs/controlled-vocabularies.md
+++ b/docs/controlled-vocabularies.md
@@ -502,18 +502,20 @@ term count. `AUTHORITIES_PATH` overrides which directories are read; passing mor
 one lets a knapsack's copy of a vocabulary take precedence over Hyku's, with the
 earlier path winning.
 
-The task is safe to run more than once. Terms are matched on their term ID, so
-existing ones are not duplicated, and a label or description edited in the dashboard is
-kept — only blank fields are filled from the file. A vocabulary is named after its
+The task is safe to run more than once, and only ever adds: a vocabulary the tenant
+already has is left untouched, terms included. Once a vocabulary is in the database it
+belongs to the tenant, so a term deleted in the dashboard stays deleted, an edited label
+keeps its wording, and terms added to the YAML file afterwards are not backfilled —
+use the dashboard import to add terms to a vocabulary that already exists.
+
+Running it again therefore picks up only vocabularies the tenant does not have yet,
+which is what makes it safe to run after adding a file. A vocabulary is named after its
 file, so a file whose name is not a usable source key aborts the task before any tenant
 is touched, rather than part way through.
 
-Because terms are matched rather than replaced, a term deleted from a YAML file stays
-in the database of a tenant already seeded from it.
-
-Terms are keyed on their ID, so a file listing the same ID twice — `licenses.yml` does,
-for two Creative Commons URIs — yields one row rather than two. A term's `active` flag
-carries over, and an inactive term is kept rather than skipped.
+On first seeding, terms are keyed on their ID, so a file listing the same ID twice —
+`licenses.yml` does, for two Creative Commons URIs — yields one row rather than two. A
+term's `active` flag carries over, and an inactive term is kept rather than skipped.
 
 ### File Structure
 

--- a/lib/tasks/populate_qa_tables.rake
+++ b/lib/tasks/populate_qa_tables.rake
@@ -17,8 +17,8 @@ task populate_qa: :environment do
 
     puts "=============== #{account.name} ==============="
     Apartment::Tenant.switch(account.tenant) do
-      LocalVocabularyService.seed!(paths).each do |name, count|
-        puts "✓ #{name} (#{count} terms)"
+      LocalVocabularyService.seed!(paths).each do |name, count, seeded|
+        puts seeded ? "✓ #{name} (#{count} terms)" : "· #{name} (already imported, #{count} terms)"
       end
     end
   end

--- a/spec/helpers/hyrax/form_helper_behavior_spec.rb
+++ b/spec/helpers/hyrax/form_helper_behavior_spec.rb
@@ -44,7 +44,29 @@ RSpec.describe Hyrax::FormHelperBehavior, type: :helper do
       end
     end
 
-    it 'returns nil for a source that is neither registered nor in the database' do
+    # A deployment can drop a yaml file into config/authorities and cite it in the
+    # profile without registering a service class for it. The field still has to
+    # render as a dropdown, and a stored value still has to label.
+    #
+    # Every yaml authority Hyku ships is registered, so the case is set up by
+    # withholding the registry entry for one that exists on disk rather than by
+    # naming a file that does not: Qa raises InvalidSubAuthority for a name its own
+    # registry does not know, whatever this helper believes about it.
+    context 'with a yaml vocabulary that has no registered service' do
+      before do
+        allow(Hyrax::ControlledVocabularies).to receive(:services)
+          .and_return(Hyrax::ControlledVocabularies.services.except('licenses'))
+      end
+
+      it 'returns a tolerant service bound to that vocabulary' do
+        service = helper.controlled_vocabulary_service_for('licenses')
+
+        expect(service).to be_a Hyrax::TolerantSelectService
+        expect(service.select_all_options).to be_present
+      end
+    end
+
+    it 'returns nil for a source no vocabulary of any kind backs' do
       expect(helper.controlled_vocabulary_service_for('nothing_here')).to be_nil
     end
   end

--- a/spec/models/qa/local_authority_entry_spec.rb
+++ b/spec/models/qa/local_authority_entry_spec.rb
@@ -135,6 +135,42 @@ RSpec.describe Qa::LocalAuthorityEntry, type: :model do
     end
   end
 
+  describe 'position' do
+    it 'numbers a new term after the ones already there' do
+      first = described_class.create!(local_authority: authority, label: 'Botany', uri: 'bot')
+      second = described_class.create!(local_authority: authority, label: 'Alchemy', uri: 'alc')
+
+      expect([first.position, second.position]).to eq [1, 2]
+    end
+
+    it 'keeps a position given to it' do
+      entry = described_class.create!(local_authority: authority, label: 'Zoology', uri: 'zoo', position: 7)
+
+      expect(entry.position).to eq 7
+    end
+
+    # Numbered per vocabulary, so one tenant's terms do not push another's along.
+    it 'numbers each vocabulary from the start' do
+      other = Qa::LocalAuthority.create!(name: 'other_rooms', label: 'Other Rooms')
+      described_class.create!(local_authority: authority, label: 'Botany', uri: 'bot')
+
+      entry = described_class.create!(local_authority: other, label: 'Botany', uri: 'bot')
+
+      expect(entry.position).to eq 1
+    end
+
+    # Rows predating the assignment hold NULL, which Postgres sorts last, so the
+    # next term has to clear them rather than reuse a low number.
+    it 'numbers a new term after rows that have no position' do
+      described_class.create!(local_authority: authority, label: 'Alpha', uri: 'a').update_column(:position, nil) # rubocop:disable Rails/SkipsModelValidations
+      described_class.create!(local_authority: authority, label: 'Beta', uri: 'b').update_column(:position, nil) # rubocop:disable Rails/SkipsModelValidations
+
+      entry = described_class.create!(local_authority: authority, label: 'Gamma', uri: 'g')
+
+      expect(entry.position).to eq 3
+    end
+  end
+
   describe 'scopes' do
     let!(:live) { described_class.create!(local_authority: authority, label: 'Botany', uri: 'bot') }
     let!(:retired) { described_class.create!(local_authority: authority, label: 'Alchemy', uri: 'alc', active: false) }
@@ -145,8 +181,10 @@ RSpec.describe Qa::LocalAuthorityEntry, type: :model do
       expect(authority.local_authority_entries.inactive).to contain_exactly(retired)
     end
 
-    it 'orders pinned terms first, then unpinned terms by label' do
-      expect(authority.local_authority_entries.ordered.to_a).to eq [pinned, retired, live]
+    # live and retired are numbered on create, so the explicit position: 1 ties with
+    # live's and the label breaks it.
+    it 'orders by position, then by label' do
+      expect(authority.local_authority_entries.ordered.to_a).to eq [live, pinned, retired]
     end
   end
 end

--- a/spec/models/qa/local_authority_spec.rb
+++ b/spec/models/qa/local_authority_spec.rb
@@ -33,6 +33,55 @@ RSpec.describe Qa::LocalAuthority, type: :model do
       expect(described_class.new(name: 'lab_names')).not_to be_valid
     end
 
+    context 'against the authorities that already exist' do
+      it 'rejects a remote service key' do
+        authority = described_class.new(name: 'geonames', staff_created: true)
+
+        expect(authority).not_to be_valid
+        expect(authority.errors[:name].join).to include('already in use')
+      end
+
+      it 'rejects a name registered to an imported copy' do
+        expect(described_class.new(name: 'mesh', staff_created: true)).not_to be_valid
+      end
+
+      # A profile can cite `getty/aat`, but the format rule rejects a slash before the
+      # collision check is reached, so the reserved list holds service keys only.
+      it 'rejects a qualified key on its format' do
+        authority = described_class.new(name: 'getty/aat', staff_created: true)
+
+        expect(authority).not_to be_valid
+        expect(authority.errors[:name].join).to include('lowercase letters')
+      end
+
+      # Only the whole key collides. A vocabulary about places does not conflict with
+      # geonames merely because the word appears in its name.
+      it 'allows a name that only resembles a remote key' do
+        expect(described_class.new(name: 'geonames_local', staff_created: true)).to be_valid
+      end
+
+      it 'does not reserve a yaml vocabulary name, which is the override path' do
+        expect(described_class.new(name: 'map_regions', staff_created: true)).to be_valid
+      end
+
+      # The mesh import task creates this row itself, and reserving the name must not
+      # stop it.
+      it 'leaves a row not created by staff alone' do
+        expect(described_class.new(name: 'mesh')).to be_valid
+      end
+
+      # One authority that cannot be resolved must not empty the reserved list: a row
+      # named `mesh` would then be created and hijack the field wherever a profile
+      # cites it.
+      it 'still reserves the names it can resolve when one authority fails' do
+        allow(Qa::Authorities::Local).to receive(:subauthority_for).and_call_original
+        allow(Qa::Authorities::Local).to receive(:subauthority_for)
+          .with('resource_types').and_raise(Qa::InvalidSubAuthority, 'boom')
+
+        expect(described_class.new(name: 'mesh', staff_created: true)).not_to be_valid
+      end
+    end
+
     it 'lets a row with a legacy name be relabeled' do
       authority = described_class.create!(name: 'legacy')
       authority.update_columns(name: 'Legacy Name') # rubocop:disable Rails/SkipsModelValidations

--- a/spec/presenters/hyku/deposit_wizard/presenter_spec.rb
+++ b/spec/presenters/hyku/deposit_wizard/presenter_spec.rb
@@ -206,6 +206,55 @@ RSpec.describe Hyku::DepositWizard::Presenter do
     end
   end
 
+  # The review step labels stored values through the same resolution the deposit form
+  # renders them with, so the two cannot disagree about what a property is controlled
+  # by. The helper owns that decision.
+  describe '#controlled_service_for' do
+    let(:helpers) { double }
+    let(:context) do
+      double(session: session, current_user: nil, current_ability: nil, params: params,
+             main_app: nil, blacklight_config: nil, helpers: helpers)
+    end
+
+    it 'asks the helper to resolve the property' do
+      service = Hyrax::TolerantSelectService.new('licenses')
+      allow(helpers).to receive(:controlled_vocabulary_source_for).with('license').and_return('licenses')
+      allow(helpers).to receive(:controlled_vocabulary_service_for).with('licenses').and_return(service)
+
+      expect(presenter.controlled_service_for('license')).to be service
+    end
+
+    it 'instantiates a service the helper returns as a class' do
+      allow(helpers).to receive(:controlled_vocabulary_source_for).with('license').and_return('licenses')
+      allow(helpers).to receive(:controlled_vocabulary_service_for)
+        .with('licenses').and_return(Hyrax::LicenseService)
+
+      expect(presenter.controlled_service_for('license')).to be_a Hyrax::LicenseService
+    end
+
+    it 'is nil for a property the profile does not control' do
+      allow(helpers).to receive(:controlled_vocabulary_source_for).with('title').and_return(nil)
+
+      expect(presenter.controlled_service_for('title')).to be_nil
+    end
+
+    it 'is nil when the helper cannot resolve the source' do
+      allow(helpers).to receive(:controlled_vocabulary_source_for).with('license').and_return('licenses')
+      allow(helpers).to receive(:controlled_vocabulary_service_for).with('licenses').and_return(nil)
+
+      expect(presenter.controlled_service_for('license')).to be_nil
+    end
+
+    it 'resolves a property once per request' do
+      allow(helpers).to receive(:controlled_vocabulary_source_for).with('license').and_return('licenses')
+      allow(helpers).to receive(:controlled_vocabulary_service_for).with('licenses').and_return(nil)
+
+      2.times { presenter.controlled_service_for('license') }
+
+      expect(helpers).to have_received(:controlled_vocabulary_source_for).once
+    end
+  end
+
   describe '#file_type_label' do
     it 'returns the uppercase extension' do
       uf = double(file: double(file: double(filename: 'thesis.PDF')))
@@ -227,9 +276,14 @@ RSpec.describe Hyku::DepositWizard::Presenter do
       double(session: session, current_user: nil, current_ability: nil,
              params: params, main_app: nil, blacklight_config: nil, helpers: helpers)
     end
-    let(:helpers) { double }
-
-    before { allow(helpers).to receive(:controlled_vocabulary_source_for).with(:a_term).and_return(source) }
+    # The real helper for resolution, so these assert what the deposit form itself
+    # would build rather than a stubbed stand-in. Only the profile lookup is stubbed,
+    # since there is no profile in this example group.
+    let(:helpers) do
+      Class.new { include Hyrax::FormHelperBehavior }.new.tap do |helper|
+        allow(helper).to receive(:controlled_vocabulary_source_for).with(:a_term).and_return(source)
+      end
+    end
 
     # Asserted on the resolved service rather than through the returned labels:
     # every module-backed vocabulary Hyrax ships labels its ids with themselves

--- a/spec/requests/controlled_vocabularies_spec.rb
+++ b/spec/requests/controlled_vocabularies_spec.rb
@@ -42,6 +42,15 @@ RSpec.describe 'Controlled vocabularies', type: :request, clean: true, multitena
         expect(response.body).to include 'reading_rooms'
       end
 
+      # Hyrax sets `.table-responsive { overflow-x: visible }` app-wide, cancelling
+      # Bootstrap's scroll for every table. Without the extra class the listing is
+      # cut off at the container edge on a narrow screen rather than scrolling.
+      it 'keeps the listing scrollable on a narrow screen' do
+        get "http://#{account.cname}/dashboard/controlled_vocabularies"
+
+        expect(response.body).to include 'controlled-vocabularies-scroll'
+      end
+
       # Only vocabularies managed here have one, so it sits under the name rather
       # than in a column that would be empty for most rows.
       it 'shows the description of a vocabulary that has one' do
@@ -237,6 +246,49 @@ RSpec.describe 'Controlled vocabularies', type: :request, clean: true, multitena
       end
     end
 
+    # Every authority has a page, because it reports where the vocabulary is used.
+    # A remote service cannot be enumerated, so the page says where its terms live
+    # rather than showing an empty list that reads as "none".
+    describe 'a remote authority' do
+      it 'opens, and explains that its terms are not listed' do
+        get "http://#{account.cname}/dashboard/controlled_vocabularies/loc/subjects"
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include 'loc/subjects'
+        # Fragments rather than the whole translations: they carry apostrophes, which
+        # the body escapes to &#39;, so a literal match would pass vacuously.
+        expect(response.body).not_to include 'has no terms yet'
+        expect(response.body).to include 'no list to show here'
+      end
+    end
+
+    # A remote source key carries a slash, which the default :id segment stops at.
+    # The url helper escapes it to %2F, so a wrong route yields a link that renders
+    # and then 404s rather than failing loudly.
+    it 'routes a source key containing a slash' do
+      get "http://#{account.cname}/dashboard/controlled_vocabularies/loc/iso639-1"
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include 'loc/iso639-1'
+    end
+
+    describe 'a vocabulary whose terms cannot be read' do
+      before do
+        allow(ControlledVocabularyCatalog).to receive(:file_based_names).and_return(%w[map_regions])
+        allow(ControlledVocabularyCatalog).to receive(:terms_for).and_return(nil)
+      end
+
+      # nil is "cannot say", not "none": reporting it empty sends staff looking for
+      # terms they never added.
+      it 'says so instead of claiming it has no terms' do
+        get "http://#{account.cname}/dashboard/controlled_vocabularies/map_regions"
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).to include 'terms cannot be read'
+        expect(response.body).not_to include 'has no terms yet'
+      end
+    end
+
     it 'returns not found for a vocabulary that does not exist' do
       get "http://#{account.cname}/dashboard/controlled_vocabularies/not_a_vocabulary"
 
@@ -250,9 +302,98 @@ RSpec.describe 'Controlled vocabularies', type: :request, clean: true, multitena
         expect(response).to have_http_status(:success)
       end
 
+      # A vocabulary cannot be deleted and its source key is fixed at creation, so
+      # the values are shown for review before anything is written. The key is
+      # derived server-side here, so what the page shows is what gets saved.
+      describe 'the confirmation step' do
+        it 'shows what will be saved instead of creating straight away' do
+          post "http://#{account.cname}/dashboard/controlled_vocabularies",
+               params: { param_key => { label: 'Lab Names', description: 'Where the work was done.' } }
+
+          created = Apartment::Tenant.switch(account.tenant) { Qa::LocalAuthority.exists?(name: 'lab_names') }
+
+          expect(response).to have_http_status(:success)
+          expect(created).to be false
+          expect(response.body).to include 'Lab Names'
+          expect(response.body).to include 'lab_names'
+          expect(response.body).to include 'Where the work was done.'
+        end
+
+        # parameterize transliterates, so an accented label does not yield the key a
+        # reader would guess. This is the case the review step earns its keep on.
+        it 'shows the transliterated key for an accented name' do
+          post "http://#{account.cname}/dashboard/controlled_vocabularies",
+               params: { param_key => { label: 'Café Terms' } }
+
+          expect(response.body).to include 'cafe_terms'
+        end
+
+        it 'offers a way back to the form without saving' do
+          post "http://#{account.cname}/dashboard/controlled_vocabularies",
+               params: { param_key => { label: 'Lab Names' } }
+
+          expect(response.body).to include '/dashboard/controlled_vocabularies/new'
+        end
+
+        it 'carries the values back without the csrf token' do
+          post "http://#{account.cname}/dashboard/controlled_vocabularies",
+               params: { param_key => { label: 'Lab Names' } }
+
+          # The link that carries the values, not the breadcrumb to a blank form.
+          back = response.body.scan(%r{href="([^"]*controlled_vocabularies/new\?[^"]*)"})
+                              .flatten.find { |href| href.include?('local_authority') }
+
+          expect(back).to include 'Lab+Names'
+          expect(back).not_to include 'authenticity_token'
+        end
+
+        # The way back carries the values with it, so spotting a typo on review does
+        # not mean retyping the name and description.
+        it 'returns to the form with what was entered still filled in' do
+          get "http://#{account.cname}/dashboard/controlled_vocabularies/new",
+              params: { param_key => { label: 'Lab Names', description: 'Where the work was done.' } }
+
+          expect(response.body).to include 'Lab Names'
+          expect(response.body).to include 'Where the work was done.'
+        end
+
+        # The row cannot be deleted once written, so anything short of an actual
+        # confirmation has to land on the review step rather than saving.
+        it 'reviews rather than saves when the confirmation is empty' do
+          post "http://#{account.cname}/dashboard/controlled_vocabularies",
+               params: { param_key => { label: 'Lab Names' }, confirmed: '' }
+
+          created = Apartment::Tenant.switch(account.tenant) { Qa::LocalAuthority.exists?(name: 'lab_names') }
+
+          expect(created).to be false
+          expect(response).to have_http_status(:success)
+        end
+
+        it 'reviews rather than saves when the confirmation says false' do
+          post "http://#{account.cname}/dashboard/controlled_vocabularies",
+               params: { param_key => { label: 'Lab Names' }, confirmed: 'false' }
+
+          created = Apartment::Tenant.switch(account.tenant) { Qa::LocalAuthority.exists?(name: 'lab_names') }
+
+          expect(created).to be false
+          expect(response).to have_http_status(:success)
+        end
+
+        # Validation runs before the review, so a name that cannot be saved is
+        # reported at once rather than after a confirmation that would fail.
+        it 'redisplays the form rather than confirming an invalid vocabulary' do
+          post "http://#{account.cname}/dashboard/controlled_vocabularies",
+               params: { param_key => { label: 'geonames' } }
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response.body).to include 'already in use'
+        end
+      end
+
       it 'creates the vocabulary and opens it so terms can be added' do
         post "http://#{account.cname}/dashboard/controlled_vocabularies",
-             params: { param_key => { label: 'Lab Names', description: 'Where the work was done.' } }
+             params: { param_key => { label: 'Lab Names', description: 'Where the work was done.' },
+                       confirmed: 'true' }
 
         vocabulary = Apartment::Tenant.switch(account.tenant) { Qa::LocalAuthority.find_by(name: 'lab_names') }
 
@@ -262,9 +403,22 @@ RSpec.describe 'Controlled vocabularies', type: :request, clean: true, multitena
         expect(response.location).to include '/dashboard/controlled_vocabularies/lab_names'
       end
 
+      # The review page invites a re-submit, so two confirmations of the same name can
+      # race past the validation and collide on the unique index.
+      it 'reports a name taken between validation and save' do
+        allow_any_instance_of(Qa::LocalAuthority).to receive(:save) # rubocop:disable RSpec/AnyInstance
+          .and_raise(ActiveRecord::RecordNotUnique, 'duplicate key value violates unique constraint')
+
+        post "http://#{account.cname}/dashboard/controlled_vocabularies",
+             params: { param_key => { label: 'Lab Names' }, confirmed: 'true' }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.body).to include 'lab_names'
+      end
+
       it 'ignores a name supplied in the request' do
         post "http://#{account.cname}/dashboard/controlled_vocabularies",
-             params: { param_key => { label: 'Lab Names', name: 'something_else' } }
+             params: { param_key => { label: 'Lab Names', name: 'something_else' }, confirmed: 'true' }
 
         names = Apartment::Tenant.switch(account.tenant) { Qa::LocalAuthority.pluck(:name) }
 
@@ -287,17 +441,84 @@ RSpec.describe 'Controlled vocabularies', type: :request, clean: true, multitena
         expect(response.body).to include '/dashboard/controlled_vocabularies/new'
       end
 
-      # An accented label is the case a client-side preview would get wrong:
-      # parameterize transliterates, so the key is cafe_terms, not caf_terms.
-      it 'shows the source key it will use when redisplaying' do
-        post "http://#{account.cname}/dashboard/controlled_vocabularies",
-             params: { param_key => { label: 'Café Terms' } }
-        # Duplicate the label so the form comes back rather than saving.
+      it 'refuses a duplicate, naming the key already taken' do
+        Apartment::Tenant.switch(account.tenant) { Qa::LocalAuthority.create!(label: 'Café Terms') }
+
         post "http://#{account.cname}/dashboard/controlled_vocabularies",
              params: { param_key => { label: 'Café Terms' } }
 
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.body).to include 'cafe_terms'
+      end
+    end
+
+    describe 'adding a term' do
+      let(:term_key) { Qa::LocalAuthorityEntry.model_name.param_key }
+
+      it 'saves the term and returns to the vocabulary' do
+        Apartment::Tenant.switch(account.tenant) { Qa::LocalAuthority.create!(label: 'Lab Names') }
+
+        post "http://#{account.cname}/dashboard/controlled_vocabularies/lab_names/terms",
+             params: { term_key => { label: 'Wet Lab' } }
+
+        term = Apartment::Tenant.switch(account.tenant) { Qa::LocalAuthorityEntry.find_by(label: 'Wet Lab') }
+
+        expect(term).to be_present
+        expect(response.location).to include '/dashboard/controlled_vocabularies/lab_names'
+      end
+
+      # `ordered` sorts on position, and Postgres puts NULL last — so a term saved
+      # without one sorts below every seeded term, and falls off the page entirely in
+      # a vocabulary longer than the display limit.
+      it 'adds the term after the ones already there' do
+        Apartment::Tenant.switch(account.tenant) do
+          vocabulary = Qa::LocalAuthority.create!(label: 'Lab Names')
+          vocabulary.local_authority_entries.create!(label: 'Wet Lab', uri: 'wet', position: 1)
+        end
+
+        post "http://#{account.cname}/dashboard/controlled_vocabularies/lab_names/terms",
+             params: { term_key => { label: 'Dry Lab' } }
+
+        labels = Apartment::Tenant.switch(account.tenant) do
+          Qa::LocalAuthority.find_by(name: 'lab_names').local_authority_entries.ordered.pluck(:label)
+        end
+
+        expect(labels).to eq ['Wet Lab', 'Dry Lab']
+      end
+
+      # The case the position fix exists for: rows seeded before positions were
+      # assigned hold NULL, which Postgres sorts last — so a naive max+1 gives 1 and
+      # the new term jumps to the top of the list instead of the bottom.
+      it 'adds the term last even when the existing ones have no position' do
+        Apartment::Tenant.switch(account.tenant) do
+          vocabulary = Qa::LocalAuthority.create!(label: 'Lab Names')
+          vocabulary.local_authority_entries.create!(label: 'Alpha', uri: 'a')
+          vocabulary.local_authority_entries.create!(label: 'Beta', uri: 'b')
+        end
+
+        post "http://#{account.cname}/dashboard/controlled_vocabularies/lab_names/terms",
+             params: { term_key => { label: 'Gamma' } }
+
+        labels = Apartment::Tenant.switch(account.tenant) do
+          Qa::LocalAuthority.find_by(name: 'lab_names').local_authority_entries.ordered.pluck(:label)
+        end
+
+        expect(labels.last).to eq 'Gamma'
+      end
+
+      # An imported copy has a row, so find_by! locates it and the write goes
+      # through. The next import then replaces every row, silently discarding the
+      # term — the view hides the button, but nothing stops a direct POST.
+      it 'refuses a vocabulary whose terms are not this tenant to change' do
+        Apartment::Tenant.switch(account.tenant) { Qa::LocalAuthority.create!(name: 'mesh', label: 'MeSH') }
+
+        post "http://#{account.cname}/dashboard/controlled_vocabularies/mesh/terms",
+             params: { term_key => { label: 'Sneaked In' } }
+
+        saved = Apartment::Tenant.switch(account.tenant) { Qa::LocalAuthorityEntry.exists?(label: 'Sneaked In') }
+
+        expect(saved).to be false
+        expect(response).to have_http_status(:not_found)
       end
     end
   end
@@ -345,7 +566,7 @@ RSpec.describe 'Controlled vocabularies', type: :request, clean: true, multitena
 
     it 'refuses the create' do
       post "http://#{account.cname}/dashboard/controlled_vocabularies",
-           params: { param_key => { label: 'Lab Names' } }
+           params: { param_key => { label: 'Lab Names' }, confirmed: 'true' }
 
       created = Apartment::Tenant.switch(account.tenant) { Qa::LocalAuthority.exists?(name: 'lab_names') }
 

--- a/spec/requests/controlled_vocabularies_spec.rb
+++ b/spec/requests/controlled_vocabularies_spec.rb
@@ -341,7 +341,7 @@ RSpec.describe 'Controlled vocabularies', type: :request, clean: true, multitena
 
           # The link that carries the values, not the breadcrumb to a blank form.
           back = response.body.scan(%r{href="([^"]*controlled_vocabularies/new\?[^"]*)"})
-                              .flatten.find { |href| href.include?('local_authority') }
+                         .flatten.find { |href| href.include?('local_authority') }
 
           expect(back).to include 'Lab+Names'
           expect(back).not_to include 'authenticity_token'

--- a/spec/services/controlled_vocabularies_spec.rb
+++ b/spec/services/controlled_vocabularies_spec.rb
@@ -171,6 +171,9 @@ RSpec.describe 'Controlled Vocabularies Integration', type: :service do
         # Library of Congress authorities
         expect(remote_authorities).to have_key('loc/subjects')
         expect(remote_authorities).to have_key('loc/names')
+        expect(remote_authorities).to have_key('loc/genreForms')
+        # The spelling profiles used before the dashboard advertised the camelCase
+        # key. Both resolve, so an existing profile keeps working.
         expect(remote_authorities).to have_key('loc/genre_forms')
         expect(remote_authorities).to have_key('loc/countries')
         expect(remote_authorities).to have_key('loc/languages')
@@ -352,6 +355,7 @@ RSpec.describe 'Controlled Vocabularies Integration', type: :service do
         loc/languages
         loc/iso639-1
         loc/iso639-2
+        loc/genreForms
         loc/genre_forms
         loc/countries
         getty/aat

--- a/spec/services/controlled_vocabulary_catalog_spec.rb
+++ b/spec/services/controlled_vocabulary_catalog_spec.rb
@@ -5,8 +5,7 @@ require 'rails_helper'
 RSpec.describe ControlledVocabularyCatalog do
   # The suite seeds every real yaml vocabulary into the tables, so an unstubbed
   # file_based_names would be entirely claimed by database rows. Naming a fictional
-  # file set keeps these examples independent of that seed state, and clear of
-  # Qa::LocalAuthority's validation against shadowing a real yaml file.
+  # file set keeps these examples independent of that seed state.
   #
   # `map_regions` stands for a file present on disk, `geo_regions` for one named in
   # a profile but missing, so the uncountable path is covered too.
@@ -40,6 +39,15 @@ RSpec.describe ControlledVocabularyCatalog do
 
       expect(keys).to eq keys.uniq
     end
+
+    # Sorting reads the label, so an authority that resolves without one must not
+    # take the whole page down with it.
+    it 'lists an authority whose label cannot be determined' do
+      allow(described_class).to receive(:remote)
+        .and_return([described_class::Entry.new(source_key: 'nameless', origin: :remote)])
+
+      expect(described_class.all.map(&:source_key)).to include 'nameless'
+    end
   end
 
   describe '.database' do
@@ -64,14 +72,14 @@ RSpec.describe ControlledVocabularyCatalog do
 
     # An empty vocabulary is where the first term gets added, so having no terms must
     # not close the page that adds them.
-    it 'is editable and viewable before it has any terms' do
+    it 'is editable before it has any terms' do
       Qa::LocalAuthority.create!(name: 'lab_names', label: 'Lab Names')
 
       entry = described_class.database.detect { |e| e.source_key == 'lab_names' }
 
       expect(entry.term_count).to eq 0
       expect(entry).to be_editable
-      expect(entry).to be_viewable
+      expect(entry).to be_listable
     end
   end
 
@@ -109,6 +117,69 @@ RSpec.describe ControlledVocabularyCatalog do
       entry = described_class.remote.detect { |e| e.source_key == 'loc/subjects' }
 
       expect(described_class.terms_for(entry)).to be_nil
+    end
+
+    # nil and [] are different answers: nil is "cannot say", [] is "nothing here".
+    # A page that collapses them tells a reader an unreadable vocabulary is empty.
+    it 'distinguishes a yaml file it cannot read from one with no terms' do
+      allow(Qa::Authorities::Local).to receive(:subauthority_for)
+        .with('geo_regions').and_raise(Qa::InvalidSubAuthority, 'missing')
+      unreadable = described_class.file_based.detect { |e| e.source_key == 'geo_regions' }
+
+      expect(described_class.terms_for(unreadable)).to be_nil
+    end
+
+    it 'reports an empty database vocabulary as empty, not unreadable' do
+      Qa::LocalAuthority.create!(name: 'lab_names')
+      entry = described_class.database.detect { |e| e.source_key == 'lab_names' }
+
+      expect(described_class.terms_for(entry)).to eq []
+    end
+  end
+
+  describe '.find!' do
+    it 'finds a database vocabulary' do
+      Qa::LocalAuthority.create!(name: 'reading_rooms', label: 'Reading Rooms')
+
+      expect(described_class.find!('reading_rooms').origin).to eq :database
+    end
+
+    it 'finds a remote authority' do
+      expect(described_class.find!('loc/subjects').origin).to eq :remote
+    end
+
+    it 'raises for a key no authority answers to' do
+      expect { described_class.find!('not_a_vocabulary') }
+        .to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    # A profile written before the dashboard advertised the camelCase spelling can
+    # still deposit against the field, so its page has to open too.
+    it 'resolves a legacy spelling to the vocabulary it names' do
+      entry = described_class.find!('loc/genre_forms')
+
+      expect(entry.source_key).to eq 'loc/genreForms'
+    end
+
+    # A miss used to fall through to .all, which builds the database list again on
+    # top of the one already searched.
+    it 'builds the database list once when it has to fall through' do
+      allow(described_class).to receive(:database).and_call_original
+
+      described_class.find!('loc/subjects')
+
+      expect(described_class).to have_received(:database).once
+    end
+
+    # Resolving through an alias searches a second time, once per spelling tried.
+    # Bounded by how many spellings remote_authorities gives one url, and reached
+    # only by a profile citing a legacy key.
+    it 'searches once per spelling when it resolves through an alias' do
+      allow(described_class).to receive(:database).and_call_original
+
+      described_class.find!('loc/genre_forms')
+
+      expect(described_class).to have_received(:database).twice
     end
   end
 
@@ -154,6 +225,14 @@ RSpec.describe ControlledVocabularyCatalog do
 
     it 'is not editable' do
       expect(described_class.remote.map(&:editable?).uniq).to eq [false]
+    end
+
+    # The service holds the terms and is searched as staff type, so the page says
+    # that rather than showing an empty list.
+    it 'has a page, but no term list to show on it' do
+      entry = described_class.remote.detect { |e| e.source_key == 'loc/subjects' }
+
+      expect(entry).not_to be_listable
     end
 
     it 'names the service behind each authority' do
@@ -262,6 +341,21 @@ RSpec.describe ControlledVocabularyCatalog do
         expect(described_class.remote.detect { |e| e.source_key == 'geonames' }).not_to be_configured
       end
     end
+
+    # An unanswerable check is not an answer of "configured". Reporting ready on a
+    # failed lookup sends staff to debug a form that was never going to work.
+    context 'when the credential check itself fails' do
+      before do
+        account = instance_double(Account)
+        allow(account).to receive(:geonames_username).and_raise(StandardError, 'settings unreadable')
+        allow(account).to receive(:discogs_user_token).and_return('')
+        allow(Site).to receive(:account).and_return(account)
+      end
+
+      it 'flags the service rather than reporting it ready' do
+        expect(described_class.remote.detect { |e| e.source_key == 'geonames' }).not_to be_configured
+      end
+    end
   end
 
   # mesh keeps its terms in the same tables as a staff vocabulary, but a MeSH import
@@ -297,15 +391,15 @@ RSpec.describe ControlledVocabularyCatalog do
       expect(entry).to be_cached
     end
 
-    # A MeSH release runs to about 30,000 terms, so the list is not offered at all
-    # and the index does not link it.
-    it 'has no term list, imported or not' do
+    # A MeSH release runs to about 30,000 terms, so the list is not offered — but the
+    # page still is, because it says where the vocabulary is used.
+    it 'has a page but no term list, imported or not' do
       Qa::LocalAuthority.create!(name: 'mesh')
                         .local_authority_entries.create!(label: 'Diabetes', uri: 'mesh:diabetes')
 
       entry = described_class.database.detect { |e| e.source_key == 'mesh' }
 
-      expect(entry).not_to be_viewable
+      expect(entry).not_to be_listable
       expect(described_class.terms_for(entry)).to be_nil
     end
 

--- a/spec/services/controlled_vocabulary_usage_spec.rb
+++ b/spec/services/controlled_vocabulary_usage_spec.rb
@@ -24,6 +24,13 @@ RSpec.describe ControlledVocabularyUsage do
         'creator' => {
           'available_on' => { 'class' => ['GenericWorkResource'] },
           'controlled_values' => { 'sources' => ['null'] }
+        },
+        # Its authority is hardcoded in the form partial, so the profile declares no
+        # source. It is still controlled, and the profile is where the work types
+        # come from.
+        'based_near' => {
+          'available_on' => { 'class' => ['GenericWorkResource', 'ImageResource'] },
+          'controlled_values' => { 'sources' => ['null'] }
         }
       }
     }
@@ -45,6 +52,27 @@ RSpec.describe ControlledVocabularyUsage do
       expect(Hyrax::FlexibleSchema).to have_received(:current_version).once
     end
 
+    # The based_near partial hardcodes the geonames autocomplete, so the profile
+    # never names it as a source. Reading only controlled_values would report the
+    # service unused on a tenant whose deposit form offers it on every work type.
+    context 'a vocabulary a form partial reads directly' do
+      it 'reports the property the partial controls' do
+        expect(described_class.citing('geonames').map(&:name)).to eq %w[based_near]
+      end
+
+      it 'takes its work types from the profile' do
+        work_types = described_class.citing('geonames').first.work_types
+
+        expect(work_types.map(&:name)).to eq %w[GenericWorkResource ImageResource]
+      end
+
+      it 'is unused when the profile does not offer the property at all' do
+        profile['properties'].delete('based_near')
+
+        expect(described_class.citing('geonames')).to eq []
+      end
+    end
+
     it 'labels each work type from its class name, keeping the class itself' do
       work_types = described_class.citing('licenses').first.work_types
 
@@ -64,6 +92,18 @@ RSpec.describe ControlledVocabularyUsage do
 
     it 'returns an empty array when no property cites the vocabulary' do
       expect(described_class.citing('subjects')).to eq []
+    end
+
+    # The dashboard resolves `loc/genre_forms` to the entry keyed `loc/genreForms`,
+    # then asks for that key's usage — so a profile citing the older spelling has to
+    # be found under either one, or its page reports the vocabulary unused.
+    it 'finds a property citing another spelling of the same vocabulary' do
+      profile['properties']['genre'] = {
+        'available_on' => { 'class' => ['GenericWorkResource'] },
+        'controlled_values' => { 'sources' => ['loc/genre_forms'] }
+      }
+
+      expect(described_class.citing('loc/genreForms').map(&:name)).to eq ['genre']
     end
 
     # Some shipped profiles label CollectionResource "pcdmcollection"; the class

--- a/spec/services/local_vocabulary_service_spec.rb
+++ b/spec/services/local_vocabulary_service_spec.rb
@@ -78,6 +78,64 @@ RSpec.describe LocalVocabularyService do
       expect(Qa::LocalAuthority.find_by(name:).label).to eq 'Legacy Terms'
     end
 
+    # Seeding and the model have to agree on where numbering starts, or the first term
+    # added in the dashboard skips a number.
+    it 'numbers seeded terms from one, as a dashboard-added term is' do
+      name = write_vocabulary('sequenced_vocabulary')
+
+      described_class.seed!(path)
+      authority = Qa::LocalAuthority.find_by(name:)
+      added = authority.local_authority_entries.create!(label: 'B', uri: 'b')
+
+      expect(authority.local_authority_entries.order(:position).pluck(:position)).to eq [1, 2]
+      expect(added.position).to eq 2
+    end
+
+    # A migration, not a sync: a later run must not undo what staff did to a vocabulary
+    # the tenant already has, but still imports one it has not seen.
+    context 'run a second time' do
+      it 'leaves a term deleted through the dashboard deleted' do
+        name = write_vocabulary('settled_vocabulary')
+        described_class.seed!(path)
+        Qa::LocalAuthority.find_by(name:).local_authority_entries.find_by(uri: 'a').destroy
+
+        described_class.seed!(path)
+
+        expect(Qa::LocalAuthority.find_by(name:).local_authority_entries).to be_empty
+      end
+
+      it 'leaves a term edited through the dashboard alone' do
+        name = write_vocabulary('renamed_vocabulary')
+        described_class.seed!(path)
+        Qa::LocalAuthority.find_by(name:).local_authority_entries.find_by(uri: 'a').update!(label: 'Renamed')
+
+        described_class.seed!(path)
+
+        expect(Qa::LocalAuthority.find_by(name:).local_authority_entries.first.label).to eq 'Renamed'
+      end
+
+      it 'imports a vocabulary the tenant does not have yet' do
+        write_vocabulary('first_vocabulary')
+        described_class.seed!(path)
+        later = write_vocabulary('second_vocabulary')
+
+        described_class.seed!(path)
+
+        expect(Qa::LocalAuthority.find_by(name: later).local_authority_entries.count).to eq 1
+      end
+
+      it 'does not add a term the file gained after seeding' do
+        name = write_vocabulary('grown_vocabulary')
+        described_class.seed!(path)
+        File.write(File.join(path, "#{name}.yml"),
+                   { 'terms' => [{ 'id' => 'a', 'term' => 'A' }, { 'id' => 'b', 'term' => 'B' }] }.to_yaml)
+
+        described_class.seed!(path)
+
+        expect(Qa::LocalAuthority.find_by(name:).local_authority_entries.pluck(:uri)).to eq ['a']
+      end
+    end
+
     it 'leaves a label and description an admin edited alone' do
       name = write_vocabulary('edited_vocabulary', 'label' => 'Licenses', 'description' => 'Shipped copy.')
       Qa::LocalAuthority.create!(name:, label: 'Reuse Terms', description: 'What we allow.')

--- a/spec/services/qa/authority_registry_spec.rb
+++ b/spec/services/qa/authority_registry_spec.rb
@@ -41,6 +41,18 @@ RSpec.describe Qa::AuthorityRegistry do
       expect(services.keys.grep(/subauthority/)).to be_empty
     end
 
+    # Building the list loads and locates every constant under Qa::Authorities, and
+    # the index page asks for it once per remote vocabulary. What the gem provides
+    # cannot change while the process runs, so the walk happens once.
+    it 'walks the gem once' do
+      described_class.remote_services
+      allow(Qa::Authorities).to receive(:constants).and_call_original
+
+      described_class.remote_services
+
+      expect(Qa::Authorities).not_to have_received(:constants)
+    end
+
     # Qa::Authorities::Oclcts reads config/oclcts-authorities.yml when it loads, so
     # a host without that file must still get the rest of the list.
     it 'skips an authority that cannot be loaded' do

--- a/spec/support/solr_setup.rb
+++ b/spec/support/solr_setup.rb
@@ -42,7 +42,7 @@ def ensure_standalone_test_core_available
     response = RSolr.connect(url: admin_base).get('/solr/admin/cores', params: { action: 'STATUS', core: core })
     raise "Standalone Solr core #{core.inspect} is missing (STATUS returned no entry)" unless response.dig('status', core)&.any?
     Rails.logger.info "[solr_setup] Standalone Solr core #{core.inspect} verified OK"
-  rescue RSolr::Error::ConnectionRefused, RSolr::Error::Http, StandardError => e
+  rescue StandardError => e
     raise "ensure_standalone_test_core_available: cannot reach Solr core #{core.inspect}: #{e.message}"
   end
 end


### PR DESCRIPTION
## Summary
Addresses followup issues from the initial creation of the views.
- Refs notch8/palni_palci_knapsack#710

## Details
- Creating a vocabulary shows the derived source key for confirmation first, since a vocabulary cannot be deleted and its key is permanent once set.
- Names colliding with a remote service or an imported copy are refused; a duplicate now names the source key it collides on.
- New terms are given a sequence number so they land at the end of the list. Existing terms without one are left alone, to be sequenced by hand.
- `populate_qa` now seeds a vocabulary only once: a second run leaves one the tenant already has untouched and imports only the ones it has not seen. It used to re-create a term deleted in the dashboard and backfill any the yaml file had gained since.
- A profile citing `loc/genre_forms` now opens its page and reports its usage, instead of 404ing on the older spelling.
- A yaml vocabulary with no registered service class renders as a dropdown rather than free text.
- Column hint icons explain themselves on hover instead of looking clickable and doing nothing.
- "Back to edit" on the review step is a link rather than a GET form submit, which was putting the CSRF token in the query string.

## Testing
- Create a vocabulary from `/dashboard/controlled_vocabularies`. Confirm the review step shows the derived source key (try an accented name — `Café Terms` should show `cafe_terms`), and that "Back to edit" keeps what you typed.
- Confirm creation, then add a term. It should appear at the end of the term list.
- Try creating a vocabulary named `geonames` or `mesh` — both should be refused, naming the key.
- Open a vocabulary that holds an imported copy (`mesh`, once imported). The "Add term" button should be absent.
- Hover and then tab to a column heading's `?` mark on the index and show pages. The explanation should appear both ways.
- Confirm the terms download (CSV and YAML) still works from both the index and a vocabulary's page.
- Delete a term from a seeded vocabulary, then run `bundle exec rake populate_qa`. The term should stay deleted, and the task should report that vocabulary as already imported.
