### PR TITLE
Controlled labels renderer subclasses

### DIFF
--- a/app/controllers/concerns/hyrax/flexible_catalog_behavior_decorator.rb
+++ b/app/controllers/concerns/hyrax/flexible_catalog_behavior_decorator.rb
@@ -29,7 +29,7 @@ module Hyrax
     private
 
     def apply_controlled_vocabulary_labels!
-      drop_surrogate_facets!
+      hide_surrogate_facets!
 
       controlled_properties.each do |itemprop|
         show_labels_in_search_results!(itemprop)
@@ -120,12 +120,14 @@ module Hyrax
     end
 
     # OVERRIDE: upstream registers a facet under the surrogate's own key, which
-    # holds no values.
-    def drop_surrogate_facets!
+    # holds no values. Hidden rather than unregistered, for the same reason
+    # facet_on_labels! keeps the id facet: an unconfigured facet makes Blacklight
+    # drop a filter silently and raise from facet_field_response.
+    def hide_surrogate_facets!
       profile_properties.each do |itemprop, config|
         next if indexed_name_for(itemprop, config).to_s == itemprop.to_s
 
-        blacklight_config.facet_fields.delete("#{itemprop}_sim")
+        blacklight_config.facet_fields["#{itemprop}_sim"]&.show = false
       end
     end
 

--- a/app/presenters/hyrax/presents_attributes_decorator.rb
+++ b/app/presenters/hyrax/presents_attributes_decorator.rb
@@ -30,22 +30,29 @@ module Hyrax
       document = solr_document
       return unless document.respond_to?(:[])
 
-      label_keys(document, field).lazy
-                                 .filter_map { |key| Array(document[key]).presence }
-                                 .first
+      label_keys(document, field)
+        .filter_map { |key| Array(document[key]).presence }
+        .first
     rescue StandardError => e
       Hyrax.logger.debug("controlled_labels_for(#{field}): #{e.message}")
       nil
     end
 
     # The suffix follows whatever the property was indexed under, so the pair we
-    # know is checked first and any other "<field>_label_*" after it.
+    # know is checked first and any other "<field>_label_*" after it. Lazy because
+    # this runs per attribute per show page and the scan walks every solr key.
     def label_keys(document, field)
       known = ["#{field}_label_tesim", "#{field}_label_sim"]
       prefix = "#{field}_label_"
