### PR TITLE
Hide menu link for vocabulary sidebar

### DIFF
--- a/config/initializers/hyrax_sidebar.rb
+++ b/config/initializers/hyrax_sidebar.rb
@@ -3,9 +3,21 @@
 # Adds this app's entries to the dashboard sidebar through the registry Hyrax
 # provides for it, so a section gains a link without this app carrying a copy of the
 # sidebar partial and inheriting the job of re-syncing it.
-Rails.application.config.to_prepare do
-  # Assigned rather than appended: to_prepare runs again on every reload in
-  # development, and << would register the same partial a second time.
-  Hyrax::DashboardController.sidebar_partials[:repository_content] |=
-    ['hyrax/dashboard/sidebar/controlled_vocabularies']
+#
+# Offered in development and on staging, withheld from production while the
+# vocabulary dashboard is still settling. The pages stay reachable by url either
+# way; this only decides whether staff are shown a link to them.
+#
+# Staging opts in through HYKU_VOCABULARY_SIDEBAR_ENABLED=true rather than
+# Rails.env.staging? - staging deployments run with RAILS_ENV=production (see
+# config/initializers/bullet.rb), so staging.rb never loads there and Rails.env
+# cannot tell the two apart. Production simply leaves the variable unset.
+if Rails.env.development? || Rails.env.test? ||
+   ActiveModel::Type::Boolean.new.cast(ENV.fetch('HYKU_VOCABULARY_SIDEBAR_ENABLED', 'false'))
+  Rails.application.config.to_prepare do
+    # Assigned rather than appended: to_prepare runs again on every reload in
+    # development, and << would register the same partial a second time.
+    Hyrax::DashboardController.sidebar_partials[:repository_content] |=
+      ['hyrax/dashboard/sidebar/controlled_vocabularies']
+  end
 end

--- a/ops/demo-deploy.tmpl.yaml
+++ b/ops/demo-deploy.tmpl.yaml
@@ -139,6 +139,8 @@ extraEnvVars: &envVars
     value: no-reply@hykudemo.org
   - name: HYKU_FILE_ACL
     value: "false"
+  - name: HYKU_VOCABULARY_SIDEBAR_ENABLED
+    value: "false"
   - name: HYRAX_ANALYTICS
     value: "true"
   - name: HYRAX_ANALYTICS_PROVIDER

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -141,6 +141,8 @@ extraEnvVars: &envVars
     value: no-reply@hykustaging.org
   - name: HYKU_FILE_ACL
     value: "false"
+  - name: HYKU_VOCABULARY_SIDEBAR_ENABLED
+    value: "true"
   - name: HYRAX_ANALYTICS
     value: "true"
   - name: HYRAX_ANALYTICS_PROVIDER

--- a/ops/test-deploy.tmpl.yaml
+++ b/ops/test-deploy.tmpl.yaml
@@ -139,6 +139,8 @@ extraEnvVars: &envVars
     value: no-reply@hykutest.org
   - name: HYKU_FILE_ACL
     value: "false"
+  - name: HYKU_VOCABULARY_SIDEBAR_ENABLED
+    value: "true"
   - name: HYRAX_ANALYTICS
     value: "true"
   - name: HYRAX_ANALYTICS_PROVIDER


### PR DESCRIPTION
## Summary

Adds a config variable HYKU_VOCABULARY_SIDEBAR_ENABLED to control the menu option in production environments. Variable defaults to false until we are ready to have it appear in production. 

No code or routes are disabled... this only hides the menu option. 