### PR TITLE
Refuse work types the tenant does not offer

### DIFF
--- a/app/controllers/concerns/hyku/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyku/works_controller_behavior.rb
@@ -7,6 +7,7 @@
 #           - use Hyku::WorkShowPresenter rather than Hyrax's presenter
 #           - refuse a parent_id the depositor cannot edit or whose type cannot
 #             contain the work being created
+#           - refuse a work type the tenant does not offer
 module Hyku
   # include this module after including Hyrax::WorksControllerBehavior to override
   # Hyrax::WorksControllerBehavior methods with the ones defined here
@@ -18,6 +19,7 @@ module Hyku
     included do
       # add around action to load theme show page views
       around_action :inject_show_theme_views, except: :delete
+      before_action :ensure_work_type_offered, only: %i[new create]
       before_action :ensure_parent_accepts_child, only: :create
       self.show_presenter = Hyku::WorkShowPresenter
 
@@ -42,6 +44,18 @@ module Hyku
     end
 
     private
+
+    # Routes are drawn for every registered curation concern, so /concern/<type>/new is
+    # reachable on a tenant that does not offer the type.
+    def ensure_work_type_offered
+      return if Site.instance.offerable_work_types.include?(offered_work_type_name)
+
+      redirect_to main_app.root_path, alert: I18n.t('hyku.works.errors.work_type_not_offered')
+    end
+
+    def offered_work_type_name
+      Hyrax::ModelRegistry.rdf_representations_from([self.class.curation_concern_type]).first
+    end
 
     # parent_id reaches Steps::AddToParent straight from params, and that step
     # validates neither the type pairing nor the user's access to the parent.

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -23,6 +23,23 @@ class Site < ApplicationRecord
   belongs_to :account, optional: true
   accepts_nested_attributes_for :account, update_only: true
 
+  # A type the profile omits gets no metadata behaviour, so offering it can only fail.
+  #
+  # @return [Array<String>] work type names this tenant may offer a depositor
+  def offerable_work_types
+    enabled = available_works || []
+    return enabled unless Hyrax.config.flexible?
+    # Search-only tenants have no profile of their own.
+    return enabled if account&.search_only?
+
+    profile = Hyrax::FlexibleSchema.current_version
+    return enabled unless profile
+
+    declared = (profile['classes']&.keys || []).map { |klass| klass.gsub(/Resource$/, '') }
+
+    enabled & declared & Hyrax.config.registered_curation_concern_types
+  end
+
   class << self
     delegate :account, :application_name, :institution_name, :favicon,
              :institution_name_full, :reload, :update, :contact_email,

--- a/app/services/hyrax/quick_classification_query_decorator.rb
+++ b/app/services/hyrax/quick_classification_query_decorator.rb
@@ -22,23 +22,8 @@ module Hyrax
 
     private
 
-    # Filter available works based on metadata profile when flexible metadata is enabled
     def filtered_available_works
-      available_works = Site.instance.available_works
-      return available_works unless Hyrax.config.flexible?
-
-      # Search-only tenants don't have their own flexible metadata profiles
-      # They should use the basic available_works configuration
-      return available_works if Site.account&.search_only?
-
-      profile = Hyrax::FlexibleSchema.current_version
-      return available_works unless profile
-
-      profile_classes = profile['classes']&.keys || []
-      profile_work_types = profile_classes.map { |klass| klass.gsub(/Resource$/, '') } & Hyrax.config.registered_curation_concern_types
-
-      # Only include work types that are both enabled in site AND in the metadata profile
-      available_works & profile_work_types
+      Site.instance.offerable_work_types
     end
   end
 end

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -254,6 +254,9 @@ de:
       part_of:
         heading: Teil von
   hyku:
+    works:
+      errors:
+        work_type_not_offered: Dieser Werktyp ist auf dieser Website nicht verfügbar. Wählen Sie einen anderen aus.
     account:
       signup_disabled: Kontoanmeldung ist deaktiviert
     deposit_wizard:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -269,6 +269,7 @@ en:
     works:
       errors:
         parent_not_allowed: That work cannot contain this deposit.
