### PR TITLE
🎨 Edit a vocabulary's name and description in place

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -37,6 +37,7 @@
 //= require hyku/admin/appearance/default_images
 //= require hyku/admin/appearance/fonts
 //= require hyku/admin/appearance/themes
+//= require hyku/admin/controlled_vocabulary_fields
 //= require hyku/admin/features_scroll
 //= require hyku/groups/per_page
 //= require hyku/groups/add_member

--- a/app/assets/javascripts/hyku/admin/controlled_vocabulary_fields.js
+++ b/app/assets/javascripts/hyku/admin/controlled_vocabulary_fields.js
@@ -1,0 +1,25 @@
+// Swap a vocabulary's name or description for its form in place, so editing two
+// fields does not mean leaving the page. Scoped to the vocabulary page: the early
+// return makes this a no-op everywhere else (it is in the global bundle).
+$(document).on('turbolinks:load', function () {
+  var fields = document.querySelectorAll('.vocabulary-field');
+  if (!fields.length) return;
+
+  function toggle(field, editing) {
+    $(field).find('.vocabulary-field-display').toggleClass('d-none', editing);
+    $(field).find('.vocabulary-field-form').toggleClass('d-none', !editing);
+    if (editing) $(field).find('input[type=text], textarea').trigger('focus');
+  }
+
+  $('.vocabulary-field').on('click', '.vocabulary-field-edit', function () {
+    // One at a time, so two open forms cannot each claim to hold the current value.
+    $('.vocabulary-field').each(function () { toggle(this, false); });
+    toggle($(this).closest('.vocabulary-field'), true);
+  });
+
+  $('.vocabulary-field').on('click', '.vocabulary-field-cancel', function () {
+    var field = $(this).closest('.vocabulary-field');
+    field.find('form')[0].reset();
+    toggle(field, false);
+  });
+});

--- a/app/helpers/controlled_vocabulary_helper.rb
+++ b/app/helpers/controlled_vocabulary_helper.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module ControlledVocabularyHelper
+  INLINE_FIELDS = {
+    label: { input: :text_field, options: { class: 'form-control form-control-sm' } },
+    description: { input: :text_area, options: { class: 'form-control form-control-sm', rows: 3 } }
+  }.freeze
+
+  def controlled_vocabulary_field_input(field)
+    INLINE_FIELDS.fetch(field.to_sym)
+  end
+end

--- a/app/views/hyrax/dashboard/controlled_vocabularies/_editable_field.html.erb
+++ b/app/views/hyrax/dashboard/controlled_vocabularies/_editable_field.html.erb
@@ -1,0 +1,28 @@
+<% input = controlled_vocabulary_field_input(field) %>
+<dd class="col-sm-9 vocabulary-field">
+  <div class="vocabulary-field-display">
+    <% if value.present? %>
+      <span><%= value %></span>
+    <% else %>
+      <span class="text-muted"><%= blank_text %></span>
+    <% end %>
+    <button type="button" class="btn btn-link btn-sm vocabulary-field-edit"
+            title="<%= t('hyku.admin.controlled_vocabulary.edit_field', field: heading) %>">
+      <span class="fa fa-pencil" aria-hidden="true"></span>
+      <span class="sr-only"><%= t('hyku.admin.controlled_vocabulary.edit_field', field: heading) %></span>
+    </button>
+  </div>
+
+  <%= form_for vocabulary,
+               url: main_app.controlled_vocabulary_path(vocabulary.name),
+               method: :patch,
+               html: { class: 'vocabulary-field-form d-none' } do |f| %>
+    <%= f.public_send(input[:input], field, input[:options]) %>
+    <div class="mt-2">
+      <%= f.submit t('hyku.admin.controlled_vocabulary.save'), class: 'btn btn-primary btn-sm' %>
+      <button type="button" class="btn btn-link btn-sm vocabulary-field-cancel">
+        <%= t('helpers.action.cancel', default: 'Cancel') %>
+      </button>
+    </div>
+  <% end %>
+</dd>