-      others = document.respond_to?(:keys) ? document.keys.grep(/\A#{Regexp.escape(prefix)}/) : []
 
-      (known + others).uniq
+      Enumerator.new do |yielder|
+        known.each { |key| yielder << key }
+        next unless document.respond_to?(:keys)
+
+        document.keys.each do |key|
+          yielder << key if key.to_s.start_with?(prefix) && known.exclude?(key)
+        end
+      end.lazy
     end
   end
 end

--- a/app/renderers/hyrax/renderers/attribute_renderer_decorator.rb
+++ b/app/renderers/hyrax/renderers/attribute_renderer_decorator.rb
@@ -13,14 +13,22 @@ module Hyrax
 
       def attribute_value_to_html(value)
         return controlled_value_to_html(value) if controlled_label_for(value)
+        return markdown(value) if field.to_s == 'abstract'
+        # No indexed label: a subclass resolves the value through its own authority,
+        # and every work indexed before labels existed arrives that way.
+        return super unless instance_of_base_renderer?
 
-        if field.to_s == 'abstract'
-          markdown(value)
-        elsif microdata_value_attributes(field).present?
+        if microdata_value_attributes(field).present?
           "<span#{html_attributes(microdata_value_attributes(field))}>#{markdown(li_value(value))}</span>"
         else
           markdown(li_value(value))
         end
+      end
+
+      # True for AttributeRenderer itself, where super is upstream's plain
+      # implementation and Hyku's markdown handling has to stay here instead.
+      def instance_of_base_renderer?
+        self.class == Hyrax::Renderers::AttributeRenderer
       end
 
       # The generic form of what LicenseAttributeRenderer and

--- a/app/renderers/hyrax/renderers/attribute_renderer_decorator.rb
+++ b/app/renderers/hyrax/renderers/attribute_renderer_decorator.rb
@@ -59,4 +59,11 @@ module Hyrax
   end
 end
 
-Hyrax::Renderers::AttributeRenderer.prepend(Hyrax::Renderers::AttributeRendererDecorator)
+# Each of these defines attribute_value_to_html itself, so prepending to the
+# parent alone would leave them rendering ids. Only the two authority-backed
+# renderers are listed: a date or rich text is never a controlled term.
+[Hyrax::Renderers::AttributeRenderer,
+ Hyrax::Renderers::LicenseAttributeRenderer,
+ Hyrax::Renderers::RightsStatementAttributeRenderer].each do |renderer|
+  renderer.prepend(Hyrax::Renderers::AttributeRendererDecorator)
+end

--- a/spec/controllers/catalog_controller_controlled_labels_spec.rb
+++ b/spec/controllers/catalog_controller_controlled_labels_spec.rb
@@ -100,10 +100,18 @@ RSpec.describe 'catalog rendering of controlled vocabulary labels' do
       end
     end
 
-    it 'drops the facet upstream builds under a surrogate own key, which holds nothing' do
+    it 'hides the facet upstream builds under a surrogate own key, which holds nothing' do
       load_profile!
 
-      expect(catalog.blacklight_config.facet_fields).not_to have_key 'oer_resource_type_sim'
+      expect(catalog.blacklight_config.facet_fields['oer_resource_type_sim'].show).to be false
+    end
+
+    # Worth registering even though the key holds nothing: an unconfigured facet
+    # raises from facet_field_response and drops a bookmarked filter silently.
+    it 'leaves the surrogate facet resolvable' do
+      load_profile!
+
+      expect(catalog.blacklight_config.facet_fields).to have_key 'oer_resource_type_sim'
     end
   end
 
@@ -112,7 +120,8 @@ RSpec.describe 'catalog rendering of controlled vocabulary labels' do
     4.times { catalog.load_flexible_schema }
     facets = catalog.blacklight_config.facet_fields
 
-    expect(facets.keys.grep(/resource_type/)).to eq %w[resource_type_sim resource_type_label_sim]
+    expect(facets.keys.grep(/resource_type/))
+      .to eq %w[resource_type_sim oer_resource_type_sim resource_type_label_sim]
     expect(facets.select { |_, f| f.show != false }.keys.grep(/resource_type/))
       .to eq ['resource_type_label_sim']
   end

--- a/spec/features/oai_pmh_spec.rb
+++ b/spec/features/oai_pmh_spec.rb
@@ -61,6 +61,31 @@ RSpec.describe "OAI PMH Support", type: :feature do
         expect(page).to have_no_content('Attribution 3.0 United States')
       end
     end
+
+    # The examples above build an ActiveFedora work, which never routes through
+    # Hyrax::Indexer, so no label is written for it and "no label in the feed"
+    # would hold even if label indexing had never run. A valkyrie work is indexed
+    # with one, which is what makes the absence below mean the id won.
+    context 'when the work is indexed with a label' do
+      let(:admin_set) { FactoryBot.valkyrie_create(:hyku_admin_set, with_permission_template: true) }
+      let(:work) do
+        FactoryBot.valkyrie_create(:generic_work_resource,
+                                   depositor: user.user_key,
+                                   visibility_setting: 'open',
+                                   admin_set_id: admin_set.id,
+                                   license: ['http://creativecommons.org/licenses/by/3.0/us/'])
+      end
+
+      it 'emits the stored id rather than the term label' do
+        indexed = Hyrax::SolrService.query("id:#{work.id}", fl: 'license_label_tesim').first
+        expect(indexed['license_label_tesim']).to eq ['Attribution 3.0 United States']
+
+        visit oai_catalog_path(verb: 'GetRecord', metadataPrefix: 'oai_dc', identifier:)
+
+        expect(page).to have_content('http://creativecommons.org/licenses/by/3.0/us/')
+        expect(page).to have_no_content('Attribution 3.0 United States')
+      end
+    end
   end
 
   context 'when using the oai_hyku prefix' do

--- a/spec/renderers/hyrax/renderers/attribute_renderer_decorator_spec.rb
+++ b/spec/renderers/hyrax/renderers/attribute_renderer_decorator_spec.rb
@@ -84,6 +84,36 @@ RSpec.describe Hyrax::Renderers::AttributeRendererDecorator do
     end
   end
 
+  # Not hypothetical: rights_statement is controlled in the shipped profile and
+  # declares render_as: rights_statement, so a term whose id is not a URI reaches
+  # its own renderer on a stock install.
+  context 'for a renderer subclass that defines its own attribute_value_to_html' do
+    let(:values) { ['local_rights_7'] }
+    let(:options) { { labels: ['Custom Rights Label'] } }
+
+    it 'shows the label for a rights statement' do
+      renderer = Hyrax::Renderers::RightsStatementAttributeRenderer.new(:rights_statement, values, options)
+
+      expect(renderer.render).to include 'Custom Rights Label'
+    end
+
+    it 'shows the label for a license' do
+      renderer = Hyrax::Renderers::LicenseAttributeRenderer.new(:license, values, options)
+
+      expect(renderer.render).to include 'Custom Rights Label'
+    end
+
+    # The service still resolves a URI the authority knows, so the dedicated
+    # renderers keep working where no indexed label exists.
+    it 'leaves a URI the service resolves alone' do
+      renderer = Hyrax::Renderers::LicenseAttributeRenderer.new(
+        :license, ['http://creativecommons.org/licenses/by/3.0/us/'], {}
+      )
+
+      expect(renderer.render).to include 'href="http://creativecommons.org/licenses/by/3.0/us/"'
+    end
+  end
+
   context 'for a free-text field' do
     let(:field) { :abstract }
     let(:values) { ['An *emphasized* abstract'] }

--- a/spec/renderers/hyrax/renderers/attribute_renderer_decorator_spec.rb
+++ b/spec/renderers/hyrax/renderers/attribute_renderer_decorator_spec.rb
@@ -103,14 +103,14 @@ RSpec.describe Hyrax::Renderers::AttributeRendererDecorator do
       expect(renderer.render).to include 'Custom Rights Label'
     end
 
-    # The service still resolves a URI the authority knows, so the dedicated
-    # renderers keep working where no indexed label exists.
-    it 'leaves a URI the service resolves alone' do
+    # The no-label case is every work indexed before this feature, not an edge case.
+    it 'falls back to the renderer authority when no label is indexed' do
       renderer = Hyrax::Renderers::LicenseAttributeRenderer.new(
         :license, ['http://creativecommons.org/licenses/by/3.0/us/'], {}
       )
 
       expect(renderer.render).to include 'href="http://creativecommons.org/licenses/by/3.0/us/"'
+      expect(renderer.render).to include 'Attribution 3.0 United States'
     end
   end
 


### PR DESCRIPTION
## Summary
Controlled term labels now appear on license and rights statement fields, which were still showing the stored id.
- Follow-up to the review on #3253

## Details
- `LicenseAttributeRenderer` and `RightsStatementAttributeRenderer` define `attribute_value_to_html` themselves, so the module prepended to `AttributeRenderer` never reached them. `rights_statement` is controlled in the shipped profile and declares `render_as: rights_statement`, so a term whose id is not a URI showed the raw id on a stock install. A URI the authority resolves still renders through its own service.
- The facet built under a surrogate property's key is now hidden rather than unregistered, matching how the id facet is handled a few lines above — the two had contradicted each other.
- The label field lookup no longer scans every Solr key when a known suffix hits.
- The OAI examples now include a work that is actually indexed with a label, so "no label in the feed" means the id won rather than meaning no label existed.
- Not included: sorting a multi-valued controlled field orders by stored id rather than by the displayed label. Nothing in Hyku passes `sort` and the fix belongs in upstream's `render`; better handled in samvera/hyrax#7618.