+        work_type_not_offered: That work type is not available on this site. Choose a different one.
     admin:
       controlled_vocabularies: Controlled Vocabularies
       controlled_vocabulary:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -255,6 +255,9 @@ es:
       part_of:
         heading: Parte de
   hyku:
+    works:
+      errors:
+        work_type_not_offered: Ese tipo de obra no está disponible en este sitio. Elija otro.
     account:
       signup_disabled: El registro de la cuenta está deshabilitado
     deposit_wizard:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -255,6 +255,9 @@ fr:
       part_of:
         heading: Fait partie de
   hyku:
+    works:
+      errors:
+        work_type_not_offered: Ce type d'œuvre n'est pas disponible sur ce site. Veuillez en choisir un autre.
     account:
       signup_disabled: L'enregistrement du compte est désactivé
     deposit_wizard:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -255,6 +255,9 @@ it:
       part_of:
         heading: Parte di
   hyku:
+    works:
+      errors:
+        work_type_not_offered: Questo tipo di opera non è disponibile su questo sito. Scegline un altro.
     account:
       signup_disabled: La registrazione dell'account è disattivata
     deposit_wizard:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -137,6 +137,9 @@ pt-BR:
       part_of:
         heading: Parte de
   hyku:
+    works:
+      errors:
+        work_type_not_offered: Esse tipo de obra não está disponível neste site. Escolha outro.
     account:
       signup_disabled: O registro da conta está desativado
     deposit_wizard:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -271,6 +271,9 @@ zh:
       part_of:
         heading: 所属
   hyku:
+    works:
+      errors:
+        work_type_not_offered: 本站点不提供该作品类型。请选择其他类型。
     account:
       signup_disabled: 帐户注册被禁用
     deposit_wizard:

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -334,6 +334,47 @@ RSpec.describe Site, type: :model do
     end
   end
 
+  describe '#offerable_work_types' do
+    subject(:site) { create(:site, available_works: %w[GenericWork Image Etd]) }
+
+    before do
+      allow(Hyrax.config).to receive(:registered_curation_concern_types)
+        .and_return(%w[GenericWork Image Etd])
+    end
+
+    context 'without flexible metadata' do
+      before { allow(Hyrax.config).to receive(:flexible?).and_return(false) }
+
+      it 'offers everything the site enables' do
+        expect(site.offerable_work_types).to eq(%w[GenericWork Image Etd])
+      end
+    end
+
+    context 'with a profile declaring fewer types than the site enables' do
+      before do
+        allow(Hyrax.config).to receive(:flexible?).and_return(true)
+        allow(Hyrax::FlexibleSchema).to receive(:current_version).and_return(
+          'classes' => { 'GenericWorkResource' => {}, 'ImageResource' => {} }
+        )
+      end
+
+      it 'drops the type the profile does not declare' do
+        expect(site.offerable_work_types).to eq(%w[GenericWork Image])
+      end
+    end
+
+    context 'with no current profile' do
+      before do
+        allow(Hyrax.config).to receive(:flexible?).and_return(true)
+        allow(Hyrax::FlexibleSchema).to receive(:current_version).and_return(nil)
+      end
+
+      it 'offers everything the site enables rather than nothing' do
+        expect(site.offerable_work_types).to eq(%w[GenericWork Image Etd])
+      end
+    end
+  end
+
   describe '.reset!' do
     it 'drops the tenant-scoped caches and leaves keys it does not own' do
       RequestStore.store[:site_instance] = 'stale site'

