### PR TITLE
Extend build triggers to staging and production

### DIFF
--- a/.github/workflows/build-test-lint.yaml
+++ b/.github/workflows/build-test-lint.yaml
@@ -4,9 +4,13 @@ on:
   push:
     branches:
       - main
+      - staging
+      - production
   pull_request:
     branches:
       - main
+      - staging
+      - production
   workflow_dispatch:
     inputs:
       debug_step:


### PR DESCRIPTION
Part of notch8/hyku-community-issues#146

`staging` and `production` require 12 status checks, but `build-test-lint.yaml` only triggers on `main`. The workflow never runs for PRs targeting those branches, so the checks sit at "Expected" forever and nothing can merge into either one.

Six added lines, no job or logic changes.

