### PR TITLE
Delete static public/robots.txt shadowing the dynamic robots view

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,1 +1,0 @@
-# See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file


### PR DESCRIPTION
We need to delete the auto-created public/robots.txt comment-only file so that we can display the dynamic one from Hyrax.

Confirmed live on a production tenant (`d-scholarship.pitt.edu/robots.txt`) — it serves only the stub, not the dynamic content.

Closes #2919