### PR TITLE
Remove duplicate licenses

### DIFF
--- a/config/authorities/licenses.yml
+++ b/config/authorities/licenses.yml
@@ -42,12 +42,6 @@ terms:
   - id: http://creativecommons.org/licenses/by-nc-sa/3.0/us/
     term: Attribution-NonCommercial-ShareAlike 3.0 United States
     active: false
-  - id: http://creativecommons.org/publicdomain/mark/1.0/
-    term: Public Domain Mark 1.0
-    active: false
-  - id: http://creativecommons.org/publicdomain/zero/1.0/
-    term: CC0 1.0 Universal
-    active: false
   - id: http://www.europeana.eu/portal/rights/rr-r.html
     term: All rights reserved
     active: false


### PR DESCRIPTION
## Summary

The licenses yml has two duplicate entries which have been removed. These cannot migrate into our new database, so the inactive entries have been removed since the current behavior shows them as active.
