### PR TITLE
Exempt all /healthz subpaths from the http->https redirect

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -61,7 +61,7 @@ Rails.application.configure do # rubocop:disable Metrics/BlockLength
   config.force_ssl = true
   config.ssl_options = {
     redirect: {
-      exclude: ->(request) { request.path == '/healthz' }
+      exclude: ->(request) { request.path.start_with?('/healthz') }
     }
   }
   # Skip http-to-https redirect for the default health check endpoint.

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -51,7 +51,7 @@ Rails.application.configure do
   config.force_ssl = true
   config.ssl_options = {
     redirect: {
-      exclude: ->(request) { request.path == '/healthz' }
+      exclude: ->(request) { request.path.start_with?('/healthz') }
     }
   }
   # Use the lowest log level to ensure availability of diagnostic information


### PR DESCRIPTION
`OkComputer` mounts more than the bare root: `/healthz` runs its "default" check, `/healthz/all` runs every registered check (Solr, migrations, cache), `/healthz/<name>` runs one specific check. The `config.force_ssl` redirect exclude only matched `request.path == '/healthz'`, so any of those other paths gets redirected to `https://` instead of being answered directly.

That silently breaks plain-HTTP health checks against anything but the bare path — e.g. a Kubernetes `readinessProbe` pointed at `/healthz/all` for a deeper check gets a 302 it can't follow (Puma has no TLS listener), and fails forever. Found this while enabling k8s probes on a Hyku-based app ([hykuup_knapsack#726](https://github.com/notch8/hykuup_knapsack/pull/726)) — confirmed live on a staging deploy that a plain `httpGet` probe against `/healthz/all` never succeeds while the bare `/healthz` path works fine.

Widens the exclude to `request.path.start_with?('/healthz')` so all of OkComputer's mounted paths are exempt, not just the bare root.
