### PR TITLE
Modify vocabulary creation gating

### DIFF
--- a/app/controllers/hyrax/dashboard/controlled_vocabularies_controller.rb
+++ b/app/controllers/hyrax/dashboard/controlled_vocabularies_controller.rb
@@ -14,7 +14,8 @@ module Hyrax
       with_themed_layout 'dashboard'
 
       before_action -> { authorize! :view, :controlled_vocabularies }, only: %i[index show]
-      before_action -> { authorize! :manage, :controlled_vocabularies }, only: %i[new create edit update]
+      before_action -> { authorize! :manage, :controlled_vocabularies }, only: %i[edit update]
+      before_action -> { authorize! :create, :new_controlled_vocabulary }, only: %i[new create]
       before_action :load_vocabulary, only: %i[edit update]
 
       def index

--- a/app/models/concerns/hyrax/ability/controlled_vocabulary_ability.rb
+++ b/app/models/concerns/hyrax/ability/controlled_vocabulary_ability.rb
@@ -6,6 +6,9 @@
 # the terms a field offers and which of them are retired. Managing is restricted
 # to admins: a vocabulary's terms are the values works store, so editing one
 # affects every work already citing it.
+#
+# Creating a new vocabulary needs flexible metadata, since the m3 profile is the
+# only way to attach it to a property.
 module Hyrax
   module Ability
     module ControlledVocabularyAbility
@@ -13,6 +16,10 @@ module Hyrax
       # because CanCan does not alias the two, and Hyrax callers reach for :read.
       def controlled_vocabulary_abilities
         can %i[manage view read], :controlled_vocabularies if admin?
+
+        # A new subject because `can :manage` above already covers every action on
+        # :controlled_vocabularies, so an action there would need a `cannot`.
+        can %i[create], :new_controlled_vocabulary if admin? && Hyrax.config.flexible?
 
         # Same check Bulkrax uses to gate importing, so anyone who can deposit
         # through it can also look up the vocabularies behind those fields.

--- a/app/views/hyrax/dashboard/controlled_vocabularies/index.html.erb
+++ b/app/views/hyrax/dashboard/controlled_vocabularies/index.html.erb
@@ -3,7 +3,7 @@
   <h1><span class="fa fa-tags" aria-hidden="true"></span> <%= t('hyku.admin.controlled_vocabularies') %></h1>
 <% end %>
 
-<% if can? :manage, :controlled_vocabularies %>
+<% if can? :create, :new_controlled_vocabulary %>
   <div class="mb-3 text-right">
     <%= link_to main_app.new_controlled_vocabulary_path, class: 'btn btn-primary' do %>
       <%= t('hyku.admin.controlled_vocabulary.new_title') %>

--- a/docs/controlled-vocabularies.md
+++ b/docs/controlled-vocabularies.md
@@ -1,6 +1,6 @@
 # Controlled Vocabularies in Hyku
 
-Hyku supports both local and remote controlled vocabularies for form fields through the flexible metadata system. When `HYRAX_FLEXIBLE` is enabled, you can specify controlled vocabularies directly in your metadata profile YAML files by configuring the `controlled_values.sources` array for most properties.
+Hyku supports both local and remote controlled vocabularies for form fields. With `HYRAX_FLEXIBLE` enabled, a property cites a vocabulary through the `controlled_values.sources` array in the metadata profile. Without it, the property-to-vocabulary mapping lives in code, and only that mapping step differs — vocabularies, their terms, and the dashboard that manages them work in both modes.
 
 ## How It Works
 
@@ -50,7 +50,6 @@ Shipped with the application:
 - `discipline` - Academic disciplines and subject areas
 - `education_levels` - Educational levels (K-12, undergraduate, etc.)
 - `learning_resource_types` - Types of educational resources
-- `media_viewer` - Which player renders a work's media on its show page
 - `oer_types` - Open Educational Resource types
 - `licenses` - Creative Commons and other license options for the work
 - `resource_types` - Types of resources, such as "Article" or "Image"
@@ -464,6 +463,13 @@ The listing marks each authority with its origin:
 
 ### Creating a Vocabulary
 
