### PR TITLE
Resolve the demo seed csv path in one place

### DIFF
--- a/app/jobs/demo_tenant_reset_job.rb
+++ b/app/jobs/demo_tenant_reset_job.rb
@@ -44,19 +44,12 @@ class DemoTenantResetJob < ApplicationJob
 
   private
 
-  def service_options(account)
+  def service_options(_account)
     {
-      seed_csv_path: seed_csv_path_for(account),
+      seed_csv_path: ENV['DEMO_SEED_CSV_PATH'].presence,
       keep_emails: ENV.fetch('DEMO_KEEP_USERS', '').split(','),
       import_user_email: ENV['DEMO_IMPORT_USER'].presence,
       health_check: ENV['DEMO_HEALTH_CHECK'].presence&.constantize
     }
-  end
-
-  def seed_csv_path_for(account)
-    template = ENV['DEMO_SEED_CSV_PATH'].presence
-    return unless template
-
-    format(template, tenant: account.name)
   end
 end

--- a/app/jobs/demo_tenant_reset_job.rb
+++ b/app/jobs/demo_tenant_reset_job.rb
@@ -38,13 +38,13 @@ class DemoTenantResetJob < ApplicationJob
       return
     end
 
-    DemoTenantResetService.new(account:, **service_options(account)).reset!
+    DemoTenantResetService.new(account:, **service_options).reset!
     self.class.set(wait_until: Date.tomorrow.midnight).perform_later
   end
 
   private
 
