### PR TITLE
Reduce ability role queries

### DIFF
--- a/app/authorities/qa/authorities/local_vocabulary.rb
+++ b/app/authorities/qa/authorities/local_vocabulary.rb
@@ -39,6 +39,10 @@ module Qa::Authorities
       local_authority.nil?
     end
 
+    def local_authority
+      RequestStore.fetch(:qa_local_authorities) { Qa::LocalAuthority.all.index_by(&:name) }[subauthority.to_s]
+    end
+
     def file_based
       Qa::Authorities::Local::FileBasedAuthority.new(subauthority)
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -170,15 +170,21 @@ class ApplicationController < ActionController::Base
 
   # Find themes set on Site model, or return default
   def home_page_theme
-    current_account.sites&.first&.home_theme || 'default_home'
+    current_account_site&.home_theme || 'default_home'
   end
 
   def show_page_theme
-    current_account.sites&.first&.show_theme || 'default_show'
+    current_account_site&.show_theme || 'default_show'
   end
 
   def search_results_theme
-    current_account.sites&.first&.search_theme || 'list_view'
+    current_account_site&.search_theme || 'list_view'
+  end
+
+  def current_account_site
+    return @current_account_site if defined?(@current_account_site)
+
+    @current_account_site = current_account.sites&.first
   end
 
   # Add context information to the lograge entries

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -42,10 +42,10 @@ class Ability
 
     @user_groups = default_user_groups
     # TODO: necessary to include #hyrax_group_names?
-    @user_groups |= current_user.hyrax_group_names if current_user.respond_to? :hyrax_group_names
-    @user_groups |= ['registered'] if !current_user.new_record? && current_user.roles.count.positive?
+    @user_groups |= current_user_hyrax_groups(Site.instance).map(&:name) if current_user.respond_to?(:hyrax_groups)
     # OVERRIDE: add the names of all user's roles to the array of user_groups
     @user_groups |= all_user_and_group_roles
+    @user_groups |= ['registered'] if !current_user.new_record? && current_user.roles.any?
 
     @user_groups
   end
@@ -89,11 +89,11 @@ class Ability
 
   # TODO: move method to GroupAwareRoleChecker, or use the GroupAwareRoleChecker
   def superadmin?
-    current_user.has_role? :superadmin
+    current_user.has_cached_role? :superadmin
   end
 
   def tenant_superadmin?
-    current_user.has_role?(:superadmin, Site.instance)
+    current_user.has_cached_role?(:superadmin, Site.instance)
   end
 
   # @return [Array<String>] a list of all role names that apply to the user

--- a/app/models/content_block.rb
+++ b/app/models/content_block.rb
@@ -23,6 +23,8 @@ class ContentBlock < ApplicationRecord
     homepage_about_section_content: :homepage_about_section_content
   }.freeze
 
+  after_commit { RequestStore.delete(:content_blocks) }
+
   # NOTE: method defined outside the metaclass wrapper below because
   # `for` is a reserved word in Ruby.
   def self.for(key)
@@ -39,8 +41,9 @@ class ContentBlock < ApplicationRecord
     #
     # @return [Object] either the named block's value or the fallback_value.
     def block_for(name:, fallback_value: false)
-      block = ContentBlock.find_by(name:)
-      block&.value.presence || fallback_value
+      cache = RequestStore.fetch(:content_blocks) { {} }
+      cache[name.to_s] = ContentBlock.find_by(name:) unless cache.key?(name.to_s)
+      cache[name.to_s]&.value.presence || fallback_value
     end
 
     # @api public

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -38,9 +38,10 @@ class Site < ApplicationRecord
       end
     end
 
-    # Clears the memoized Site so the next call to .instance re-fetches it.
+    # Clears the request-scoped caches that only hold rows from the tenant they
+    # were read under, the memoized Site included.
     def reset!
-      RequestStore.delete(:site_instance)
+      RequestStore.store.except!(:site_instance, :content_blocks, :qa_local_authorities)
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -129,7 +129,7 @@ class User < ApplicationRecord
   #   => [#<Hyrax::Group id: 2, name: "registered", description: nil,...>]
   def hyrax_groups
     # Why compact?  In theory we shouldn't need this.  But in tests we're seeing a case
-    roles.where(name: 'member', resource_type: 'Hyrax::Group').map(&:resource).uniq.compact
+    roles.where(name: 'member', resource_type: 'Hyrax::Group').includes(:resource).map(&:resource).uniq.compact
   end
 
   # Override method from hydra-access-controls v11.0.0 to use Hyrax::Groups.

--- a/app/services/group_aware_role_checker.rb
+++ b/app/services/group_aware_role_checker.rb
@@ -14,8 +14,10 @@ module GroupAwareRoleChecker
 
   def current_user_hyrax_groups(site_instance)
     @current_user_hyrax_groups_memo ||= {}
-    cache_key = [site_instance.id, current_user.id || current_user.object_id]
-    @current_user_hyrax_groups_memo[cache_key] ||= current_user.hyrax_groups
+    cache_key = [Apartment::Tenant.current, site_instance.id, current_user.id || current_user.object_id]
+    @current_user_hyrax_groups_memo[cache_key] ||= current_user.hyrax_groups.tap do |groups|
+      ActiveRecord::Associations::Preloader.new(records: groups, associations: :roles).call
+    end
   end
 
   # Check for the presence of the passed role_name in the User's Roles and
