### PR TITLE
Add filterCache, queryResultCache, and documentCache to solrconfig.xml

### DIFF
--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -46,8 +46,17 @@
   <dataDir>${solr.blacklight-core.data.dir:}</dataDir>
 
   <query>
-    <filterCache class="solr.search.FastLRUCache" size="512" initialSize="512" autowarmCount="128"/>
-    <queryResultCache class="solr.search.LRUCache" size="512" initialSize="512" autowarmCount="128"/>
+    <filterCache class="solr.search.FastLRUCache"
+                 size="${solr.filterCache.size:512}"
+                 initialSize="${solr.filterCache.initialSize:512}"
+                 autowarmCount="${solr.filterCache.autowarmCount:128}"/>
+    <queryResultCache class="solr.search.LRUCache"
+                       size="${solr.queryResultCache.size:512}"
+                       initialSize="${solr.queryResultCache.initialSize:512}"
+                       autowarmCount="${solr.queryResultCache.autowarmCount:128}"/>
+    <documentCache class="solr.search.LRUCache"
+                    size="${solr.documentCache.size:512}"
+                    initialSize="${solr.documentCache.initialSize:512}"/>
   </query>
 
   <requestDispatcher handleSelect="true" >

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -45,6 +45,11 @@
 
   <dataDir>${solr.blacklight-core.data.dir:}</dataDir>
 
+  <query>
+    <filterCache class="solr.search.FastLRUCache" size="512" initialSize="512" autowarmCount="128"/>
+    <queryResultCache class="solr.search.LRUCache" size="512" initialSize="512" autowarmCount="128"/>
+  </query>
+
   <requestDispatcher handleSelect="true" >
     <requestParsers enableRemoteStreaming="false" multipartUploadLimitInKB="2048000" />
   </requestDispatcher>


### PR DESCRIPTION
`filterCache`/`queryResultCache`/`documentCache` were never defined in `solr/conf/solrconfig.xml`, so every tenant collection runs without them.

Pulled real Solr traffic via Loki to check whether caching would actually help in a deployed environment:
- **filterCache/queryResultCache**: a full hour of queries for one tenant (on the shared Hyrax query-building path every tenant uses) had only ~60 distinct `fq`/query signatures covering over 90% of 11,401 requests, repeating every 0.2-2s — dominated by the access-control ACL filter Hyrax attaches to nearly every request and the default anonymous browse query.
- **documentCache**: a ~3.4-minute sample of `qt=permissions`/`qt=document` lookups across many tenants showed 24% of distinct (collection, id) lookups repeating within the window (50% of all lookup traffic), median gap ~15s. Checked whether those repeats would actually land on a warm cache given Hyrax's `commitWithin`-triggered soft commits reopen the searcher on write: the busiest collection had ~55,000 reads in an hour but zero `/update` requests, so no invalidation was happening during that traffic.

Sizes are overridable via system property (`${solr.filterCache.size:512}` etc.), matching the `${solr.autoCommit.maxTime:...}` pattern this file already uses for the same reason: distinct-ID cardinality on the busiest observed collection was ~2,400 in under 4 minutes vs. double digits on quieter tenants, so no single hardcoded size fits every deployment. Defaults fall back to the same conservative values across all three; a busy knapsack can raise `documentCache`'s specifically via `SOLR_OPTS` without touching this file.

Not yet verified against a live Solr instance — opening as a draft for that and for review of the cache sizing/defaults.

**Rollout for already-created collections**: this file only gets read when a configset is first uploaded — each app's `bin/solrcloud-upload-configset.sh` skips the upload if the configset name already exists. Since every knapsack already has a configset registered under its production name, merging this alone won't reach existing *or* newly-created tenant collections. Picking it up needs a forced re-upload (`UPLOAD&overwrite=true`, or a new configset name) followed by `action=RELOAD` against every collection using it.
