### PR TITLE
Seed rake task for performance testing

### DIFF
--- a/app/services/sample/valkyrie_service.rb
+++ b/app/services/sample/valkyrie_service.rb
@@ -59,6 +59,17 @@ module Sample
 
     private
 
+    # 80% public / 15% authenticated / 5% private, so access-control checks have real variety to chew on.
+    VISIBILITY_POOL = (
+      [Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC] * 80 +
+      [Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED] * 15 +
+      [Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE] * 5
+    ).freeze
+
+    def random_visibility
+      VISIBILITY_POOL.sample
+    end
+
     def confirm_cleanup # rubocop:disable Metrics/AbcSize
       # Skip confirmation if CONFIRM environment variable is set to 'true'
       return true if ENV['CONFIRM']&.downcase == 'true'
@@ -210,12 +221,15 @@ module Sample
         description: sample_data[:descriptions][index % sample_data[:descriptions].length],
         creator: sample_data[:creators][index % sample_data[:creators].length],
         subject: sample_data[:subjects][index % sample_data[:subjects].length],
-        visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC,
         collection_type_gid: collection_type.to_global_id.to_s,
         depositor: user.user_key
       }
 
       collection = Hyrax.persister.save(resource: CollectionResource.new(collection_attrs))
+      # visibility isn't a Dry::Struct attribute - the constructor kwarg above is silently
+      # ignored, and the ACL it builds needs an explicit save to actually persist.
+      collection.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      collection.permission_manager.acl.save
       Sample::PermissionTemplateService.create_for_valkyrie_collection(collection, user)
       Hyrax.index_adapter.save(resource: collection)
       Hyrax.publisher.publish('collection.metadata.updated', collection: collection, user: user)
@@ -229,13 +243,16 @@ module Sample
         description: sample_data[:descriptions][index % sample_data[:descriptions].length],
         creator: sample_data[:creators][index % sample_data[:creators].length],
         subject: sample_data[:subjects][index % sample_data[:subjects].length],
-        visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC,
         bulkrax_identifier: "SampleValk-#{work_class}#{index}",
         depositor: user.user_key,
         admin_set_id: admin_set.id
       }
 
       work = Hyrax.persister.save(resource: work_class.new(work_attrs))
+      # visibility isn't a Dry::Struct attribute - the constructor kwarg above is silently
+      # ignored, and the ACL it builds needs an explicit save to actually persist.
+      work.visibility = random_visibility
+      work.permission_manager.acl.save
       Hyrax.index_adapter.save(resource: work)
       Hyrax.publisher.publish('object.deposited', object: work, user: user)
       Hyrax.publisher.publish('object.metadata.updated', object: work, user: user)

--- a/app/services/sample/valkyrie_service.rb
+++ b/app/services/sample/valkyrie_service.rb
@@ -26,7 +26,7 @@ module Sample
 
         index_all_works(collections + images + generic_works)
 
-        print_completion_summary(collections, images, generic_works, total_works)
+        print_completion_summary(collections, images, generic_works, [], total_works)
       ensure
         restore_job_configuration
       end

--- a/app/services/sample/valkyrie_service.rb
+++ b/app/services/sample/valkyrie_service.rb
@@ -226,8 +226,7 @@ module Sample
       }
 
       collection = Hyrax.persister.save(resource: CollectionResource.new(collection_attrs))
-      # visibility isn't a Dry::Struct attribute - the constructor kwarg above is silently
-      # ignored, and the ACL it builds needs an explicit save to actually persist.
+      # visibility= builds an ACL that needs an explicit acl.save - setting it via the constructor is silently ignored.
       collection.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
       collection.permission_manager.acl.save
       Sample::PermissionTemplateService.create_for_valkyrie_collection(collection, user)
@@ -249,8 +248,7 @@ module Sample
       }
 
       work = Hyrax.persister.save(resource: work_class.new(work_attrs))
