### PR TITLE
⬆️ Update hyrax gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,10 +29,10 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: 6fac65d85de8307d194b8608f48b33a7be0a4947
+  revision: 3be706ecdb75cfda4c5111f47dbc6c1875d4902d
   branch: main
   specs:
-    hyrax (5.2.0)
+    hyrax (5.3.0)
       active-fedora (~> 15.0)
       almond-rails (~> 0.1)
       awesome_nested_set (~> 3.1)

--- a/app/views/catalog/_index_list_default.html.erb
+++ b/app/views/catalog/_index_list_default.html.erb
@@ -1,24 +1,19 @@
-<%# OVERRIDE Hyrax v5.2.0 %>
+<%# OVERRIDE Hyrax v5.3.0 %>
 <%#   - enable markdown for index field values in search results %>
 <%#   - handle search only accounts %>
 <%#   - display label only when a property has a value, to prevent blank metadata %>
-<%#   - compute field_value inside the should_render check so a bad authority %>
-<%#     value cannot raise during catalog rendering before the field is even %>
-<%#     decided to render %>
 
 <div class="col-md-9 col-lg-6">
   <div class="metadata">
     <dl>
-      <% doc_presenter = index_presenter(document) %>
-      <% index_fields(document).each do |field_name, field| -%>
-        <% if should_render_index_field?(document, field) %>
-          <% field_value = doc_presenter.field_value(field) %>
-          <% if field_value.present? %>
-            <div class="row">
-              <dt class="col-5 text-right" data-solr-field-name="<%= field_name %>"><%= render_index_field_label document, field: field_name %></dt>
-              <dd class="col-7"><%= markdown(field_value) %></dd>
-            </div>
-          <% end %>
+      <% doc_presenter = document_presenter(document) %>
+      <% doc_presenter.fields_to_render.each do |field_name, _field_config, field_presenter| -%>
+        <% field_value = field_presenter.render %>
+        <% if field_value.present? %>
+          <div class="row">
+            <dt class="col-5 text-right" data-solr-field-name="<%= field_name %>"><%= t('blacklight.search.index.label', label: index_field_label(document, field_name)) %></dt>
+            <dd class="col-7"><%= markdown(field_value) %></dd>
+          </div>
         <% end %>
       <% end %>
       <% if current_account.search_only %>

--- a/app/views/hyrax/my/_search_header.html.erb
+++ b/app/views/hyrax/my/_search_header.html.erb
@@ -1,5 +1,5 @@
-<%# OVERRIDE Hyrax 5.2.0 to add catalog/sort_widget %>
-<%= render 'did_you_mean' %>
+<%# OVERRIDE Hyrax 5.3.0 to add catalog/sort_widget %>
+<%= render 'catalog/did_you_mean' %>
 
 <%= render 'facets' %>
 <%= render 'constraints' %>

--- a/spec/views/hyrax/my/_search_header.html.erb_spec.rb
+++ b/spec/views/hyrax/my/_search_header.html.erb_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+RSpec.describe 'hyrax/my/_search_header.html.erb', type: :view do
+  before do
+    stub_template 'catalog/_did_you_mean.html.erb' => ''
+    stub_template 'hyrax/my/_facets.html.erb' => ''
+    stub_template 'hyrax/my/_constraints.html.erb' => ''
+    stub_template 'hyrax/my/_sort_and_per_page.html.erb' => ''
+    stub_template 'catalog/_sort_widget.html.erb' => ''
+    stub_template 'hyrax/my/_search_form.html.erb' => ''
+    stub_template 'hyrax/collections/_form_for_select_collection.html.erb' => ''
+    view.extend Hyrax::BatchEditsHelper
+    allow(view).to receive(:on_the_dashboard?).and_return(true)
+    allow(view).to receive(:can?).and_return(true)
+  end
+
+  context 'on my works page' do
+    before do
+      view.lookup_context.prefixes.push 'hyrax/my/works'
+      render 'hyrax/my/search_header', current_tab: 'works'
+    end
+
+    it 'has batch action buttons' do
+      expect(rendered).to have_selector('input[value="Delete Selected"]')
+      expect(rendered).to have_selector('button', text: 'Add to collection')
+      expect(rendered).to have_selector('input[value="Edit Selected"]')
+    end
+  end
+
+  context 'on my collections page' do
+    before do
+      view.lookup_context.prefixes.push 'hyrax/my/collections'
+      render 'hyrax/my/search_header', current_tab: 'shared'
+    end
+
+    it 'has batch action buttons' do
+      expect(rendered).to have_selector('button', text: 'Delete collections')
+    end
+  end
+end


### PR DESCRIPTION
Update Hyrax 5.2.0 => 5.3.0.  Brings in the deprecated helper migration, and points _search_header at catalog/did_you_mean since Hyrax deleted its own copy of that partial.

Ref:
- https://github.com/samvera/hyrax/pull/7574