+Creating a vocabulary from the dashboard requires flexible metadata, and the button is
+hidden without it: a new vocabulary is reached by citing its source key in a metadata
+profile, and there is no profile to cite it from. See
+[Adding a vocabulary without flexible metadata](#adding-a-vocabulary-without-flexible-metadata)
+for that case. Editing a vocabulary, managing its terms, and importing terms are
+unaffected and work in both modes.
+
 Administrators can create a vocabulary from the dashboard. The name is typed; the
 source key is derived from it (`Lab Names` becomes `lab_names`, and accented
 characters are transliterated), and the derived key is shown for confirmation before
@@ -597,8 +603,8 @@ effect immediately and are per-tenant.
 
 ### Adding Local Vocabularies
 
-Either create one through the dashboard, which needs no deployment, or ship a YAML
-file:
+With flexible metadata, create one through the dashboard — it needs no deployment. To
+ship one instead:
 
 1. Create a YAML file in `config/authorities/` following the existing pattern
 2. Reference the file name (without .yml extension) in your metadata profile's `sources` array
@@ -606,6 +612,27 @@ file:
 
 A YAML vocabulary is deployment-wide; a dashboard-created one belongs to the tenant it
 was created in.
+
+### Adding a vocabulary without flexible metadata
+
+There is no metadata profile to cite a source key from, so the property-to-vocabulary
+mapping is a code change. A developer is needed for the vocabulary itself; its terms are
+then managed from the dashboard like any other.
+
+1. Add `config/authorities/<name>.yml` following the pattern in
+   [File Structure](#file-structure). The filename is the source key and must be
+   lowercase letters, numbers, underscores and hyphens, starting with a letter or number.
+2. Import it into the tenant tables: `bundle exec rake populate_qa`. This runs for every
+   tenant, and `AUTHORITIES_PATH` overrides the directory. A newly created tenant is
+   seeded automatically, so this is for tenants that already exist.
+3. Map the property to the vocabulary in `controlled_vocab_mappings` in
+   `config/initializers/hyrax_controlled_vocabularies.rb`. Without this the vocabulary
+   exists but no property uses it.
+4. Confirm the property exists in the relevant schema under `config/metadata/`.
+5. Restart, then reindex so existing works pick up the term labels.
+
+The YAML seeds the terms once. After that the tenant's rows are the source of truth, so
+editing the YAML has no further effect and terms are managed from the dashboard.
 
 ### Registering a Service Class
 

--- a/spec/abilities/controlled_vocabulary_ability_spec.rb
+++ b/spec/abilities/controlled_vocabulary_ability_spec.rb
@@ -13,6 +13,22 @@ RSpec.describe Hyrax::Ability::ControlledVocabularyAbility do
 
     it { is_expected.to be_able_to(:manage, :controlled_vocabularies) }
     it { is_expected.to be_able_to(:view, :controlled_vocabularies) }
+
+    context 'with flexible metadata' do
+      before { allow(Hyrax.config).to receive(:flexible?).and_return(true) }
+
+      it { is_expected.to be_able_to(:create, :new_controlled_vocabulary) }
+    end
+
+    context 'without flexible metadata' do
+      before { allow(Hyrax.config).to receive(:flexible?).and_return(false) }
+
+      it { is_expected.not_to be_able_to(:create, :new_controlled_vocabulary) }
+
+      it 'still manages the vocabularies that exist' do
+        expect(ability).to be_able_to(:manage, :controlled_vocabularies)
+      end
+    end
   end
 
   # Stubbed on the class rather than the instance: CanCan evaluates ability_logic

--- a/spec/requests/controlled_vocabularies_spec.rb
+++ b/spec/requests/controlled_vocabularies_spec.rb
@@ -296,6 +296,8 @@ RSpec.describe 'Controlled vocabularies', type: :request, clean: true, multitena
     end
 
     describe 'creating a vocabulary' do
+      before { allow(Hyrax.config).to receive(:flexible?).and_return(true) }
+
       it 'offers the form' do
         get "http://#{account.cname}/dashboard/controlled_vocabularies/new"
 
@@ -449,6 +451,31 @@ RSpec.describe 'Controlled vocabularies', type: :request, clean: true, multitena
 
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.body).to include 'cafe_terms'
+      end
+    end
+
+    # The rule itself is covered in spec/abilities; these two only prove it reaches
+    # the route and the view.
+    describe 'creating a vocabulary without flexible metadata' do
+      before { allow(Hyrax.config).to receive(:flexible?).and_return(false) }
+
+      it 'refuses a confirmed create posted directly, and hides the add button' do
+        post "http://#{account.cname}/dashboard/controlled_vocabularies",
+             params: { param_key => { label: 'Lab Names' }, confirmed: 'true' }
+        created = Apartment::Tenant.switch(account.tenant) { Qa::LocalAuthority.exists?(name: 'lab_names') }
+
+        get "http://#{account.cname}/dashboard/controlled_vocabularies"
+
+        expect(created).to be false
+        expect(response.body).not_to include 'dashboard/controlled_vocabularies/new'
+      end
+
+      it 'still allows managing an existing vocabulary and its terms' do
+        get "http://#{account.cname}/dashboard/controlled_vocabularies/reading_rooms/edit"
+        expect(response).to have_http_status(:success)
+
+        get "http://#{account.cname}/dashboard/controlled_vocabularies/reading_rooms/terms/new"
+        expect(response).to have_http_status(:success)
       end
     end
 


### PR DESCRIPTION
## Summary
The dashboard no longer offers to create a controlled vocabulary when flexible metadata is off, where a new one could never be attached to a property. It retains the ability to add and modify terms.

## Rationale
With flexible mode, a vocabulary is attached to a property by citing its source key in a metadata profile. Without `flexibility=true`, a new vocabulary could be created in the UI but would require code changes to put it into use. Allowing UI-based creation implies a usability that doesn't exist.

## Changes
- Editing a vocabulary, managing its terms, and importing terms are unchanged and work in both modes.
- The guide covers what adding a vocabulary takes in that case: a YAML file, a rake task, and a mapping entry.

