### PR TITLE
🐛 Fix reference theme search bar

### DIFF
--- a/app/assets/stylesheets/themes/reference.scss
+++ b/app/assets/stylesheets/themes/reference.scss
@@ -60,10 +60,16 @@
   }
 
   .ref-hero-lede {
+    flex: 0 1 1040px;
     max-width: 1040px;
     min-width: 0;
     position: relative;
     z-index: 1;
+
+    @media (max-width: $ref-mobile-max) {
+      flex-basis: auto;
+      width: 100%;
+    }
   }
 
   .ref-hero-eyebrow {


### PR DESCRIPTION
The search bar width was dependent on the size of the home page text.

## Before

<img width="1705" height="438" alt="image" src="https://github.com/user-attachments/assets/bdc098a9-9c01-4135-9726-8baf38f55a43" />

## After

<img width="1699" height="502" alt="image" src="https://github.com/user-attachments/assets/f1cef241-46ba-400a-8380-935d34a6aefa" />