--- a/spec/requests/work_type_not_offered_spec.rb
+++ b/spec/requests/work_type_not_offered_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Requesting a work type the tenant does not offer', type: :request, singletenant: true, clean: true do
+  let(:admin) { FactoryBot.create(:admin) }
+
+  before do
+    FactoryBot.create(:admin_group)
+    FactoryBot.create(:registered_group)
+    FactoryBot.create(:editors_group)
+    FactoryBot.create(:depositors_group)
+
+    login_as admin
+  end
+
+  context 'when the site does not enable the type' do
+    before { Site.instance.update!(available_works: %w[Image]) }
+
+    it 'refuses new with a message rather than building the form' do
+      get new_hyrax_generic_work_path
+
+      expect(response).to redirect_to(root_path)
+      expect(flash[:alert]).to eq(I18n.t('hyku.works.errors.work_type_not_offered'))
+    end
+
+    it 'refuses create rather than persisting a work' do
+      expect do
+        post hyrax_generic_works_path, params: { generic_work: { title: ['Should not be created'] } }
+      end.not_to change { Hyrax.query_service.count_all_of_model(model: GenericWorkResource) }
+
+      expect(response).to redirect_to(root_path)
+      expect(flash[:alert]).to eq(I18n.t('hyku.works.errors.work_type_not_offered'))
+    end
+  end
+
+  context 'when the site enables the type' do
+    before { Site.instance.update!(available_works: %w[GenericWork Image]) }
+
+    it 'allows new through' do
+      get new_hyrax_generic_work_path
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/services/hyrax/quick_classification_query_decorator_spec.rb
+++ b/spec/services/hyrax/quick_classification_query_decorator_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Hyrax::QuickClassificationQuery, type: :decorator do
         end
 
         before do
-          allow(Site).to receive(:account).and_return(search_only_account)
+          allow(site).to receive(:account).and_return(search_only_account)
         end
 
         it 'returns Site.instance.available_works without trying to access flexible schema' do


### PR DESCRIPTION
Fixes #3259.

## TL;DR

- **Problem:** a signed-in depositor can go straight to `/concern/<type>/new` for a work type the tenant does not offer. Stock types render a form and **save a real record**; profile-backed types raise `NoMethodError: undefined method 'depositor='` and return a 500.
- **Cause:** routes exist for every registered curation concern, and the only filtering lives in `QuickClassificationQueryDecorator`, private to the picker. The controllers never check.
- **Fix:** move that filter to `Site#offerable_work_types` and guard `new` and `create` with it, redirecting with a flash instead of raising or saving.

- **Search-only tenants keep their existing bypass.** They have no profile of their own, so their offerable set stays whatever the site enables. That keeps the picker and the guard in agreement, but leaves #3259's third point unaddressed — happy to follow up if you would rather those tenants were filtered too.

## Reproduction

Clean Hyku, `HYRAX_FLEXIBLE=true`, no downstream app. Tenant offers `GenericWork, Image, Etd`; `Oer` is registered but not offered, and the picker correctly omits it.

`/concern/oers/new` renders anyway, and saving creates a real work (`Oer` id `5e18d8d5…`, since deleted):

| before | before | after |
|---|---|---|
| ![form renders](https://raw.githubusercontent.com/samvera/hyku/work-type-guard-screenshots/docs/screenshots/hyku-before-oer-form-renders.png) | ![work created](https://raw.githubusercontent.com/samvera/hyku/work-type-guard-screenshots/docs/screenshots/hyku-before-oer-created.png) | ![refused](https://raw.githubusercontent.com/samvera/hyku/work-type-guard-screenshots/docs/screenshots/hyku-after-oer-refused.png) |

Images live on the `work-type-guard-screenshots` branch to keep them out of this one; delete it once reviewed.

## Both flexible modes

With `HYRAX_FLEXIBLE=false`, `offerable_work_types` returns `available_works` untouched and never reaches `Hyrax::FlexibleSchema`, so the guard still enforces the offer list — a type absent from `available_works` is refused either way. `curation_concern_type` is the `Resource` class in both modes, so the `ModelRegistry` lookup is mode-independent.

The suite runs flexible by default, so I ran the request spec with the var set explicitly both ways rather than assume the non-flexible path.

## Testing

```
bundle exec rspec spec/requests/work_type_not_offered_spec.rb                      # 3 examples, 0 failures
HYRAX_FLEXIBLE=false bundle exec rspec spec/requests/work_type_not_offered_spec.rb # 3 examples, 0 failures
bundle exec rspec spec/models/site_spec.rb \
  spec/services/hyrax/quick_classification_query_decorator_spec.rb                 # 37 examples, 0 failures
```

The existing picker spec passing unchanged against the extracted method is the check that the move preserved behaviour. Rubocop clean. `hyku.works.errors.work_type_not_offered` added to `en` and the six translated locales.
