### PR TITLE
Key the redirects predicate as property_uri

### DIFF
--- a/config/metadata_profiles/m3_profile.yaml
+++ b/config/metadata_profiles/m3_profile.yaml
@@ -2151,7 +2151,7 @@ properties:
       display: false
     indexing:
       - editor_only
-    predicate: http://samvera.org/ns/hyku/redirects
+    property_uri: http://samvera.org/ns/hyku/redirects
     range: http://www.w3.org/2001/XMLSchema#string
     view:
       render_term: redirects_path


### PR DESCRIPTION
The `redirects` property added in #3251 declares its RDF predicate as `predicate:`. `Hyrax::FlexibleSchema#values_map` assigns `values['predicate'] = values['property_uri']` unconditionally, so the declared URI is discarded and the property ends up with a nil predicate. `property_uri` is the input key; `predicate` is derived from it.

- `redirects` was the only property in this profile using `predicate`, and the only one of the 80 with no `property_uri`. The other 72 that declare a predicate all use `property_uri`.
- Behaviour change is confined to the property gaining the predicate it was always meant to have. Nothing reads `predicate` from profile YAML, so no existing consumer moves.

Testing: profile parses, and no property is left declaring `predicate` without `property_uri`. No spec asserts a predicate for `redirects`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)