### PR TITLE
🎨 Open the vocabulary edit form in a modal

### DIFF
--- a/app/views/hyrax/dashboard/controlled_vocabularies/_edit_modal.html.erb
+++ b/app/views/hyrax/dashboard/controlled_vocabularies/_edit_modal.html.erb
@@ -1,0 +1,36 @@
+<div class="modal fade" id="edit-vocabulary" tabindex="-1" role="dialog"
+     aria-labelledby="edit-vocabulary-title" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <%= form_for vocabulary,
+                   url: main_app.controlled_vocabulary_path(vocabulary.name),
+                   method: :patch,
+                   html: { class: 'controlled-vocabulary-form' } do |f| %>
+        <div class="modal-header">
+          <h4 class="modal-title" id="edit-vocabulary-title">
+            <%= t('hyku.admin.controlled_vocabulary.edit_heading', name: vocabulary.display_label) %>
+          </h4>
+          <button type="button" class="close" data-dismiss="modal"
+                  aria-label="<%= t('helpers.action.close', default: 'Close') %>">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+
+        <div class="modal-body">
+          <p class="text-muted"><%= t('hyku.admin.controlled_vocabulary.edit_help') %></p>
+          <%= render 'fields', f: f %>
+          <p class="form-text text-muted mb-0">
+            <%= t('hyku.admin.controlled_vocabulary.source_key') %>:
+            <code><%= vocabulary.source_key %></code>
+          </p>
+        </div>
+
+        <div class="modal-footer">
+          <%= link_to t('helpers.action.cancel', default: 'Cancel'), '#',
+                      class: 'btn btn-link', data: { dismiss: 'modal' } %>
+          <%= f.submit t('hyku.admin.controlled_vocabulary.save'), class: 'btn btn-primary' %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/hyrax/dashboard/controlled_vocabularies/show.html.erb
+++ b/app/views/hyrax/dashboard/controlled_vocabularies/show.html.erb
@@ -11,9 +11,12 @@
     <%= render 'download_menu', entry: @entry %>
   <% end %>
   <% if @entry.editable? && can?(:manage, :controlled_vocabularies) %>
+    <%# href, not just the toggle: the edit page is what a reader without javascript
+        gets, and what update re-renders when the form comes back invalid. %>
     <%= link_to t('hyku.admin.controlled_vocabulary.edit'),
                 main_app.edit_controlled_vocabulary_path(@entry.source_key),
-                class: 'btn btn-outline-secondary' %>
+                class: 'btn btn-outline-secondary',
+                data: { toggle: 'modal', target: '#edit-vocabulary' } %>
     <%= link_to t('hyku.admin.controlled_vocabulary.import.button'),
                 main_app.new_controlled_vocabulary_import_path(@entry.source_key),
                 class: 'btn btn-outline-secondary' %>
@@ -22,6 +25,11 @@
                 class: 'btn btn-primary' %>
   <% end %>
 </div>
+
+<%# Outside the button row, which is right-aligned. %>
+<% if @entry.editable? && can?(:manage, :controlled_vocabularies) %>
+  <%= render 'edit_modal', vocabulary: @entry.vocabulary %>
+<% end %>
 
 <div class="card">
   <div class="card-body border-bottom">

--- a/spec/requests/controlled_vocabularies_spec.rb
+++ b/spec/requests/controlled_vocabularies_spec.rb
@@ -464,6 +464,16 @@ RSpec.describe 'Controlled vocabularies', type: :request, clean: true, multitena
         expect(response.body).to include 'Reading Rooms'
       end
 
+      # The button opens a modal holding the form, and still links to the edit page
+      # for a reader without javascript.
+      it 'carries the form on the vocabulary page' do
+        get "http://#{account.cname}/dashboard/controlled_vocabularies/reading_rooms"
+
+        expect(response.body).to include 'data-target="#edit-vocabulary"'
+        expect(response.body).to include '/dashboard/controlled_vocabularies/reading_rooms/edit'
+        expect(response.body).to include 'id="edit-vocabulary"'
+      end
+
       it 'saves the wording and returns to the vocabulary' do
         patch "http://#{account.cname}/dashboard/controlled_vocabularies/reading_rooms",
               params: { param_key => { label: 'Reading Areas', description: 'Rooms open to readers.' } }


### PR DESCRIPTION
Nick's feedback on #3241: clicking Edit takes you out of the vocabulary page to edit two fields. The record is already loaded, so the form can open on the page instead.

Stacked on #3241, so review that one first. Base is `vocabulary-metadata-edit`.

- Bootstrap 4 modal, the pattern the codebase already uses for citations and the screening room player. No new javascript file, no Hotwire, nothing added to the stack.
- The button keeps its `href` to the edit page. That is what a reader without javascript gets, and what `update` re-renders when the form comes back invalid, so `edit.html.erb` stays.
- Saving still round-trips: the page reloads to the same vocabulary with its flash. If the reload is what Nick is actually reacting to, a `remote: true` submit is the next step, but it has to handle the label-blanked fallback and the description row appearing or disappearing, so I would rather see whether this is enough first.

Testing: `bundle exec rspec spec/requests/controlled_vocabularies_spec.rb`. 69 examples, 0 failures. Rubocop clean. Opened, saved, and confirmed the flash by hand.

## Screenshots

The form opens over the vocabulary page:
<img width="1352" alt="Edit form open in a modal" src="https://github.com/user-attachments/assets/d7e58860-6f5a-4ef7-b7be-b3b40e835a7e" />

Saved, back on the same page:
<img width="1352" alt="Vocabulary page after saving from the modal" src="https://github.com/user-attachments/assets/854b1459-db49-465b-8bea-b8564d21ca25" />