-      # visibility isn't a Dry::Struct attribute - the constructor kwarg above is silently
-      # ignored, and the ACL it builds needs an explicit save to actually persist.
+      # visibility= builds an ACL that needs an explicit acl.save - setting it via the constructor is silently ignored.
       work.visibility = random_visibility
       work.permission_manager.acl.save
       Hyrax.index_adapter.save(resource: work)

--- a/app/services/sample/valkyrie_service.rb
+++ b/app/services/sample/valkyrie_service.rb
@@ -21,12 +21,14 @@ module Sample
         collections = create_collections(quantity)
         images = create_images(quantity, collections)
         generic_works = create_generic_works(quantity, collections)
+        # Does not currently create oers, but is needed for completion summary
+        oers = []
 
         total_works = collections.length + images.length + generic_works.length
 
         index_all_works(collections + images + generic_works)
 
-        print_completion_summary(collections, images, generic_works, [], total_works)
+        print_completion_summary(collections, images, generic_works, oers, total_works)
       ensure
         restore_job_configuration
       end
@@ -59,15 +61,15 @@ module Sample
 
     private
 
-    # 80% public / 15% authenticated / 5% private, so access-control checks have real variety to chew on.
-    VISIBILITY_POOL = (
-      [Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC] * 80 +
-      [Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED] * 15 +
-      [Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE] * 5
-    ).freeze
-
     def random_visibility
-      VISIBILITY_POOL.sample
+      visibility_pool.sample
+    end
+
+    # 80% public / 15% authenticated / 5% private by default, so access-control checks have real variety to chew on.
+    def visibility_pool
+      @visibility_pool ||= [Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC] * ENV.fetch('HYKU_SAMPLE_VISIBILITY_PUBLIC', 80).to_i +
+                           [Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED] * ENV.fetch('HYKU_SAMPLE_VISIBILITY_AUTHENTICATED', 15).to_i +
+                           [Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE] * ENV.fetch('HYKU_SAMPLE_VISIBILITY_PRIVATE', 5).to_i
     end
 
     def confirm_cleanup # rubocop:disable Metrics/AbcSize

--- a/lib/tasks/perf_seed.rake
+++ b/lib/tasks/perf_seed.rake
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+namespace :perf do
+  desc 'Create N dummy tenants with sample Valkyrie works, users, and admin sets, for tenant-count performance testing'
+  task :seed_tenants, [:count, :quantity, :users_per_tenant, :admin_sets_per_tenant] => :environment do |_t, args|
+    count = (args[:count] || 3).to_i
+    quantity = (args[:quantity] || 10).to_i
+    users_per_tenant = (args[:users_per_tenant] || 5).to_i
+    admin_sets_per_tenant = (args[:admin_sets_per_tenant] || 2).to_i
+
+    user = User.first
+    raise 'No User exists to act as depositor - create one first (e.g. via db:seed).' unless user
+
+    batch = SecureRandom.hex(3)
+    password = SecureRandom.hex(12)
+    created = []
+
+    count.times do |i|
+      name = "perf-test-#{batch}-#{i}"
+      puts "Creating tenant #{name}..."
+      account = Account.new(name: name)
+
+      unless CreateAccount.new(account, [user]).save
+        puts "  FAILED: #{account.errors.full_messages.join(', ')}"
+        next
+      end
+
+      puts "  Created (cname: #{account.cname}). Seeding #{quantity} Valkyrie works..."
+      Sample::ValkyrieService.new(account.name, quantity).create_sample_data
+
+      # still switched into account's tenant here
+      puts "  Adding #{users_per_tenant} users..."
+      users_per_tenant.times do |j|
+        new_user = User.create!(email: "perf-#{batch}-#{i}-#{j}@example.com", password: password, password_confirmation: password)
+        new_user.add_role(:admin, Site.instance) if j.zero?
+      end
+
+      puts "  Adding #{admin_sets_per_tenant} extra admin sets..."
+      admin_sets_per_tenant.times do |k|
+        admin_set = Hyrax.config.admin_set_class.new(id: "perf-admin-set-#{batch}-#{i}-#{k}", title: "Extra Admin Set #{k}")
+        Hyrax::AdminSetCreateService.call!(admin_set: admin_set, creating_user: user)
+      end
+
+      created << account
+    rescue => e
+      puts "  FAILED: #{e.message}"
+    ensure
+      Apartment::Tenant.switch!(nil)
+    end
+
+    puts "\nDone: #{created.length}/#{count} tenants created with #{quantity} works, #{users_per_tenant} users, #{admin_sets_per_tenant} extra admin sets each."
+    created.each { |a| puts "  #{a.name} -> https://#{a.cname}" }
+    puts "\nClean up with: bundle exec rake perf:destroy_tenants[#{batch}]" if created.any?
+  end
+
+  desc 'Destroy all tenants from a perf:seed_tenants batch (matches name prefix perf-test-<batch>)'
+  task :destroy_tenants, [:batch] => :environment do |_t, args|
+    raise 'Usage: bundle exec rake perf:destroy_tenants[batch]' if args[:batch].blank?
+
+    accounts = Account.where("name LIKE ?", "perf-test-#{args[:batch]}-%")
+    puts "Destroying #{accounts.count} tenant(s) matching batch #{args[:batch]}..."
+
+    accounts.find_each do |account|
+      puts "  Destroying #{account.name}..."
+      CleanupAccountJob.perform_now(account)
+    end
+
+    users = User.where("email LIKE ?", "perf-#{args[:batch]}-%@example.com")
+    puts "Destroying #{users.count} perf-test user(s)..."
+    users.destroy_all
+
+    puts "Done."
+  end
+end

