### PR TITLE
Give the demo reset importer its tenant field mappings

### DIFF
--- a/app/services/demo_tenant_reset_service.rb
+++ b/app/services/demo_tenant_reset_service.rb
@@ -56,6 +56,10 @@ class DemoTenantResetService
   SITE_IMAGE_COLUMNS = %w[banner_image logo_image favicon directory_image
                           default_collection_image default_work_image].freeze
 
+  # Keyed the same way Bulkrax.field_mappings is, so the seed importer can look
+  # its own mappings up.
+  PARSER_KLASS = 'Bulkrax::CsvParser'
+
   attr_reader :account, :seed_csv_path, :keep_emails, :import_user_email,
               :health_check, :logger, :import_timeout, :poll_interval
 
@@ -254,7 +258,11 @@ class DemoTenantResetService
       admin_set_id: default_admin_set_id,
       user: import_user,
       frequency: 'PT0S',
-      parser_klass: 'Bulkrax::CsvParser',
+      parser_klass: PARSER_KLASS,
+      # Bulkrax::Importer#mapping ignores the tenant's mappings when
+      # field_mapping is blank and derives them from the CSV headers, losing
+      # `split`, so pipe-delimited values would import as a single value.
+      field_mapping: Bulkrax.field_mappings[PARSER_KLASS],
       parser_fields: { 'import_file_path' => seed_csv_path, 'update_files' => false }
     )
   end

--- a/spec/services/demo_tenant_reset_service_spec.rb
+++ b/spec/services/demo_tenant_reset_service_spec.rb
@@ -136,6 +136,28 @@ RSpec.describe DemoTenantResetService do
     end
   end
 
+  describe 'seed importer creation' do
+    subject(:importer) { service.send(:create_importer!) }
+
+    let(:service) { described_class.new(account:, seed_csv_path: '/tmp/seed.csv') }
+
+    before do
+      allow(service).to receive(:default_admin_set_id).and_return('admin-set-1')
+      allow(service).to receive(:import_user).and_return(FactoryBot.create(:user))
+    end
+
+    it 'copies the configured field mappings onto the importer' do
+      # field_mapping is serialized as JSON, so a Regexp split round-trips to
+      # its source string. Compare the fields covered, not the raw values.
+      expect(importer.field_mapping.keys)
+        .to match_array Bulkrax.field_mappings[described_class::PARSER_KLASS].keys
+    end
+
+    it 'keeps the split option that pipe-delimited seed values depend on' do
+      expect(importer.field_mapping['subject']['split']).to be_present
+    end
+  end
+
   describe 'import verification' do
     it 'raises ImportFailed when the importer run recorded failures' do
       service = described_class.new(account:)


### PR DESCRIPTION
# Story

## Give the demo reset importer its tenant field mappings

87338bcc8fa0e47ff72f9e09f931219d620d6e75

DemoTenantResetService#create_importer! built a Bulkrax::Importer without
field_mapping. Bulkrax::Importer#mapping treats a blank field_mapping as a
signal to derive mappings from the CSV headers instead of using the ones the
tenant is configured with, so every mapping option is lost, including `split`.

The visible result is that pipe-delimited seed values do not split. A subject
column holding "Harbors|Boats|Marblehead" imports as one subject with the
pipes intact, and because `subject` is in Bulkrax's parsed_fields list it also
picks up parse_subject, which downcases everything but the first character. On
a tenant seeded this way the subject facet ends up with one unique term per
work, so browse by subject cannot group anything.

Importers created through the Bulkrax UI are unaffected: ImportersController
sets field_mapping from Bulkrax.field_mappings. This mirrors that.

# Expected Behavior Before Changes

A nightly reset on a `public_demo_tenant` re-imports its seed CSV through an importer whose `field_mapping` is `nil`. Bulkrax discards the tenant's configured mappings and derives its own from the CSV header row, so:

- Pipe-delimited multi-values import as a single value with the pipes intact. `Harbors|Boats|Marblehead` becomes one subject.
- `subject` additionally picks up `Bulkrax::ApplicationMatcher#parse_subject`, which lowercases the string and re-capitalizes only its first character. `Crab Nebula|Hubble Space Telescope` becomes `Crab nebula|hubble space telescope`.
- The subject facet gains one unique term per work, so every facet count is 1 and browse by subject groups nothing.

Fields whose mapping carries an explicit regex `split` (`based_near`, `license`, `related_url`) are unaffected, which is what makes the configuration look like it is being honoured when it is not.

# Expected Behavior After Changes

The seed importer carries the same mappings an admin-UI importer would, resolved inside `within_tenant` so `Bulkrax::PerTenantFieldMappingDecorator` picks up `Site.account.bulkrax_field_mappings` where a tenant has customized them. Pipe-delimited values split, `subject` keeps its casing, and facet terms are shared across works.

# Screenshots / Video

<details>
<summary>Subject facet terms on a tenant seeded without <code>field_mapping</code></summary>

Pulled from the rendered home page of a deployed `public_demo_tenant`. All 10 distinct terms carry pipes, so each groups exactly one work:

```
'Biodiversity|coastal ecosystems|ecological risk|ecosystems|habitats|recreation'
'Buzz aldrin|moon|apollo 11|lunar landing'
'Crab nebula|hubble space telescope'
'Harbors|boats|united states--massachusetts--marblehead'
'Harbors|bridges|united states--michigan--petoskey'
'Hubble reveals heart of lagoon nebula|space|nasa|nebula|hubble|hubblespacetelescope'
'Hubble reveals the ring nebula’s true shape|nasa|nebula|hubble|hubblespacetelescope'
'Leg 122|site 763|hole 763c|odp leg 122|exmouth plateau|tropical se indian'
'Lifeboats--california--san francisco|lifesaving--california--san francisco|...'
'Peaks island (portland, me.)--aerial views|united states--maine--peaks island (portland)'
```

The source CSV holds these as `Harbors|Boats|United States--Massachusetts--Marblehead`, so both the split and the casing are lost at import.

Importer records on the same deployment, three tenants seeded through the admin UI and one by script:

```
ellison    importer=1  field_mapping: 73 keys   creator {"from"=>["creator"], "split"=>true}
harborview importer=1  field_mapping: 73 keys   creator {"from"=>["creator"], "split"=>true}
meridian   importer=1  field_mapping: 73 keys   creator {"from"=>["creator"], "split"=>true}
sandbox    importer=1  field_mapping: nil
```

</details>

# Notes

Two specs added to `spec/services/demo_tenant_reset_service_spec.rb`: the importer carries the configured mappings, and `subject` keeps its `split`.

The first compares mapping keys rather than the whole hash, because `field_mapping` is serialized as JSON and a `Regexp` `split` does not survive the round trip. The `file` mapping is configured as `split: /\s*[|]\s*/` and reads back as the string `"(?-mix:\\s*[|]\\s*)"`, so a whole-hash comparison fails on representation rather than content. It still fails if `field_mapping` is left nil, which is the regression being guarded.

`PARSER_KLASS` was extracted because the parser class name is now referenced twice and the two must not drift.

**No deploy or migration steps.** One caveat for operators rather than reviewers: this fixes the reset path only. Content already imported through an importer with a blank `field_mapping` stays corrupt and needs re-importing, and a `public_demo_tenant` should be re-seeded and re-snapshotted after this lands, otherwise the next nightly reset restores the snapshot's corrupt values.

Reported by @kirkkwang.

@samvera/hyku-code-reviewers
