### PR TITLE
🎁 Index controlled vocabulary labels

### DIFF
--- a/app/indexers/concerns/hyku_indexing.rb
+++ b/app/indexers/concerns/hyku_indexing.rb
@@ -4,6 +4,7 @@
 # A mixin for all additional Hyku applicable indexing; both Valkyrie and ActiveFedora friendly.
 module HykuIndexing
   include ScrubText
+  include IndexesControlledLabels
   # TODO: Once we've fully moved to Valkyrie, remove the generate_solr_document and move `#to_solr`
   #      to a more conventional method def (e.g. `def to_solr`).  However, we need to tap into two
   #      different inheritance paths based on ActiveFedora or Valkyrie
@@ -29,6 +30,7 @@ module HykuIndexing
         solr_doc['creator_ssi'] = object.creator&.first
         solr_doc[CatalogController.created_field] ||= Array(object.try(:date_created)).first
         add_date(solr_doc)
+        relabel_controlled_values(solr_doc)
       end
     end
   end

--- a/app/indexers/concerns/indexes_controlled_labels.rb
+++ b/app/indexers/concerns/indexes_controlled_labels.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+module IndexesControlledLabels
+  delegate :controlled_vocabulary_service_for, to: 'ApplicationController.helpers', private: true
+
+  private
+
+  def relabel_controlled_values(solr_doc)
+    return solr_doc unless Hyrax.config.flexible?
+
+    controlled_index_keys.each do |key|
+      next unless solr_doc.key?(key)
+
+      solr_doc[key] = Array(solr_doc[key]).map { |value| authority_label(services_for(key), value) }
+    end
+
+    solr_doc
+  end
+
+  def controlled_index_keys
+    controlled_properties.flat_map(&:first).uniq
+  end
+
+  def services_for(key)
+    controlled_properties.filter_map { |indexing_keys, service| service if indexing_keys.include?(key) }.uniq
+  end
+
+  def controlled_properties
+    @controlled_properties ||= profile_properties.filter_map do |_name, config|
+      service = authority_service_for(authority_source(config))
+      next unless service.respond_to?(:label)
+
+      indexing_keys = Array(config['indexing'])
+
+      [indexing_keys, service]
+    end
+  end
+
+  def profile_properties
+    @profile_properties ||= Hyrax::FlexibleSchema.order('created_at asc').last&.profile&.dig('properties') || {}
+  end
+
+  def authority_source(config)
+    return unless config.is_a?(Hash)
+
+    sources = Array(config.dig('controlled_values', 'sources')).map { |source| source.to_s.strip }
+    sources.find { |source| source.present? && source != 'null' }
+  end
+
+  def authority_service_for(source)
+    return if source.blank?
+
+    @authority_service ||= {}
+    return @authority_service[source] if @authority_service.key?(source)
+
+    service = controlled_vocabulary_service_for(source)
+    service = service.new if service.is_a?(Class)
+    @authority_service[source] = backed_by_authority?(service, source) ? service : nil
+  end
+
+  def backed_by_authority?(service, source)
+    return false unless service.respond_to?(:authority)
+
+    service.authority.present?
+  rescue Qa::InvalidSubAuthority => e
+    Rails.logger.warn "No authority backs the controlled vocabulary #{source}: #{e.message}"
+    false
+  end
+
+  def authority_label(services, value)
+    return value if identifier?(value)
+
+    services.each do |service|
+      label = service.label(value) { nil }
+      return label if label.present?
+    end
+
+    value
+  end
+
+  def identifier?(value)
+    URI.parse(value.to_s).absolute?
+  rescue URI::InvalidURIError
+    false
+  end
+end

--- a/app/indexers/hyku/indexers/file_set_indexer.rb
+++ b/app/indexers/hyku/indexers/file_set_indexer.rb
@@ -5,13 +5,12 @@ module Hyku
     class FileSetIndexer < Hyrax::Indexers::FileSetIndexer
       include Hyrax::Indexer(:bulkrax_metadata) unless Hyrax.config.flexible?
       include ScrubText
+      include IndexesControlledLabels
 
       def to_solr
-        return super unless Flipflop.default_pdf_viewer?
-
-        super.tap do |solr_doc|
-          solr_doc['all_text_timv'] = solr_doc['all_text_tsimv'] = pdf_text
-        end
+        solr_doc = super
+        solr_doc['all_text_timv'] = solr_doc['all_text_tsimv'] = pdf_text if Flipflop.default_pdf_viewer?
+        relabel_controlled_values(solr_doc)
       end
 
       private

