### PR TITLE
Stop boosting two Solr fields nothing indexes

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -303,12 +303,11 @@ class CatalogController < ApplicationController
       }
     end
 
-    date_fields = ['date_created_tesim', 'sorted_date_isi', 'sorted_month_isi']
-
     config.add_search_field('date_created') do |field|
+      solr_name = 'date_created_tesim'
       field.solr_local_parameters = {
-        qf: date_fields.join(' '),
-        pf: date_fields.join(' ')
+        qf: solr_name,
+        pf: solr_name
       }
     end
 

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -28,6 +28,22 @@ RSpec.describe CatalogController do
     end
   end
 
+  describe "date_created search field" do
+    let(:field) { described_class.blacklight_config.search_fields['date_created'] }
+
+    it "queries only fields an indexer writes" do
+      expect(field.solr_local_parameters[:qf]).to eq 'date_created_tesim'
+    end
+
+    it "boosts the same fields it queries" do
+      expect(field.solr_local_parameters[:pf]).to eq field.solr_local_parameters[:qf]
+    end
+
+    it "names no int field, which only a numeric term could ever match" do
+      expect(field.solr_local_parameters[:qf].split.grep(/_isim?\z/)).to be_empty
+    end
+  end
+
   describe "GET /show" do
     let(:file_set) { create(:file_set) }
 


### PR DESCRIPTION
Fixes #3291

Stop boosting two Solr fields nothing indexes

The `date_created` search field has listed `sorted_date_isi` and `sorted_month_isi` in its `qf` and `pf` since the Hyrax 5 upgrade (#2047) in January 2024:

```ruby
date_fields = ['date_created_tesim', 'sorted_date_isi', 'sorted_month_isi']
```

`app/controllers/catalog_controller.rb:306` is the only occurrence of either name in this repository, and neither appears anywhere in Hyrax's `app/` or `lib/`, so nothing has ever written them. Both clauses can only contribute zero matches and a phrase boost that can never apply.

**This is dead configuration, not breakage**, which is why it went unnoticed. Both names match the `*_isi` dynamic field, `type="int"` in `solr/conf/schema.xml`, so a bare year would have been a perfectly valid query against them had anything indexed them; nothing does. A non-numeric term is tolerated quietly rather than raising: measured against `solr.TrieIntField`, `dismax` and `edismax` both return no error and no match, and only an explicit fielded lucene query against an int field is rejected, with a 400. So the cost is two useless clauses per Date Created query rather than a failure.

**Removing them changes no result set.** The normalized date that `AppIndexer#add_date` and `HykuIndexing#add_date` do write is `date_tesi`, which is `text_en` and searchable. Adding that to this `qf` would broaden date matching and looks like what the two `sorted_*` names were reaching for, but it is a behavior change, so it is left out of this PR for a separate decision. Happy to follow up with it if you want it.

Changes proposed in this pull request:
* Drop `sorted_date_isi` and `sorted_month_isi` from the `date_created` search field's `qf` and `pf`, and name the remaining Solr field inline the way every other search field in this method does
* Add three examples to `spec/controllers/catalog_controller_spec.rb` pinning that field's `qf`/`pf`, including one asserting it names no `*_isi`/`*_isim` field, since only a numeric term could ever match one

Verified against `main` at 761f9859, not against a pinned older release.

@samvera/hyku-code-reviewers

Generated-by: Claude Opus 5