--- a/app/views/hyrax/dashboard/controlled_vocabularies/show.html.erb
+++ b/app/views/hyrax/dashboard/controlled_vocabularies/show.html.erb
@@ -1,3 +1,4 @@
+<% editable = @entry.editable? && can?(:manage, :controlled_vocabularies) %>
 <% provide :page_title, construct_page_title(@entry.label, t('hyku.admin.controlled_vocabularies'), t('hyku.admin.title')) %>
 <% provide :page_header do %>
   <h1>
@@ -10,10 +11,7 @@
   <% if @entry.downloadable? %>
     <%= render 'download_menu', entry: @entry %>
   <% end %>
-  <% if @entry.editable? && can?(:manage, :controlled_vocabularies) %>
-    <%= link_to t('hyku.admin.controlled_vocabulary.edit'),
-                main_app.edit_controlled_vocabulary_path(@entry.source_key),
-                class: 'btn btn-outline-secondary' %>
+  <% if editable %>
     <%= link_to t('hyku.admin.controlled_vocabulary.import.button'),
                 main_app.new_controlled_vocabulary_import_path(@entry.source_key),
                 class: 'btn btn-outline-secondary' %>
@@ -26,6 +24,16 @@
 <div class="card">
   <div class="card-body border-bottom">
     <dl class="row mb-0">
+      <% if editable %>
+        <dt class="col-sm-3"><%= t('hyku.admin.controlled_vocabulary.name') %></dt>
+        <%= render 'editable_field',
+                   vocabulary: @entry.vocabulary,
+                   field: :label,
+                   heading: t('hyku.admin.controlled_vocabulary.name'),
+                   value: @entry.label,
+                   blank_text: nil %>
+      <% end %>
+
       <dt class="col-sm-3"><%= t('hyku.admin.controlled_vocabulary.source_key') %></dt>
       <dd class="col-sm-9"><code><%= @entry.source_key %></code></dd>
 
@@ -53,7 +61,15 @@
         </dd>
       <% end %>
 
-      <% if @entry.description.present? %>
+      <% if editable %>
+        <dt class="col-sm-3"><%= t('hyku.admin.controlled_vocabulary.description') %></dt>
+        <%= render 'editable_field',
+                   vocabulary: @entry.vocabulary,
+                   field: :description,
+                   heading: t('hyku.admin.controlled_vocabulary.description'),
+                   value: @entry.description,
+                   blank_text: t('hyku.admin.controlled_vocabulary.no_description') %>
+      <% elsif @entry.description.present? %>
         <dt class="col-sm-3"><%= t('hyku.admin.controlled_vocabulary.description') %></dt>
         <dd class="col-sm-9"><%= @entry.description %></dd>
       <% end %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -417,6 +417,7 @@ de:
         edit: Details bearbeiten
         edit_heading: '%{name} bearbeiten'
         edit_help: Ändern Sie, wie dieses Vokabular für Mitarbeitende lautet. Sein Quellschlüssel ist fest, sodass ein Metadatenprofil, das ihn zitiert, weiterhin funktioniert.
+        edit_field: '%{field} bearbeiten'
         edit_title: Vokabular bearbeiten
         import:
           additions_heading: Hinzuzufügende Begriffe

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -289,6 +289,7 @@ en:
         edit: Edit details
         edit_heading: 'Edit %{name}'
         edit_help: Change how this vocabulary reads for staff. Its source key is fixed, so a metadata profile citing it keeps working.
+        edit_field: 'Edit %{field}'
         edit_title: Edit vocabulary
         import:
           additions_heading: Terms to add

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -418,6 +418,7 @@ es:
         edit: Editar detalles
         edit_heading: 'Editar %{name}'
         edit_help: Cambie cómo se lee este vocabulario para el personal. Su clave de origen es fija, por lo que un perfil de metadatos que la cite sigue funcionando.
+        edit_field: 'Editar %{field}'
         edit_title: Editar vocabulario
         import:
           additions_heading: Términos a agregar

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -418,6 +418,7 @@ fr:
         edit: Modifier les détails
         edit_heading: 'Modifier %{name}'
         edit_help: Modifiez la façon dont ce vocabulaire se lit pour le personnel. Sa clé source est fixe, donc un profil de métadonnées qui la cite continue de fonctionner.
