### PR TITLE
Honor collection and admin set model config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ gem 'good_job', '~> 4.10' # Updated for Rails 7.2 compatibility
 gem 'googleauth', '~> 1.9.0'
 gem 'google-protobuf'
 gem 'grpc'
-gem 'hyrax', github: 'samvera/hyrax', branch: 'main'
+gem 'hyrax', github: 'samvera/hyrax', branch: 'honor-collection-and-admin-set-model-config'
 gem 'hyrax-doi', github: 'samvera-labs/hyrax-doi', branch: 'rails_hyrax_upgrade'
 gem 'i18n-debug', require: false, group: %i[development test]
 gem 'i18n-tasks', group: %i[development test]

--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ gem 'good_job', '~> 4.10' # Updated for Rails 7.2 compatibility
 gem 'googleauth', '~> 1.9.0'
 gem 'google-protobuf'
 gem 'grpc'
-gem 'hyrax', github: 'samvera/hyrax', branch: 'honor-collection-and-admin-set-model-config'
+gem 'hyrax', github: 'samvera/hyrax', branch: 'main'
 gem 'hyrax-doi', github: 'samvera-labs/hyrax-doi', branch: 'rails_hyrax_upgrade'
 gem 'i18n-debug', require: false, group: %i[development test]
 gem 'i18n-tasks', group: %i[development test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,8 +29,8 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: 4bd778e968d135d254968f41ef30f02d2a170dd5
-  branch: main
+  revision: 340380fbc1fe421a1b367eb96d1279cedf6ae57e
+  branch: honor-collection-and-admin-set-model-config
   specs:
     hyrax (5.3.0)
       active-fedora (~> 15.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,8 +29,8 @@ GIT
 
 GIT
   remote: https://github.com/samvera/hyrax.git
-  revision: 340380fbc1fe421a1b367eb96d1279cedf6ae57e
-  branch: honor-collection-and-admin-set-model-config
+  revision: 39141755e744858a734b8fd3ee95cc85c7836533
+  branch: main
   specs:
     hyrax (5.3.0)
       active-fedora (~> 15.0)

--- a/app/services/demo_tenant_reset_service.rb
+++ b/app/services/demo_tenant_reset_service.rb
@@ -262,7 +262,7 @@ class DemoTenantResetService
   # Reuses the existing admin set rather than triggering creation, which runs
   # workflow grants that fail on partially provisioned tenants.
   def default_admin_set_id
-    existing = Hyrax.query_service.find_all_of_model(model: AdminSetResource).first
+    existing = Hyrax.query_service.find_all_of_model(model: Hyrax.config.admin_set_class).first
     (existing&.id || Hyrax::AdminSetCreateService.find_or_create_default_admin_set.id).to_s
   end
 

--- a/app/services/sample/valkyrie_service.rb
+++ b/app/services/sample/valkyrie_service.rb
@@ -46,7 +46,7 @@ module Sample
         Hyrax.config.use_valkyrie = true
 
         counts = {
-          collections: clean_works_by_pattern(CollectionResource, "%CollectionResource %:%"),
+          collections: clean_works_by_pattern(Hyrax.config.collection_class, "%CollectionResource %:%"),
           images: clean_works_by_pattern(ImageResource, "%ImageResource %:%"),
           generic_works: clean_works_by_pattern(GenericWorkResource, "%GenericWorkResource %:%"),
           file_sets: clean_works_by_pattern(Hyrax::FileSet, "%Hyrax::FileSet %:%")
@@ -227,7 +227,7 @@ module Sample
         depositor: user.user_key
       }
 
-      collection = Hyrax.persister.save(resource: CollectionResource.new(collection_attrs))
+      collection = Hyrax.persister.save(resource: Hyrax.config.collection_class.new(collection_attrs))
       # visibility= builds an ACL that needs an explicit acl.save - setting it via the constructor is silently ignored.
       collection.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
       collection.permission_manager.acl.save

--- a/app/views/catalog/_index_header_list_default.html.erb
+++ b/app/views/catalog/_index_header_list_default.html.erb
@@ -1,10 +1,15 @@
-<%# OVERRIDE Hyrax v5.0.1 to collection badge and markdown of links %>
+<%# OVERRIDE Hyrax v5.3.0
+    - render the title once for both branches, at h3, so a works-only result
+      list does not jump h2 -> h4 (axe heading-order)
+    - render titles through markdown, linked with generate_work_url
+    - show a PermissionBadge for works, where upstream shows nothing
+    - identify collections with SolrDocument#collection? %>
 <div class="search-results-title-row col-12 d-flex flex-row align-items-center pb-2">
   <h3 class="search-result-title">
     <%= link_to markdown(document.title_or_label), generate_work_url(document, request, params) %>
   </h3>
 
-  <% if document.hydra_model == Hyrax.config.collection_class || document.hydra_model < Hyrax.config.collection_class %>
+  <% if document.collection? %>
     <%= Hyrax::CollectionPresenter.new(document, current_ability).collection_type_badge %>
   <% else %>
     <%= Hyrax::PermissionBadge.new(document.visibility).render %>

--- a/app/views/catalog/_thumbnail_list_default.html.erb
+++ b/app/views/catalog/_thumbnail_list_default.html.erb
@@ -1,7 +1,7 @@
-<!-- OVERRIDE Hyrax v5.0 to allow passign options to the thumbnail tag
-     to allow carrying along the query to the universal viewer -->
-<% model = document.hydra_model %>
-
+<!-- OVERRIDE Hyrax v5.3.0
+     - pass options to the work thumbnail tag, carrying the query along to the
+       universal viewer
+     - identify collections with SolrDocument#collection? -->
 <% if params['q'].present? && document.any_highlighting_in_all_text_fields? %>
   <% additional_options = params.slice('q').merge( { :highlight=>'true' } ) %>
 <% elsif params['q'].present? %>
@@ -11,7 +11,7 @@
 <% end %>
 
 <div class="col-md-3">
-  <% if model == Hyrax::PcdmCollection || model < Hyrax::PcdmCollection %>
+  <% if document.collection? %>
     <%= document_presenter(document)&.thumbnail&.thumbnail_tag({ alt: thumbnail_alt_text_for(document, block_name: 'default_collection_image_text') }, suppress_link: true) %>
   <% else %>
     <div class="list-thumbnail">

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -30,10 +30,10 @@ require 'spec_helper'
 simple_work_spec = Hyrax::Engine.root.join("lib/hyrax/specs/shared_specs/simple_work.rb").to_s
 require simple_work_spec unless Hyrax.config.disable_wings
 
-# I want to set this so that our factory finder will have the right values.
-Hyrax.config.admin_set_model = "AdminSetResource"
-Hyrax.config.collection_model = "CollectionResource"
-
+# Do not pin admin_set_model/collection_model here for the factories' benefit; the
+# suite would then exercise those classes whatever the app configures, leaving a
+# substituted collection or admin set class untested.
+#
 # First find the Hyrax factories; then find the local factories (which extend/modify Hyrax
 # factories).
 FactoryBot.definition_file_paths = [

--- a/spec/views/catalog/_index_header_list_default.html.erb_spec.rb
+++ b/spec/views/catalog/_index_header_list_default.html.erb_spec.rb
@@ -11,17 +11,48 @@ RSpec.describe 'catalog/_index_header_list_default.html.erb', type: :view do
 
   before do
     allow(view).to receive(:generate_work_url).and_return('/concern/generic_works/work1')
-    render partial: 'catalog/index_header_list_default', locals: { document: }
   end
 
-  it 'renders the result title at the same heading level as collection results (h3)' do
-    # Collections render h3.search-result-title; works rendered h4, so a
-    # works-only results page jumped h2 -> h4 (axe heading-order).
-    expect(rendered).to have_css('h3.search-result-title', text: 'Assessment of Coastal Ecosystems')
-    expect(rendered).not_to have_css('h4.search-result-title')
+  context 'with a work' do
+    before { render partial: 'catalog/index_header_list_default', locals: { document: } }
+
+    it 'renders the result title at the same heading level as collection results (h3)' do
+      # Collections render h3.search-result-title; works rendered h4, so a
+      # works-only results page jumped h2 -> h4 (axe heading-order).
+      expect(rendered).to have_css('h3.search-result-title', text: 'Assessment of Coastal Ecosystems')
+      expect(rendered).not_to have_css('h4.search-result-title')
+    end
+
+    it 'shows the access-status badge for the work' do
+      expect(rendered).to have_css('span.badge', text: t('hyrax.visibility.open.text'))
+    end
   end
 
-  it 'shows the access-status badge for the work' do
-    expect(rendered).to have_css('span.badge', text: t('hyrax.visibility.open.text'))
+  context 'with the configured collection class' do
+    let(:document) do
+      SolrDocument.new('id' => 'collection1',
+                       'has_model_ssim' => [Hyrax.config.collection_model],
+                       'title_tesim' => ['Coastal Survey Collection'],
+                       'read_access_group_ssim' => ['public'],
+                       'visibility_ssi' => 'open')
+    end
+
+    let(:badge) do
+      ActionController::Base.helpers.tag.span('Collection', class: 'badge', style: 'background-color: #fff;')
+    end
+
+    before do
+      allow(view).to receive(:current_ability).and_return(Ability.new(nil))
+      allow(Hyrax::CollectionPresenter).to receive(:new).and_return(
+        instance_double(Hyrax::CollectionPresenter, collection_type_badge: badge)
+      )
+      render partial: 'catalog/index_header_list_default', locals: { document: }
+    end
+
+    # Both badges render span.badge; only the collection type badge carries an
+    # inline background-color, so the style is the only way to tell them apart.
+    it 'shows the collection type badge rather than the access-status badge' do
+      expect(rendered).to have_css('span.badge[style*="background-color"]')
+    end
   end
 end


### PR DESCRIPTION
## Summary
Collections and admin sets now follow the class named in `config.collection_model` / `config.admin_set_model`, so an installation that substitutes its own class gets the right search-result display, sample data, and demo resets.
- Refs notch8/utk_knapsack#13
- Depends on samvera/hyrax#7631, which fixes the same defect upstream.

## Details
- **Collections could render as works in search results.** The two catalog partials identified collections by descent from a hardcoded class, so a configured class outside that hierarchy lost its type badge and thumbnail treatment. Both now use `SolrDocument#collection?`.
- **The spec suite could never test a substituted class.** `spec/rails_helper.rb` pinned `collection_model` and `admin_set_model` for the whole suite, overriding the initializer, so specs exercised those two classes whatever the app configured.
- **Sample data and demo tenant resets** named their classes directly rather than resolving from config.