-  def service_options(_account)
+  def service_options
     {
       seed_csv_path: ENV['DEMO_SEED_CSV_PATH'].presence,
       keep_emails: ENV.fetch('DEMO_KEEP_USERS', '').split(','),

--- a/app/services/demo_tenant_reset_service.rb
+++ b/app/services/demo_tenant_reset_service.rb
@@ -60,6 +60,9 @@ class DemoTenantResetService
   # its own mappings up.
   PARSER_KLASS = 'Bulkrax::CsvParser'
 
+  # The service runs inside it, so its row is in the queue it waits on.
+  RESET_JOB_CLASS = 'DemoTenantResetJob'
+
   attr_reader :account, :seed_csv_path, :keep_emails, :import_user_email,
               :health_check, :logger, :import_timeout, :poll_interval
 
@@ -140,11 +143,8 @@ class DemoTenantResetService
     raise NotDemoTenant, "#{account&.cname || account.inspect} is not flagged public_demo_tenant; refusing"
   end
 
-  # A deployment configures one path for every demo tenant, so it carries a
-  # %{tenant} placeholder. Resolving it here rather than in each caller is what
-  # keeps the rake task and the nightly job agreeing about what they were given.
-  # Substitution rather than format, which would parse every other % in the
-  # path and raise on the ones it could not read as a placeholder.
+  # Substitution rather than format, which parses every other % in the path and
+  # raises on the ones it cannot read as a placeholder.
   def resolve_seed_csv_path(path)
     return path if path.blank?
 
@@ -332,18 +332,26 @@ class DemoTenantResetService
     end
   end
 
-  # Only jobs due now: recurring jobs scheduled into the future must not
-  # block the drain.
-  def pending_good_jobs
+  # good_jobs is an Apartment excluded model, so one table holds every tenant's
+  # rows and both queries below have to say which tenant they mean.
+  def unfinished_jobs_for_tenant
     GoodJob::Job.where(finished_at: nil)
-                .where('scheduled_at IS NULL OR scheduled_at <= ?', Time.current)
-                .count
+                .where("serialized_params->>'tenant' = ?", account.tenant)
+  end
+
+  # Every reset row for the tenant, not only this one: its own is unfinished and
+  # due for as long as the drain runs, so counting it would wait on itself.
+  def pending_good_jobs
+    unfinished_jobs_for_tenant
+      .where('scheduled_at IS NULL OR scheduled_at <= ?', Time.current)
+      .where.not(job_class: RESET_JOB_CLASS)
+      .count
   end
 
   def pull_relationship_jobs_forward!
-    scope = GoodJob::Job.where(finished_at: nil)
-                        .where('scheduled_at > ?', Time.current)
-                        .where('job_class ILIKE ?', '%Relationship%')
+    scope = unfinished_jobs_for_tenant
+            .where('scheduled_at > ?', Time.current)
+            .where('job_class ILIKE ?', '%Relationship%')
     count = scope.count
     scope.update_all(scheduled_at: Time.current) if count.positive? # rubocop:disable Rails/SkipsModelValidations
     count

--- a/app/services/demo_tenant_reset_service.rb
+++ b/app/services/demo_tenant_reset_service.rb
@@ -64,7 +64,8 @@ class DemoTenantResetService
               :health_check, :logger, :import_timeout, :poll_interval
 
   # @param account [Account] must be flagged public_demo_tenant
-  # @param seed_csv_path [String, nil] absolute path to a Bulkrax CSV to re-import; nil skips the import
+  # @param seed_csv_path [String, nil] path to a Bulkrax CSV to re-import; a %{tenant}
+  #   placeholder expands to the account name. nil skips the import
   # @param keep_emails [Array<String>] user emails that survive the reset in addition to superadmins
   # @param import_user_email [String, nil] owner of the seed import; defaults to the first tenant admin
   # @param health_check [#call, nil] called with the account after restore; a falsey return fails the reset
@@ -75,7 +76,7 @@ class DemoTenantResetService
   def initialize(account:, seed_csv_path: nil, keep_emails: [], import_user_email: nil,
                  health_check: nil, logger: Rails.logger, import_timeout: 3600, poll_interval: 5)
     @account = account
-    @seed_csv_path = seed_csv_path
+    @seed_csv_path = resolve_seed_csv_path(seed_csv_path)
     @keep_emails = Array(keep_emails).map { |email| email.to_s.downcase.strip }.reject(&:empty?)
     @import_user_email = import_user_email
     @health_check = health_check
@@ -137,6 +138,17 @@ class DemoTenantResetService
     return if account&.public_demo_tenant?
 
     raise NotDemoTenant, "#{account&.cname || account.inspect} is not flagged public_demo_tenant; refusing"
+  end
+
+  # A deployment configures one path for every demo tenant, so it carries a
+  # %{tenant} placeholder. Resolving it here rather than in each caller is what
+  # keeps the rake task and the nightly job agreeing about what they were given.
+  # Substitution rather than format, which would parse every other % in the
+  # path and raise on the ones it could not read as a placeholder.
+  def resolve_seed_csv_path(path)
+    return path if path.blank?
+
+    path.gsub('%{tenant}') { account.name }
   end
 
   # Both switches are needed: Account#switch only moves the endpoints,

--- a/lib/tasks/demo.rake
+++ b/lib/tasks/demo.rake
@@ -25,7 +25,8 @@ namespace :hyku do
       snapshot first with hyku:demo:snapshot.
 
       Options (environment variables):
-        DEMO_SEED_CSV_PATH  absolute path to a Bulkrax CSV to re-import (optional)
+        DEMO_SEED_CSV_PATH  path to a Bulkrax CSV to re-import; a %{tenant}
+                            placeholder expands to the account name (optional)
         DEMO_KEEP_USERS     comma-separated emails that survive the reset in
                             addition to superadmins (optional)
         DEMO_IMPORT_USER    email of the user that owns the seed import

--- a/spec/jobs/demo_tenant_reset_job_spec.rb
+++ b/spec/jobs/demo_tenant_reset_job_spec.rb
@@ -60,11 +60,13 @@ RSpec.describe DemoTenantResetJob do
         original ? ENV['DEMO_SEED_CSV_PATH'] = original : ENV.delete('DEMO_SEED_CSV_PATH')
       end
 
-      it 'expands the tenant name into DEMO_SEED_CSV_PATH' do
+      # Expanding %{tenant} moved into DemoTenantResetService so hyku:demo:reset
+      # gets it too, and is asserted there. This only checks the handover.
+      it 'passes DEMO_SEED_CSV_PATH through for the service to resolve' do
         switch!(account)
         described_class.perform_now
         expect(DemoTenantResetService).to have_received(:new)
-          .with(hash_including(seed_csv_path: "/imports/#{account.name}/metadata.csv"))
+          .with(hash_including(seed_csv_path: '/imports/%{tenant}/metadata.csv'))
       end
     end
   end

--- a/spec/services/demo_tenant_reset_service_spec.rb
+++ b/spec/services/demo_tenant_reset_service_spec.rb
@@ -147,11 +147,6 @@ RSpec.describe DemoTenantResetService do
       expect(service.seed_csv_path).to eq '/srv/seed/metadata.csv'
     end
 
-    it 'does not raise on a path carrying a percent that is not a placeholder' do
-      expect { described_class.new(account:, seed_csv_path: '/srv/100%/metadata.csv') }
-        .not_to raise_error
-    end
-
     it 'expands the placeholder without interpreting other percent sequences' do
       service = described_class.new(account:, seed_csv_path: 'tmp/imports/%{tenant}/100%/metadata.csv')
       expect(service.seed_csv_path).to eq "tmp/imports/#{account.name}/100%/metadata.csv"
@@ -164,6 +159,102 @@ RSpec.describe DemoTenantResetService do
 
     it 'leaves a nil path nil, so a reset with no seed still restores branding' do
       expect(described_class.new(account:).seed_csv_path).to be_nil
+    end
+  end
+
+  describe 'draining background jobs' do
+    subject(:pending_count) { described_class.new(account:).send(:pending_good_jobs) }
+
+    let(:due) do
+      { queue_name: 'default', scheduled_at: 1.minute.ago, job_class: 'ValkyrieCharacterizationJob',
+        serialized_params: { 'tenant' => account.tenant } }
+    end
+
+    # import_timeout is small on purpose: a drain regression fails the example
+    # instead of busy-looping for the default hour.
+    def draining(**options)
+      described_class.new(account:, poll_interval: 0.05, import_timeout: 1, **options)
+    end
+
+    def enqueue(**overrides)
+      GoodJob::Job.create!(active_job_id: SecureRandom.uuid, **due.merge(overrides))
+    end
+
+    it 'counts jobs due for this tenant' do
+      enqueue
+      expect(pending_count).to eq 1
+    end
+
+    it 'ignores jobs scheduled into the future, such as the recurring cron' do
+      enqueue(scheduled_at: 1.hour.from_now, job_class: 'EmbargoAutoExpiryJob')
+      expect(pending_count).to eq 0
+    end
+
+    it 'ignores another tenant, since good_jobs is not split by schema' do
+      enqueue(serialized_params: { 'tenant' => 'some-other-tenant' })
+      expect(pending_count).to eq 0
+    end
+
+    it 'ignores its own row, which is unfinished for as long as it runs' do
+      enqueue(job_class: described_class::RESET_JOB_CLASS)
+      expect(pending_count).to eq 0
+    end
+
+    it 'ignores jobs that have already finished' do
+      enqueue(finished_at: Time.current)
+      expect(pending_count).to eq 0
+    end
+
+    # The production failure was the loop, not the count: it spun for the whole
+    # import_timeout because the count could never reach zero.
+    it 'returns instead of spinning when only its own row remains' do
+      enqueue(job_class: described_class::RESET_JOB_CLASS)
+      expect { draining.send(:drain_good_job_queue!) }.not_to raise_error
+    end
+
+    it 'raises ImportFailed if the tenant queue never clears' do
+      enqueue
+      expect { draining.send(:drain_good_job_queue!) }
+        .to raise_error(described_class::ImportFailed, /did not drain/)
+    end
+
+    it 'pulls this tenant deferred relationship jobs forward' do
+      job = enqueue(scheduled_at: 10.minutes.from_now, job_class: 'Bulkrax::CreateRelationshipsJob')
+      expect { draining.send(:pull_relationship_jobs_forward!) }
+        .to change { job.reload.scheduled_at }
+    end
+
+    it 'leaves another tenant deferred relationship jobs alone' do
+      job = enqueue(scheduled_at: 10.minutes.from_now, job_class: 'Bulkrax::CreateRelationshipsJob',
+                    serialized_params: { 'tenant' => 'some-other-tenant' })
+      expect { draining.send(:pull_relationship_jobs_forward!) }
+        .not_to change { job.reload.scheduled_at }
+    end
+
+    # Only deferred ones count as pulled, or the outer loop never breaks.
+    it 'does not count relationship jobs that are already due' do
+      enqueue(job_class: 'Bulkrax::CreateRelationshipsJob')
+      expect(draining.send(:pull_relationship_jobs_forward!)).to eq 0
+    end
+
+    # It rewrites scheduled_at, so anything but a relationship job losing its
+    # backoff here would drag tomorrow's reset and every retry forward with it.
+    it 'leaves other deferred jobs, including tomorrow reset, where they are' do
+      job = enqueue(scheduled_at: 1.hour.from_now, job_class: 'EmbargoAutoExpiryJob')
+      expect { draining.send(:pull_relationship_jobs_forward!) }
+        .not_to change { job.reload.scheduled_at }
+    end
+
+    it 'leaves finished relationship jobs alone' do
+      enqueue(scheduled_at: 10.minutes.from_now, finished_at: Time.current,
+              job_class: 'Bulkrax::CreateRelationshipsJob')
+      expect(draining.send(:pull_relationship_jobs_forward!)).to eq 0
+    end
+
+    # The constant is a string, so a rename of the job would silently stop the
+    # drain excluding its own row and the hang would return with a green suite.
+    it 'names a job class that exists' do
+      expect(described_class::RESET_JOB_CLASS).to eq DemoTenantResetJob.name
     end
   end
 

--- a/spec/services/demo_tenant_reset_service_spec.rb
+++ b/spec/services/demo_tenant_reset_service_spec.rb
@@ -136,6 +136,37 @@ RSpec.describe DemoTenantResetService do
     end
   end
 
+  describe 'seed csv path' do
+    it 'expands a %{tenant} template to the account name' do
+      service = described_class.new(account:, seed_csv_path: 'tmp/imports/%{tenant}/seed/metadata.csv')
+      expect(service.seed_csv_path).to eq "tmp/imports/#{account.name}/seed/metadata.csv"
+    end
+
+    it 'leaves a literal path alone' do
+      service = described_class.new(account:, seed_csv_path: '/srv/seed/metadata.csv')
+      expect(service.seed_csv_path).to eq '/srv/seed/metadata.csv'
+    end
+
+    it 'does not raise on a path carrying a percent that is not a placeholder' do
+      expect { described_class.new(account:, seed_csv_path: '/srv/100%/metadata.csv') }
+        .not_to raise_error
+    end
+
+    it 'expands the placeholder without interpreting other percent sequences' do
+      service = described_class.new(account:, seed_csv_path: 'tmp/imports/%{tenant}/100%/metadata.csv')
+      expect(service.seed_csv_path).to eq "tmp/imports/#{account.name}/100%/metadata.csv"
+    end
+
+    it 'leaves a placeholder it does not support alone rather than raising' do
+      service = described_class.new(account:, seed_csv_path: 'tmp/imports/%{tenant}/%{env}/metadata.csv')
+      expect(service.seed_csv_path).to eq "tmp/imports/#{account.name}/%{env}/metadata.csv"
+    end
+
+    it 'leaves a nil path nil, so a reset with no seed still restores branding' do
+      expect(described_class.new(account:).seed_csv_path).to be_nil
+    end
+  end
+
   describe 'seed importer creation' do
     subject(:importer) { service.send(:create_importer!) }
 


### PR DESCRIPTION
# Story

## Resolve the demo seed csv path in one place

9083c43a4dffd14b9bdfdab9b21a9c1f70c830be

DEMO_SEED_CSV_PATH is one setting for every demo tenant on a deployment, so it
carries a %{tenant} placeholder. Only DemoTenantResetJob expanded it.
hyku:demo:reset passed ENV['DEMO_SEED_CSV_PATH'] straight through, so the
literal string reached File.exist? and the reset aborted:

    DemoTenantResetService::ImportFailed: seed csv not found at
    tmp/imports/%{tenant}/seed/metadata.csv; refusing to wipe sandbox.example.com

That is the documented way to run a reset by hand, and it disagreed with the
scheduled path about what it had been given. The task's own docstring said
"absolute path" while deployments supply a template.

Resolving it in DemoTenantResetService#initialize means both entry points get
the same behavior and a third caller cannot repeat the mistake. The expansion
is a plain gsub of %{tenant} rather than format, so no other percent in the
path is parsed: format raises ArgumentError on tmp/%{tenant}/100%/metadata.csv
and KeyError on an unsupported tmp/%{tenant}/%{env}/metadata.csv.

Worth noting the failure was safe rather than destructive: the guard on
wipe_content! refused before touching content, so the tenant was left intact
rather than emptied and then failed.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

## Scope the reset drain to its own tenant

f8601270b28da8654e64d9887654b2cc7895a86d

wait_for_quiescence! waits for pending_good_jobs to reach zero. GoodJob::Job is
an Apartment excluded model, so one good_jobs table holds every tenant's rows
and the count included the reset job's own row, unfinished with a past
scheduled_at for as long as it runs. It raised ImportFailed at the 3600s
import_timeout, retry_on tried three times, and since the run ends in failure
the job neither stamps last_reset_at nor enqueues tomorrow, and
restore_featured_works! never runs because it sits after import_seed!.

Observed on production three nights running: about three worker-hours a night
on work that finishes in eleven minutes, featured works left at 0, and the
nightly chain stopped.

The same table-wide scope meant any busy tenant could stall a demo reset, and
pull_relationship_jobs_forward! would update_all across tenants, yanking an
unrelated tenant's Bulkrax backoff forward mid-import. Both queries now derive
from unfinished_jobs_for_tenant so they cannot drift apart again.

RESET_JOB_CLASS stays a string rather than DemoTenantResetJob.name to keep the
service off the job's autoload path; a spec asserts the two agree, since a
rename would otherwise reopen the hang with a green suite.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

# Expected Behavior Before Changes

Neither entry point to a demo tenant reset worked end to end on a real deployment, and the drain reached across tenants.

**`hyku:demo:reset`** passed `DEMO_SEED_CSV_PATH` through unexpanded. A deployment configures one path for every demo tenant, so it carries a `%{tenant}` placeholder, and only the job expanded it:

```
DemoTenantResetService::ImportFailed: seed csv not found at
tmp/imports/%{tenant}/seed/metadata.csv; refusing to wipe sandbox.example.com
```

**`DemoTenantResetJob`** never finished. `wait_for_quiescence!` waits for `pending_good_jobs` to reach zero, but `GoodJob::Job` is an Apartment excluded model, so one `good_jobs` table holds every tenant's rows and the count included the reset job's own row, which is unfinished with a past `scheduled_at` for as long as it runs. It raised `ImportFailed` at the 3600 second `import_timeout`, `retry_on` tried three times, and because the run ends in failure the job neither stamps `last_reset_at` nor enqueues tomorrow, and `restore_featured_works!` never runs because it sits after `import_seed!`. Observed on production three nights running: roughly three worker-hours burned per night on work that completes in about eleven minutes, featured works left at 0, and the nightly chain stopped.

The same table-wide scope meant **any** busy tenant could stall a demo reset indefinitely, and `pull_relationship_jobs_forward!` would `update_all(scheduled_at: Time.current)` across tenants, yanking an unrelated tenant's Bulkrax backoff forward mid-import.

# Expected Behavior After Changes

Both entry points resolve the seed path identically, and the drain waits only on this tenant's own outstanding work.

# Screenshots / Video

Measured on production. The reset itself was always correct; only the drain hung.

```
reset job started 21:33:17 UTC
  126 jobs spawned, all finished, last at 21:44:35   -> ingest took 11.3 min
content in place after ~2.5 min:
  works=10  filesets=10  collections=2  pipes=0
  depositors={"demo-depositor@hykuup.com"=>10}
  importer entries={"Complete"=>12}  field_mapping=73 keys
drain state at 19 min, every spawned job already finished:
  due now = 1
    DemoTenantResetJob  active_job_id=79599108  performed=21:33:17
```

Evidence for the tenant scope, gathered from the same deployment on GoodJob 4.12.0:

```
Apartment.excluded_models includes "GoodJob::Job"
all 118 jobs a reset spawned carried serialized_params['tenant'] == account.tenant
  across 13 classes: Bulkrax::ImportWorkJob, Bulkrax::CreateRelationshipsJob,
  ValkyrieCharacterizationJob, ValkyrieCreateDerivativesJob, ValkyrieIngestJob,
  ReindexItemJob, and the event jobs
0 spawned jobs without a tenant, 0 with a different tenant
retries reuse one good_jobs row rather than inserting more
recent rows span four different tenants
```

# Notes

`unfinished_jobs_for_tenant` exists so the count and the update cannot drift apart again. An earlier revision of this change scoped only the count, which left the hang reachable through `pull_relationship_jobs_forward!` and left its `update_all` writing across tenants.

`RESET_JOB_CLASS` is a string rather than `DemoTenantResetJob.name` so the service does not trigger the job's autoload at class-load time; a spec asserts the two agree, since a rename would otherwise reintroduce the hang with a green suite.

`resolve_seed_csv_path` uses `gsub` with a String pattern and a block rather than `format`. `format` parses every other `%` in the path, so `tmp/imports/%{tenant}/100%/metadata.csv` raises `ArgumentError`, and `%{env}` raises `KeyError`. The block form also stops a `\1` in an account name being read as a backreference.

Twenty examples in `spec/services/demo_tenant_reset_service_spec.rb`: five on path resolution, thirteen on draining, two on importer creation. Each of the four clauses of each drain query has an example that fails if that clause alone is deleted, including the `finished_at IS NULL` and `job_class ILIKE` clauses that bound the `update_all`.

`DemoTenantResetJob#seed_csv_path_for` is deleted rather than left in place, so the interpolation cannot drift between callers, and `service_options` no longer needs the account.

**Not addressed here, worth its own issue.** `drain_import_jobs!` gates on `defined?(GoodJob::Job)`, which is always true because good_job is an unconditional dependency, while `HYRAX_ACTIVE_JOB_QUEUE` defaults to `sidekiq`. On a Sidekiq install the drain therefore returns having waited for nothing and `verify_import!` reads a half-built tenant. That predates this branch and changing adapter gating reaches every Hyku installation, so it does not belong in this PR.

@samvera/hyku-code-reviewers