@@ -23,15 +25,23 @@ module GroupAwareRoleChecker
   def group_aware_role?(role_name)
     return false if current_user.new_record?
 
+    discard_partially_loaded_roles
     @group_role_memo ||= {}
 
     site_instance = Site.instance
 
-    memo_key = [role_name, site_instance.id, current_user.id || current_user.object_id]
+    memo_key = [role_name, Apartment::Tenant.current, site_instance.id, current_user.id || current_user.object_id]
     return @group_role_memo[memo_key] if @group_role_memo.key?(memo_key)
 
     @group_role_memo[memo_key] =
-      current_user.has_role?(role_name, site_instance) ||
+      current_user.has_cached_role?(role_name, site_instance) ||
       current_user_hyrax_groups(site_instance).any? { |group| group.site_role?(role_name) }
+  end
+
+  def discard_partially_loaded_roles
+    return if @roles_reset_for == Apartment::Tenant.current
+
+    @roles_reset_for = Apartment::Tenant.current
+    current_user.roles.reset
   end
 end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -101,9 +101,10 @@ RSpec.describe CatalogController do
       expect(third_ability.admin?).to be false # populate the memoization on the new instance
       third_cache = third_ability.instance_variable_get(:@group_role_memo)
       site_id = Site.instance.id
+      tenant = Apartment::Tenant.current
       admin_role = RolesService::ADMIN_ROLE
-      expect(second_cache[[admin_role, site_id, second_ability.current_user.id]]).to be true
-      expect(third_cache[[admin_role, site_id, third_ability.current_user.id]]).to be false
+      expect(second_cache[[admin_role, tenant, site_id, second_ability.current_user.id]]).to be true
+      expect(third_cache[[admin_role, tenant, site_id, third_ability.current_user.id]]).to be false
       expect(second_cache).not_to eq(third_cache)
     end
   end

--- a/spec/models/content_block_spec.rb
+++ b/spec/models/content_block_spec.rb
@@ -252,4 +252,17 @@ RSpec.describe ContentBlock, type: :model do
       end
     end
   end
+
+  describe 'cached reads', truncation: true do
+    let(:block_name) { 'announcement_text' }
+
+    it 'reflects a write made through a NAME_REGISTRY setter' do
+      described_class.update_block(name: block_name, value: 'first')
+      expect(described_class.block_for(name: block_name)).to eq('first')
+
+      described_class.announcement_text = 'second'
+
+      expect(described_class.block_for(name: block_name)).to eq('second')
+    end
+  end
 end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -333,4 +333,17 @@ RSpec.describe Site, type: :model do
       end
     end
   end
+
+  describe '.reset!' do
+    it 'drops the tenant-scoped caches and leaves keys it does not own' do
+      RequestStore.store[:site_instance] = 'stale site'
+      RequestStore.store[:content_blocks] = { 'block' => 'stale' }
+      RequestStore.store[:qa_local_authorities] = { 'vocab' => 'stale' }
+      RequestStore.store[:lograge_location] = '/keep/me'
+
+      described_class.reset!
+
+      expect(RequestStore.store.keys).to eq([:lograge_location])
+    end
+  end
 end

--- a/spec/services/group_aware_role_checker_spec.rb
+++ b/spec/services/group_aware_role_checker_spec.rb
@@ -141,4 +141,21 @@ RSpec.describe GroupAwareRoleChecker, clean: true do
       end
     end
   end
+
+  describe 'roles loaded outside this checker' do
+    let(:user) { FactoryBot.create(:user) }
+
+    before do
+      user.add_role('work_editor')
+      user.add_role('work_depositor')
+    end
+
+    it 'sees a role that a filtered preload left out of the association' do
+      partial = User.includes(:roles).references(:roles)
+                    .where(id: user.id, roles: { name: 'work_editor' }).first
+
+      expect(partial.roles.map(&:name)).to eq(['work_editor'])
+      expect(partial.ability.work_depositor?).to be true
+    end
+  end
 end


### PR DESCRIPTION
## 🐛 Preload roles' resources in User#hyrax_groups

a63d49dd97992d296c89e0a6ab5fbc55d4c412ec

map(&:resource) loaded each Hyrax::Group with its own query, which
Bullet reported as an N+1 on every request including each thumbnail
download.

## 🧹 Ask rolify for cached roles in permission path

b874b082da1c87319bff3912e6fa9a3573e73b1d

has_role? queries on every call, so checking all eight default roles
cost eight queries.  has_cached_role? filters the already-loaded
association instead.  Do not drop discard_partially_loaded_roles: roles
are per-tenant while users are not, so a User loaded under another
tenant reports its roles.

## 🧹 Cache per-request reads that repeat every render

4b6259e18cb6eeb74a42b6de06304d32ecbcf5a1

ContentBlock rows were re-queried per call, 100 of them on a 100-doc
catalog page, and Qa authorities once per subauthority.  RequestStore
holds both for the request.  Site.reset! drops all three tenant-scoped
keys when the tenant switches; after_commit drops the ContentBlock one
when a block is written.
