### PR TITLE
Loosen health checks to avoid taking healthy pods out of circulation

### DIFF
--- a/ops/demo-deploy.tmpl.yaml
+++ b/ops/demo-deploy.tmpl.yaml
@@ -8,7 +8,6 @@ resources:
     memory: "2Gi"
     cpu: "100m"
 
-# Chart default path "/" does a full Solr+DB-backed page render - too slow/heavy for a health check. /healthz (okcomputer, standard Hyrax dependency) is cheap and dependency-free.
 startupProbe:
   enabled: true
   path: "/healthz"
@@ -16,7 +15,10 @@ startupProbe:
 livenessProbe:
   enabled: true
   path: "/healthz"
-# Loosened timing to tolerate /healthz queuing behind slow large-work renders (hyrax/_items.html.erb N+1) without pulling pods from rotation mid-spike - utk-hyku hit this same cascade on chart-default timing (notch8/utk-hyku#882).
+  initialDelaySeconds: 15
+  periodSeconds: 60
+  timeoutSeconds: 60
+  failureThreshold: 6
 readinessProbe:
   enabled: true
   path: "/healthz"

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -8,7 +8,6 @@ resources:
     memory: "2Gi"
     cpu: "100m"
 
-# Chart default path "/" does a full Solr+DB-backed page render - too slow/heavy for a health check. /healthz (okcomputer, standard Hyrax dependency) is cheap and dependency-free.
 startupProbe:
   enabled: true
   path: "/healthz"
@@ -16,7 +15,10 @@ startupProbe:
 livenessProbe:
   enabled: true
   path: "/healthz"
-# Loosened timing to tolerate /healthz queuing behind slow large-work renders (hyrax/_items.html.erb N+1) without pulling pods from rotation mid-spike - utk-hyku hit this same cascade on chart-default timing (notch8/utk-hyku#882).
+  initialDelaySeconds: 15
+  periodSeconds: 60
+  timeoutSeconds: 60
+  failureThreshold: 6
 readinessProbe:
   enabled: true
   path: "/healthz"

--- a/ops/test-deploy.tmpl.yaml
+++ b/ops/test-deploy.tmpl.yaml
@@ -8,7 +8,6 @@ resources:
     memory: "2Gi"
     cpu: "100m"
 
-# Chart default path "/" does a full Solr+DB-backed page render - too slow/heavy for a health check. /healthz (okcomputer, standard Hyrax dependency) is cheap and dependency-free.
 startupProbe:
   enabled: true
   path: "/healthz"
@@ -16,7 +15,10 @@ startupProbe:
 livenessProbe:
   enabled: true
   path: "/healthz"
-# Loosened timing to tolerate /healthz queuing behind slow large-work renders (hyrax/_items.html.erb N+1) without pulling pods from rotation mid-spike - utk-hyku hit this same cascade on chart-default timing (notch8/utk-hyku#882).
+  initialDelaySeconds: 15
+  periodSeconds: 60
+  timeoutSeconds: 60
+  failureThreshold: 6
 readinessProbe:
   enabled: true
   path: "/healthz"


### PR DESCRIPTION
Makes startup, readiness, and liveness probes more forgiving, to make sure healthy pods are not prematurely taken out of circulation.

@samvera/hyku-code-reviewers