+        edit_field: 'Modifier %{field}'
         edit_title: Modifier le vocabulaire
         import:
           additions_heading: Termes à ajouter

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -418,6 +418,7 @@ it:
         edit: Modifica dettagli
         edit_heading: 'Modifica %{name}'
         edit_help: Cambia come questo vocabolario appare al personale. La sua chiave di origine è fissa, quindi un profilo dei metadati che la cita continua a funzionare.
+        edit_field: 'Modifica %{field}'
         edit_title: Modifica vocabolario
         import:
           additions_heading: Termini da aggiungere

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -300,6 +300,7 @@ pt-BR:
         edit: Editar detalhes
         edit_heading: 'Editar %{name}'
         edit_help: Altere como este vocabulário aparece para a equipe. Sua chave de origem é fixa, então um perfil de metadados que a cita continua funcionando.
+        edit_field: 'Editar %{field}'
         edit_title: Editar vocabulário
         import:
           additions_heading: Termos a adicionar

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -434,6 +434,7 @@ zh:
         edit: 编辑详情
         edit_heading: '编辑 %{name}'
         edit_help: 更改此词表对馆员显示的措辞。其源键固定不变，因此引用它的元数据配置档仍可正常使用。
+        edit_field: '编辑%{field}'
         edit_title: 编辑词表
         import:
           additions_heading: 待添加的词条

--- a/spec/requests/controlled_vocabularies_spec.rb
+++ b/spec/requests/controlled_vocabularies_spec.rb
@@ -508,14 +508,16 @@ RSpec.describe 'Controlled vocabularies', type: :request, clean: true, multitena
         expect(response.body).to include 'Reading Rooms'
       end
 
-      it 'drops the description row rather than rendering it empty' do
+      # The row stays for a manager, since it is what they click to write one. A
+      # reader who cannot edit still loses it, as before.
+      it 'says a cleared description is unwritten rather than rendering it empty' do
         patch "http://#{account.cname}/dashboard/controlled_vocabularies/reading_rooms",
               params: { param_key => { description: '' } }
 
         get "http://#{account.cname}/dashboard/controlled_vocabularies/reading_rooms"
 
         expect(response.body).not_to include 'Where an item may be consulted on site.'
-        expect(response.body).not_to include '<dt class="col-sm-3">Description</dt>'
+        expect(response.body).to include 'None given'
       end
 
       it 'reorders the listing to match the new label' do


### PR DESCRIPTION
Nick's feedback on #3241 was that clicking Edit takes you out of the vocabulary page. #3242 answers that with a modal; this answers it with editing in place, and the two are alternatives, not a stack. Base is `vocabulary-metadata-edit`, so review #3241 first.

There is no Edit details button here. Each editable value carries a pencil, and clicking it swaps that value for its own input with Save and Cancel.

- The name gains a row of its own. It was only in the heading, which is not somewhere a field can sit.
- The description row now stays for a manager even when empty, reading "None given", because it is what they click to write one. A reader who cannot edit still loses the row, as before. This is worth a look: #707 asks for a blank description to hide the row, which is what #3241 does.
- Each field posts only itself, so saving the name cannot overwrite a description someone changed in another tab.
- Saving reloads the page, which keeps the heading, breadcrumb, and page title honest when the name changes. A `remote: true` version would have to update all three by hand.
- About 20 lines of jQuery in the global bundle, scoped by an early return, following `hyku/admin/features_scroll.js`.

Testing: `bundle exec rspec spec/requests/controlled_vocabularies_spec.rb`. 68 examples, 0 failures. Rubocop clean. Walked through by hand: opened, saved, cancelled, and confirmed the flash.

## Screenshots

A pencil next to each editable value, and no Edit details button:
<img width="1352" alt="Vocabulary page with a pencil beside the name and description" src="https://github.com/user-attachments/assets/2e5afc81-3683-433d-beaa-b9a746a0a832" />

Clicking one swaps that value for its field:
<img width="1352" alt="The name field open in place" src="https://github.com/user-attachments/assets/3f07369a-d744-44f1-87fc-37b277305da5" />

Saved:
<img width="1352" alt="Vocabulary page after saving in place" src="https://github.com/user-attachments/assets/b49b0442-bd8f-4b5f-a81c-099032111b71" />