--- a/lib/tasks/perf_seed.rake
+++ b/lib/tasks/perf_seed.rake
@@ -16,36 +16,44 @@ namespace :perf do
     created = []
 
     count.times do |i|
-      name = "perf-test-#{batch}-#{i}"
-      puts "Creating tenant #{name}..."
-      account = Account.new(name: name)
+      # Rails.application.reloader.wrap keeps autoloaded constants fresh across
+      # many tenant switches in one long-lived process - without it, a long
+      # batch can hit spurious "uninitialized constant" NameErrors partway through.
+      Rails.application.reloader.wrap do
+        name = "perf-test-#{batch}-#{i}"
+        puts "Creating tenant #{name}..."
+        account = Account.new(name: name)
 
-      unless CreateAccount.new(account, [user]).save
-        puts "  FAILED: #{account.errors.full_messages.join(', ')}"
-        next
+        if CreateAccount.new(account, [user]).save
+          puts "  Created (cname: #{account.cname}). Seeding #{quantity} Valkyrie works..."
+          Sample::ValkyrieService.new(account.name, quantity).create_sample_data
+
+          # still switched into account's tenant here
+          puts "  Adding #{users_per_tenant} users..."
+          users_per_tenant.times do |j|
+            new_user = User.create!(email: "perf-#{batch}-#{i}-#{j}@example.com", password: password, password_confirmation: password)
+            new_user.add_role(:admin, Site.instance) if j.zero?
+          end
+
+          puts "  Adding #{admin_sets_per_tenant} extra admin sets..."
+          admin_sets_per_tenant.times do |k|
+            admin_set = Hyrax.config.admin_set_class.new(id: "perf-admin-set-#{batch}-#{i}-#{k}", title: "Extra Admin Set #{k}")
+            Hyrax::AdminSetCreateService.call!(admin_set: admin_set, creating_user: user)
+          end
+
+          created << account
+        else
+          puts "  FAILED: #{account.errors.full_messages.join(', ')}"
+        end
+      rescue => e
+        puts "  FAILED: #{e.message}"
+      ensure
+        begin
+          Apartment::Tenant.switch!(nil)
+        rescue => e
+          puts "  WARNING: failed to reset tenant after iteration #{i}: #{e.message}"
+        end
       end