--- a/spec/indexers/concerns/indexes_controlled_labels_spec.rb
+++ b/spec/indexers/concerns/indexes_controlled_labels_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe IndexesControlledLabels do
+  let(:indexer) { Class.new { include IndexesControlledLabels }.new }
+  let(:profile) do
+    { 'properties' => {
+      'rights_statement' => {
+        'controlled_values' => { 'sources' => ['rights_statements'] },
+        'indexing' => ['rights_statement_sim', 'rights_statement_tesim', 'facetable']
+      },
+      'title' => { 'indexing' => ['title_tesim'] }
+    } }
+  end
+
+  before do
+    allow(Hyrax.config).to receive(:flexible?).and_return(true)
+    allow(Hyrax::FlexibleSchema).to receive(:order).with('created_at asc')
+                                                   .and_return([instance_double(Hyrax::FlexibleSchema, profile: profile)])
+  end
+
+  def unbacked_service
+    Module.new do
+      def self.authority
+        Qa::Authorities::Local.subauthority_for('does_not_exist')
+      end
+
+      def self.label(id, &block)
+        authority.find(id).fetch('term', &block)
+      end
+    end
+  end
+
+  def relabel(doc)
+    indexer.send(:relabel_controlled_values, doc)
+  end
+
+  it 'replaces a schemeless term id with its authority label' do
+    Qa::LocalAuthorityEntry.create!(local_authority: Qa::LocalAuthority.find_or_create_by!(name: 'rights_statements'),
+                                    uri: 'local_auth_123', label: 'Opaque Term', active: true)
+
+    doc = relabel('rights_statement_tesim' => ['local_auth_123'])
+
+    expect(doc['rights_statement_tesim']).to eq(['Opaque Term'])
+  end
+
+  it 'leaves an http uri alone so machine consumers still read it' do
+    doc = relabel('rights_statement_tesim' => ['http://rightsstatements.org/vocab/InC/1.0/'])
+
+    expect(doc['rights_statement_tesim']).to eq(['http://rightsstatements.org/vocab/InC/1.0/'])
+  end
+
+  it 'leaves a non-url uri alone' do
+    doc = relabel('rights_statement_tesim' => ['info:lc/authorities/subjects/sh85021262'])
+
+    expect(doc['rights_statement_tesim']).to eq(['info:lc/authorities/subjects/sh85021262'])
+  end
+
+  it 'keeps a value the authority does not know' do
+    doc = relabel('rights_statement_tesim' => ['Ask the library'])
+
+    expect(doc['rights_statement_tesim']).to eq(['Ask the library'])
+  end
+
+  it 'ignores indexing hints that are not solr fields' do
+    expect { relabel('rights_statement_tesim' => ['Ask the library']) }.not_to raise_error
+  end
+
+  it 'leaves uncontrolled properties alone' do
+    doc = relabel('title_tesim' => ['local_auth_123'])
+
+    expect(doc['title_tesim']).to eq(['local_auth_123'])
+  end
+
+  it 'keeps the value when no authority backs the profile source' do
+    allow(ApplicationController.helpers).to receive(:controlled_vocabulary_service_for)
+      .with('rights_statements').and_return(unbacked_service)
+
+    doc = relabel('rights_statement_tesim' => ['local_auth_123'])
+
+    expect(doc['rights_statement_tesim']).to eq(['local_auth_123'])
+  end
+
+  it 'relabels a key shared by two properties once, using whichever authority knows the value' do
+    profile['properties']['rights_statement_optional'] = {
+      'controlled_values' => { 'sources' => ['flex_subjects'] },
+      'indexing' => ['rights_statement_tesim']
+    }
+    Qa::LocalAuthorityEntry.create!(local_authority: Qa::LocalAuthority.find_or_create_by!(name: 'flex_subjects'),
+                                    uri: 'other_auth_9', label: 'Other Term', active: true)
+
+    doc = relabel('rights_statement_tesim' => ['other_auth_9'])
+
+    expect(doc['rights_statement_tesim']).to eq(['Other Term'])
+  end
+
+  it 'does nothing when flexible metadata is off' do
+    allow(Hyrax.config).to receive(:flexible?).and_return(false)
+
+    doc = relabel('rights_statement_tesim' => ['local_auth_123'])
+
+    expect(doc['rights_statement_tesim']).to eq(['local_auth_123'])
+  end
+end


### PR DESCRIPTION
Locally created vocabulary terms index their id, so the search, facets, and work page showed the raw id instead of the label. Resolve the id through the term's authority at index time. Values carrying a URI scheme are left as-is, since OAI serializes those same Solr fields.