-
-      puts "  Created (cname: #{account.cname}). Seeding #{quantity} Valkyrie works..."
-      Sample::ValkyrieService.new(account.name, quantity).create_sample_data
-
-      # still switched into account's tenant here
-      puts "  Adding #{users_per_tenant} users..."
-      users_per_tenant.times do |j|
-        new_user = User.create!(email: "perf-#{batch}-#{i}-#{j}@example.com", password: password, password_confirmation: password)
-        new_user.add_role(:admin, Site.instance) if j.zero?
-      end
-
-      puts "  Adding #{admin_sets_per_tenant} extra admin sets..."
-      admin_sets_per_tenant.times do |k|
-        admin_set = Hyrax.config.admin_set_class.new(id: "perf-admin-set-#{batch}-#{i}-#{k}", title: "Extra Admin Set #{k}")
-        Hyrax::AdminSetCreateService.call!(admin_set: admin_set, creating_user: user)
-      end
-
-      created << account
-    rescue => e
-      puts "  FAILED: #{e.message}"
-    ensure
-      Apartment::Tenant.switch!(nil)
     end
 
     puts "\nDone: #{created.length}/#{count} tenants created with #{quantity} works, #{users_per_tenant} users, #{admin_sets_per_tenant} extra admin sets each."

--- a/lib/tasks/perf_seed.rake
+++ b/lib/tasks/perf_seed.rake
@@ -2,9 +2,9 @@
 
 namespace :perf do
   desc 'Create N dummy tenants with sample Valkyrie works, users, and admin sets, for tenant-count performance testing'
-  task :seed_tenants, [:count, :quantity, :users_per_tenant, :admin_sets_per_tenant] => :environment do |_t, args|
-    count = (args[:count] || 3).to_i
-    quantity = (args[:quantity] || 10).to_i
+  task :seed_tenants, [:tenant_count, :work_count, :users_per_tenant, :admin_sets_per_tenant] => :environment do |_t, args|
+    tenant_count = (args[:tenant_count] || 3).to_i
+    work_count = (args[:work_count] || 10).to_i
     users_per_tenant = (args[:users_per_tenant] || 5).to_i
     admin_sets_per_tenant = (args[:admin_sets_per_tenant] || 2).to_i
 
@@ -15,7 +15,7 @@ namespace :perf do
     password = SecureRandom.hex(12)
     created = []
 
-    count.times do |i|
+    tenant_count.times do |i|
       # Rails.application.reloader.wrap keeps autoloaded constants fresh across
       # many tenant switches in one long-lived process - without it, a long
       # batch can hit spurious "uninitialized constant" NameErrors partway through.
@@ -25,8 +25,8 @@ namespace :perf do
         account = Account.new(name: name)
 
         if CreateAccount.new(account, [user]).save
-          puts "  Created (cname: #{account.cname}). Seeding #{quantity} Valkyrie works..."
-          Sample::ValkyrieService.new(account.name, quantity).create_sample_data
+          puts "  Created (cname: #{account.cname}). Seeding #{work_count} Valkyrie works..."
+          Sample::ValkyrieService.new(account.name, work_count).create_sample_data
 
           # still switched into account's tenant here
           puts "  Adding #{users_per_tenant} users..."
@@ -56,7 +56,7 @@ namespace :perf do
       end
     end
 
-    puts "\nDone: #{created.length}/#{count} tenants created with #{quantity} works, #{users_per_tenant} users, #{admin_sets_per_tenant} extra admin sets each."
+    puts "\nDone: #{created.length}/#{count} tenants created with #{work_count} works, #{users_per_tenant} users, #{admin_sets_per_tenant} extra admin sets each."
     created.each { |a| puts "  #{a.name} -> https://#{a.cname}" }
     puts "\nClean up with: bundle exec rake perf:destroy_tenants[#{batch}]" if created.any?
   end


### PR DESCRIPTION
This PR creates a pair of rake tasks for seeding an environment with a large number of objects, to aid in performance testing (see also PR #3238 which adds tooling for performance)

Also fixes bug where the visibility was not being set successfully in the Sample::ValkyrieService.

@samvera/hyku-code-reviewers
